### PR TITLE
Improve CI Speed

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,16 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project:
-          [
-            identity,
-            identity-core,
-            identity-credential,
-            identity-did,
-            identity-diff,
-            identity-iota,
-          ]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -39,7 +30,7 @@ jobs:
           override: true
 
       - name: Get current date
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
         run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Get current date
@@ -51,42 +42,52 @@ jobs:
         with:
           path: ~/.cargo/registry
           # Add date to the cache to keep it up to date
-          key: ${{ matrix.project }}-${{ matrix.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}-${{ env.CURRENT_DATE }}
+          key: ${{ matrix.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}-${{ env.CURRENT_DATE }}
           # Restore from outdated cache for speed
           restore-keys: |
-            ${{ matrix.project }}-${{ matrix.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+            ${{ matrix.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Cache cargo index
         uses: actions/cache@v2
         with:
           path: ~/.cargo/git
           # Add date to the cache to keep it up to date
-          key: ${{ matrix.project }}-${{ matrix.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}-${{ env.CURRENT_DATE }}
+          key: ${{ matrix.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}-${{ env.CURRENT_DATE }}
           # Restore from outdated cache for speed
           restore-keys: |
-            ${{ matrix.project }}-${{ matrix.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
+            ${{ matrix.os }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Cache cargo target
         uses: actions/cache@v2
         with:
-          path: ${{ matrix.project}}/target
+          path: target
           # Add date to the cache to keep it up to date
-          key: ${{ matrix.project }}-${{ matrix.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}-${{ env.CURRENT_DATE }}
+          key: ${{ matrix.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}-${{ env.CURRENT_DATE }}
           # Restore from outdated cache for speed
           restore-keys: |
-            ${{ matrix.project }}-${{ matrix.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
+            ${{ matrix.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
 
-      - name: Build ${{ matrix.project }}
+      - name: Cache wasm cargo target
+        uses: actions/cache@v2
+        with:
+          path: bindings/wasm/target
+          # Add date to the cache to keep it up to date
+          key: ${{ matrix.os }}-cargo-build-wasm-target-${{ hashFiles('**/Cargo.toml') }}-${{ env.CURRENT_DATE }}
+          # Restore from outdated cache for speed
+          restore-keys: |
+            ${{ matrix.os }}-cargo-build-wasm-target-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Build
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --manifest-path=${{ matrix.project }}/Cargo.toml --all --release
+          args: --all --release
 
-      - name: Run tests for ${{ matrix.project }}
+      - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=${{ matrix.project }}/Cargo.toml --all --release
+          args: --all --release
 
   build-and-test-wasm:
     runs-on: ubuntu-latest

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -17,17 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        project:
-          [
-            identity,
-            identity-core,
-            identity-credential,
-            identity-did,
-            identity-diff,
-            identity-iota,
-            bindings/wasm,
-          ]
 
     steps:
       - uses: actions/checkout@v2
@@ -38,8 +27,15 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
-      - uses: actions-rs/clippy-check@v1
+      - name: core clippy check
+        uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --manifest-path=${{ matrix.project }}/Cargo.toml --all-targets --all-features -- -D warnings
-          name: clippy-${{ matrix.project }}
+          args: --all-targets --all-features -- -D warnings
+          name: core
+      - name: wasm clippy check
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --manifest-path ./bindings/wasm/Cargo.toml --all-targets --all-features -- -D warnings
+          name: wasm

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,17 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        project:
-          [
-            identity,
-            identity-core,
-            identity-credential,
-            identity-did,
-            identity-diff,
-            identity-iota,
-            bindings/wasm,
-          ]
 
     steps:
       - uses: actions/checkout@v2
@@ -38,7 +27,13 @@ jobs:
           toolchain: nightly
           override: true
           components: rustfmt
-      - uses: actions-rs/cargo@v1
+      - name: core fmt check
+        uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --manifest-path=${{ matrix.project }}/Cargo.toml --all -- --check
+          args: --all -- --check
+      - name: wasm fmt check
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --manifest-path ./bindings/wasm/Cargo.toml --all -- --check


### PR DESCRIPTION
Reduces the number of GitHub actions from 34 to 6 by targeting the entire workspace (bindings are still separate).

This is an overall improvement to the speed of CI and the platform matrix now includes `macos-latest`