### PR TITLE
Fix diff chain

### DIFF
--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -22,7 +22,7 @@ wasm-bindgen-futures = { version = "0.4", default-features = false }
 
 [dependencies.iota-core]
 git = "https://github.com/iotaledger/iota.rs"
-rev = "04de91aebc211b7d2291c17a900a4f2174109184"
+rev = "3201689a58e615b0b7ffb984b8ce46bff1546f9d"
 default-features = false
 features = ["async", "wasm"]
 

--- a/identity-core/src/crypto/merkle_key/verifier.rs
+++ b/identity-core/src/crypto/merkle_key/verifier.rs
@@ -101,14 +101,14 @@ where
     // Ensure the target hash of the user-provided public key is part
     // of the Merkle tree
     if !merkle_proof.verify(&merkle_root, target_hash) {
-      return Err(Error::InvalidProofValue);
+      return Err(Error::InvalidProofValue("merkle key - bad proof"));
     }
 
     // If a set of revocation flags was provided, ensure the public key
     // was not revoked
     if let Some(revocation) = public.revocation {
       if revocation.contains(merkle_proof.index() as u32) {
-        return Err(Error::InvalidProofValue);
+        return Err(Error::InvalidProofValue("merkle key - revoked"));
       }
     }
 

--- a/identity-core/src/crypto/proof/jcs_ed25519.rs
+++ b/identity-core/src/crypto/proof/jcs_ed25519.rs
@@ -58,7 +58,10 @@ where
   where
     X: Serialize,
   {
-    let signature: &str = signature.as_signature().ok_or(Error::InvalidProofValue)?;
+    let signature: &str = signature
+      .as_signature()
+      .ok_or(Error::InvalidProofValue("jcs ed25519"))?;
+
     let signature: Vec<u8> = decode_b58(signature)?;
     let message: Vec<u8> = data.to_jcs()?;
 

--- a/identity-core/src/crypto/signature/ed25519.rs
+++ b/identity-core/src/crypto/signature/ed25519.rs
@@ -42,7 +42,7 @@ where
     if key.verify(&sig, message) {
       Ok(())
     } else {
-      Err(Error::InvalidProofValue)
+      Err(Error::InvalidProofValue("ed25519"))
     }
   }
 }

--- a/identity-core/src/crypto/signature/traits/core.rs
+++ b/identity-core/src/crypto/signature/traits/core.rs
@@ -87,7 +87,7 @@ pub trait Verifier<Public: ?Sized>: Named {
     let signature: &Signature = data.try_signature()?;
 
     if signature.type_() != Self::NAME {
-      return Err(Error::InvalidProofValue);
+      return Err(Error::InvalidProofValue("signature name"));
     }
 
     signature.hide_value();

--- a/identity-core/src/error.rs
+++ b/identity-core/src/error.rs
@@ -45,8 +45,8 @@ pub enum Error {
   #[error("Invalid Timestamp: {0}")]
   InvalidTimestamp(#[from] chrono::ParseError),
   /// Raised by a validation attempt against an invalid DID proof.
-  #[error("Invalid Proof Value")]
-  InvalidProofValue,
+  #[error("Invalid Proof Value: {0}")]
+  InvalidProofValue(&'static str),
   /// Caused by attempting to parse an invalid DID proof.
   #[error("Invalid Proof Format")]
   InvalidProofFormat,

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = { version = "1.0", default-features = false }
 
 [dependencies.iota-core]
 git = "https://github.com/iotaledger/iota.rs"
-rev = "04de91aebc211b7d2291c17a900a4f2174109184"
+rev = "3201689a58e615b0b7ffb984b8ce46bff1546f9d"
 default-features = false
 features = ["async", "wasm"]
 

--- a/identity-iota/src/client/client.rs
+++ b/identity-iota/src/client/client.rs
@@ -12,7 +12,7 @@ use crate::did::DID;
 use crate::error::Error;
 use crate::error::Result;
 use futures::stream::FuturesUnordered;
-use futures::stream::StreamExt;
+use futures::stream::TryStreamExt;
 use identity_core::common::Url;
 use identity_core::convert::ToJson;
 use iota::Message;
@@ -173,9 +173,8 @@ impl Client {
       .iter()
       .map(|message| self.client.get_message().data(message))
       .collect::<FuturesUnordered<_>>()
-      .filter_map(|message| async move { message.ok() })
-      .collect()
-      .await;
+      .try_collect()
+      .await?;
 
     Ok(Messages { message_ids, messages })
   }

--- a/identity-iota/src/did/doc/diff.rs
+++ b/identity-iota/src/did/doc/diff.rs
@@ -26,9 +26,11 @@ use iota::MessageId;
 pub struct DocumentDiff {
   pub(crate) did: DID,
   pub(crate) diff: String,
-  pub(crate) previous_message_id: MessageId,
-  pub(crate) proof: Option<Signature>,
   #[serde(default = "MessageId::null", skip_serializing_if = "MessageIdExt::is_null")]
+  pub(crate) previous_message_id: MessageId,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub(crate) proof: Option<Signature>,
+  #[serde(default = "MessageId::null", skip)]
   pub(crate) message_id: MessageId,
 }
 
@@ -99,7 +101,7 @@ impl DocumentDiff {
       }
     };
 
-    // Update the `self` with the `MessageId` of the bundled transaction.
+    // Update `self` with the `MessageId` of the bundled transaction.
     self.set_message_id(message);
 
     Ok(())

--- a/identity-iota/src/tangle/mod.rs
+++ b/identity-iota/src/tangle/mod.rs
@@ -9,3 +9,6 @@ pub use self::message_ext::MessageExt;
 pub use self::message_ext::MessageIdExt;
 pub use self::message_index::MessageIndex;
 pub use self::traits::TangleRef;
+
+#[doc(inline)]
+pub use iota::MessageId;


### PR DESCRIPTION
# Description of change

Fix `DocumentDiff` signature verification - this was failing because `message_id` was included in the serialized data

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran examples locally

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
