### PR TITLE
Add license header

### DIFF
--- a/.license_template
+++ b/.license_template
@@ -1,0 +1,2 @@
+// Copyright {20\d{2}(-20\d{2})?} IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0

--- a/bindings/wasm/.license_template
+++ b/bindings/wasm/.license_template
@@ -1,0 +1,1 @@
+../../.license_template

--- a/bindings/wasm/rustfmt.toml
+++ b/bindings/wasm/rustfmt.toml
@@ -1,0 +1,1 @@
+../../rustfmt.toml

--- a/bindings/wasm/src/did.rs
+++ b/bindings/wasm/src/did.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use identity_core::utils::decode_b58;
 use identity_iota::did::IotaDID;
 use wasm_bindgen::prelude::*;

--- a/bindings/wasm/src/doc.rs
+++ b/bindings/wasm/src/doc.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use identity_core::{
     convert::{FromJson as _, SerdeInto as _},
     did_doc::{

--- a/bindings/wasm/src/iota.rs
+++ b/bindings/wasm/src/iota.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use identity_core::common::Object;
 use identity_iota::{
     client::{Client, ClientBuilder, Network, TxnPrinter},

--- a/bindings/wasm/src/key.rs
+++ b/bindings/wasm/src/key.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use identity_core::{
     crypto::{KeyPair, PublicKey, SecretKey},
     did_doc::MethodType,

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use wasm_bindgen::prelude::*;
 
 pub mod did;

--- a/bindings/wasm/src/pubkey.rs
+++ b/bindings/wasm/src/pubkey.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use identity_core::did_doc::{Method, MethodBuilder, MethodData};
 use identity_iota::did::IotaDID;
 use wasm_bindgen::prelude::*;

--- a/bindings/wasm/src/vc.rs
+++ b/bindings/wasm/src/vc.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use identity_core::{
     common::{OneOrMany, Url},
     credential::{Credential, CredentialBuilder, CredentialSubject, VerifiableCredential as VC},

--- a/bindings/wasm/src/vp.rs
+++ b/bindings/wasm/src/vp.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use identity_core::{
     common::{OneOrMany, Url},
     credential::{Presentation, PresentationBuilder, VerifiableCredential, VerifiablePresentation as VP},

--- a/examples/credential/src/main.rs
+++ b/examples/credential/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 //! A basic example that generates and publishes subject and issuer DID
 //! Documents, creates a VerifiableCredential specifying claims about the
 //! subject, and retrieves information through the CredentialValidator API.

--- a/examples/diff-chain/src/main.rs
+++ b/examples/diff-chain/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 //! An example that utilizes a diff and auth chain to publish updates to a
 //! DID Document.
 use identity_core::{

--- a/examples/resolution/src/main.rs
+++ b/examples/resolution/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 //! A basic example that generates a DID Document, publishes it to the Tangle,
 //! and retrieves information through DID Document resolution/dereferencing.
 use identity_core::resolver::{dereference, resolve, Dereference, Resolution};

--- a/identity-core/src/common/context.rs
+++ b/identity-core/src/common/context.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::fmt::{Debug, Formatter, Result};
 use serde::{Deserialize, Serialize};
 

--- a/identity-core/src/common/mod.rs
+++ b/identity-core/src/common/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 //! Definitions of common types.
 
 mod context;

--- a/identity-core/src/common/one_or_many.rs
+++ b/identity-core/src/common/one_or_many.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::{
     fmt::{Debug, Display, Formatter, Result as FmtResult},
     hash::Hash,

--- a/identity-core/src/common/timestamp.rs
+++ b/identity-core/src/common/timestamp.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{DateTime, SecondsFormat, Utc};
 use core::{
     convert::TryFrom,

--- a/identity-core/src/common/url.rs
+++ b/identity-core/src/common/url.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::{
     fmt::{Debug, Display, Formatter, Result as FmtResult},
     ops::{Deref, DerefMut},

--- a/identity-core/src/convert/json.rs
+++ b/identity-core/src/convert/json.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
 

--- a/identity-core/src/convert/mod.rs
+++ b/identity-core/src/convert/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 //! Traits for conversions between types.
 
 mod json;

--- a/identity-core/src/convert/serde_into.rs
+++ b/identity-core/src/convert/serde_into.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     convert::{AsJson, ToJson},
     error::Result,

--- a/identity-core/src/credential/credential.rs
+++ b/identity-core/src/credential/credential.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::fmt::{Display, Error as FmtError, Formatter, Result as FmtResult};
 use did_doc::{Document, LdSuite, MethodQuery, MethodType, MethodWrap, SignatureOptions};
 use serde::Serialize;

--- a/identity-core/src/credential/credential_builder.rs
+++ b/identity-core/src/credential/credential_builder.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     common::{Context, Object, Timestamp, Url, Value},
     credential::{

--- a/identity-core/src/credential/mod.rs
+++ b/identity-core/src/credential/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 //! Types and traits for working with Verifiable Credentials.
 
 #![allow(clippy::module_inception)]

--- a/identity-core/src/credential/presentation.rs
+++ b/identity-core/src/credential/presentation.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::fmt::{Display, Error as FmtError, Formatter, Result as FmtResult};
 use serde::Serialize;
 

--- a/identity-core/src/credential/presentation_builder.rs
+++ b/identity-core/src/credential/presentation_builder.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     common::{Context, Object, Url, Value},
     credential::{Presentation, RefreshService, TermsOfUse, VerifiableCredential},

--- a/identity-core/src/credential/types/credential_schema.rs
+++ b/identity-core/src/credential/types/credential_schema.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::common::{Object, OneOrMany, Url};
 
 /// Information used to validate the structure of a `Credential`.

--- a/identity-core/src/credential/types/credential_status.rs
+++ b/identity-core/src/credential/types/credential_status.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::common::{Object, OneOrMany, Url};
 
 /// Information used to determine the current status of a `Credential`.

--- a/identity-core/src/credential/types/credential_subject.rs
+++ b/identity-core/src/credential/types/credential_subject.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::common::{Object, Url};
 
 /// An entity who is the target of a set of claims.

--- a/identity-core/src/credential/types/evidence.rs
+++ b/identity-core/src/credential/types/evidence.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::common::{Object, OneOrMany};
 
 /// Information used to increase confidence in the claims of a `Credential`

--- a/identity-core/src/credential/types/issuer.rs
+++ b/identity-core/src/credential/types/issuer.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::common::{Object, Url};
 
 /// A `Credential` issuer in object form.

--- a/identity-core/src/credential/types/mod.rs
+++ b/identity-core/src/credential/types/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 mod credential_schema;
 mod credential_status;
 mod credential_subject;

--- a/identity-core/src/credential/types/refresh_service.rs
+++ b/identity-core/src/credential/types/refresh_service.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::common::{Object, OneOrMany, Url};
 
 /// Information used to refresh or assert the status of a `Credential`.

--- a/identity-core/src/credential/types/terms_of_use.rs
+++ b/identity-core/src/credential/types/terms_of_use.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::common::{Object, OneOrMany, Url};
 
 /// Information used to express obligations, prohibitions, and permissions about

--- a/identity-core/src/credential/verifiable_credential.rs
+++ b/identity-core/src/credential/verifiable_credential.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::{
     fmt::{Display, Error as FmtError, Formatter, Result as FmtResult},
     ops::{Deref, DerefMut},

--- a/identity-core/src/credential/verifiable_presentation.rs
+++ b/identity-core/src/credential/verifiable_presentation.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::{
     fmt::{Display, Error as FmtError, Formatter, Result as FmtResult},
     ops::{Deref, DerefMut},

--- a/identity-core/src/crypto/key_impl.rs
+++ b/identity-core/src/crypto/key_impl.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 macro_rules! impl_bytes {
     ($ident:ident) => {
         /// A cryptographic key.

--- a/identity-core/src/crypto/key_pair.rs
+++ b/identity-core/src/crypto/key_pair.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use zeroize::Zeroize;
 
 use crate::crypto::{PublicKey, SecretKey};

--- a/identity-core/src/crypto/mod.rs
+++ b/identity-core/src/crypto/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 //! Cryptographic Utilities
 
 mod key_impl;

--- a/identity-core/src/error.rs
+++ b/identity-core/src/error.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 //! Errors that may occur when Self-sovereign Identity goes wrong.
 
 /// Alias for a `Result` with the error type [`Error`].

--- a/identity-core/src/lib.rs
+++ b/identity-core/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 //! Identity Core
 
 #![warn(

--- a/identity-core/src/proof/jcsed25519signature2020.rs
+++ b/identity-core/src/proof/jcsed25519signature2020.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::convert::TryInto as _;
 use did_doc::{Error, Method, Result, Sign, SignatureData, SuiteName, Verify};
 use ed25519_zebra::{Signature, SigningKey, VerificationKey, VerificationKeyBytes};

--- a/identity-core/src/proof/mod.rs
+++ b/identity-core/src/proof/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 //! Types and traits for helping ensure the authenticity and integrity of
 //! DID Documents and Verifiable Credentials.
 

--- a/identity-core/src/resolver/dereference.rs
+++ b/identity-core/src/resolver/dereference.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use crate::resolver::{DocumentMetadata, ResolutionMetadata, Resource};

--- a/identity-core/src/resolver/document_metadata.rs
+++ b/identity-core/src/resolver/document_metadata.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::common::{Object, Timestamp};
 use serde::{Deserialize, Serialize};
 

--- a/identity-core/src/resolver/error_kind.rs
+++ b/identity-core/src/resolver/error_kind.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 /// Types of errors that be returned from a [DID resolution][SPEC] process.

--- a/identity-core/src/resolver/impls.rs
+++ b/identity-core/src/resolver/impls.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::anyhow;
 use did_doc::{url::Url, Document};
 use did_url::DID;

--- a/identity-core/src/resolver/input_metadata.rs
+++ b/identity-core/src/resolver/input_metadata.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use crate::common::Object;

--- a/identity-core/src/resolver/mod.rs
+++ b/identity-core/src/resolver/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 //! Types and traits for supporting DID Document resolution.
 
 mod dereference;

--- a/identity-core/src/resolver/resolution.rs
+++ b/identity-core/src/resolver/resolution.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use did_doc::Document;
 use serde::{Deserialize, Serialize};
 

--- a/identity-core/src/resolver/resolution_metadata.rs
+++ b/identity-core/src/resolver/resolution_metadata.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::time::Duration;
 use did_url::DID;
 use serde::{Deserialize, Serialize};

--- a/identity-core/src/resolver/resource.rs
+++ b/identity-core/src/resolver/resource.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use did_doc::{url::Url, DIDKey, Document, Method, MethodRef, Service};
 use did_url::DID;
 use serde::{Deserialize, Serialize};

--- a/identity-core/src/resolver/traits.rs
+++ b/identity-core/src/resolver/traits.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use async_trait::async_trait;
 use did_doc::Document;
 use did_url::DID;

--- a/identity-core/src/utils/base58.rs
+++ b/identity-core/src/utils/base58.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::error::{Error, Result};
 
 /// Decodes the given `data` as base58-btc.

--- a/identity-core/src/utils/jcs_sha256.rs
+++ b/identity-core/src/utils/jcs_sha256.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use sha2::{digest::Output, Digest, Sha256};
 
 use crate::{convert::ToJson, error::Result};

--- a/identity-core/src/utils/mod.rs
+++ b/identity-core/src/utils/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 //! Misc. utility functions.
 
 mod base58;

--- a/identity-diff/derive/src/impls.rs
+++ b/identity-diff/derive/src/impls.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 mod enums;
 mod structs;
 

--- a/identity-diff/derive/src/impls/enums.rs
+++ b/identity-diff/derive/src/impls/enums.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #![allow(non_snake_case)]
 
 use crate::model::{DataFields, EVariant, InputModel, SVariant};

--- a/identity-diff/derive/src/impls/structs.rs
+++ b/identity-diff/derive/src/impls/structs.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #![allow(non_snake_case)]
 
 use crate::model::{InputModel, SVariant};

--- a/identity-diff/derive/src/lib.rs
+++ b/identity-diff/derive/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};

--- a/identity-diff/derive/src/model.rs
+++ b/identity-diff/derive/src/model.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::{

--- a/identity-diff/derive/src/utils.rs
+++ b/identity-diff/derive/src/utils.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use proc_macro2::{Delimiter, TokenTree};
 
 use syn::{DeriveInput, Field, Meta, MetaList, NestedMeta, Path, PathSegment};

--- a/identity-diff/src/did_doc.rs
+++ b/identity-diff/src/did_doc.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::convert::TryFrom as _;
 use did_doc::{
     url::Url, DIDKey, Document, DocumentBuilder, Method, MethodBuilder, MethodData, MethodRef, MethodType, Object,

--- a/identity-diff/src/error.rs
+++ b/identity-diff/src/error.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::Result as AnyhowResult;
 use core::fmt::Display;
 use thiserror::Error as DeriveError;

--- a/identity-diff/src/hashmap.rs
+++ b/identity-diff/src/hashmap.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::Diff;
 use serde::{Deserialize, Serialize};
 use std::{

--- a/identity-diff/src/hashset.rs
+++ b/identity-diff/src/hashset.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::Diff;
 use serde::{Deserialize, Serialize};
 use std::{

--- a/identity-diff/src/lib.rs
+++ b/identity-diff/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 /// This module implements a `Diff` trait type.  The Diff trait gives data structures an ability to compare
 /// themselves to another data structure of the same type over time.  The library pairs off with `identity_derive` which
 /// implements a derive macro for the `Diff` Trait. Types supported include `HashMap`, `Option`, `String`,

--- a/identity-diff/src/macros.rs
+++ b/identity-diff/src/macros.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::traits::Diff;
 
 use std::fmt::{Debug, Formatter, Result as FmtResult};

--- a/identity-diff/src/option.rs
+++ b/identity-diff/src/option.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use std::fmt::{Debug, Formatter, Result as FmtResult};

--- a/identity-diff/src/string.rs
+++ b/identity-diff/src/string.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use crate::Diff;

--- a/identity-diff/src/traits.rs
+++ b/identity-diff/src/traits.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 

--- a/identity-diff/src/value.rs
+++ b/identity-diff/src/value.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 

--- a/identity-diff/src/vec.rs
+++ b/identity-diff/src/vec.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::Diff;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter, Result as FmtResult};

--- a/identity-diff/tests/derive_enum_test.rs
+++ b/identity-diff/tests/derive_enum_test.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #![allow(unused_variables)]
 
 use identity_diff::Diff;

--- a/identity-diff/tests/derive_struct_test.rs
+++ b/identity-diff/tests/derive_struct_test.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 // use identity_diff::Diff;
 // use serde::{Deserialize, Serialize};
 

--- a/identity-iota/src/chain/auth.rs
+++ b/identity-iota/src/chain/auth.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::mem;
 
 use crate::{

--- a/identity-iota/src/chain/diff.rs
+++ b/identity-iota/src/chain/diff.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::slice::Iter;
 
 use crate::{

--- a/identity-iota/src/chain/document.rs
+++ b/identity-iota/src/chain/document.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     chain::{AuthChain, DiffChain},
     did::{DocumentDiff, IotaDID, IotaDocument},

--- a/identity-iota/src/chain/mod.rs
+++ b/identity-iota/src/chain/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 mod auth;
 mod diff;
 mod document;

--- a/identity-iota/src/client/client.rs
+++ b/identity-iota/src/client/client.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::slice::from_ref;
 use identity_core::{common::Url, convert::ToJson};
 use iota::{

--- a/identity-iota/src/client/client_builder.rs
+++ b/identity-iota/src/client/client_builder.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     client::{Client, Network},
     error::Result,

--- a/identity-iota/src/client/mod.rs
+++ b/identity-iota/src/client/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #[allow(clippy::module_inception)]
 mod client;
 mod client_builder;

--- a/identity-iota/src/client/network.rs
+++ b/identity-iota/src/client/network.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use identity_core::common::Url;
 use iota::client::builder;
 

--- a/identity-iota/src/client/resolver.rs
+++ b/identity-iota/src/client/resolver.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use async_trait::async_trait;
 use identity_core::{
     convert::SerdeInto as _,

--- a/identity-iota/src/client/txn_printer.rs
+++ b/identity-iota/src/client/txn_printer.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::{
     fmt::{Debug, Display, Formatter, Result},
     marker::PhantomData,

--- a/identity-iota/src/credential/mod.rs
+++ b/identity-iota/src/credential/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 mod validator;
 
 pub use validator::*;

--- a/identity-iota/src/credential/validator.rs
+++ b/identity-iota/src/credential/validator.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use identity_core::{
     common::Object,
     convert::FromJson as _,

--- a/identity-iota/src/did/did.rs
+++ b/identity-iota/src/did/did.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::{
     convert::TryFrom,
     fmt::{Debug, Display, Formatter, Result as FmtResult},

--- a/identity-iota/src/did/did_segments.rs
+++ b/identity-iota/src/did/did_segments.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::did::IotaDID;
 
 macro_rules! get {

--- a/identity-iota/src/did/document.rs
+++ b/identity-iota/src/did/document.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::{
     convert::TryFrom,
     fmt::{Debug, Display, Formatter, Result as FmtResult},

--- a/identity-iota/src/did/document_builder.rs
+++ b/identity-iota/src/did/document_builder.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use identity_core::{
     crypto::KeyPair,
     did_doc::{DocumentBuilder, Method, MethodBuilder, MethodData, MethodType, VerifiableDocument},

--- a/identity-iota/src/did/document_diff.rs
+++ b/identity-iota/src/did/document_diff.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use identity_core::{
     convert::{AsJson as _, SerdeInto as _},
     did_doc::{Document, SetSignature, Signature, TrySignature, TrySignatureMut},

--- a/identity-iota/src/did/document_properties.rs
+++ b/identity-iota/src/did/document_properties.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use identity_core::common::{Object, Timestamp};
 
 use crate::tangle::MessageId;

--- a/identity-iota/src/did/mod.rs
+++ b/identity-iota/src/did/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 #[allow(clippy::module_inception)]
 mod did;
 mod did_segments;

--- a/identity-iota/src/error.rs
+++ b/identity-iota/src/error.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]

--- a/identity-iota/src/lib.rs
+++ b/identity-iota/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 // #![warn(
 //   missing_docs,
 //   missing_crate_level_docs,

--- a/identity-iota/src/tangle/message.rs
+++ b/identity-iota/src/tangle/message.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::fmt::{Debug, Formatter, Result as FmtResult};
 use identity_core::convert::FromJson as _;
 use iota::{

--- a/identity-iota/src/tangle/message_id.rs
+++ b/identity-iota/src/tangle/message_id.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::fmt::{Debug, Formatter, Result};
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]

--- a/identity-iota/src/tangle/message_index.rs
+++ b/identity-iota/src/tangle/message_index.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::{
     borrow::Borrow,
     iter::FromIterator,

--- a/identity-iota/src/tangle/mod.rs
+++ b/identity-iota/src/tangle/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 mod message;
 mod message_id;
 mod message_index;

--- a/identity-iota/src/tangle/traits.rs
+++ b/identity-iota/src/tangle/traits.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::tangle::MessageId;
 
 pub trait TangleRef {

--- a/identity-iota/src/utils.rs
+++ b/identity-iota/src/utils.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use core::{cmp::Ordering, iter::once};
 use iota::{
     crypto::ternary::{


### PR DESCRIPTION
Adds a SPDX license declaration to all files (copied from [stronghold](https://github.com/iotaledger/stronghold.rs))

* The format is set in `.license_template` and checked automatically with `cargo fmt`