### PR TITLE
fix(bindings/wasm): Use npmignore so that WASM binaries are included

### DIFF
--- a/bindings/wasm/.npmignore
+++ b/bindings/wasm/.npmignore
@@ -1,0 +1,10 @@
+/target
+Cargo.lock
+
+node_modules
+wasm-web
+wasm-node
+pkg
+
+package-lock.json
+yarn.lock


### PR DESCRIPTION
When `.npmignore` does not exist, NPM will use the `.gitignore` instead. Since the `web` and `node` folders are gitignored, they won't be present in the NPM package. This PR creates a `.npmignore` so that they are included.