### PR TITLE
Use crypto.rs

### DIFF
--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -31,7 +31,7 @@ features = [
 wasm-bindgen-test = { version = "0.3" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-rand = { version = "0.7", default-features = false, features = ["wasm-bindgen"] }
+getrandom = { version = "0.2", features = ["js"] }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/bindings/wasm/src/document.rs
+++ b/bindings/wasm/src/document.rs
@@ -1,8 +1,6 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::credential::VerifiableCredential;
-use crate::credential::VerifiablePresentation;
 use identity::core::decode_b58;
 use identity::core::FromJson;
 use identity::crypto::merkle_key::MerkleKey;
@@ -19,6 +17,8 @@ use identity::iota::DocumentDiff;
 use identity::iota::Method as IotaMethod;
 use wasm_bindgen::prelude::*;
 
+use crate::credential::VerifiableCredential;
+use crate::credential::VerifiablePresentation;
 use crate::crypto::KeyPair;
 use crate::crypto::KeyType;
 use crate::did::DID;

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,8 +6,7 @@ publish = false
 
 [dependencies]
 identity = { path = "../identity" }
-rand = { version = "0.7" }
-sha2 = { version = "0.9" }
+rand = { version = "0.8" }
 smol = { version = "0.1", features = ["tokio02"] }
 smol-potat = { version = "0.3" }
 

--- a/examples/merkle_key.rs
+++ b/examples/merkle_key.rs
@@ -12,6 +12,7 @@ use identity::core::Url;
 use identity::credential::CredentialBuilder;
 use identity::credential::Subject;
 use identity::credential::VerifiableCredential;
+use identity::crypto::merkle_key::Sha256;
 use identity::crypto::merkle_tree::Proof;
 use identity::crypto::KeyCollection;
 use identity::crypto::KeyPair;
@@ -27,7 +28,6 @@ use identity::iota::Result;
 use identity::iota::TangleRef;
 use rand::rngs::OsRng;
 use rand::Rng;
-use sha2::Sha256;
 
 const LEAVES: usize = 1 << 10;
 
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
   println!("credential (unsigned): {:#}", credential);
 
   // Select a random key from the collection
-  let index: usize = OsRng.gen_range(0, LEAVES);
+  let index: usize = OsRng.gen_range(0..LEAVES);
 
   let public: &PublicKey = keys.public(index).unwrap();
   let secret: &SecretKey = keys.secret(index).unwrap();

--- a/identity-core/Cargo.toml
+++ b/identity-core/Cargo.toml
@@ -14,18 +14,24 @@ homepage = "https://www.iota.org"
 base64 = { version = "0.13", default-features = false, features = ["std"] }
 bs58 = { version = "0.4", default-features = false, features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
-digest = { version = "0.9", default-features = false }
-ed25519-zebra = { version = "2.2", default-features = false }
 erased-serde = { version = "0.3", default-features = false, features = ["alloc"] }
 hex = { version = "0.4", default-features = false }
 identity-diff = { version = "=0.2.0", path = "../identity-diff", default-features = false }
-rand = { version = "0.7", default-features = false, features = ["alloc", "getrandom"] }
 roaring = { version = "0.6", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
 serde_jcs = { version = "0.1", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["preserve_order", "std"] }
-sha2 = { version = "0.9", default-features = false }
-subtle = { version = "2.4" }
+subtle = { version = "2.4", default-features = false }
 thiserror = { version = "1.0", default-features = false }
+typenum = { version = "1.12", default-features = false }
 url = { version = "2.2", default-features = false, features = ["serde"] }
 zeroize = { version = "1.2", default-features = false }
+
+[dependencies.iota-crypto]
+git = "https://github.com/iotaledger/crypto.rs"
+rev = "c3bf565eba62d0b81144174c2ff917bfde282e49"
+default-features = false
+features = ["blake2b", "ed25519", "random", "sha"]
+
+[dev-dependencies]
+rand = { version = "0.8" }

--- a/identity-core/src/convert/json.rs
+++ b/identity-core/src/convert/json.rs
@@ -1,11 +1,11 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use crypto::hashes::sha::Sha256;
+use crypto::hashes::Digest;
+use crypto::hashes::Output;
 use erased_serde::Serialize;
 use serde::Deserialize;
-use sha2::digest::Digest;
-use sha2::digest::Output;
-use sha2::Sha256;
 
 use crate::error::Error;
 use crate::error::Result;

--- a/identity-core/src/crypto/merkle_key/base.rs
+++ b/identity-core/src/crypto/merkle_key/base.rs
@@ -61,7 +61,7 @@ impl MerkleKey {
 
 #[cfg(test)]
 mod tests {
-  use sha2::Sha256;
+  use crypto::hashes::sha::Sha256;
 
   use crate::crypto::merkle_key::MerkleKey;
   use crate::crypto::merkle_key::MerkleTag;

--- a/identity-core/src/crypto/merkle_key/impls.rs
+++ b/identity-core/src/crypto/merkle_key/impls.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[doc(inline)]
-pub use sha2::Sha256;
+pub use crypto::hashes::sha::Sha256;
+
+#[doc(inline)]
+pub use crypto::hashes::blake2b::Blake2b256;
 
 use crate::crypto::merkle_key::MerkleDigest;
 use crate::crypto::merkle_key::MerkleSignature;
@@ -15,6 +18,13 @@ use crate::crypto::KeyType;
 impl MerkleDigest for Sha256 {
   fn tag(&self) -> MerkleTag {
     MerkleTag::SHA256
+  }
+}
+
+// Add support for using Blake2b-256 as a Merkle Key Collection digest algorithm.
+impl MerkleDigest for Blake2b256 {
+  fn tag(&self) -> MerkleTag {
+    MerkleTag::BLAKE2B_256
   }
 }
 

--- a/identity-core/src/crypto/merkle_key/mod.rs
+++ b/identity-core/src/crypto/merkle_key/mod.rs
@@ -10,6 +10,7 @@ mod traits;
 mod verifier;
 
 pub use self::base::MerkleKey;
+pub use self::impls::Blake2b256;
 pub use self::impls::Sha256;
 pub use self::signer::DynSigner;
 pub use self::signer::Signer;

--- a/identity-core/src/crypto/merkle_key/traits.rs
+++ b/identity-core/src/crypto/merkle_key/traits.rs
@@ -27,6 +27,9 @@ impl MerkleTag {
   /// A Merkle Key Collection tag specifying `SHA-256` as the digest algorithm.
   pub const SHA256: Self = Self::new(0x0);
 
+  /// A Merkle Key Collection tag specifying `Blake2b-256` as the digest algorithm.
+  pub const BLAKE2B_256: Self = Self::new(0x1);
+
   /// Creates a new [`MerkleTag`] object.
   pub const fn new(tag: u8) -> Self {
     Self(tag)

--- a/identity-core/src/crypto/merkle_tree/digest.rs
+++ b/identity-core/src/crypto/merkle_tree/digest.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[doc(inline)]
-pub use digest::Digest;
+pub use crypto::hashes::Digest;
 #[doc(inline)]
-pub use digest::Output;
+pub use crypto::hashes::Output;
 
-use digest::generic_array::typenum::Unsigned;
+use typenum::Unsigned;
 
 use crate::crypto::merkle_tree::Hash;
 

--- a/identity-core/src/crypto/merkle_tree/merkle.rs
+++ b/identity-core/src/crypto/merkle_tree/merkle.rs
@@ -109,7 +109,7 @@ fn __split_pow2<T>(slice: &[T]) -> (&[T], &[T]) {
 
 #[cfg(test)]
 mod tests {
-  use sha2::Sha256;
+  use crypto::hashes::sha::Sha256;
 
   use crate::crypto::merkle_tree::compute_merkle_proof;
   use crate::crypto::merkle_tree::compute_merkle_root;

--- a/identity-core/src/crypto/merkle_tree/node.rs
+++ b/identity-core/src/crypto/merkle_tree/node.rs
@@ -62,7 +62,7 @@ impl<D: DigestExt> Debug for Node<D> {
 
 #[cfg(test)]
 mod tests {
-  use sha2::Sha256;
+  use crypto::hashes::sha::Sha256;
 
   use crate::crypto::merkle_tree::Digest;
   use crate::crypto::merkle_tree::DigestExt;

--- a/identity-core/src/error.rs
+++ b/identity-core/src/error.rs
@@ -11,6 +11,9 @@ use crate::crypto::merkle_key::MerkleTag;
 /// This type represents all possible errors that can occur in the library.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+  /// Caused when a cryptographic operation fails.
+  #[error("Crypto Error: {0}")]
+  Crypto(crypto::Error),
   /// Caused by a failure to encode Rust types as JSON.
   #[error("Failed to encode JSON: {0}")]
   EncodeJSON(serde_json::Error),
@@ -50,6 +53,12 @@ pub enum Error {
   /// Caused by attempting to parse an invalid cryptographic key.
   #[error("Invalid Key Format")]
   InvalidKeyFormat,
+  /// Caused byt attempting to parse as invalid cryptographic key.
+  #[error("Invalid Key Length. Received {0}, Expected {1}")]
+  InvalidKeyLength(usize, usize),
+  /// Caused byt attempting to parse as invalid digital signature.
+  #[error("Invalid Signature Length. Received {0}, Expected {1}")]
+  InvalidSigLength(usize, usize),
   /// Caused by attempting to parse an invalid Merkle Key Collection tag.
   #[error("Invalid Merkle Key Tag: {0:?}")]
   InvalidMerkleKeyTag(Option<MerkleTag>),
@@ -59,4 +68,10 @@ pub enum Error {
   /// Caused by attempting to create a KeyCollection of invalid size.
   #[error("Invalid Key Collection Size: {0}")]
   InvalidKeyCollectionSize(usize),
+}
+
+impl From<crypto::Error> for Error {
+  fn from(other: crypto::Error) -> Self {
+    Self::Crypto(other)
+  }
 }

--- a/identity-core/src/utils/generate_ed25519.rs
+++ b/identity-core/src/utils/generate_ed25519.rs
@@ -1,10 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use ed25519_zebra::SigningKey;
-use ed25519_zebra::VerificationKey;
-use ed25519_zebra::VerificationKeyBytes;
-use rand::rngs::OsRng;
+use crypto::signatures::ed25519;
 
 use crate::crypto::PublicKey;
 use crate::crypto::SecretKey;
@@ -12,12 +9,11 @@ use crate::error::Result;
 
 /// Generates a new pair of public/secret ed25519 keys.
 pub fn generate_ed25519() -> Result<(PublicKey, SecretKey)> {
-  let secret: SigningKey = SigningKey::new(OsRng);
-  let public: VerificationKey = (&secret).into();
-  let public: VerificationKeyBytes = public.into();
+  let secret: ed25519::SecretKey = ed25519::SecretKey::generate()?;
+  let public: ed25519::PublicKey = secret.public_key();
 
-  let public: PublicKey = public.as_ref().to_vec().into();
-  let secret: SecretKey = secret.as_ref().to_vec().into();
+  let secret: SecretKey = secret.to_le_bytes().to_vec().into();
+  let public: PublicKey = public.to_compressed_bytes().to_vec().into();
 
   Ok((public, secret))
 }

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -20,6 +20,11 @@ iota-conversion = { version = "0.5", default-features = false }
 iota-core = { git = "https://github.com/Thoralf-M/iota.rs", rev = "d7c8c64fc3ac2340f0148708a916c245f42fd454" }
 lazy_static = { version = "1.4", default-features = false }
 log = { version = "0.4", default-features = false }
-multihash = { version = "0.13", default-features = false, features = ["blake2b"] }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
 thiserror = { version = "1.0", default-features = false }
+
+[dependencies.iota-crypto]
+git = "https://github.com/iotaledger/crypto.rs"
+rev = "c3bf565eba62d0b81144174c2ff917bfde282e49"
+default-features = false
+features = ["blake2b"]

--- a/identity-iota/src/did/url/did.rs
+++ b/identity-iota/src/did/url/did.rs
@@ -8,12 +8,12 @@ use core::fmt::Formatter;
 use core::fmt::Result as FmtResult;
 use core::ops::Deref;
 use core::str::FromStr;
+use crypto::hashes::blake2b::Blake2b256;
+use crypto::hashes::Digest;
 use identity_core::utils::decode_b58;
 use identity_core::utils::encode_b58;
 use identity_did::did::Error as DIDError;
 use identity_did::did::DID as CoreDID;
-use multihash::Blake2b256;
-use multihash::Hasher;
 
 use crate::did::Segments;
 use crate::error::Error;


### PR DESCRIPTION
Part of https://github.com/iotaledger/identity.rs/issues/132 - (Update Identity.rs to use Crypto.rs)

Also closes https://github.com/iotaledger/identity.rs/issues/143 - (Blake2b256 with Merkle Key Collections)