### PR TITLE
add credential Options, Schema, Issuance interactions, more

### DIFF
--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -83,6 +83,7 @@ report: {
     }
 }
 ```
+[Source 1: Aries Report Problem Protocol](https://github.com/hyperledger/aries-rfcs/blob/master/features/0035-report-problem/README.md);
 
 ## Interactions
 
@@ -146,7 +147,7 @@ ping: {
 }
 ```
 
-[Source 1: DIF Trust Ping](https://identity.foundation/didcomm-messaging/spec/#trust-ping-protocol-10); [Source 2: Aries Trust Ping](https://github.com/hyperledger/aries-rfcs/tree/master/features/0048-trust-ping)
+[Source 1: DIF Trust Ping](https://identity.foundation/didcomm-messaging/spec/#trust-ping-protocol-10); [Source 2: Aries Trust Ping](https://github.com/hyperledger/aries-rfcs/tree/master/features/0048-trust-ping);
 
 ---
 ### did-discovery
@@ -287,6 +288,8 @@ resolutionResponse: {
 }
 ```
 
+[Source 1: Jolocom Peer Resolution](https://jolocom.github.io/jolocom-sdk/1.0.0/guides/interaction_flows/#peer-resolution); [Source 2: Aries DID Resolution Protocol](https://github.com/hyperledger/aries-rfcs/tree/master/features/0124-did-resolution-protocol);
+
 ---
 ### authentication
 
@@ -367,6 +370,8 @@ authenticationResponse: {
 ```
 
 The `signature` provided here must correspond to the `#authentication` public key provided in the DID Document of the identity that the <u>verifier</u> has received earlier. If that is the case, the identifier is authenticated successfully.
+
+[Source 1: Jolocom Authentication](https://jolocom.github.io/jolocom-sdk/1.0.0/guides/interaction_flows/#authentication);
 
 ---
 ### credential-options
@@ -452,6 +457,8 @@ credentialOptionsResponse: {
 }
 ```
 
+[Source 1: Jolocom VC Issuance](https://jolocom.github.io/jolocom-sdk/1.0.0/guides/interaction_flows/#verifiable-credential-issuance); [Source 2: Aries Issue Credential Protocol](https://github.com/hyperledger/aries-rfcs/tree/master/features/0453-issue-credential-v2);
+
 ---
 ### credential-schema
 Querying an agent for the schema of a specific VC that the agent can issue.
@@ -531,6 +538,8 @@ credentialSchemaResponse: {
 }
 ```
 
+[Source 1: Jolocom VC Issuance](https://jolocom.github.io/jolocom-sdk/1.0.0/guides/interaction_flows/#verifiable-credential-issuance); [Source 2: Aries Issue Credential Protocol](https://github.com/hyperledger/aries-rfcs/tree/master/features/0453-issue-credential-v2);
+
 ---
 ### credential-issuance
 Creating an authenticated statement about a DID.
@@ -608,6 +617,8 @@ credentialIssuance: {
 }
 ```
 
+[Source 1: Jolocom VC Issuance](https://jolocom.github.io/jolocom-sdk/1.0.0/guides/interaction_flows/#verifiable-credential-issuance); [Source 2: Aries Issue Credential Protocol](https://github.com/hyperledger/aries-rfcs/tree/master/features/0453-issue-credential-v2);
+
 ---
 ### credential-revocation
 
@@ -649,6 +660,8 @@ revocation: {
     "comment": "Revoked because reasons.",
 }
 ```
+
+[Source 1: Aries Revocation Notification](https://github.com/hyperledger/aries-rfcs/tree/master/features/0183-revocation-notification);
 
 ---
 ### presentation-verification
@@ -728,7 +741,7 @@ presentationResponse: {
 }
 ```
 
-
+[Source 1: Jolocom Credential Verification](https://jolocom.github.io/jolocom-sdk/1.0.0/guides/interaction_flows/#credential-verification);
 
 
 
@@ -817,7 +830,8 @@ TODO authentication tell what we are signing
 TODO create sequence diagrams for every interaction
 TODO take final TODOs and put them into, dunno, pr?
 TODO rework descriptions
-
+TODO rem interactions header ping response
+TODO ip in trust ping
 
 FINAL TODOs
 report/report: Define an actual error communication / information field that is parseable.

--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -10,7 +10,7 @@
 
 `responseRequested` as Boolean, e.g. `true` or `false`: In messages where it is defined it asks the recipient of the message to repond in the form of an acknowledging report. This request can be honored, but doesn't have to be honored. The only exception to this behaviour is in `trust-ping`, where the acknowledging report is to be sent if and only if this field is `true`. If this field is undefined, it counts as `false`.
 
-`id` as String, e.g. `did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v`: An IOTA decentralized identifier.
+`id` as String, e.g. `did:iota:57edacef81828010b314b96c0915780f206341e0ce8892a1b56678c174eef2e8`: An IOTA decentralized identifier.
 
 `didDocument` as JSON: An IOTA DID Document (see e.g. in <a href="#did-resolution">DID Resolution</a>).
 
@@ -139,7 +139,7 @@ ping: {
     "callbackURL": "https://www.bobsworld.com/",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
     "responseRequested": true,
-    "id": "did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v",
+    "id": "did:iota:57edacef81828010b314b96c0915780f206341e0ce8892a1b56678c174eef2e8",
     "timing": {
         "delay_milli": 1337
     }
@@ -182,7 +182,7 @@ didRequest: {
     "context": "did-discovery/1.0/didRequest",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
     "callbackURL": "https://www.bobsworld.com/",
-    "id": "did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v",
+    "id": "did:iota:57edacef81828010b314b96c0915780f206341e0ce8892a1b56678c174eef2e8",
 }
 ```
 
@@ -207,7 +207,7 @@ didResponse: {
 {
     "context": "did-discovery/1.0/didResponse",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
-    "id": "did:iota:86b7t9786tb9JHFGJKHG8796UIZGUk87guzgUZIuggez"
+    "id": "did:iota:42edacef81828010b314b96c0915780f206341e0ce8892a1b56678c174eef242"
 }
 ```
 
@@ -225,7 +225,7 @@ DID resolution consists of a simple request-response message exchange, where the
 #### Messages
 
 #### resolutionRequest
-The Requester broadcasts a message which may or may not contain a DID.
+The Requester broadcasts a message which may or may not contain a DID (see below).
 
 ###### Layout
 
@@ -247,7 +247,7 @@ resolutionRequest: {
     "context": "did-resolution/1.0/resolutionRequest",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
     "callbackURL": "https://www.bobsworld.com/",
-    "id": "did:iota:86b7t9786tb9JHFGJKHG8796UIZGUk87guzgUZIuggez",
+    "id": "did:iota:57edacef81828010b314b96c0915780f206341e0ce8892a1b56678c174eef2e8",
 }
 ```
 
@@ -275,11 +275,11 @@ resolutionResponse: {
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
     "didDocument": {
         "@context": "https://www.w3.org/ns/did/v1",
-        "id": "did:iota:86b7t9786tb9JHFGJKHG8796UIZGUk87guzgUZIuggez",
+        "id": "did:iota:57edacef81828010b3--SNIP--a1b56678c174eef2e8",
         "authentication": [{
-            "id": "did:iota:86b7t9786tb9JHFGJKHG8796UIZGUk87guzgUZIuggez#keys-1",
+            "id": "did:iota:57edacef81828010b314--SNIP--a1b56678c174eef2e8#keys-1",
             "type": "Ed25519VerificationKey2020",
-            "controller": "did:iota:86b7t9786tb9JHFGJKHG8796UIZGUk87guzgUZIuggez",
+            "controller": "did:iota:57edacef81828010b3--SNIP--a1b56678c174eef2e8",
             "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
         }]
     },
@@ -325,7 +325,7 @@ authenticationRequest: {
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
     "callbackURL": "https://www.bobsworld.com/",
     "challenge": "please sign this",
-    "id": "did:iota:86b7t9786tb9JHFGJKHG8796UIZGUk87guzgUZIuggez",
+    "id": "did:iota:57edacef81828010b314b96c0915780f206341e0ce8892a1b56678c174eef2e8",
     "timing": {
         "out_time": "1991-04-20T13:37:11Z",
         "expires_time": "2069-04-20T13:37:02Z",
@@ -345,7 +345,8 @@ authenticationResponse: {
     "thread",
     "signature",
     "callbackURL", // OPTIONAL!
-    "responseRequested" //OPTIONAL!
+    "responseRequested", //OPTIONAL!
+    "id" // OPTIONAL!
 }
 ```
 
@@ -360,7 +361,8 @@ authenticationResponse: {
         "verificationMethod": "#authentication",
         "signatureValue": "5Hw1JWv4a6hZH5obtAshbbKZQAJK6h8YbEwZvdxgWCXSL81fvRYoMCjt22vaBtZewgGq641dqR31C27YhDusoo4N"
    },
-   "callbackURL": "https://www.aliceswonderland.com/"
+   "callbackURL": "https://www.aliceswonderland.com/",
+   "id": "did:iota:42edacef81828010b314b96c0915780f206341e0ce8892a1b56678c174eef242",
 }
 ```
 
@@ -426,6 +428,7 @@ credentialOptionsResponse: {
     ],
     "callbackURL", // OPTIONAL!
     "responseRequested", //OPTIONAL!
+    "id", // OPTIONAL!
     "timing" // OPTIONAL!
 }
 ```
@@ -504,6 +507,7 @@ credentialSchemaResponse: {
     "schemas",
     "callbackURL", // OPTIONAL!
     "responseRequested", //OPTIONAL!
+    "id", // OPTIONAL!
     "timing" // OPTIONAL!
 }
 ```
@@ -554,7 +558,8 @@ credentialSelection: {
             "type 2",
             "type n"
     ],
-    "responseRequested" //OPTIONAL!
+    "responseRequested", //OPTIONAL!
+    "id" // OPTIONAL!
 }
 ```
 
@@ -584,7 +589,8 @@ credentialIssuance: {
         ...
     ],
     "callbackURL", // OPTIONAL!
-    "responseRequested" //OPTIONAL!
+    "responseRequested", //OPTIONAL!
+    "id" // OPTIONAL!
 }
 ```
 
@@ -625,6 +631,7 @@ revocation: {
     "credentialId",
     "callbackURL", // OPTIONAL!
     "responseRequested", //OPTIONAL!
+    "id", // OPTIONAL!
     "comment" // OPTIONAL!
 }
 ```
@@ -638,8 +645,8 @@ revocation: {
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
     "credentialId": "gfiweuzg89w3bgi8wbgi8wi8t",
     "callbackURL": "https://www.aliceswonderland.com/",
+    "id": "did:iota:42edacef81828010b314b96c0915780f206341e0ce8892a1b56678c174eef242",
     "comment": "Revoked because reasons.",
-    "id": "did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v",
 }
 ```
 
@@ -671,7 +678,8 @@ presentationRequest: {
             "type"
         },
     ],
-    "responseRequested" //OPTIONAL!
+    "responseRequested", //OPTIONAL!
+    "id" // OPTIONAL!
 }
 ```
 
@@ -704,7 +712,8 @@ presentationResponse: {
     "thread",
     "callbackURL", // OPTIONAL!
     "responseRequested", //OPTIONAL!
-    "verifiablePresentation"
+    "verifiablePresentation",
+    "id" // OPTIONAL!
 }
 ```
 
@@ -790,10 +799,6 @@ TODO make callbackURL optional except in the first of each interaction messages
 TODO revisit each field:
 
 
-`id` as String, e.g. `did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v`: An IOTA decentralized identifier.
-
-`didDocument` as JSON: An IOTA DID Document (see e.g. in <a href="#did-resolution">DID Resolution</a>).
-
 `comment` as String: A comment. Can be literally any String.
 
 `challenge` as JSON, e.g. `{"foo": "sign this"}`: A JSON acting as a signing challenge.
@@ -833,3 +838,4 @@ TODO rework descriptions
 FINAL TODOs
 report/report: Define an actual error communication / information field that is parseable.
 revocation: How do we deal with unauthorized revocations (i.e. invalid ones)?
+field id: Discuss optionality over whole spec.

--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -56,15 +56,42 @@ Messages that are shared across interactions.
 - <u>**Sender**</u>: Agent who sends the message
 - <u>**Receiver**</u>: Agent who receives the message
 
-##### acknowledgement
-The <u>sender</u> sends an `acknowledgement` message to the <u>receiver</u> to let him know that a previous message has been received.
-
-###### Layout
+##### report
+The <u>sender</u> sends a `report` message to the <u>receiver</u> to provide him with details about a previously received message. This can be a simple acknowledgement or e.g. an error report.
 TODO only do acks on request
 TODO merge ack and error into report
 TODO make thread not optional
 TODO make thread a UUID
+TODO ackkontext errkontext
 TODO make callbackURL optional except in the first of each interaction messages
+
+###### Layout
+
+```JSON
+report: {
+    "context",
+    "thread",
+    "ackContext",
+    "comment" // OPTIONAL!
+}
+```
+
+###### Example(s)
+
+```JSON
+{
+    "context": "report/1.0/report",
+    "thread": "sdfgfjghsdfg-12345-sdf-b",
+    "errContext": "did-resolution/1.0/resolutionResponse",
+    "comment": "Can't resolve: Signature invalid!"
+}
+```
+
+##### acknowledgement
+The <u>sender</u> sends an `acknowledgement` message to the <u>receiver</u> to let him know that a previous message has been received.
+
+###### Layout
+
 ```JSON
 acknowledgement: {
     "context",

--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -6,7 +6,7 @@
 
 `thread` as UUID, e.g. `f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c`: A UUID as String, defined by the agent that initiated an interaction, to be used to identify this specific interaction to track it agent-locally. Together with the context, these two fields can be used to identity a message / state within a specific interaction.
 
-`callbackURL` as URL/String, e.g. `https://www.bobsworld.com/` or `https://www.aliceswonderland/`: Defines the URL or API call where a request or response is to be delivered to.
+`callbackURL` as URL/String, e.g. `https://www.bobsworld.com/` or `https://www.aliceswonderland/serviceEndpoint`: Defines the URL (or API call) where a message is to be delivered to.
 
 `id` as String, e.g. `did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v`: An IOTA decentralized identifier.
 
@@ -282,13 +282,12 @@ resolutionResponse: {
     "thread",
     "didDocument",
     "callbackURL", // OPTIONAL!
-    "id", // OPTIONAL!
     "timing" // OPTIONAL!
 }
 ```
 
 ###### Example(s)
-TODO why is ID optional
+
 ```JSON
 {
     "context": "did-resolution/1.0/resolutionResponse",
@@ -636,11 +635,10 @@ revocation: {
     "thread",
     "credentialId",
     "callbackURL", // OPTIONAL!
-    "comment", // OPTIONAL!
-    "id" // OPTIONAL!
+    "comment" // OPTIONAL!
 }
 ```
-TODO why id optional, why need it
+
 
 ###### Example(s)
 
@@ -801,7 +799,6 @@ TODO only do acks on request
 TODO make callbackURL optional except in the first of each interaction messages
 TODO revisit each field:
 
-`callbackURL` as URL/String, e.g. `https://www.bobsworld.com/ping` or `https://www.aliceswonderland/authz`: Defines the URL or API call where a request or response is to be delivered to.
 
 `id` as String, e.g. `did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v`: An IOTA decentralized identifier.
 
@@ -847,3 +844,4 @@ TODO rework descriptions
 
 FINAL TODOs
 report/report: Define an actual error communication / information field that is parseable.
+revocation: How do we deal with unauthorized revocations (i.e. invalid ones)?

--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -6,7 +6,7 @@
 
 `thread` as UUID, e.g. `f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c`: A UUID as String, defined by the agent that initiated an interaction, to be used to identify this specific interaction to track it agent-locally. Together with the context, these two fields can be used to identity a message / state within a specific interaction.
 
-`callbackURL` as URL/String, e.g. `https://www.bobsworld.com/ping` or `https://www.aliceswonderland/authz`: Defines the URL or API call where a request or response is to be delivered to.
+`callbackURL` as URL/String, e.g. `https://www.bobsworld.com/` or `https://www.aliceswonderland/`: Defines the URL or API call where a request or response is to be delivered to.
 
 `id` as String, e.g. `did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v`: An IOTA decentralized identifier.
 
@@ -154,6 +154,7 @@ The <u>receiver</u> answers with a `pingResponse` if and only if `responseReques
 pingResponse: {
     "context",
     "thread", // OPTIONAL!
+    "callbackURL", // OPTIONAL!
     "id", // OPTIONAL!
     "timing": {...} // OPTIONAL! All subfields OPTIONAL!
 }
@@ -202,7 +203,7 @@ didRequest: {
 {
     "context": "did-discovery/1.0/didRequest",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
-    "callbackURL": "https://www.aliceswonderland.com/didreq",
+    "callbackURL": "https://www.bobsworld.com/",
     "id": "did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v",
 }
 ```
@@ -216,7 +217,8 @@ The <u>endpoint</u> answers with a `didResponse`, containing its DID.
 didResponse: {
     "context",
     "thread",
-    "id"
+    "id",
+    "callbackURL" // OPTIONAL!
 }
 ```
 
@@ -264,7 +266,7 @@ resolutionRequest: {
 {
     "context": "did-resolution/1.0/resolutionRequest",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
-    "callbackURL": "https://www.aliceswonderland.com/res",
+    "callbackURL": "https://www.bobsworld.com/",
     "id": "did:iota:86b7t9786tb9JHFGJKHG8796UIZGUk87guzgUZIuggez",
 }
 ```
@@ -278,7 +280,8 @@ If the message contains a DID (in the `id` field), the Resolver resolves the DID
 resolutionResponse: {
     "context",
     "thread",
-    "didDocument"
+    "didDocument",
+    "callbackURL", // OPTIONAL!
     "id", // OPTIONAL!
     "timing" // OPTIONAL!
 }
@@ -299,7 +302,8 @@ TODO why is ID optional
             "controller": "did:iota:86b7t9786tb9JHFGJKHG8796UIZGUk87guzgUZIuggez",
             "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
         }]
-    }
+    },
+    "callbackURL": "https://www.aliceswonderland.com/"
 }
 ```
 
@@ -338,7 +342,7 @@ authenticationRequest: {
 {
     "context": "authentication/1.0/authenticationRequest",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
-    "callbackURL": "https://www.aliceswonderland.com/auth",
+    "callbackURL": "https://www.bobsworld.com/",
     "challenge": "please sign this",
     "id": "did:iota:86b7t9786tb9JHFGJKHG8796UIZGUk87guzgUZIuggez",
     "timing": {
@@ -358,7 +362,8 @@ The <u>authenticator</u> answers with an `authenticationResponse`, providing a `
 authenticationResponse: {
     "context",
     "thread",
-    "signature"
+    "signature",
+    "callbackURL" // OPTIONAL!
 }
 ```
 
@@ -372,7 +377,8 @@ authenticationResponse: {
         "type": "JcsEd25519Signature2020",
         "verificationMethod": "#authentication",
         "signatureValue": "5Hw1JWv4a6hZH5obtAshbbKZQAJK6h8YbEwZvdxgWCXSL81fvRYoMCjt22vaBtZewgGq641dqR31C27YhDusoo4N"
-   }
+   },
+   "callbackURL": "https://www.aliceswonderland.com/"
 }
 ```
 
@@ -412,7 +418,7 @@ credentialOptionsRequest: {
 {
     "context": "credential-options/1.0/credentialOptionsRequest",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
-    "callbackURL": "https://www.alicesworld.com/credsList"
+    "callbackURL": "https://www.bobsworld.com/"
 }
 ```
 
@@ -435,6 +441,7 @@ credentialOptionsResponse: {
         "issuer id 2",
         "issuer id n"
     ],
+    "callbackURL", // OPTIONAL!
     "timing" // OPTIONAL!
 }
 ```
@@ -453,7 +460,8 @@ credentialOptionsResponse: {
     "supportedIssuers": [
         "did:iota:afbsdjhfbasuidfb8asifb4bfkawuiefjhdfgsukdfb",
         "did:iota:jahsdbfukgsiudfgisdufgi8sdfgzsbegbesudgbudf"
-    ]
+    ],
+    "callbackURL": "https://www.aliceswonderland.com/",
 }
 ```
 
@@ -491,7 +499,7 @@ credentialSchemaRequest: {
 {
     "context": "credential-options/1.0/credentialSchemaRequest",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
-    "callbackURL": "https://www.alicesworld.com/credsList",
+    "callbackURL": "https://www.bobsworld.com/",
     "credentialTypes": [
         "YouHaveNiceHairCredential",
         "DriversLicenseCredential"
@@ -509,6 +517,7 @@ credentialSchemaResponse: {
     "context",
     "thread",
     "schemas",
+    "callbackURL", // OPTIONAL!
     "timing" // OPTIONAL!
 }
 ```
@@ -568,7 +577,7 @@ credentialSelection: {
 {
     "context": "credential-issuance/1.0/credentialSelection",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
-    "callbackURL": "https://www.bobsworld.com/serviceEndpoint",
+    "callbackURL": "https://www.bobsworld.com/",
     "selectedCredentials": [
             "YouHaveNiceHairCredential"
     ],
@@ -587,6 +596,7 @@ credentialIssuance: {
     "issued": [
         ...
     ],
+    "callbackURL" // OPTIONAL!
 }
 ```
 
@@ -600,6 +610,7 @@ credentialIssuance: {
             {...},
             {...}
     ],
+    "callbackURL": "https://www.aliceswonderland.com/"
 }
 ```
 
@@ -624,11 +635,13 @@ revocation: {
     "context",
     "thread",
     "credentialId",
+    "callbackURL", // OPTIONAL!
     "comment", // OPTIONAL!
     "id" // OPTIONAL!
 }
 ```
 TODO why id optional, why need it
+
 ###### Example(s)
 
 ```JSON
@@ -636,6 +649,7 @@ TODO why id optional, why need it
     "context": "credential-revocation/1.0/revocation",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
     "credentialId": "gfiweuzg89w3bgi8wbgi8wi8t",
+    "callbackURL": "https://www.aliceswonderland.com/",
     "comment": "Revoked because reasons.",
     "id": "did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v",
 }
@@ -678,7 +692,7 @@ presentationRequest: {
 {
     "context": "presentation-verification/1.0/presentationRequest",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
-    "callbackURL": "https://www.bobsworld.com/pres",
+    "callbackURL": "https://www.bobsworld.com/",
     "credentialRequirements": [
         {
             "type": "YouHaveNiceHairCredential"
@@ -699,6 +713,7 @@ The <u>holder</u> sends a Verifiable Presentation to the <u>verifier</u> using a
 presentationResponse: {
     "context",
     "thread",
+    "callbackURL", // OPTIONAL!
     "verifiablePresentation"
 }
 ```
@@ -709,6 +724,7 @@ presentationResponse: {
 {
     "context": "presentation-verification/1.0/presentationResponse",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
+    "callbackURL": "https://www.aliceswonderland.com/",
     "verifiablePresentation": {...}
 }
 ```
@@ -785,10 +801,6 @@ TODO only do acks on request
 TODO make callbackURL optional except in the first of each interaction messages
 TODO revisit each field:
 
-`context` & `reference` as URL/String, e.g. `did-resolution/1.0/resolutionResponse`: Defines the context that a specific message either adheres to, or refers to in case of a report.
-
-`thread` as String, e.g. `jdhgbksdbgjksdbgkjdkg` or `thread-132-a`: A String, defined by the agent, to be used to identify this specific interaction to track it agent-locally.
-
 `callbackURL` as URL/String, e.g. `https://www.bobsworld.com/ping` or `https://www.aliceswonderland/authz`: Defines the URL or API call where a request or response is to be delivered to.
 
 `id` as String, e.g. `did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v`: An IOTA decentralized identifier.
@@ -828,7 +840,10 @@ TODO revisit each field:
 `timing[wait_until_time]` as ISO 8601 timestamp, e.g. `2069-04-20T13:37:00Z`: Wait until this time before processing the message.
 
 TODO authentication tell what we are signing
+TODO sequence diagrams
+TODO take final TODOs and put them into, dunno, pr?
+TODO rework descriptions
+
 
 FINAL TODOs
-
 report/report: Define an actual error communication / information field that is parseable.

--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -12,6 +12,8 @@
 
 `didDocument` as JSON: An IOTA DID Document (see e.g. in <a href="#did-resolution">DID Resolution</a>).
 
+`comment` as String: A comment.
+
 `thread` as String, e.g. `jdhgbksdbgjksdbgkjdkg` or `thread-132-a`: A String, defined by the agent, to be used to identify this specific interaction to track it agent-locally.
 
 `challenge` as String, e.g. `please-sign-this`: A String acting as a signing challenge.
@@ -59,6 +61,10 @@
 ◈ <a href="#credential-schema">**Credential Schema**</a> - Querying an agent for the schema of a specific VC that the agent can issue.
 
 ◈ <a href="#credential-issuance">**Credential Issuance**</a> - Creating an authenticated statement about a DID.
+
+◈ <a href="#credential-revocation">**Credential Revocation**</a> - Notifying a holder that a previously issued credential has been revoked.
+
+◈ <a href="#presentation-verification">**Presentation Verification**</a> - Proving a set of statements about an identifier.
 
 ---
 ## Trust Ping
@@ -487,3 +493,117 @@ credentialIssuance: {
 ### Examples
 
 TBD after above flow is cleared up
+
+---
+## Credential Revocation
+
+Notifying a holder that a previously issued credential has been revoked.
+
+### Roles
+- <u>**Issuer**</u>: Agent who revokes the credential
+- <u>**Holder**</u>: Agent who holds the credential to be revoked
+
+### Messages
+
+#### revocation
+The <u>issuer</u> sends the `credentialRevocation` to the <u>holder</u>, notifying him of the revocation.
+
+###### Layout
+
+```JSON
+credentialRevocation: {
+    "credentialId",
+    "comment", // OPTIONAL!
+    "context", // OPTIONAL!
+    "id" // OPTIONAL!
+}
+```
+
+###### Example(s)
+
+```JSON
+{
+    "credentialId": "gfiweuzg89w3bgi8wbgi8wi8t",
+    "comment": "Revoked because reasons.",
+    "id": "did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v",
+}
+```
+
+---
+## Presentation Verification
+
+Proving a set of statements about an identifier.
+
+The credential verification flow is a simple request-response message exchange between the <u>verifier</u> and the <u>prover</u>. The interaction can consist of up to three messages, however two of them are OPTIONAL.
+
+### Roles
+- **Verifier**: Agent who requests a set of Verifiable Credentials with associated requirements
+- **Prover**: Agent who provides a set of Verifiable Credentials in the form of a Verifiable Presentation attempting to satisfy the request
+
+### Messages
+
+#### presentationRequest
+The <u>verifier</u> requests a set of Verifiable Credentials from the <u>prover</u>. This message is OPTIONAL within this interaction.
+
+###### Layout
+
+```JSON
+presentationRequest: {
+    "callbackURL": "<URL as String>",
+    "credentialRequirements": [
+        {
+            "type": "<Type as String>",
+            "constraints": [
+                <Constraint 1>,
+                <Constraint 2>,
+            ],
+        },
+    ],
+}
+```
+
+###### Example(s)
+
+```JSON
+{
+    tbd
+}
+```
+
+#### presentationResponse
+The <u>holder</u> sends a Verifiable Presentation to the <u>verifier</u> using a `presentationResponse` message.
+
+###### Layout
+
+```JSON
+presentationResponse: {
+    "verifiablePresentation": {...}
+}
+```
+
+###### Example(s)
+
+```JSON
+{
+    tbd
+}
+```
+
+#### presentationAcknowledgement
+The <u>verifier</u> responds to the presented Verifiable Presentation. This message is OPTIONAL within this interaction.
+
+###### Layout
+
+```JSON
+presentationAcknowledgement: {
+    bool yes/no?
+}
+```
+
+###### Example(s)
+
+```JSON
+{
+    tbd
+}
+```

--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -1,6 +1,6 @@
 # DID Communications Message Specification
 
-> ### Field Definitions
+## Field Definitions
 
 `context` as URL/String, e.g. `did-resolution/1.0/resolution-result`: Defines the context that a specific message adheres to.
 
@@ -48,7 +48,7 @@
 
 [(Source 1: Aries Message Timing)](https://github.com/hyperledger/aries-rfcs/blob/master/features/0032-message-timing/README.md)
 
-> ### Standalone Messages
+## Standalone Messages
 
 Messages that are shared across interactions.
 
@@ -60,7 +60,11 @@ Messages that are shared across interactions.
 The <u>sender</u> sends an `acknowledgement` message to the <u>receiver</u> to let him know that a previous message has been received.
 
 ###### Layout
-
+TODO only do acks on request
+TODO merge ack and error into report
+TODO make thread not optional
+TODO make thread a UUID
+TODO make callbackURL optional except in the first of each interaction messages
 ```JSON
 acknowledgement: {
     "context",
@@ -104,15 +108,28 @@ error: {
 }
 ```
 
-> ### Interactions
+## Interactions
 
 ◈ <a href="#trust-ping">**trust-ping**</a> - Testing a pairwise channel.
 
+    ping
+
+    pingResponse
+
 ◈ <a href="#did-discovery">**did-discovery**</a> - Requesting a DID from an agent.
+&nbsp;&nbsp;&nbsp;&nbsp;ping
+&nbsp;&nbsp;&nbsp;&nbsp;pingResponse
 
 ◈ <a href="#did-resolution">**did-resolution**</a> - Using another agent as a Resolver.
 
+&nbsp;&nbsp;&nbsp;&nbsp;ping
+
+&nbsp;&nbsp;&nbsp;&nbsp;pingResponse
+
 ◈ <a href="#authentication">**authentication**</a> - Proving control over a DID.
+
+&nbsp;&nbsp;&nbsp;&nbsp;ping
+&nbsp;&nbsp;&nbsp;&nbsp;pingResponse
 
 ◈ <a href="#credential-options">**credential-options**</a> - Querying an agent for the VCs that the agent can issue.
 
@@ -125,17 +142,17 @@ error: {
 ◈ <a href="#presentation-verification">**presentation-verification**</a> - Proving a set of statements about an identifier.
 
 ---
-## trust-ping
+### trust-ping
 
 Testing a pairwise channel.
 
-### Roles
+#### Roles
 - <u>**Sender**</u>: Agent who initiates the trust ping
 - <u>**Receiver**</u>: Agent who responds to the <u>senders</u> trust ping
 
-### Messages
+#### Messages
 
-#### ping
+##### ping
 The <u>sender</u> sends the `ping` to the <u>receiver</u>, specifying a `callbackURL` for the `pingResponse` to be posted to.
 
 ###### Layout
@@ -165,7 +182,7 @@ ping: {
 }
 ```
 
-#### pingResponse
+##### pingResponse
 The <u>receiver</u> answers with a `pingResponse` if and only if `responseRequested` was `true` in the `ping` message:
 
 ###### Layout
@@ -191,17 +208,17 @@ pingResponse: {
 [Source 1: DIF Trust Ping](https://identity.foundation/didcomm-messaging/spec/#trust-ping-protocol-10); [Source 2: Aries Trust Ping](https://github.com/hyperledger/aries-rfcs/tree/master/features/0048-trust-ping)
 
 ---
-## did-discovery
+### did-discovery
 
 Requesting a DID from an agent.
 
-### Roles
+#### Roles
 - <u>**Requester**</u>: Agent who requests a DID from the <u>endpoint</u>
 - <u>**Endpoint**</u>: Agent who provides the requested DID to the <u>requester</u>
 
-### Messages
+#### Messages
 
-#### didRequest
+##### didRequest
 The <u>requester</u> sends the `didRequest` to the <u>endpoint</u>, specifying a `callbackURL` for the `didResponse` to be posted to. 
 
 ###### Layout
@@ -226,7 +243,7 @@ didRequest: {
 }
 ```
 
-#### didResponse
+##### didResponse
 The <u>endpoint</u> answers with a `didResponse`, containing its DID.
 
 ###### Layout
@@ -248,19 +265,19 @@ didResponse: {
 ```
 
 ---
-## did-resolution
+### did-resolution
 
 Using another Agent as a Resolver.
 
 DID resolution consists of a simple request-response message exchange, where the Requester asks the Resolver to perform DID resolution and return the result.
 
-### Roles
+#### Roles
 - **Requester**: Agent who requests the resolution of a DID
 - **Resolver**: Agent who resolves the given DID (or their own) and returns the result
 
-### Messages
+#### Messages
 
-#### resolutionRequest
+##### resolutionRequest
 The Requester broadcasts a message which may or may not contain a DID.
 
 ###### Layout
@@ -286,7 +303,7 @@ resolutionRequest: {
 }
 ```
 
-#### resolutionResult
+##### resolutionResult
 If the message contains a DID (in the `id` field), the Resolver resolves the DID and returns the DID Resolution Result. Otherwise, the Resolver returns the result of resolving it's own DID. This is intended for the special case of "local" DID methods, which do not have a globally resolvable state.
 
 ###### Layout
@@ -302,7 +319,7 @@ resolutionResult: {
 ```
 
 ###### Example(s)
-
+TODO why is ID optional
 ```JSON
 {
     "context": "did-resolution/1.0/resolutionResult",
@@ -321,19 +338,19 @@ resolutionResult: {
 ```
 
 ---
-## authentication
+### authentication
 
 Proving control over an identifier.
 
 The authentication flow consists of a simple request-response message exchange, where the contents of the response must match those of the request. Because all messages are signed and authenticated, the response functions as proof of control by nature of being correctly signed by the keys listed in the DID Document of the issuer. Because of this, in scenarios where a more complex functionality (e.g. Credential Verification) is needed, an additional authentication flow is not necessary.
 
-### Roles
+#### Roles
 - <u>**Verifier**</u>: Agent who requests and verifies the authenticity of the <u>authenticator</u>
 - <u>**Authenticator**</u>: Agent who proves control over their identifier
 
-### Messages
+#### Messages
 
-#### authenticationRequest
+##### authenticationRequest
 The <u>verifier</u> sends the `authenticationRequest` to the authentication service endpoint of the <u>authenticator</u>, specifying a `callbackURL` for the `authenticationResponse` to be posted to. The `thread` is used as a challenge and also serves to identity the `authenticationRequest`. The whole request is to be signed by the <u>authenticator</u>. 
 
 ###### Layout
@@ -366,7 +383,7 @@ authenticationRequest: {
 }
 ```
 
-#### authenticationResponse
+##### authenticationResponse
 The <u>authenticator</u> answers with an `authenticationResponse`, providing a `signature` of the whole `authenticationRequest` JSON - the complete original `authenticationRequest`.
 
 ###### Layout
@@ -396,19 +413,19 @@ authenticationResponse: {
 The `signature` provided here must correspond to the `#authentication` public key provided in the DID Document of the identity that the <u>verifier</u> has received earlier. If that is the case, the identifier is authenticated successfully.
 
 ---
-## credential-options
+### credential-options
 
 Querying an agent for the VCs that the agent can issue.
 
 The Verifiable Credential (VC) issuance flow consists of a three step interaction process between two parties, the <u>issuer</u> and the <u>holder</u>. This is the first interaction in this process. In this interaction, the <u>holder</u> queries the <u>issuer</u> for a list of VC types that the <u>issuer</u> offers to issue.
 
-### Roles
+#### Roles
 - **Issuer**: Agent who offers and issues one or more Verifiable Credentials
 - **Holder**: Agent who selects and receives one or more Verifiable Credentials
 
-### Messages
+#### Messages
 
-#### credentialOptionsRequest
+##### credentialOptionsRequest
 The <u>holder</u> queries the <u>issuer</u> for a list of VC types that the <u>issuer</u> offers.
 
 ###### Layout
@@ -432,7 +449,7 @@ credentialOptionsRequest: {
 }
 ```
 
-#### credentialOptionsResponse
+##### credentialOptionsResponse
 The <u>issuer</u> responds with a list of offered VC types.
 
 ###### Layout
@@ -473,18 +490,18 @@ credentialOptionsResponse: {
 ```
 
 ---
-## credential-schema
+### credential-schema
 Querying an agent for the schema of a specific VC that the agent can issue.
 
 The Verifiable Credential (VC) issuance flow consists of a three step interaction process between two parties, the <u>issuer</u> and the <u>holder</u>. This is the second interaction in this process. In this interaction, the <u>holder</u> queries the <u>issuer</u> for the precise schema of one of the VCs that the <u>issuer</u> offers to issue, with it's own list of requirements which must be satisfied by the <u>holder</u> in order to qualify for the credential.
 
-### Roles
+#### Roles
 - **Issuer**: Agent who offers and issues one or more Verifiable Credentials
 - **Holder**: Agent who selects and receives one or more Verifiable Credentials
 
-### Messages
+#### Messages
 
-#### credentialSchemaRequest
+##### credentialSchemaRequest
 The <u>holder</u> queries the <u>issuer</u> for the schema of a specific VC that the <u>issuer</u> offers.
 
 ###### Layout
@@ -513,7 +530,7 @@ credentialSchemaRequest: {
 }
 ```
 
-#### credentialSchemaResponse
+##### credentialSchemaResponse
 The <u>issuer</u> responds with the schema of the requested `credentialTypes`.
 
 ###### Layout
@@ -546,18 +563,18 @@ credentialSchemaResponse: {
 ```
 
 ---
-## credential-issuance
+### credential-issuance
 Creating an authenticated statement about a DID.
 
 The Verifiable Credential (VC) issuance flow consists of a three step interaction process between two parties, the <u>issuer</u> and the <u>holder</u>. This is the third interaction in this process. In this interaction, the <u>holder</u> asks the <u>issuer</u> for issuance of a specific VC.
 
-### Roles
+#### Roles
 - **Issuer**: Agent who offers and issues one or more Verifiable Credentials
 - **Holder**: Agent who selects and receives one or more Verifiable Credentials
 
-### Messages
+#### Messages
 
-#### credentialSelection
+##### credentialSelection
 The <u>holder</u> sends a message containing a list of selected credentials with associated data for satisfying requirements.
 
 ###### Layout
@@ -586,7 +603,7 @@ credentialSelection: {
 }
 ```
 
-#### credentialIssuance
+##### credentialIssuance
 The <u>issuer</u> responds with a message containing a list of newly issued credentials corrosponding to the selected set.
 
 ###### Layout
@@ -613,17 +630,17 @@ credentialIssuance: {
 ```
 
 ---
-## credential-revocation
+### credential-revocation
 
 Notifying a holder that a previously issued credential has been revoked. Note that this revocation is declaratory, not constitutive, so the actual revocation has to be done elsewhere (e.g. in the backend of the issuer).
 
-### Roles
+#### Roles
 - <u>**Issuer**</u>: Agent who revokes the credential
 - <u>**Holder**</u>: Agent who holds the credential to be revoked
 
-### Messages
+#### Messages
 
-#### revocation
+##### revocation
 The <u>issuer</u> sends the `revocation` to the <u>holder</u>, notifying him of the revocation. The most important field here is `credentialId`, which specifies the credential that has been revoked.
 
 ###### Layout
@@ -649,19 +666,19 @@ revocation: {
 ```
 
 ---
-## presentation-verification
+### presentation-verification
 
 Proving a set of statements about an identifier.
 
 The credential verification flow is a simple request-response message exchange between the <u>verifier</u> and the <u>prover</u>. The interaction can consist of up to two messages, the first one is OPTIONAL.
 
-### Roles
+#### Roles
 - **Verifier**: Agent who requests a set of Verifiable Credentials with associated requirements
 - **Prover**: Agent who provides a set of Verifiable Credentials in the form of a Verifiable Presentation attempting to satisfy the request
 
-### Messages
+#### Messages
 
-#### presentationRequest
+##### presentationRequest
 The <u>verifier</u> requests a set of Verifiable Credentials from the <u>prover</u>. This message is OPTIONAL within this interaction.
 
 ###### Layout
@@ -695,7 +712,7 @@ presentationRequest: {
 }
 ```
 
-#### presentationResponse
+##### presentationResponse
 The <u>holder</u> sends a Verifiable Presentation to the <u>verifier</u> using a `presentationResponse` message.
 
 ###### Layout
@@ -746,7 +763,8 @@ TODO credentialSchemaResponse:
     TODO SRC https://w3c-ccg.github.io/vc-json-schemas/
 
 
-
+https://w3c-ccg.github.io/vc-json-schemas/
+https://github.com/hyperledger/aries-rfcs/blob/master/features/0035-report-problem/README.md
 
     TODO make nice interaction pictures / state machines
 

--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -16,6 +16,10 @@
 
 `challenge` as String, e.g. `please-sign-this`: A String acting as a signing challenge.
 
+`offeredCredentialTypes` as JSON: A field specific to VC issuance, contains a list of possible credential types, see <a href="#credential-options">Credential Options</a>.
+
+`credentialType` as String, e.g. `SimpleDiplomaCredential`: A VC type.
+
 `signature` as JSON, e.g. `{...}`: Includes a signature. Fields defined below.
 
 `signature[type]` as String, e.g. `JcsEd25519Signature2020`: Signature type.
@@ -50,11 +54,11 @@
 
 ◈ <a href="#authentication">**Authentication**</a> - Proving control over a DID.
 
-◈ (WIP) <a href="#credential-issuance">**Credential Issuance**</a> - Creating an authenticated statement about a DID.
+◈ <a href="#credential-options">**Credential Options**</a> - Querying an agent for the VCs that the agent can issue.
 
-◈ (WIP) <a href="#credential-revocation">**Credential Revocation**</a> - Notifying a holder that a previously issued credential has been revoked.
+◈ <a href="#credential-schema">**Credential Schema**</a> - Querying an agent for the schema of a specific VC that the agent can issue.
 
-◈ (WIP) <a href="#presentation-verification">**Presentation Verification**</a> - Proving a set of statements about a DID.
+◈ <a href="#credential-issuance">**Credential Issuance**</a> - Creating an authenticated statement about a DID.
 
 ---
 ## Trust Ping
@@ -313,3 +317,173 @@ authenticationResponse: {
 ```
 
 The `signature` provided here must correspond to the `#authentication` public key provided in the DID Document of the identity that the <u>verifier</u> has received earlier. If that is the case, the identifier is authenticated successfully.
+
+---
+## Credential Options
+Querying an agent for the VCs that the agent can issue.
+
+The Verifiable Credential (VC) issuance flow consists of a three step interaction process between two parties, the <u>issuer</u> and the <u>holder</u>. This is the first interaction in this process. In this interaction, the <u>holder</u> queries the <u>issuer</u> for a list of VC types that the <u>issuer</u> offers to issue.
+
+### Roles
+- **Issuer**: Agent who offers and issues one or more Verifiable Credentials
+- **Holder**: Agent who selects and receives one or more Verifiable Credentials
+
+### Messages
+
+#### credentialOptionsRequest
+The <u>holder</u> queries the <u>issuer</u> for a list of VC types that the <u>issuer</u> offers.
+
+###### Layout
+
+```JSON
+credentialOptionsRequest: {
+    "callbackURL",
+    "thread", // OPTIONAL!
+    "id", // OPTIONAL!
+    "timing" // OPTIONAL!
+}
+```
+
+###### Example(s)
+
+```JSON
+{
+    "callbackURL": "https://www.alicesworld.com/credsList"
+}
+```
+
+#### credentialOptionsResponse
+The <u>issuer</u> responds with a list of offered VC types.
+
+###### Layout
+
+```JSON
+credentialOptionsResponse: {
+    "offeredCredentialTypes": [
+        "credentialType 1",
+        "credentialType 2",
+        "credentialType n"
+    ],
+    "thread", // OPTIONAL!
+    "timing" // OPTIONAL!
+}
+```
+
+###### Example(s)
+
+```JSON
+{
+    "offeredCredentialTypes": [
+        "DiplomaCredential",
+        "YouHaveNiceHairCredential",
+        "DriversLicenseCredential"
+    ]
+}
+```
+
+---
+## Credential Schema
+Querying an agent for the schema of a specific VC that the agent can issue.
+
+The Verifiable Credential (VC) issuance flow consists of a three step interaction process between two parties, the <u>issuer</u> and the <u>holder</u>. This is the second interaction in this process. In this interaction, the <u>holder</u> queries the <u>issuer</u> for the precise schema of one of the VCs that the <u>issuer</u> offers to issue, with it's own list of requirements which must be satisfied by the <u>holder</u> in order to qualify for the credential.
+
+### Roles
+- **Issuer**: Agent who offers and issues one or more Verifiable Credentials
+- **Holder**: Agent who selects and receives one or more Verifiable Credentials
+
+### Messages
+
+#### credentialSchemaRequest
+The <u>holder</u> queries the <u>issuer</u> for the schema of a specific VC that the <u>issuer</u> offers.
+
+###### Layout
+
+```JSON
+credentialSchemaRequest: {
+    "callbackURL",
+    "credentialType",
+    "thread", // OPTIONAL!
+    "id", // OPTIONAL!
+    "timing" // OPTIONAL!
+}
+```
+
+###### Example(s)
+
+```JSON
+{
+    "callbackURL": "https://www.alicesworld.com/credsList",
+    "credentialType": "YouHaveNiceHairCredential"
+}
+```
+
+#### credentialSchemaResponse
+The <u>issuer</u> responds with the schema of the requested `credentialType`.
+
+###### Layout
+
+```JSON
+credentialSchemaResponse: {
+    "YouHaveNiceHairCredential": {...}, //TODO: Discuss!
+    "thread", // OPTIONAL!
+    "timing" // OPTIONAL!
+}
+```
+
+###### Example(s)
+
+```JSON
+{
+    "YouHaveNiceHairCredential": {
+        "type": "YouHaveNiceHairCredential",
+        ... //TODO: Discuss!
+    }, //TODO: Discuss!
+}
+```
+
+---
+## Credential Issuance
+Creating an authenticated statement about a DID.
+
+The Verifiable Credential (VC) issuance flow consists of a three step interaction process between two parties, the <u>issuer</u> and the <u>holder</u>. This is the third interaction in this process. In this interaction, the <u>holder</u> asks the <u>issuer</u> for issuance of a specific VC.
+
+### Roles
+- **Issuer**: Agent who offers and issues one or more Verifiable Credentials
+- **Holder**: Agent who selects and receives one or more Verifiable Credentials
+
+### Messages
+
+#### credentialSelection
+The <u>holder</u> sends a message containing a list of selected credentials with associated data for satisfying requirements. //TODO: Discuss: List or single issuance?
+
+###### Layout
+
+```JSON
+credentialSelection: {
+    "callbackURL",
+    "selectedCredentials": [
+        {
+            "type": "<Type as String>"
+        },
+    ],
+}
+```
+
+#### credentialIssuance
+The <u>issuer</u> responds with a message containing a list of newly issued credentials corrosponding to the selected set.
+
+###### Layout
+
+```JSON
+credentialIssuance: {
+    "issued": [
+        {
+            "type": "<Type as String>"
+        },
+    ],
+}
+```
+
+### Examples
+
+TBD after above flow is cleared up

--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -1,5 +1,7 @@
 # DID Communications Message Specification
 
+*version 0.2, last changed April 2021*
+
 ## Field Definitions
 
 `context` & `reference` as URL/String, e.g. `did-resolution/1.0/resolutionResponse`: Defines the context that a specific message either adheres to or, in case of a report, refers to.
@@ -14,17 +16,27 @@
 
 `didDocument` as JSON: An IOTA DID Document (see e.g. in <a href="#did-resolution">DID Resolution</a>).
 
-`credential` as [VC JSON](https://w3c-ccg.github.io/vc-json-schemas/): A syntactically valid credential.
-
 `comment` as String: A comment, mostly used to provide more information about something. Can be literally any String.
 
-`challenge` as JSON, e.g. `{"foo": "sign this"}`: A JSON acting as a signing challenge.
+`challenge` as JSON, e.g. `{"task": "Sign this!"}`: A JSON acting as a signing challenge. Can contain basically anything.
 
-`offeredCredentialTypes` as JSON: A field specific to VC issuance, contains a list of possible credential types, see <a href="#credential-options">Credential Options</a>.
+`credential` as [VC JSON](https://w3c-ccg.github.io/vc-json-schemas/): A syntactically valid credential.
 
-`credentialType` as String, e.g. `SimpleDiplomaCredential`: A VC type.
+`credentials`: A list of credentials.
 
-`signature` as JSON, e.g. `{...}`: Includes a signature. Fields defined below.
+`credentialId` as String, e.g.`credential-69420-delicious-lasagna`: The id of a credential.
+
+`credentialType` as String, e.g. `YouHaveNiceHairCredential`: A VC type.
+
+`credentialTypes` as JSON, e.g. `["YouHaveNiceHairCredential", "YourLasagnaIsDeliciousCredential"]`: Contains a list of possible credential types, see e.g. <a href="#credential-options">Credential Options</a>.
+
+`supportedIssuers` as JSON: Contains a list of supported issuer `id`, see <a href="#credential-options">Credential Options</a>.
+
+`schemata` as JSON: A named list of credential schemata, see <a href="#credential-schema">Credential Schema</a>.
+
+`verifiablePresentation` as JSON: A Verifiable Presentation.
+
+`signature` as JSON: Defines a signature. Fields defined below.
 
 `signature[type]` as String, e.g. `JcsEd25519Signature2020`: Signature type.
 
@@ -32,7 +44,7 @@
 
 `signature[signatureValue]` as String, e.g. `5Hw1JWv4a6hZH5obtAshbbKZQAJK6h8YbEwZvdxgWCXSL81fvRYoMCjt22vaBtZewgGq641dqR31C27YhDusoo4N`: Actual signature.
 
-`timing` as JSON, e.g. `{...}`: A decorator to include timing information into a message. Fields defined below.
+`timing` as JSON: A decorator to include timing information into a message. Fields defined below.
 
 `timing[out_time]` as ISO 8601 timestamp, e.g. `2069-04-20T13:37:00Z`: The timestamp when the message was emitted.
 
@@ -67,7 +79,7 @@ report: {
     "thread",
     "reference",
     "comment", // OPTIONAL!
-    "timing": {...} // OPTIONAL! All subfields OPTIONAL!
+    "timing" // OPTIONAL! All subfields OPTIONAL!
 }
 ```
 
@@ -130,7 +142,7 @@ ping: {
     "thread", // OPTIONAL!
     "responseRequested", //OPTIONAL!
     "id", // OPTIONAL!
-    "timing": {...} // OPTIONAL! All subfields OPTIONAL!
+    "timing" // OPTIONAL! All subfields OPTIONAL!
 }
 ```
 
@@ -201,6 +213,7 @@ didResponse: {
     "id",
     "callbackURL", // OPTIONAL!
     "responseRequested", //OPTIONAL!
+    "timing" // OPTIONAL!
 }
 ```
 
@@ -329,7 +342,9 @@ authenticationRequest: {
     "context": "authentication/1.0/authenticationRequest",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
     "callbackURL": "https://www.bobsworld.com/",
-    "challenge": "please sign this",
+    "challenge": {
+        "task": "Sign this!"
+    },
     "id": "did:iota:57edacef81828010b314b96c0915780f206341e0ce8892a1b56678c174eef2e8",
     "timing": {
         "out_time": "1991-04-20T13:37:11Z",
@@ -351,7 +366,8 @@ authenticationResponse: {
     "signature",
     "callbackURL", // OPTIONAL!
     "responseRequested", //OPTIONAL!
-    "id" // OPTIONAL!
+    "id", // OPTIONAL!
+    "timing" // OPTIONAL!
 }
 ```
 
@@ -423,15 +439,10 @@ The <u>issuer</u> responds with a list of offered VC types.
 credentialOptionsResponse: {
     "context",
     "thread",
-    "offeredCredentialTypes": [
+    "credentialTypes": [
         "credentialType 1",
         "credentialType 2",
         "credentialType n"
-    ],
-    "supportedIssuers": [
-        "issuer id 1",
-        "issuer id 2",
-        "issuer id n"
     ],
     "callbackURL", // OPTIONAL!
     "responseRequested", //OPTIONAL!
@@ -446,14 +457,10 @@ credentialOptionsResponse: {
 {
     "context": "credential-options/1.0/credentialOptionsResponse",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
-    "offeredCredentialTypes": [
-        "DiplomaCredential",
+    "credentialTypes": [
+        "YourCatHasAnAttitudeCredential",
         "YouHaveNiceHairCredential",
-        "DriversLicenseCredential"
-    ],
-    "supportedIssuers": [
-        "did:iota:afbsdjhfbasuidfb8asifb4bfkawuiefjhdfgsukdfb",
-        "did:iota:jahsdbfukgsiudfgisdufgi8sdfgzsbegbesudgbudf"
+        "YourLasagnaIsDeliciousCredential"
     ],
     "callbackURL": "https://www.aliceswonderland.com/",
 }
@@ -499,13 +506,13 @@ credentialSchemaRequest: {
     "callbackURL": "https://www.bobsworld.com/",
     "credentialTypes": [
         "YouHaveNiceHairCredential",
-        "DriversLicenseCredential"
+        "YourLasagnaIsDeliciousCredential"
     ]
 }
 ```
 
 #### credentialSchemaResponse
-The <u>issuer</u> responds with the schema of the requested `credentialTypes`.
+The <u>issuer</u> responds with the schemata of the requested `credentialTypes`.
 
 ###### Layout
 
@@ -513,7 +520,7 @@ The <u>issuer</u> responds with the schema of the requested `credentialTypes`.
 credentialSchemaResponse: {
     "context",
     "thread",
-    "schemas",
+    "schemata",
     "callbackURL", // OPTIONAL!
     "responseRequested", //OPTIONAL!
     "id", // OPTIONAL!
@@ -527,13 +534,13 @@ credentialSchemaResponse: {
 {
     "context": "credential-options/1.0/credentialSchemaResponse",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
-    "schemas": [
+    "schemata": [
         "YouHaveNiceHairCredential": {
             "type": "YouHaveNiceHairCredential",
             ...
         },
-        "DriversLicenseCredential": {
-            "type": "DriversLicenseCredential",
+        "YourLasagnaIsDeliciousCredential": {
+            "type": "YourLasagnaIsDeliciousCredential",
             ...
         },
     ]
@@ -555,7 +562,7 @@ The Verifiable Credential (VC) issuance flow consists of a three step interactio
 #### Messages
 
 #### credentialSelection
-The <u>holder</u> sends a message containing a list of selected credentials with associated data for satisfying requirements.
+The <u>holder</u> sends a message containing a list of selected credentials.
 
 ###### Layout
 
@@ -564,13 +571,10 @@ credentialSelection: {
     "context",
     "thread",
     "callbackURL",
-    "selectedCredentials": [
-            "type 1",
-            "type 2",
-            "type n"
-    ],
+    "credentialTypes",
     "responseRequested", //OPTIONAL!
-    "id" // OPTIONAL!
+    "id", // OPTIONAL!
+    "timing" // OPTIONAL!
 }
 ```
 
@@ -581,8 +585,9 @@ credentialSelection: {
     "context": "credential-issuance/1.0/credentialSelection",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
     "callbackURL": "https://www.bobsworld.com/",
-    "selectedCredentials": [
-            "YouHaveNiceHairCredential"
+    "credentialTypes": [
+        "YourCatHasAnAttitudeCredential",
+        "YourLasagnaIsDeliciousCredential"
     ],
 }
 ```
@@ -596,12 +601,11 @@ The <u>issuer</u> responds with a message containing a list of newly issued cred
 credentialIssuance: {
     "context",
     "thread",
-    "issued": [
-        ...
-    ],
+    "credentials",
     "callbackURL", // OPTIONAL!
     "responseRequested", //OPTIONAL!
-    "id" // OPTIONAL!
+    "id", // OPTIONAL!
+    "timing" // OPTIONAL!
 }
 ```
 
@@ -611,9 +615,10 @@ credentialIssuance: {
 {
     "context": "credential-issuance/1.0/credentialIssuance",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
-    "issued": [
-            {...},
-            {...}
+    "credentials": [
+            "credential 1",
+            "credential 2",
+            "credential n"
     ],
     "callbackURL": "https://www.aliceswonderland.com/"
 }
@@ -645,7 +650,8 @@ revocation: {
     "callbackURL", // OPTIONAL!
     "responseRequested", //OPTIONAL!
     "id", // OPTIONAL!
-    "comment" // OPTIONAL!
+    "comment", // OPTIONAL!
+    "timing" // OPTIONAL!
 }
 ```
 
@@ -688,13 +694,11 @@ presentationRequest: {
     "context",
     "thread",
     "callbackURL",
-    "credentialRequirements": [
-        {
-            "type"
-        },
-    ],
+    "credentialTypes", // OPTIONAL!
+    "supportedIssuers", // OPTIONAL!
     "responseRequested", //OPTIONAL!
-    "id" // OPTIONAL!
+    "id", // OPTIONAL!
+    "timing" // OPTIONAL!
 }
 ```
 
@@ -705,13 +709,14 @@ presentationRequest: {
     "context": "presentation-verification/1.0/presentationRequest",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
     "callbackURL": "https://www.bobsworld.com/",
-    "credentialRequirements": [
-        {
-            "type": "YouHaveNiceHairCredential"
-        },
-        {
-            "type": "DriversLicenseCredential"
-        }
+    "credentialTypes": [
+        "YourCatHasAnAttitudeCredential",
+        "YouHaveNiceHairCredential",
+        "YourLasagnaIsDeliciousCredential"
+    ],
+    "supportedIssuers": [
+        "did:iota:58c35471071b3dbb97585ee06bb1dd0239ca338629534296cfbb2db6bc857e21",
+        "did:iota:23f0b94812c402a1dea1c424303b178d01485a5dcf26cf977333f3b629bd90ec"
     ]
 }
 ```
@@ -728,7 +733,8 @@ presentationResponse: {
     "callbackURL", // OPTIONAL!
     "responseRequested", //OPTIONAL!
     "verifiablePresentation",
-    "id" // OPTIONAL!
+    "id", // OPTIONAL!
+    "timing" // OPTIONAL!
 }
 ```
 
@@ -739,99 +745,8 @@ presentationResponse: {
     "context": "presentation-verification/1.0/presentationResponse",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
     "callbackURL": "https://www.aliceswonderland.com/",
-    "verifiablePresentation": {...}
+    "verifiablePresentation": {...} // Omitted for brevity
 }
 ```
 
 [Source 1: Jolocom Credential Verification](https://jolocom.github.io/jolocom-sdk/1.0.0/guides/interaction_flows/#credential-verification);
-
-
-
-vvvvv here be dragons vvvvv
-
-
-
-
-
-
-TODO presentationRequest:
-    TODO add field challenge (nonce (or sign with timestamp)), maybe optional
-    TODO signature issues
-    field "credentialRequirements"
-TODO credentialOptionsReponse:
-    TODO and i offer therse types of sig suites that this supports
-
-    TODO also add the actual signature types / methods like ed25519-merkle (verification method types)
-    "error": {
-        "errorCode": 200
-      
-        TODO
- 
-    }
-
-TODO credentialSchemaResponse:
-
-    TODO make nice interaction pictures / state machines
-
-
-
-
-
-TODO more sources https://identity.foundation/#wgs
-TODO VERSION, date, last changed, etc
-
-
-Other ToDos:
-
-timestamp or random value or challenge/nonce, sign everything
-check WHAT EXACTLY others are actually signing
-thread if instead of sending challenge back
-put down sources for all interactions into the document
-say what is OPTIONAL
-
-
-TODO revisit each field:
-
-
-`challenge` as JSON, e.g. `{"foo": "sign this"}`: A JSON acting as a signing challenge.
-
-`offeredCredentialTypes` as JSON: A field specific to VC issuance, contains a list of possible credential types, see <a href="#credential-options">Credential Options</a>.
-
-`credentialType` as String, e.g. `SimpleDiplomaCredential`: A VC type.
-
-`signature` as JSON, e.g. `{...}`: Includes a signature. Fields defined below.
-
-`signature[type]` as String, e.g. `JcsEd25519Signature2020`: Signature type.
-
-`signature[verificationMethod]` as String, e.g. `#authentication`: Reference to verification method in signer's DID Document used to produce the signature.
-
-`signature[signatureValue]` as String, e.g. `5Hw1JWv4a6hZH5obtAshbbKZQAJK6h8YbEwZvdxgWCXSL81fvRYoMCjt22vaBtZewgGq641dqR31C27YhDusoo4N`: Actual signature.
-
-`timing` as JSON, e.g. `{...}`: A decorator to include timing information into a message. Fields defined below.
-
-`timing[out_time]` as ISO 8601 timestamp, e.g. `2069-04-20T13:37:00Z`: The timestamp when the message was emitted.
-
-`timing[in_time]` as ISO 8601 timestamp, e.g. `2069-04-20T13:37:00Z`: The timestamp when the preceding message in this thread (the one that elicited this message as a response) was received.
-
-`timing[stale_time]` as ISO 8601 timestamp, e.g. `2069-04-20T13:37:00Z`: Ideally, the decorated message should be processed by the the specified timestamp. After that, the message may become irrelevant or less meaningful than intended. This is a hint only.
-
-`timing[expires_time]` as ISO 8601 timestamp, e.g. `2069-04-20T13:37:00Z`: The decorated message should be considered invalid or expired if encountered after the specified timestamp. This is a much stronger claim than the one for stale_time; it says that the receiver should cancel attempts to process it once the deadline is past, because the sender won't stand behind it any longer. While processing of the received message should stop, the thread of the message should be retained as the sender may send an updated/replacement message. In the case that the sender does not follow up, the policy of the receiver agent related to abandoned threads would presumably be used to eventually delete the thread.
-
-`timing[delay_milli]` as Integer, e.g. `1337`: Wait at least this many milliseconds before processing the message. This may be useful to defeat temporal correlation. It is recommended that agents supporting this field should not honor requests for delays longer than 10 minutes (600,000 milliseconds).
-
-`timing[wait_until_time]` as ISO 8601 timestamp, e.g. `2069-04-20T13:37:00Z`: Wait until this time before processing the message.
-
-`credential` as [VC JSON](https://w3c-ccg.github.io/vc-json-schemas/): A syntactically valid credential.
-
-
-TODO authentication tell what we are signing
-TODO create sequence diagrams for every interaction
-TODO take final TODOs and put them into, dunno, pr?
-TODO rework descriptions
-TODO rem interactions header ping response
-TODO ip in trust ping
-
-FINAL TODOs
-report/report: Define an actual error communication / information field that is parseable.
-revocation: How do we deal with unauthorized revocations (i.e. invalid ones)?
-field id: Discuss optionality over whole spec.

--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -2,9 +2,9 @@
 
 ## Field Definitions
 
-`context` as URL/String, e.g. `did-resolution/1.0/resolution-result`: Defines the context that a specific message adheres to.
+`context` as URL/String, e.g. `did-resolution/1.0/resolutionResponse`: Defines the context that a specific message adheres to.
 
-`ackContext` & `errContext` as URL/String, e.g. `did-resolution/1.0/resolution-result`: Variants of `context` that describe the context of a message that is being acknowledged or the message that errored.
+`ackContext` & `errContext` as URL/String, e.g. `did-resolution/1.0/resolutionResponse`: Variants of `context` that describe the context of a message that is being acknowledged or the message that errored.
 
 `thread` as String, e.g. `jdhgbksdbgjksdbgkjdkg` or `thread-132-a`: A String, defined by the agent, to be used to identify this specific interaction to track it agent-locally.
 
@@ -79,7 +79,7 @@ acknowledgement: {
 {
     "context": "acknowledgement/1.0/acknowledgement",
     "thread": "sdfgfjghsdfg-12345-sdf-b",
-    "ackContext": "did-resolution/1.0/resolution-result"
+    "ackContext": "did-resolution/1.0/resolutionResponse"
 }
 ```
 
@@ -103,7 +103,7 @@ error: {
 {
     "context": "error/1.0/error",
     "thread": "sdfgfjghsdfg-12345-sdf-b",
-    "errContext": "did-resolution/1.0/resolution-result",
+    "errContext": "did-resolution/1.0/resolutionResponse",
     "comment": "Can't resolve: Signature invalid!"
 }
 ```
@@ -114,7 +114,7 @@ error: {
 
 ◈ <a href="#did-discovery">**did-discovery**</a> (*didRequest*, *didResponse*): Requesting a DID from an agent.
 
-◈ <a href="#did-resolution">**did-resolution**</a> (*resolutionRequest*, *resolutionResult*): Using another agent as a Resolver.
+◈ <a href="#did-resolution">**did-resolution**</a> (*resolutionRequest*, *resolutionResponse*): Using another agent as a Resolver.
 
 ◈ <a href="#authentication">**authentication**</a> (*authenticationRequest*, *authenticationResponse*): Proving control over a DID.
 
@@ -290,13 +290,13 @@ resolutionRequest: {
 }
 ```
 
-##### resolutionResult
+##### resolutionResponse
 If the message contains a DID (in the `id` field), the Resolver resolves the DID and returns the DID Resolution Result. Otherwise, the Resolver returns the result of resolving it's own DID. This is intended for the special case of "local" DID methods, which do not have a globally resolvable state.
 
 ###### Layout
 
 ```JSON
-resolutionResult: {
+resolutionResponse: {
     "context",
     "didDocument"
     "id", // OPTIONAL!
@@ -309,7 +309,7 @@ resolutionResult: {
 TODO why is ID optional
 ```JSON
 {
-    "context": "did-resolution/1.0/resolutionResult",
+    "context": "did-resolution/1.0/resolutionResponse",
     "thread": "req-1-1337b",
     "didDocument": {
         "@context": "https://www.w3.org/ns/did/v1",

--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -2,21 +2,23 @@
 
 > ### Field Definitions
 
+`context` as URL/String, e.g. `did-resolution/1.0/resolution-result`: Defines the context that a specific message adheres to.
+
+`ackContext` & `errContext` as URL/String, e.g. `did-resolution/1.0/resolution-result`: Variants of `context` that describe the context of a message that is being acknowledged or the message that errored.
+
+`thread` as String, e.g. `jdhgbksdbgjksdbgkjdkg` or `thread-132-a`: A String, defined by the agent, to be used to identify this specific interaction to track it agent-locally.
+
 `callbackURL` as URL/String, e.g. `https://www.bobsworld.com/ping` or `https://www.aliceswonderland/authz`: Defines the URL or API call where a request or response is to be delivered to.
-
-`responseRequested` as Boolean, e.g. `true` or `false`: In Messages where it is defined a reponse is to be sent to a request if and only if this is `true`. Undefined counts as `false`.
-
-`context` as URL/String, e.g. `https://didcomm.org/trust_ping/1.0/ping`: Defines the context that a specific message adheres to.
 
 `id` as String, e.g. `did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v`: An IOTA decentralized identifier.
 
 `didDocument` as JSON: An IOTA DID Document (see e.g. in <a href="#did-resolution">DID Resolution</a>).
 
+`responseRequested` as Boolean, e.g. `true` or `false`: In messages where it is defined a reponse is to be sent to a request if and only if this is `true`. Undefined counts as `false`.
+
 `comment` as String: A comment.
 
-`thread` as String, e.g. `jdhgbksdbgjksdbgkjdkg` or `thread-132-a`: A String, defined by the agent, to be used to identify this specific interaction to track it agent-locally.
-
-`challenge` as String, e.g. `please-sign-this`: A String acting as a signing challenge.
+`challenge` as JSON, e.g. `{"foo": "sign this"}`: A JSON acting as a signing challenge.
 
 `offeredCredentialTypes` as JSON: A field specific to VC issuance, contains a list of possible credential types, see <a href="#credential-options">Credential Options</a>.
 
@@ -45,29 +47,85 @@
 `timing[wait_until_time]` as ISO 8601 timestamp, e.g. `2069-04-20T13:37:00Z`: Wait until this time before processing the message.
 
 [(Source 1: Aries Message Timing)](https://github.com/hyperledger/aries-rfcs/blob/master/features/0032-message-timing/README.md)
-  
+
+> ### Standalone Messages
+
+Messages that are shared across interactions.
+
+### Roles
+- <u>**Sender**</u>: Agent who sends the message
+- <u>**Receiver**</u>: Agent who receives the message
+
+#### acknowledgement
+The <u>sender</u> sends an `acknowledgement` message to the <u>receiver</u> to let him know that a previous message has been received.
+
+###### Layout
+
+```JSON
+acknowledgement: {
+    "context",
+    "thread",
+    "ackContext"
+}
+```
+
+###### Example(s)
+
+```JSON
+{
+    "context": "acknowledgement/1.0/acknowledgement",
+    "thread": "sdfgfjghsdfg-12345-sdf-b",
+    "ackContext": "did-resolution/1.0/resolution-result"
+}
+```
+
+#### error
+The <u>sender</u> sends an `error` message to the <u>receiver</u> to let him know that a previous message has resulted in an error.
+
+###### Layout
+
+```JSON
+error: {
+    "context",
+    "thread",
+    "ackContext",
+    "comment" // OPTIONAL!
+}
+```
+
+###### Example(s)
+
+```JSON
+{
+    "context": "error/1.0/error",
+    "thread": "sdfgfjghsdfg-12345-sdf-b",
+    "errContext": "did-resolution/1.0/resolution-result",
+    "comment": "Can't resolve: Signature invalid!"
+}
+```
+
 > ### Interactions
 
-◈ <a href="#trust-ping">**Trust Ping**</a> - Testing a pairwise channel.
+◈ <a href="#trust-ping">**trust-ping**</a> - Testing a pairwise channel.
 
-◈ <a href="#did-discovery">**DID Discovery**</a> - Requesting a DID from an agent.
+◈ <a href="#did-discovery">**did-discovery**</a> - Requesting a DID from an agent.
 
-◈ <a href="#did-resolution">**DID Resolution**</a> - Using another agent as a Resolver.
+◈ <a href="#did-resolution">**did-resolution**</a> - Using another agent as a Resolver.
 
-◈ <a href="#authentication">**Authentication**</a> - Proving control over a DID.
+◈ <a href="#authentication">**authentication**</a> - Proving control over a DID.
 
-◈ <a href="#credential-options">**Credential Options**</a> - Querying an agent for the VCs that the agent can issue.
+◈ <a href="#credential-options">**credential-options**</a> - Querying an agent for the VCs that the agent can issue.
 
-◈ <a href="#credential-schema">**Credential Schema**</a> - Querying an agent for the schema of a specific VC that the agent can issue.
+◈ <a href="#credential-schema">**credential-schema**</a> - Querying an agent for the schema of a specific VC that the agent can issue.
 
-◈ <a href="#credential-issuance">**Credential Issuance**</a> - Creating an authenticated statement about a DID.
+◈ <a href="#credential-issuance">**credential-issuance**</a> - Creating an authenticated statement about a DID.
 
-◈ <a href="#credential-revocation">**Credential Revocation**</a> - Notifying a holder that a previously issued credential has been revoked.
+◈ <a href="#credential-revocation">**credential-revocation**</a> - Notifying a holder that a previously issued credential has been revoked.
 
-◈ <a href="#presentation-verification">**Presentation Verification**</a> - Proving a set of statements about an identifier.
+◈ <a href="#presentation-verification">**presentation-verification**</a> - Proving a set of statements about an identifier.
 
 ---
-## Trust Ping
+## trust-ping
 
 Testing a pairwise channel.
 
@@ -77,16 +135,16 @@ Testing a pairwise channel.
 
 ### Messages
 
-#### trustPing
-The <u>senders</u> sends the `trustPing` to the <u>receiver</u>, specifying a `callbackURL` for the `trustPingResponse` to be posted to.
+#### ping
+The <u>sender</u> sends the `ping` to the <u>receiver</u>, specifying a `callbackURL` for the `pingResponse` to be posted to.
 
 ###### Layout
 
 ```JSON
-trustPing: {
+ping: {
+    "context",
     "callbackURL",
     "responseRequested", //OPTIONAL! Counts as false if omitted!
-    "context", // OPTIONAL!
     "id", // OPTIONAL!
     "thread", // OPTIONAL!
     "timing": {...} // OPTIONAL! All subfields OPTIONAL!
@@ -97,9 +155,9 @@ trustPing: {
 
 ```JSON
 {
-    "callbackURL": "https://www.bobsworld.com/ping",
+    "context": "trust-ping/1.0/ping",
+    "callbackURL": "https://www.bobsworld.com/",
     "responseRequested": true,
-    "context": "https://didcomm.org/trust_ping/1.0/ping",
     "id": "did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v",
     "timing": {
         "delay_milli": 1337
@@ -107,13 +165,14 @@ trustPing: {
 }
 ```
 
-#### trustPingResponse
-The <u>receiver</u> answers with a `trustPingResponse` if and only if `responseRequested` was `true` in the `trustPing` message:
+#### pingResponse
+The <u>receiver</u> answers with a `pingResponse` if and only if `responseRequested` was `true` in the `ping` message:
 
 ###### Layout
 
 ```JSON
-trustPingResponse: {
+pingResponse: {
+    "context",
     "id", // OPTIONAL!
     "thread", // OPTIONAL!
     "timing": {...} // OPTIONAL! All subfields OPTIONAL!
@@ -124,6 +183,7 @@ trustPingResponse: {
 
 ```JSON
 {
+    "context": "trust-ping/1.0/pingResponse",
     "id": "did:iota:86b7t9786tb9JHFGJKHG8796UIZGUk87guzgUZIuggez",
 }
 ```
@@ -131,7 +191,7 @@ trustPingResponse: {
 [Source 1: DIF Trust Ping](https://identity.foundation/didcomm-messaging/spec/#trust-ping-protocol-10); [Source 2: Aries Trust Ping](https://github.com/hyperledger/aries-rfcs/tree/master/features/0048-trust-ping)
 
 ---
-## DID Discovery
+## did-discovery
 
 Requesting a DID from an agent.
 
@@ -148,8 +208,8 @@ The <u>requester</u> sends the `didRequest` to the <u>endpoint</u>, specifying a
 
 ```JSON
 didRequest: {
+    "context",
     "callbackURL",
-    "context", // OPTIONAL!
     "id", // OPTIONAL!
     "thread", // OPTIONAL!
     "timing" // OPTIONAL!
@@ -160,6 +220,7 @@ didRequest: {
 
 ```JSON
 {
+    "context": "did-discovery/1.0/didRequest",
     "callbackURL": "https://www.aliceswonderland.com/didreq",
     "id": "did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v",
 }
@@ -172,6 +233,7 @@ The <u>endpoint</u> answers with a `didResponse`, containing its DID.
 
 ```JSON
 didResponse: {
+    "context",
     "id"
 }
 ```
@@ -180,12 +242,13 @@ didResponse: {
 
 ```JSON
 {
+    "context": "did-discovery/1.0/didResponse",
     "id": "did:iota:86b7t9786tb9JHFGJKHG8796UIZGUk87guzgUZIuggez"
 }
 ```
 
 ---
-## DID Resolution
+## did-resolution
 
 Using another Agent as a Resolver.
 
@@ -204,6 +267,7 @@ The Requester broadcasts a message which may or may not contain a DID.
 
 ```JSON
 resolutionRequest: {
+    "context",
     "callbackURL",
     "id", // OPTIONAL!
     "thread", // OPTIONAL!
@@ -215,6 +279,7 @@ resolutionRequest: {
 
 ```JSON
 {
+    "context": "did-resolution/1.0/resolutionRequest",
     "callbackURL": "https://www.aliceswonderland.com/res",
     "id": "did:iota:86b7t9786tb9JHFGJKHG8796UIZGUk87guzgUZIuggez",
     "thread": "req-1-1337b"
@@ -228,6 +293,7 @@ If the message contains a DID (in the `id` field), the Resolver resolves the DID
 
 ```JSON
 resolutionResult: {
+    "context",
     "didDocument"
     "id", // OPTIONAL!
     "thread", // OPTIONAL!
@@ -239,6 +305,7 @@ resolutionResult: {
 
 ```JSON
 {
+    "context": "did-resolution/1.0/resolutionResult",
     "thread": "req-1-1337b",
     "didDocument": {
         "@context": "https://www.w3.org/ns/did/v1",
@@ -254,7 +321,7 @@ resolutionResult: {
 ```
 
 ---
-## Authentication
+## authentication
 
 Proving control over an identifier.
 
@@ -273,6 +340,7 @@ The <u>verifier</u> sends the `authenticationRequest` to the authentication serv
 
 ```JSON
 authenticationRequest: {
+    "context",
     "callbackURL",
     "thread",
     "challenge",
@@ -285,6 +353,7 @@ authenticationRequest: {
 
 ```JSON
 {
+    "context": "authentication/1.0/authenticationRequest",
     "callbackURL": "https://www.aliceswonderland.com/auth",
     "thread": "69-420-1337",
     "challenge": "please sign this",
@@ -304,6 +373,7 @@ The <u>authenticator</u> answers with an `authenticationResponse`, providing a `
 
 ```JSON
 authenticationResponse: {
+    "context",
     "thread",
     "signature"
 }
@@ -313,6 +383,7 @@ authenticationResponse: {
 
 ```JSON
 {
+    "context": "authentication/1.0/authenticationResponse",
     "thread": "69-420-1337",
     "signature": {
         "type": "JcsEd25519Signature2020",
@@ -325,7 +396,8 @@ authenticationResponse: {
 The `signature` provided here must correspond to the `#authentication` public key provided in the DID Document of the identity that the <u>verifier</u> has received earlier. If that is the case, the identifier is authenticated successfully.
 
 ---
-## Credential Options
+## credential-options
+
 Querying an agent for the VCs that the agent can issue.
 
 The Verifiable Credential (VC) issuance flow consists of a three step interaction process between two parties, the <u>issuer</u> and the <u>holder</u>. This is the first interaction in this process. In this interaction, the <u>holder</u> queries the <u>issuer</u> for a list of VC types that the <u>issuer</u> offers to issue.
@@ -343,6 +415,7 @@ The <u>holder</u> queries the <u>issuer</u> for a list of VC types that the <u>i
 
 ```JSON
 credentialOptionsRequest: {
+    "context",
     "callbackURL",
     "thread", // OPTIONAL!
     "id", // OPTIONAL!
@@ -354,6 +427,7 @@ credentialOptionsRequest: {
 
 ```JSON
 {
+    "context": "credential-options/1.0/credentialOptionsRequest",
     "callbackURL": "https://www.alicesworld.com/credsList"
 }
 ```
@@ -365,10 +439,16 @@ The <u>issuer</u> responds with a list of offered VC types.
 
 ```JSON
 credentialOptionsResponse: {
+    "context",
     "offeredCredentialTypes": [
         "credentialType 1",
         "credentialType 2",
         "credentialType n"
+    ],
+    "supportedIssuers": [
+        "issuer id 1",
+        "issuer id 2",
+        "issuer id n"
     ],
     "thread", // OPTIONAL!
     "timing" // OPTIONAL!
@@ -379,16 +459,21 @@ credentialOptionsResponse: {
 
 ```JSON
 {
+    "context": "credential-options/1.0/credentialOptionsResponse",
     "offeredCredentialTypes": [
         "DiplomaCredential",
         "YouHaveNiceHairCredential",
         "DriversLicenseCredential"
+    ],
+    "supportedIssuers": [
+        "did:iota:afbsdjhfbasuidfb8asifb4bfkawuiefjhdfgsukdfb",
+        "did:iota:jahsdbfukgsiudfgisdufgi8sdfgzsbegbesudgbudf"
     ]
 }
 ```
 
 ---
-## Credential Schema
+## credential-schema
 Querying an agent for the schema of a specific VC that the agent can issue.
 
 The Verifiable Credential (VC) issuance flow consists of a three step interaction process between two parties, the <u>issuer</u> and the <u>holder</u>. This is the second interaction in this process. In this interaction, the <u>holder</u> queries the <u>issuer</u> for the precise schema of one of the VCs that the <u>issuer</u> offers to issue, with it's own list of requirements which must be satisfied by the <u>holder</u> in order to qualify for the credential.
@@ -406,8 +491,9 @@ The <u>holder</u> queries the <u>issuer</u> for the schema of a specific VC that
 
 ```JSON
 credentialSchemaRequest: {
+    "context",
     "callbackURL",
-    "credentialType",
+    "credentialTypes",
     "thread", // OPTIONAL!
     "id", // OPTIONAL!
     "timing" // OPTIONAL!
@@ -418,19 +504,24 @@ credentialSchemaRequest: {
 
 ```JSON
 {
+    "context": "credential-options/1.0/credentialSchemaRequest",
     "callbackURL": "https://www.alicesworld.com/credsList",
-    "credentialType": "YouHaveNiceHairCredential"
+    "credentialTypes": [
+        "YouHaveNiceHairCredential",
+        "DriversLicenseCredential"
+    ]
 }
 ```
 
 #### credentialSchemaResponse
-The <u>issuer</u> responds with the schema of the requested `credentialType`.
+The <u>issuer</u> responds with the schema of the requested `credentialTypes`.
 
 ###### Layout
 
 ```JSON
 credentialSchemaResponse: {
-    "YouHaveNiceHairCredential": {...}, //TODO: Discuss!
+    "context",
+    "schemas",
     "thread", // OPTIONAL!
     "timing" // OPTIONAL!
 }
@@ -440,15 +531,22 @@ credentialSchemaResponse: {
 
 ```JSON
 {
-    "YouHaveNiceHairCredential": {
-        "type": "YouHaveNiceHairCredential",
-        ... //TODO: Discuss!
-    }, //TODO: Discuss!
+    "context": "credential-options/1.0/credentialSchemaResponse",
+    "schemas": [
+        "YouHaveNiceHairCredential": {
+            "type": "YouHaveNiceHairCredential",
+            ...
+        },
+        "DriversLicenseCredential": {
+            "type": "DriversLicenseCredential",
+            ...
+        },
+    ]
 }
 ```
 
 ---
-## Credential Issuance
+## credential-issuance
 Creating an authenticated statement about a DID.
 
 The Verifiable Credential (VC) issuance flow consists of a three step interaction process between two parties, the <u>issuer</u> and the <u>holder</u>. This is the third interaction in this process. In this interaction, the <u>holder</u> asks the <u>issuer</u> for issuance of a specific VC.
@@ -460,17 +558,30 @@ The Verifiable Credential (VC) issuance flow consists of a three step interactio
 ### Messages
 
 #### credentialSelection
-The <u>holder</u> sends a message containing a list of selected credentials with associated data for satisfying requirements. //TODO: Discuss: List or single issuance?
+The <u>holder</u> sends a message containing a list of selected credentials with associated data for satisfying requirements.
 
 ###### Layout
 
 ```JSON
 credentialSelection: {
+    "context",
     "callbackURL",
     "selectedCredentials": [
-        {
-            "type": "<Type as String>"
-        },
+            "type 1",
+            "type 2",
+            "type n"
+    ],
+}
+```
+
+###### Example(s)
+
+```JSON
+{
+    "context": "credential-issuance/1.0/credentialSelection",
+    "callbackURL": "https://www.bobsworld.com/serviceEndpoint",
+    "selectedCredentials": [
+            "YouHaveNiceHairCredential"
     ],
 }
 ```
@@ -482,22 +593,29 @@ The <u>issuer</u> responds with a message containing a list of newly issued cred
 
 ```JSON
 credentialIssuance: {
+    "context",
     "issued": [
-        {
-            "type": "<Type as String>"
-        },
+        ...
     ],
 }
 ```
 
-### Examples
+###### Example(s)
 
-TBD after above flow is cleared up
+```JSON
+{
+    "context": "credential-issuance/1.0/credentialIssuance",
+    "issued": [
+            {...},
+            {...}
+    ],
+}
+```
 
 ---
-## Credential Revocation
+## credential-revocation
 
-Notifying a holder that a previously issued credential has been revoked.
+Notifying a holder that a previously issued credential has been revoked. Note that this revocation is declaratory, not constitutive, so the actual revocation has to be done elsewhere (e.g. in the backend of the issuer).
 
 ### Roles
 - <u>**Issuer**</u>: Agent who revokes the credential
@@ -506,15 +624,15 @@ Notifying a holder that a previously issued credential has been revoked.
 ### Messages
 
 #### revocation
-The <u>issuer</u> sends the `credentialRevocation` to the <u>holder</u>, notifying him of the revocation.
+The <u>issuer</u> sends the `revocation` to the <u>holder</u>, notifying him of the revocation. The most important field here is `credentialId`, which specifies the credential that has been revoked.
 
 ###### Layout
 
 ```JSON
-credentialRevocation: {
+revocation: {
+    "context",
     "credentialId",
     "comment", // OPTIONAL!
-    "context", // OPTIONAL!
     "id" // OPTIONAL!
 }
 ```
@@ -523,6 +641,7 @@ credentialRevocation: {
 
 ```JSON
 {
+    "context": "credential-revocation/1.0/revocation",
     "credentialId": "gfiweuzg89w3bgi8wbgi8wi8t",
     "comment": "Revoked because reasons.",
     "id": "did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v",
@@ -530,11 +649,11 @@ credentialRevocation: {
 ```
 
 ---
-## Presentation Verification
+## presentation-verification
 
 Proving a set of statements about an identifier.
 
-The credential verification flow is a simple request-response message exchange between the <u>verifier</u> and the <u>prover</u>. The interaction can consist of up to three messages, however two of them are OPTIONAL.
+The credential verification flow is a simple request-response message exchange between the <u>verifier</u> and the <u>prover</u>. The interaction can consist of up to two messages, the first one is OPTIONAL.
 
 ### Roles
 - **Verifier**: Agent who requests a set of Verifiable Credentials with associated requirements
@@ -549,14 +668,11 @@ The <u>verifier</u> requests a set of Verifiable Credentials from the <u>prover<
 
 ```JSON
 presentationRequest: {
-    "callbackURL": "<URL as String>",
+    "context",
+    "callbackURL",
     "credentialRequirements": [
         {
-            "type": "<Type as String>",
-            "constraints": [
-                <Constraint 1>,
-                <Constraint 2>,
-            ],
+            "type"
         },
     ],
 }
@@ -566,7 +682,16 @@ presentationRequest: {
 
 ```JSON
 {
-    tbd
+    "context": "presentation-verification/1.0/presentationRequest",
+    "callbackURL": "https://www.bobsworld.com/pres",
+    "credentialRequirements": [
+        {
+            "type": "YouHaveNiceHairCredential"
+        },
+        {
+            "type": "DriversLicenseCredential"
+        }
+    ]
 }
 ```
 
@@ -577,33 +702,77 @@ The <u>holder</u> sends a Verifiable Presentation to the <u>verifier</u> using a
 
 ```JSON
 presentationResponse: {
+    "context",
+    "verifiablePresentation"
+}
+```
+
+###### Example(s)
+
+```JSON
+{
+    "context": "presentation-verification/1.0/presentationResponse",
     "verifiablePresentation": {...}
 }
 ```
 
-###### Example(s)
 
-```JSON
-{
-    tbd
-}
-```
 
-#### presentationAcknowledgement
-The <u>verifier</u> responds to the presented Verifiable Presentation. This message is OPTIONAL within this interaction.
 
-###### Layout
 
-```JSON
-presentationAcknowledgement: {
-    bool yes/no?
-}
-```
+vvvvv here be dragons vvvvv
 
-###### Example(s)
 
-```JSON
-{
-    tbd
-}
-```
+
+
+
+TODO add more sources to everything
+TODO presentationRequest:
+    TODO add field challenge (nonce (or sign with timestamp)), maybe optional
+    TODO signature issues
+    field "credentialRequirements"
+TODO credentialOptionsReponse:
+    TODO and i offer therse types of sig suites that this supports
+
+    TODO also add the actual signature types / methods like ed25519-merkle (verification method types)
+    "error": {
+        "errorCode": 200
+        "comment": Shit's on fire, yo
+        TODO
+        https://github.com/hyperledger/aries-rfcs/blob/master/features/0035-report-problem/README.md
+    }
+
+TODO credentialSchemaResponse:
+    TODO SRC https://w3c-ccg.github.io/vc-json-schemas/
+
+
+
+
+    TODO make nice interaction pictures / state machines
+
+
+
+
+
+TODO more sources https://identity.foundation/#wgs
+TODO VERSION, date, last changed, etc
+TODO all PRS
+TODO all issues:
+
+Open discussion points, among others:
+
+How exactly do we define the credentialSchemas?
+How exactly will these schemas be structured and communicated?
+Do we offer single issuance or do we use lists everywhere?
+
+    Probably some more stuff we need to talk about
+
+Other ToDos:
+
+timestamp or random value or challenge/nonce, sign everything
+check WHAT EXACTLY others are actually signing
+thread if instead of sending challenge back
+put down sources for all interactions into the document
+say what is OPTIONAL
+https://identity.foundation/didcomm-messaging/spec/#discover-features-protocol-10
+thread id

--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -769,16 +769,7 @@ https://github.com/hyperledger/aries-rfcs/blob/master/features/0035-report-probl
 
 TODO more sources https://identity.foundation/#wgs
 TODO VERSION, date, last changed, etc
-TODO all PRS
-TODO all issues:
 
-Open discussion points, among others:
-
-How exactly do we define the credentialSchemas?
-How exactly will these schemas be structured and communicated?
-Do we offer single issuance or do we use lists everywhere?
-
-    Probably some more stuff we need to talk about
 
 Other ToDos:
 
@@ -789,13 +780,6 @@ put down sources for all interactions into the document
 say what is OPTIONAL
 
 
-
-
-
-
-
-TODO only do acks on request
-TODO make callbackURL optional except in the first of each interaction messages
 TODO revisit each field:
 
 
@@ -830,7 +814,7 @@ TODO revisit each field:
 `timing[wait_until_time]` as ISO 8601 timestamp, e.g. `2069-04-20T13:37:00Z`: Wait until this time before processing the message.
 
 TODO authentication tell what we are signing
-TODO sequence diagrams
+TODO create sequence diagrams for every interaction
 TODO take final TODOs and put them into, dunno, pr?
 TODO rework descriptions
 

--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -8,11 +8,11 @@
 
 `callbackURL` as URL/String, e.g. `https://www.bobsworld.com/` or `https://www.aliceswonderland/serviceEndpoint`: Defines the URL (or API call) where a message is to be delivered to.
 
+`responseRequested` as Boolean, e.g. `true` or `false`: In messages where it is defined it asks the recipient of the message to repond in the form of an acknowledging report. This request can be honored, but doesn't have to be honored. The only exception to this behaviour is in `trust-ping`, where the acknowledging report is to be sent if and only if this field is `true`. If this field is undefined, it counts as `false`.
+
 `id` as String, e.g. `did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v`: An IOTA decentralized identifier.
 
 `didDocument` as JSON: An IOTA DID Document (see e.g. in <a href="#did-resolution">DID Resolution</a>).
-
-`responseRequested` as Boolean, e.g. `true` or `false`: In messages where it is defined a reponse is to be sent to a request if and only if this is `true`. Undefined counts as `false`.
 
 `comment` as String: A comment. Can be literally any String.
 
@@ -116,7 +116,7 @@ Testing a pairwise channel.
 #### Messages
 
 #### ping
-The <u>sender</u> sends the `ping` to the <u>receiver</u>, specifying a `callbackURL` for the `pingResponse` to be posted to.
+The <u>sender</u> sends the `ping` to the <u>receiver</u>, specifying a `callbackURL` for the `pingResponse` to be posted to. The `responseRequested` field counts as `false` if omitted. If and only if the `responseRequested` field is true should the <u>**Receiver**</u> respond to the ping with a `report` message. If it is `true`, a `thread` should be passed as well to reference the `ping`.
 
 ###### Layout
 
@@ -124,8 +124,8 @@ The <u>sender</u> sends the `ping` to the <u>receiver</u>, specifying a `callbac
 ping: {
     "context",
     "callbackURL",
+    "responseRequested", //OPTIONAL!
     "thread", // OPTIONAL!
-    "responseRequested", //OPTIONAL! Counts as false if omitted!
     "id", // OPTIONAL!
     "timing": {...} // OPTIONAL! All subfields OPTIONAL!
 }
@@ -142,30 +142,6 @@ ping: {
     "timing": {
         "delay_milli": 1337
     }
-}
-```
-
-#### pingResponse
-The <u>receiver</u> answers with a `pingResponse` if and only if `responseRequested` was `true` in the `ping` message. The OPTIONAL `thread` field is only included if there was a thread UUID provided in the `ping` message:
-
-###### Layout
-
-```JSON
-pingResponse: {
-    "context",
-    "thread", // OPTIONAL!
-    "callbackURL", // OPTIONAL!
-    "id", // OPTIONAL!
-    "timing": {...} // OPTIONAL! All subfields OPTIONAL!
-}
-```
-
-###### Example(s)
-
-```JSON
-{
-    "context": "trust-ping/1.0/pingResponse",
-    "id": "did:iota:86b7t9786tb9JHFGJKHG8796UIZGUk87guzgUZIuggez",
 }
 ```
 
@@ -786,8 +762,6 @@ check WHAT EXACTLY others are actually signing
 thread if instead of sending challenge back
 put down sources for all interactions into the document
 say what is OPTIONAL
-https://identity.foundation/didcomm-messaging/spec/#discover-features-protocol-10
-thread id
 
 
 

--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -14,7 +14,9 @@
 
 `didDocument` as JSON: An IOTA DID Document (see e.g. in <a href="#did-resolution">DID Resolution</a>).
 
-`comment` as String: A comment. Can be literally any String.
+`credential` as [VC JSON](https://w3c-ccg.github.io/vc-json-schemas/): A syntactically valid credential.
+
+`comment` as String: A comment, mostly used to provide more information about something. Can be literally any String.
 
 `challenge` as JSON, e.g. `{"foo": "sign this"}`: A JSON acting as a signing challenge.
 
@@ -654,10 +656,10 @@ revocation: {
 {
     "context": "credential-revocation/1.0/revocation",
     "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
-    "credentialId": "gfiweuzg89w3bgi8wbgi8wi8t",
+    "credentialId": "credential-69420-delicious-lasagna",
     "callbackURL": "https://www.aliceswonderland.com/",
     "id": "did:iota:42edacef81828010b314b96c0915780f206341e0ce8892a1b56678c174eef242",
-    "comment": "Revoked because reasons.",
+    "comment": "Revoked because your Lasagna isn't actually that good."
 }
 ```
 
@@ -751,7 +753,7 @@ vvvvv here be dragons vvvvv
 
 
 
-TODO add more sources to everything
+
 TODO presentationRequest:
     TODO add field challenge (nonce (or sign with timestamp)), maybe optional
     TODO signature issues
@@ -762,17 +764,12 @@ TODO credentialOptionsReponse:
     TODO also add the actual signature types / methods like ed25519-merkle (verification method types)
     "error": {
         "errorCode": 200
-        "comment": Shit's on fire, yo
+      
         TODO
-        https://github.com/hyperledger/aries-rfcs/blob/master/features/0035-report-problem/README.md
+ 
     }
 
 TODO credentialSchemaResponse:
-    TODO SRC https://w3c-ccg.github.io/vc-json-schemas/
-
-
-https://w3c-ccg.github.io/vc-json-schemas/
-https://github.com/hyperledger/aries-rfcs/blob/master/features/0035-report-problem/README.md
 
     TODO make nice interaction pictures / state machines
 
@@ -795,8 +792,6 @@ say what is OPTIONAL
 
 TODO revisit each field:
 
-
-`comment` as String: A comment. Can be literally any String.
 
 `challenge` as JSON, e.g. `{"foo": "sign this"}`: A JSON acting as a signing challenge.
 
@@ -825,6 +820,9 @@ TODO revisit each field:
 `timing[delay_milli]` as Integer, e.g. `1337`: Wait at least this many milliseconds before processing the message. This may be useful to defeat temporal correlation. It is recommended that agents supporting this field should not honor requests for delays longer than 10 minutes (600,000 milliseconds).
 
 `timing[wait_until_time]` as ISO 8601 timestamp, e.g. `2069-04-20T13:37:00Z`: Wait until this time before processing the message.
+
+`credential` as [VC JSON](https://w3c-ccg.github.io/vc-json-schemas/): A syntactically valid credential.
+
 
 TODO authentication tell what we are signing
 TODO create sequence diagrams for every interaction

--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -116,16 +116,16 @@ Testing a pairwise channel.
 #### Messages
 
 #### ping
-The <u>sender</u> sends the `ping` to the <u>receiver</u>, specifying a `callbackURL` for the `pingResponse` to be posted to. The `responseRequested` field counts as `false` if omitted. If and only if the `responseRequested` field is true should the <u>**Receiver**</u> respond to the ping with a `report` message. If it is `true`, a `thread` should be passed as well to reference the `ping`.
+The <u>sender</u> sends the `ping` to the <u>receiver</u>, specifying a `callbackURL` for the `pingResponse` to be posted to. The `responseRequested` field counts as `false` if omitted. If and only if the `responseRequested` field is true should the <u>receiver</u> respond to the ping with a `report` message. If it is `true`, a `thread` should be passed as well to reference the `ping`. The `callbackURL` is OPTIONAL here because the <u>sender</u> could, for example, just include the `id` field and timing information to let the <u>receiver</u> know of transport delays.
 
 ###### Layout
 
 ```JSON
 ping: {
     "context",
-    "callbackURL",
-    "responseRequested", //OPTIONAL!
+    "callbackURL", // OPTIONAL!
     "thread", // OPTIONAL!
+    "responseRequested", //OPTIONAL!
     "id", // OPTIONAL!
     "timing": {...} // OPTIONAL! All subfields OPTIONAL!
 }
@@ -137,6 +137,7 @@ ping: {
 {
     "context": "trust-ping/1.0/ping",
     "callbackURL": "https://www.bobsworld.com/",
+    "thread": "f7771b285a971ba25d66dbe2d82f0bf5f956f4fe548bdf8617c3f24ebc10ed8c",
     "responseRequested": true,
     "id": "did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v",
     "timing": {
@@ -168,6 +169,7 @@ didRequest: {
     "context",
     "thread",
     "callbackURL",
+    "responseRequested", //OPTIONAL!
     "id", // OPTIONAL!
     "timing" // OPTIONAL!
 }
@@ -194,7 +196,8 @@ didResponse: {
     "context",
     "thread",
     "id",
-    "callbackURL" // OPTIONAL!
+    "callbackURL", // OPTIONAL!
+    "responseRequested", //OPTIONAL!
 }
 ```
 
@@ -231,6 +234,7 @@ resolutionRequest: {
     "context",
     "thread",
     "callbackURL",
+    "responseRequested", //OPTIONAL!
     "id", // OPTIONAL!
     "timing" // OPTIONAL!
 }
@@ -258,6 +262,7 @@ resolutionResponse: {
     "thread",
     "didDocument",
     "callbackURL", // OPTIONAL!
+    "responseRequested", //OPTIONAL!
     "timing" // OPTIONAL!
 }
 ```
@@ -306,6 +311,7 @@ authenticationRequest: {
     "thread",
     "callbackURL",
     "challenge",
+    "responseRequested", //OPTIONAL!
     "id", // OPTIONAL!
     "timing" // OPTIONAL!
 }
@@ -338,7 +344,8 @@ authenticationResponse: {
     "context",
     "thread",
     "signature",
-    "callbackURL" // OPTIONAL!
+    "callbackURL", // OPTIONAL!
+    "responseRequested" //OPTIONAL!
 }
 ```
 
@@ -382,6 +389,7 @@ credentialOptionsRequest: {
     "context",
     "thread",
     "callbackURL",
+    "responseRequested", //OPTIONAL!
     "id", // OPTIONAL!
     "timing" // OPTIONAL!
 }
@@ -417,6 +425,7 @@ credentialOptionsResponse: {
         "issuer id n"
     ],
     "callbackURL", // OPTIONAL!
+    "responseRequested", //OPTIONAL!
     "timing" // OPTIONAL!
 }
 ```
@@ -463,6 +472,7 @@ credentialSchemaRequest: {
     "thread",
     "callbackURL",
     "credentialTypes",
+    "responseRequested", //OPTIONAL!
     "id", // OPTIONAL!
     "timing" // OPTIONAL!
 }
@@ -493,6 +503,7 @@ credentialSchemaResponse: {
     "thread",
     "schemas",
     "callbackURL", // OPTIONAL!
+    "responseRequested", //OPTIONAL!
     "timing" // OPTIONAL!
 }
 ```
@@ -543,6 +554,7 @@ credentialSelection: {
             "type 2",
             "type n"
     ],
+    "responseRequested" //OPTIONAL!
 }
 ```
 
@@ -571,7 +583,8 @@ credentialIssuance: {
     "issued": [
         ...
     ],
-    "callbackURL" // OPTIONAL!
+    "callbackURL", // OPTIONAL!
+    "responseRequested" //OPTIONAL!
 }
 ```
 
@@ -611,6 +624,7 @@ revocation: {
     "thread",
     "credentialId",
     "callbackURL", // OPTIONAL!
+    "responseRequested", //OPTIONAL!
     "comment" // OPTIONAL!
 }
 ```
@@ -657,6 +671,7 @@ presentationRequest: {
             "type"
         },
     ],
+    "responseRequested" //OPTIONAL!
 }
 ```
 
@@ -688,6 +703,7 @@ presentationResponse: {
     "context",
     "thread",
     "callbackURL", // OPTIONAL!
+    "responseRequested", //OPTIONAL!
     "verifiablePresentation"
 }
 ```
@@ -777,8 +793,6 @@ TODO revisit each field:
 `id` as String, e.g. `did:iota:3b8mZHjb6r6inMcDVZU4DZxNdLnxUigurg42tJPiFV9v`: An IOTA decentralized identifier.
 
 `didDocument` as JSON: An IOTA DID Document (see e.g. in <a href="#did-resolution">DID Resolution</a>).
-
-`responseRequested` as Boolean, e.g. `true` or `false`: In messages where it is defined a reponse is to be sent to a request if and only if this is `true`. Undefined counts as `false`.
 
 `comment` as String: A comment. Can be literally any String.
 

--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -110,38 +110,23 @@ error: {
 
 ## Interactions
 
-◈ <a href="#trust-ping">**trust-ping**</a> - Testing a pairwise channel.
+◈ <a href="#trust-ping">**trust-ping**</a> (*ping*, *pingResponse*): Testing a pairwise channel.
 
-    ping
+◈ <a href="#did-discovery">**did-discovery**</a> (*didRequest*, *didResponse*): Requesting a DID from an agent.
 
-    pingResponse
+◈ <a href="#did-resolution">**did-resolution**</a> (*resolutionRequest*, *resolutionResult*): Using another agent as a Resolver.
 
-◈ <a href="#did-discovery">**did-discovery**</a> - Requesting a DID from an agent.
-Messages: ping, pingResponse
+◈ <a href="#authentication">**authentication**</a> (*authenticationRequest*, *authenticationResponse*): Proving control over a DID.
 
-◈ <a href="#did-resolution">**did-resolution**</a> - Using another agent as a Resolver.
+◈ <a href="#credential-options">**credential-options**</a> (*credentialOptionsRequest*, *credentialOptionsResponse*): Querying an agent for the VCs that the agent can issue.
 
-&nbsp;&nbsp;&nbsp;&nbsp;ping
+◈ <a href="#credential-schema">**credential-schema**</a> (*credentialSchemaRequest*, *credentialSchemaResponse*): Querying an agent for the schema of a specific VC that the agent can issue.
 
-&nbsp;&nbsp;&nbsp;&nbsp;pingResponse
+◈ <a href="#credential-issuance">**credential-issuance**</a> (*credentialSelection*, *credentialIssuance*): Creating an authenticated statement about a DID.
 
-◈ <a href="#authentication">**authentication**</a> - Proving control over a DID.
+◈ <a href="#credential-revocation">**credential-revocation**</a> (*revocation*): Notifying a holder that a previously issued credential has been revoked.
 
-&nbsp;&nbsp;&nbsp;&nbsp;ping
-&nbsp;&nbsp;&nbsp;&nbsp;pingResponse
-
-- <a href="#credential-options">**credential-options**</a> - Querying an agent for the VCs that the agent can issue.
-Messages: *ping*, *pingResponse*
-
-- <a href="#credential-schema">**credential-schema**</a> - Querying an agent for the schema of a specific VC that the agent can issue.
-
-Messages: ping, pingResponse
-
-- <a href="#credential-issuance">**credential-issuance**</a> - Creating an authenticated statement about a DID.
-
-- <a href="#credential-revocation">**credential-revocation**</a> - Notifying a holder that a previously issued credential has been revoked.
-
-- <a href="#presentation-verification">**presentation-verification**</a> - Proving a set of statements about an identifier.
+◈ <a href="#presentation-verification">**presentation-verification**</a> (*presentationRequest*, *presentationResponse*): Proving a set of statements about an identifier.
 
 ---
 ### trust-ping

--- a/docs/DID Communications Research and Specification/Interactions and Messages.md
+++ b/docs/DID Communications Research and Specification/Interactions and Messages.md
@@ -52,11 +52,11 @@
 
 Messages that are shared across interactions.
 
-### Roles
+#### Roles
 - <u>**Sender**</u>: Agent who sends the message
 - <u>**Receiver**</u>: Agent who receives the message
 
-#### acknowledgement
+##### acknowledgement
 The <u>sender</u> sends an `acknowledgement` message to the <u>receiver</u> to let him know that a previous message has been received.
 
 ###### Layout
@@ -83,7 +83,7 @@ acknowledgement: {
 }
 ```
 
-#### error
+##### error
 The <u>sender</u> sends an `error` message to the <u>receiver</u> to let him know that a previous message has resulted in an error.
 
 ###### Layout
@@ -117,8 +117,7 @@ error: {
     pingResponse
 
 ◈ <a href="#did-discovery">**did-discovery**</a> - Requesting a DID from an agent.
-&nbsp;&nbsp;&nbsp;&nbsp;ping
-&nbsp;&nbsp;&nbsp;&nbsp;pingResponse
+Messages: ping, pingResponse
 
 ◈ <a href="#did-resolution">**did-resolution**</a> - Using another agent as a Resolver.
 
@@ -131,15 +130,18 @@ error: {
 &nbsp;&nbsp;&nbsp;&nbsp;ping
 &nbsp;&nbsp;&nbsp;&nbsp;pingResponse
 
-◈ <a href="#credential-options">**credential-options**</a> - Querying an agent for the VCs that the agent can issue.
+- <a href="#credential-options">**credential-options**</a> - Querying an agent for the VCs that the agent can issue.
+Messages: *ping*, *pingResponse*
 
-◈ <a href="#credential-schema">**credential-schema**</a> - Querying an agent for the schema of a specific VC that the agent can issue.
+- <a href="#credential-schema">**credential-schema**</a> - Querying an agent for the schema of a specific VC that the agent can issue.
 
-◈ <a href="#credential-issuance">**credential-issuance**</a> - Creating an authenticated statement about a DID.
+Messages: ping, pingResponse
 
-◈ <a href="#credential-revocation">**credential-revocation**</a> - Notifying a holder that a previously issued credential has been revoked.
+- <a href="#credential-issuance">**credential-issuance**</a> - Creating an authenticated statement about a DID.
 
-◈ <a href="#presentation-verification">**presentation-verification**</a> - Proving a set of statements about an identifier.
+- <a href="#credential-revocation">**credential-revocation**</a> - Notifying a holder that a previously issued credential has been revoked.
+
+- <a href="#presentation-verification">**presentation-verification**</a> - Proving a set of statements about an identifier.
 
 ---
 ### trust-ping


### PR DESCRIPTION
Discussed in issue #187 
(Didn't realize docs/didcomms_spec wasn't deleted after last merge, hence this PR)

# Description of change

Adds three interactions for Verifiable Credential issuance, one for revocation, one for VP presentation.

---

The Verifiable Credential (VC) issuance flow consists of a three step interaction process between two parties, the <u>issuer</u> and the <u>holder</u>.

In the first interaction (Credential Options), the <u>holder</u> queries the <u>issuer</u> for a list of VC types that the <u>issuer</u> offers to issue.

In the second interaction (Credential Schema), the <u>holder</u> queries the <u>issuer</u> for the precise schema of one of the VCs that the <u>issuer</u> offers to issue, with it's own list of requirements which must be satisfied by the <u>holder</u> in order to qualify for the credential.

In the third interaction (Credential Issuance), the <u>holder</u> asks the <u>issuer</u> for issuance of a specific VC.

---

Credential Revocation will be notifying a holder that a previously issued credential has been revoked.

---

The credential verification flow is a simple request-response message exchange between the <u>verifier</u> and the <u>prover</u>. The interaction can consist of up to three messages, however two of them are OPTIONAL.

---

Discussed in issue #187 