### PR TITLE
feat(vc): Signed credentials

### DIFF
--- a/identity_vc/Cargo.toml
+++ b/identity_vc/Cargo.toml
@@ -14,6 +14,10 @@ homepage = "https://www.iota.org"
 name = "vc_test_suite"
 path = "bin/vc_test_suite.rs"
 
+[[bin]]
+name = "credential"
+path = "bin/credential.rs"
+
 [dependencies]
 # error handling
 thiserror = "1.0"
@@ -28,3 +32,4 @@ serde_cbor = "0.11"
 chrono = { version = "0.4", features = ["serde"] }
 
 identity_core = { git = "https://github.com/iotaledger/identity.rs", branch = "feat/common-core-types" }
+identity_crypto = { git = "https://github.com/iotaledger/identity.rs", branch = "feat/identity-crypto" }

--- a/identity_vc/bin/credential.rs
+++ b/identity_vc/bin/credential.rs
@@ -1,0 +1,44 @@
+#[macro_use]
+extern crate identity_core;
+
+use identity_crypto::{key::*, proof::*};
+use identity_vc::prelude::*;
+use serde_json::to_string_pretty;
+
+fn main() -> anyhow::Result<()> {
+  let credential: Credential = CredentialBuilder::new()
+    .context("did:iota:university:5678")
+    .id("did:iota:cred:1234")
+    .issuer("did:iota:ident:university")
+    .type_("UniversityDegreeCredential")
+    .try_subject(object!(id: "did:iota:ident:alice", alumniOf: "ExampleUniversity"))?
+    .try_issuance_date("2020-01-01T00:00:00Z")?
+    .property("foo", 1234)
+    .property("bar", vec![5, 6, 7, 8])
+    .non_transferable("YES")
+    .build()?;
+
+  println!("[+] Available Proofs > {:?}", ProofManager::all()?);
+
+  let suite: Proof = ProofManager::get("EcdsaSecp256k1")?; // Ed25519
+  let keypair: KeyPair = suite.keypair(KeyGenerator::None)?;
+
+  println!("[+] Public Key > {}", keypair.public());
+  println!("[+] Secret Key > {}", keypair.secret());
+
+  let proof: LinkedDataProof = suite.sign(&credential, keypair.secret(), Default::default())?;
+
+  println!("[+] Linked Data Proof > {:#?}", proof);
+
+  let verifiable: VerifiableCredential = VerifiableCredential::new(credential, proof);
+
+  println!("[+] Verifiable Credential > {:#?}", verifiable);
+
+  let verified: bool = verifiable.verify(|value: &str| -> Result<PublicKey> { Ok(keypair.public().clone()) })?;
+
+  println!("[+] Verified > {}", verified);
+
+  println!("[+] VC JSON > {}", to_string_pretty(&verifiable)?);
+
+  Ok(())
+}

--- a/identity_vc/src/credential.rs
+++ b/identity_vc/src/credential.rs
@@ -1,4 +1,9 @@
 use identity_core::common::{Object, Timestamp, Value};
+use identity_crypto::{
+  error::Result as CryptoResult,
+  proof::{LinkedDataProof, ProofDocument},
+  utils::convert,
+};
 use serde_json::{from_str, to_string};
 
 use crate::{
@@ -82,6 +87,12 @@ impl Credential {
 
   pub fn to_json(&self) -> Result<String> {
     to_string(self).map_err(Error::EncodeJSON)
+  }
+}
+
+impl ProofDocument for Credential {
+  fn to_object(&self) -> CryptoResult<Object> {
+    convert(self)
   }
 }
 
@@ -223,7 +234,7 @@ impl CredentialBuilder {
   }
 
   /// Consumes the `CredentialBuilder`, returning a valid `VerifiableCredential`
-  pub fn build_verifiable(self, proof: impl Into<OneOrMany<Object>>) -> Result<VerifiableCredential> {
+  pub fn build_verifiable(self, proof: impl Into<OneOrMany<LinkedDataProof>>) -> Result<VerifiableCredential> {
     self
       .build()
       .map(|credential| VerifiableCredential::new(credential, proof))

--- a/identity_vc/src/error.rs
+++ b/identity_vc/src/error.rs
@@ -1,4 +1,6 @@
 use chrono::ParseError as ChronoError;
+use identity_core::Error as CoreError;
+use identity_crypto::error::Error as CryptoError;
 use std::result::Result as StdResult;
 use thiserror::Error as ThisError;
 
@@ -26,6 +28,10 @@ pub enum Error {
   DecodeJSON(serde_json::Error),
   #[error("Failed to encode JSON: {0}")]
   EncodeJSON(serde_json::Error),
+  #[error(transparent)]
+  CoreError(#[from] CoreError),
+  #[error(transparent)]
+  CryptoError(#[from] CryptoError),
 }
 
 pub type Result<T> = StdResult<T, Error>;

--- a/identity_vc/src/lib.rs
+++ b/identity_vc/src/lib.rs
@@ -19,8 +19,8 @@ pub mod prelude {
       Context, CredentialSchema, CredentialStatus, CredentialSubject, Evidence, Issuer, OneOrMany, RefreshService,
       TermsOfUse, URI,
     },
-    error::{Error, Result},
     credential::{Credential, CredentialBuilder},
+    error::{Error, Result},
     presentation::{Presentation, PresentationBuilder},
     verifiable::{VerifiableCredential, VerifiablePresentation},
   };

--- a/identity_vc/src/presentation.rs
+++ b/identity_vc/src/presentation.rs
@@ -1,4 +1,9 @@
 use identity_core::common::{Object, Value};
+use identity_crypto::{
+  error::Result as CryptoResult,
+  proof::{LinkedDataProof, ProofDocument},
+  utils::convert,
+};
 use serde_json::{from_str, to_string};
 
 use crate::{
@@ -60,6 +65,12 @@ impl Presentation {
 
   pub fn to_json(&self) -> Result<String> {
     to_string(self).map_err(Error::EncodeJSON)
+  }
+}
+
+impl ProofDocument for Presentation {
+  fn to_object(&self) -> CryptoResult<Object> {
+    convert(self)
   }
 }
 
@@ -159,7 +170,7 @@ impl PresentationBuilder {
   }
 
   /// Consumes the `PresentationBuilder`, returning a valid `VerifiablePresentation`
-  pub fn build_verifiable(self, proof: impl Into<OneOrMany<Object>>) -> Result<VerifiablePresentation> {
+  pub fn build_verifiable(self, proof: impl Into<OneOrMany<LinkedDataProof>>) -> Result<VerifiablePresentation> {
     self
       .build()
       .map(|credential| VerifiablePresentation::new(credential, proof))

--- a/identity_vc/src/utils/mod.rs
+++ b/identity_vc/src/utils/mod.rs
@@ -1,3 +1,4 @@
 mod validation;
+mod verification;
 
-pub use self::validation::*;
+pub use self::{validation::*, verification::*};

--- a/identity_vc/src/utils/verification.rs
+++ b/identity_vc/src/utils/verification.rs
@@ -1,0 +1,24 @@
+use identity_crypto::{
+  key::PublicKey,
+  proof::{LinkedDataProof, Proof, ProofDocument, ProofManager},
+};
+
+use crate::{common::OneOrMany, error::Result};
+
+pub fn verify_document(
+  document: &dyn ProofDocument,
+  proofs: &OneOrMany<LinkedDataProof>,
+  resolve: impl Fn(&str) -> Result<PublicKey>,
+) -> Result<bool> {
+  for proof in proofs.iter() {
+    let suite: Proof = ProofManager::get(&proof.type_)?;
+    let public: PublicKey = resolve(&proof.verification_method)?;
+    let verified: bool = suite.verify(document, &proof, &public)?;
+
+    if !verified {
+      return Ok(false);
+    }
+  }
+
+  Ok(true)
+}

--- a/identity_vc/src/verifiable/credential.rs
+++ b/identity_vc/src/verifiable/credential.rs
@@ -1,17 +1,17 @@
-use identity_core::common::Object;
+use identity_crypto::{key::PublicKey, proof::LinkedDataProof};
 use std::ops::Deref;
 
-use crate::{common::OneOrMany, credential::Credential};
+use crate::{common::OneOrMany, credential::Credential, error::Result, utils::verify_document};
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct VerifiableCredential {
   #[serde(flatten)]
   credential: Credential,
-  proof: OneOrMany<Object>,
+  proof: OneOrMany<LinkedDataProof>,
 }
 
 impl VerifiableCredential {
-  pub fn new(credential: Credential, proof: impl Into<OneOrMany<Object>>) -> Self {
+  pub fn new(credential: Credential, proof: impl Into<OneOrMany<LinkedDataProof>>) -> Self {
     Self {
       credential,
       proof: proof.into(),
@@ -26,12 +26,16 @@ impl VerifiableCredential {
     &mut self.credential
   }
 
-  pub fn proof(&self) -> &OneOrMany<Object> {
+  pub fn proof(&self) -> &OneOrMany<LinkedDataProof> {
     &self.proof
   }
 
-  pub fn proof_mut(&mut self) -> &mut OneOrMany<Object> {
+  pub fn proof_mut(&mut self) -> &mut OneOrMany<LinkedDataProof> {
     &mut self.proof
+  }
+
+  pub fn verify(&self, resolve: impl Fn(&str) -> Result<PublicKey>) -> Result<bool> {
+    verify_document(&self.credential, &self.proof, resolve)
   }
 }
 

--- a/identity_vc/src/verifiable/presentation.rs
+++ b/identity_vc/src/verifiable/presentation.rs
@@ -1,17 +1,17 @@
-use identity_core::common::Object;
+use identity_crypto::{key::PublicKey, proof::LinkedDataProof};
 use std::ops::Deref;
 
-use crate::{common::OneOrMany, presentation::Presentation};
+use crate::{common::OneOrMany, error::Result, presentation::Presentation, utils::verify_document};
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct VerifiablePresentation {
   #[serde(flatten)]
   presentation: Presentation,
-  proof: OneOrMany<Object>,
+  proof: OneOrMany<LinkedDataProof>,
 }
 
 impl VerifiablePresentation {
-  pub fn new(presentation: Presentation, proof: impl Into<OneOrMany<Object>>) -> Self {
+  pub fn new(presentation: Presentation, proof: impl Into<OneOrMany<LinkedDataProof>>) -> Self {
     Self {
       presentation,
       proof: proof.into(),
@@ -26,12 +26,16 @@ impl VerifiablePresentation {
     &mut self.presentation
   }
 
-  pub fn proof(&self) -> &OneOrMany<Object> {
+  pub fn proof(&self) -> &OneOrMany<LinkedDataProof> {
     &self.proof
   }
 
-  pub fn proof_mut(&mut self) -> &mut OneOrMany<Object> {
+  pub fn proof_mut(&mut self) -> &mut OneOrMany<LinkedDataProof> {
     &mut self.proof
+  }
+
+  pub fn verify(&self, resolve: impl Fn(&str) -> Result<PublicKey>) -> Result<bool> {
+    verify_document(&self.presentation, &self.proof, resolve)
   }
 }
 


### PR DESCRIPTION
Example using [`identity_crypto`](https://github.com/iotaledger/identity.rs/pull/23) to sign and verify `Credentials` and `Presentations`