### PR TITLE
fix(ci): Use env files for setting env vars

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,11 +45,11 @@ jobs:
 
       - name: Get current date
         if: matrix.os == 'ubuntu-latest'
-        run: echo "::set-env name=CURRENT_DATE::$(date +'%Y-%m-%d')"
+        run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Get current date
         if: matrix.os == 'windows-latest'
-        run: echo "::set-env name=CURRENT_DATE::$(Get-Date -Format "yyyy-MM-dd")"
+        run: echo "CURRENT_DATE=$(Get-Date -Format "yyyy-MM-dd")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8
 
       - name: Cache cargo registry
         uses: actions/cache@v2


### PR DESCRIPTION
The `set-env` command is now deprecated (see [GitHub blog](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/))﻿
