### PR TITLE
Replace Network From<DID> with from_did()

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ async fn main() -> Result<()> {
   document.publish(&client).await?;
 
   // Print the DID Document IOTA transaction link.
-  let network: Network = document.id().into();
+  let network = Network::from_did(document.id());
   let explore: String = format!("{}/transaction/{}", network.explorer_url(), document.message_id());
   println!("DID Document Transaction > {}", explore);
 

--- a/examples/create_did_document.rs
+++ b/examples/create_did_document.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
   document.publish(&client).await?;
 
   // Print the DID Document IOTA transaction link.
-  let network: Network = document.id().into();
+  let network = Network::from_did(document.id());
   let explore: String = format!("{}/message/{}", network.explorer_url(), document.message_id());
   println!("DID Document Transaction > {}", explore);
 

--- a/identity-iota/src/client/network.rs
+++ b/identity-iota/src/client/network.rs
@@ -26,6 +26,11 @@ impl Network {
     }
   }
 
+  /// Returns the `Network` the `DID` is associated with.
+  pub fn from_did(did: &DID) -> Self {
+    Self::from_name(did.network())
+  }
+
   pub fn matches_did(self, did: &DID) -> bool {
     did.network() == self.as_str()
   }
@@ -58,12 +63,6 @@ impl Network {
 impl Default for Network {
   fn default() -> Self {
     Network::Mainnet
-  }
-}
-
-impl<'a> From<&'a DID> for Network {
-  fn from(other: &'a DID) -> Self {
-    Self::from_name(other.network())
   }
 }
 

--- a/identity-iota/src/did/doc/diff.rs
+++ b/identity-iota/src/did/doc/diff.rs
@@ -87,7 +87,7 @@ impl DocumentDiff {
   where
     C: Into<Option<&'client Client>>,
   {
-    let network: Network = (&self.did).into();
+    let network = Network::from_did(&self.did);
 
     // Publish the DID Document diff to the Tangle.
     let message: MessageId = match client.into() {

--- a/identity-iota/src/did/doc/document.rs
+++ b/identity-iota/src/did/doc/document.rs
@@ -358,7 +358,7 @@ impl Document {
   where
     C: Into<Option<&'client Client>>,
   {
-    let network: Network = self.id().into();
+    let network = Network::from_did(self.id());
 
     // Publish the DID Document to the Tangle.
     let message: MessageId = match client.into() {

--- a/identity/README.md
+++ b/identity/README.md
@@ -1,8 +1,9 @@
 ## IOTA Identity
+
 IOTA Identity is a [Rust](https://www.rust-lang.org/) implementation of decentralized identity, also known as Self Sovereign Identity (SSI), through the [W3C Decentralized Identifiers (DID)](https://w3c.github.io/did-core/) and [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/) standards alongside supporting methods, utilizing the [IOTA Distributed Ledger](https://www.iota.org).
 
-
 ## Example
+
 ```rust
 use identity::crypto::KeyPair;
 use identity::iota::Client;
@@ -30,7 +31,7 @@ async fn main() -> Result<()> {
   document.publish(&client).await?;
 
   // Print the DID Document transaction link.
-  let network: Network = document.id().into();
+  let network = Network::from_did(document.id());
   let explore: String = format!("{}/transaction/{}", network.explorer_url(), document.message_id());
 
   println!("DID Document Transaction > {}", explore);
@@ -42,6 +43,7 @@ async fn main() -> Result<()> {
 **Output**: Example DID Document in the [Tangle Explorer](https://explorer.iota.org/mainnet/transaction/LESUXJUMJCOWGHU9CQQUIHCIPYELOBMHZT9CHCYHJPO9BONQ9IQIFJSREYNOCTYCTQYBHBMBBWJJZ9999).
 
 ## Documentation & Community Resources
+
 - [identity.rs](https://github.com/iotaledger/identity.rs): Rust source code of this library on GitHub.
 - [Identity Documentation Pages](https://identity.docs.iota.org/welcome.html): Supplementing documentation with simple examples on library usage to get you started.
 - [More Examples](https://github.com/iotaledger/identity.rs/tree/dev/examples): Practical examples to get started with the library.
@@ -55,7 +57,5 @@ async fn main() -> Result<()> {
 - Simple Example
 - Architecture/Overview
 - Get
-
-
 
 License: Apache-2.0


### PR DESCRIPTION
# Description of change

Replace `Network`'s `From<DID>` trait instance with an explicit `Network::from_did()` function.

The `From` trait is usually used to convert between representationally equivalent types, in this case an explicit `from_did()` is more clear than an `.into()`.

This is an API only change, no change in functionality. Previously, one would write:

```rust
let network: Network = document.id().into();
```

After this change, one writes:

```rust
let network = Network::from_did(document.id());
```

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

API change only, re-built full project and examples.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

