### PR TITLE
Update smol/smol-potat to compatible version

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 identity = { path = "../identity" }
-smol = { version = "1.2" }
-smol-potat = { version = "1.1" }
+smol = { version = "0.1", features = ["tokio02"] }
+smol-potat = { version = "0.3" }
 
 [[example]]
 name = "credential"


### PR DESCRIPTION
This downgrades `smol/smol-potat` dependencies used in the examples to fix compatibility issues with iota.rs

We can upgrade again or switch to using `tokio 1.0` after Chrysalis Pt.2