### PR TITLE
Ensure consistent timestamp precision

### DIFF
--- a/identity-core/src/common/timestamp.rs
+++ b/identity-core/src/common/timestamp.rs
@@ -3,6 +3,7 @@
 
 use chrono::DateTime;
 use chrono::SecondsFormat;
+use chrono::Timelike;
 use chrono::Utc;
 use core::convert::TryFrom;
 use core::fmt::Debug;
@@ -23,15 +24,15 @@ pub struct Timestamp(DateTime<Utc>);
 impl Timestamp {
   /// Parses a [`Timestamp`] from the provided input string.
   pub fn parse(input: &str) -> Result<Self> {
-    DateTime::parse_from_rfc3339(input)
-      .map_err(Into::into)
-      .map(Into::into)
-      .map(Self)
+    let this: DateTime<Utc> = DateTime::parse_from_rfc3339(input)?.into();
+    let this: DateTime<Utc> = Self::truncate(this);
+
+    Ok(Self(this))
   }
 
   /// Creates a new [`Timestamp`] with the current date and time.
   pub fn now() -> Self {
-    Self(Utc::now())
+    Self(Self::truncate(Utc::now()))
   }
 
   /// Returns the [`Timestamp`] as a Unix timestamp.
@@ -42,6 +43,11 @@ impl Timestamp {
   /// Returns the [`Timestamp`] as an RFC 3339 `String`.
   pub fn to_rfc3339(&self) -> String {
     self.0.to_rfc3339_opts(SecondsFormat::Secs, true)
+  }
+
+  fn truncate(value: DateTime<Utc>) -> DateTime<Utc> {
+    // safe to unwrap because 0 is a valid nanosecond
+    value.with_nanosecond(0).unwrap()
   }
 }
 
@@ -96,6 +102,7 @@ impl FromStr for Timestamp {
 #[cfg(test)]
 mod tests {
   use crate::common::Timestamp;
+  use crate::convert::AsJson;
 
   #[test]
   fn test_parse_valid() {
@@ -108,6 +115,15 @@ mod tests {
     let timestamp = Timestamp::parse(original).unwrap();
 
     assert_eq!(timestamp.to_rfc3339(), original);
+  }
+
+  #[test]
+  fn test_parse_valid_truncated() {
+    let original = "1980-01-01T12:34:56.789Z";
+    let expected = "1980-01-01T12:34:56Z";
+    let timestamp = Timestamp::parse(original).unwrap();
+
+    assert_eq!(timestamp.to_rfc3339(), expected);
   }
 
   #[test]
@@ -126,5 +142,14 @@ mod tests {
   #[should_panic = "InvalidTimestamp"]
   fn test_parse_invalid_fmt() {
     Timestamp::parse("2020/01/01 03:30:16").unwrap();
+  }
+
+  #[test]
+  fn test_json_roundtrip() {
+    let time1: Timestamp = Timestamp::now();
+    let json: Vec<u8> = time1.to_json_vec().unwrap();
+    let time2: Timestamp = Timestamp::from_json_slice(&json).unwrap();
+
+    assert_eq!(time1, time2);
   }
 }


### PR DESCRIPTION
The code below was failing because `Timestamp`s had sub-second precision when created with `Timestamp::now` but changed to whole seconds when serialized as JSON. This was partly a regression from https://github.com/iotaledger/identity.rs/pull/122 - there was also a case where timestamps could be parsed directly with sub-second precision.

```rust
/// Deserializes a Document from a JSON string.
pub fn from_json(json: &String) -> Result<Document, CoreError> {
    match Document::from_json(&json) {
        Ok(document) => Ok(document),
        Err(e) => Err(e),
    }
}

/// Serializes an Document into a JSON string.
pub fn to_json(document: &Document) -> Result<String, CoreError> {
    match document.to_json() {
        Ok(document) => Ok(document),
        Err(e) => Err(e),
    }
}

/// Creates a new Document
pub fn create_did_document() -> Result<Document, IotaError> {
    let keypair: KeyPair = KeyPair::new_ed25519()?;
    let mut document: Document = Document::from_keypair(&keypair)?;
    match document.sign(keypair.secret()) {
        Ok(()) => Ok(document),
        Err(e) => Err(e),
    }
}

#[test]
fn test_functions() {
    let doc1 = create_did_document().unwrap();
    let doc2 = from_json(&to_json(&doc1).unwrap()).unwrap();
    assert_eq!(doc1, doc2);
}
```