### PR TITLE
Fix MessageIndex determinism

### DIFF
--- a/identity-iota/src/tangle/message_index.rs
+++ b/identity-iota/src/tangle/message_index.rs
@@ -47,8 +47,8 @@ where
 {
   pub fn insert(&mut self, element: T) {
     let key: &MessageId = element.previous_message_id();
-    let msg_id: &MessageId = element.message_id();
     if let Some(scope) = self.inner.get_mut(key) {
+      let msg_id: &MessageId = element.message_id();
       let idx = match scope.binary_search_by(|elem| elem.message_id().cmp(msg_id)) {
         Ok(idx) => idx,
         Err(idx) => idx,

--- a/identity-iota/src/tangle/message_index.rs
+++ b/identity-iota/src/tangle/message_index.rs
@@ -3,14 +3,13 @@
 
 use crate::tangle::TangleRef;
 use core::borrow::Borrow;
-use core::hash::Hash;
 use core::iter::FromIterator;
 use core::ops::Deref;
 use core::ops::DerefMut;
 use iota::MessageId;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
-type __Index<T> = HashMap<MessageId, Vec<T>>;
+type __Index<T> = BTreeMap<MessageId, Vec<T>>;
 
 #[derive(Clone, Debug)]
 pub struct MessageIndex<T> {
@@ -20,7 +19,7 @@ pub struct MessageIndex<T> {
 impl<T> MessageIndex<T> {
   /// Creates a new `MessageIndex`.
   pub fn new() -> Self {
-    Self { inner: HashMap::new() }
+    Self { inner: BTreeMap::new() }
   }
 
   /// Returns the total size of the index.
@@ -31,7 +30,7 @@ impl<T> MessageIndex<T> {
   pub fn remove_where<U>(&mut self, key: &U, f: impl Fn(&T) -> bool) -> Option<T>
   where
     MessageId: Borrow<U>,
-    U: Hash + Eq + ?Sized,
+    U: Ord,
   {
     if let Some(list) = self.inner.get_mut(key) {
       list.iter().position(f).map(|index| list.remove(index))

--- a/identity-iota/src/tangle/message_index.rs
+++ b/identity-iota/src/tangle/message_index.rs
@@ -3,13 +3,14 @@
 
 use crate::tangle::TangleRef;
 use core::borrow::Borrow;
+use core::hash::Hash;
 use core::iter::FromIterator;
 use core::ops::Deref;
 use core::ops::DerefMut;
 use iota::MessageId;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
-type __Index<T> = BTreeMap<MessageId, Vec<T>>;
+type __Index<T> = HashMap<MessageId, Vec<T>>;
 
 #[derive(Clone, Debug)]
 pub struct MessageIndex<T> {
@@ -19,7 +20,7 @@ pub struct MessageIndex<T> {
 impl<T> MessageIndex<T> {
   /// Creates a new `MessageIndex`.
   pub fn new() -> Self {
-    Self { inner: BTreeMap::new() }
+    Self { inner: HashMap::new() }
   }
 
   /// Returns the total size of the index.
@@ -30,7 +31,7 @@ impl<T> MessageIndex<T> {
   pub fn remove_where<U>(&mut self, key: &U, f: impl Fn(&T) -> bool) -> Option<T>
   where
     MessageId: Borrow<U>,
-    U: Ord,
+    U: Hash + Eq + ?Sized,
   {
     if let Some(list) = self.inner.get_mut(key) {
       list.iter().position(f).map(|index| list.remove(index))

--- a/identity-iota/src/tangle/message_index.rs
+++ b/identity-iota/src/tangle/message_index.rs
@@ -47,9 +47,13 @@ where
 {
   pub fn insert(&mut self, element: T) {
     let key: &MessageId = element.previous_message_id();
-
+    let msg_id: &MessageId = element.message_id();
     if let Some(scope) = self.inner.get_mut(key) {
-      scope.insert(0, element);
+      let idx = match scope.binary_search_by(|elem| elem.message_id().cmp(msg_id)) {
+        Ok(idx) => idx,
+        Err(idx) => idx,
+      };
+      scope.insert(idx, element);
     } else {
       self.inner.insert(*key, vec![element]);
     }


### PR DESCRIPTION
# Description of change
- Multiple elements with the same previous_message_id are ordered by their message_id
-  
## Links to any relevant issues
- fixes #201
- 
## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
