### PR TITLE
fix(wasm): Fix license identifier

### DIFF
--- a/libraries/wasm/package.json
+++ b/libraries/wasm/package.json
@@ -26,7 +26,7 @@
     "Thoralf Müller <thoralf.mue@gmail.com>",
     "Sebastian Heusser <huhn.dev@gmail.com>"
   ],
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/iotaledger/identity.rs/issues"
   },


### PR DESCRIPTION
`Apache 2.0` -> `Apache-2.0`﻿
