### PR TITLE
Rename types to contain prefixes (Core, Iota, Wasm)

### DIFF
--- a/bindings/wasm/src/credential/credential.rs
+++ b/bindings/wasm/src/credential/credential.rs
@@ -11,8 +11,8 @@ use identity::credential::CredentialBuilder;
 use identity::credential::Subject;
 use wasm_bindgen::prelude::*;
 
-use crate::document::Document;
 use crate::utils::err;
+use crate::wasm_document::WasmDocument;
 
 #[wasm_bindgen(inspectable)]
 #[derive(Clone, Debug, PartialEq)]
@@ -56,7 +56,7 @@ impl VerifiableCredential {
 
   #[wasm_bindgen]
   pub fn issue(
-    issuer_doc: &Document,
+    issuer_doc: &WasmDocument,
     subject_data: &JsValue,
     credential_type: Option<String>,
     credential_id: Option<String>,

--- a/bindings/wasm/src/credential/presentation.rs
+++ b/bindings/wasm/src/credential/presentation.rs
@@ -8,8 +8,8 @@ use identity::credential::Presentation;
 use identity::credential::PresentationBuilder;
 use wasm_bindgen::prelude::*;
 
-use crate::document::Document;
 use crate::utils::err;
+use crate::wasm_document::WasmDocument;
 
 #[wasm_bindgen(inspectable)]
 #[derive(Clone, Debug, PartialEq)]
@@ -19,7 +19,7 @@ pub struct VerifiablePresentation(pub(crate) Presentation);
 impl VerifiablePresentation {
   #[wasm_bindgen(constructor)]
   pub fn new(
-    holder_doc: &Document,
+    holder_doc: &WasmDocument,
     credential_data: JsValue,
     presentation_type: Option<String>,
     presentation_id: Option<String>,

--- a/bindings/wasm/src/iota.rs
+++ b/bindings/wasm/src/iota.rs
@@ -9,9 +9,9 @@ use identity::iota::Network;
 use identity::iota::PresentationValidation;
 use wasm_bindgen::prelude::*;
 
-use crate::did::DID;
-use crate::document::Document;
 use crate::utils::err;
+use crate::wasm_did::WasmDID;
+use crate::wasm_document::WasmDocument;
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
@@ -52,7 +52,7 @@ async fn client(params: JsValue) -> Result<Client, JsValue> {
 #[wasm_bindgen]
 pub async fn publish(document: JsValue, params: JsValue) -> Result<JsValue, JsValue> {
   let client: Client = client(params).await?;
-  let document: Document = Document::from_json(&document)?;
+  let document: WasmDocument = WasmDocument::from_json(&document)?;
 
   client
     .publish_document(&document.0)
@@ -66,7 +66,7 @@ pub async fn publish(document: JsValue, params: JsValue) -> Result<JsValue, JsVa
 #[wasm_bindgen]
 pub async fn resolve(did: String, params: JsValue) -> Result<JsValue, JsValue> {
   let client: Client = client(params).await?;
-  let did: DID = DID::parse(&did)?;
+  let did: WasmDID = WasmDID::parse(&did)?;
 
   client
     .read_document(&did.0)

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -14,11 +14,11 @@ mod utils;
 
 pub mod credential;
 pub mod crypto;
-pub mod did;
-pub mod document;
 pub mod iota;
-pub mod method;
 pub mod service;
+pub mod wasm_did;
+pub mod wasm_document;
+pub mod wasm_method;
 
 /// Initializes the console error panic hook for better error messages
 #[wasm_bindgen(start)]

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -18,7 +18,7 @@ pub mod iota;
 pub mod service;
 pub mod wasm_did;
 pub mod wasm_document;
-pub mod wasm_method;
+pub mod wasm_verification_method;
 
 /// Initializes the console error panic hook for better error messages
 #[wasm_bindgen(start)]

--- a/bindings/wasm/src/wasm_did.rs
+++ b/bindings/wasm/src/wasm_did.rs
@@ -9,7 +9,7 @@ use crate::crypto::KeyPair;
 use crate::utils::err;
 
 /// @typicalname did
-#[wasm_bindgen(inspectable)]
+#[wasm_bindgen(js_name = DID, inspectable)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct WasmDID(pub(crate) IotaDID);
 

--- a/bindings/wasm/src/wasm_did.rs
+++ b/bindings/wasm/src/wasm_did.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use identity::core::decode_b58;
-use identity::iota::DID as IotaDID;
+use identity::iota::IotaDID;
 use wasm_bindgen::prelude::*;
 
 use crate::crypto::KeyPair;
@@ -11,13 +11,13 @@ use crate::utils::err;
 /// @typicalname did
 #[wasm_bindgen(inspectable)]
 #[derive(Clone, Debug, PartialEq)]
-pub struct DID(pub(crate) IotaDID);
+pub struct WasmDID(pub(crate) IotaDID);
 
 #[wasm_bindgen]
-impl DID {
-  /// Creates a new `DID` from a `KeyPair` object.
+impl WasmDID {
+  /// Creates a new `WasmDID` from a `KeyPair` object.
   #[wasm_bindgen(constructor)]
-  pub fn new(key: &KeyPair, network: Option<String>, shard: Option<String>) -> Result<DID, JsValue> {
+  pub fn new(key: &KeyPair, network: Option<String>, shard: Option<String>) -> Result<WasmDID, JsValue> {
     let public: &[u8] = key.0.public().as_ref();
     let network: Option<&str> = network.as_deref();
     let shard: Option<&str> = shard.as_deref();
@@ -25,9 +25,9 @@ impl DID {
     IotaDID::from_components(public, network, shard).map_err(err).map(Self)
   }
 
-  /// Creates a new `DID` from a base58-encoded public key.
+  /// Creates a new `WasmDID` from a base58-encoded public key.
   #[wasm_bindgen(js_name = fromBase58)]
-  pub fn from_base58(key: &str, network: Option<String>, shard: Option<String>) -> Result<DID, JsValue> {
+  pub fn from_base58(key: &str, network: Option<String>, shard: Option<String>) -> Result<WasmDID, JsValue> {
     let public: Vec<u8> = decode_b58(key).map_err(err)?;
     let network: Option<&str> = network.as_deref();
     let shard: Option<&str> = shard.as_deref();
@@ -35,25 +35,25 @@ impl DID {
     IotaDID::from_components(&public, network, shard).map_err(err).map(Self)
   }
 
-  /// Parses a `DID` from the input string.
+  /// Parses a `WasmDID` from the input string.
   #[wasm_bindgen]
-  pub fn parse(input: &str) -> Result<DID, JsValue> {
+  pub fn parse(input: &str) -> Result<WasmDID, JsValue> {
     IotaDID::parse(input).map_err(err).map(Self)
   }
 
-  /// Returns the IOTA tangle network of the `DID`.
+  /// Returns the IOTA tangle network of the `WasmDID`.
   #[wasm_bindgen(getter)]
   pub fn network(&self) -> String {
     self.0.network().into()
   }
 
-  /// Returns the IOTA tangle shard of the `DID` (if any).
+  /// Returns the IOTA tangle shard of the `WasmDID` (if any).
   #[wasm_bindgen(getter)]
   pub fn shard(&self) -> Option<String> {
     self.0.shard().map(Into::into)
   }
 
-  /// Returns the unique tag of the `DID`.
+  /// Returns the unique tag of the `WasmDID`.
   #[wasm_bindgen(getter)]
   pub fn tag(&self) -> String {
     self.0.tag().into()

--- a/bindings/wasm/src/wasm_document.rs
+++ b/bindings/wasm/src/wasm_document.rs
@@ -125,7 +125,7 @@ impl WasmDocument {
   }
 
   #[wasm_bindgen(js_name = removeService)]
-  pub fn remove_service(&mut self, did: &DID) -> Result<(), JsValue> {
+  pub fn remove_service(&mut self, did: &WasmDID) -> Result<(), JsValue> {
     self.0.remove_service(&did.0).map_err(err)
   }
 

--- a/bindings/wasm/src/wasm_document.rs
+++ b/bindings/wasm/src/wasm_document.rs
@@ -23,10 +23,10 @@ use crate::credential::VerifiableCredential;
 use crate::credential::VerifiablePresentation;
 use crate::crypto::KeyPair;
 use crate::crypto::KeyType;
-use crate::did::DID;
-use crate::method::Method;
 use crate::service::Service;
 use crate::utils::err;
+use crate::wasm_did::WasmDID;
+use crate::wasm_method::WasmMethod;
 
 #[wasm_bindgen(inspectable)]
 pub struct NewDocument {
@@ -78,7 +78,7 @@ impl WasmDocument {
 
   /// Creates a new DID Document from the given verification [`method`][`Method`].
   #[wasm_bindgen(js_name = fromAuthentication)]
-  pub fn from_authentication(method: &Method) -> Result<WasmDocument, JsValue> {
+  pub fn from_authentication(method: &WasmMethod) -> Result<WasmDocument, JsValue> {
     IotaDocument::from_authentication(method.0.clone())
       .map_err(err)
       .map(Self)
@@ -90,8 +90,8 @@ impl WasmDocument {
 
   /// Returns the DID Document `id`.
   #[wasm_bindgen(getter)]
-  pub fn id(&self) -> DID {
-    DID(self.0.id().clone())
+  pub fn id(&self) -> WasmDID {
+    WasmDID(self.0.id().clone())
   }
 
   /// Returns the DID Document `proof` object.
@@ -108,14 +108,14 @@ impl WasmDocument {
   // ===========================================================================
 
   #[wasm_bindgen(js_name = insertMethod)]
-  pub fn insert_method(&mut self, method: &Method, scope: Option<String>) -> Result<bool, JsValue> {
+  pub fn insert_method(&mut self, method: &WasmMethod, scope: Option<String>) -> Result<bool, JsValue> {
     let scope: MethodScope = scope.unwrap_or_default().parse().map_err(err)?;
 
     Ok(self.0.insert_method(scope, method.0.clone()))
   }
 
   #[wasm_bindgen(js_name = removeMethod)]
-  pub fn remove_method(&mut self, did: &DID) -> Result<(), JsValue> {
+  pub fn remove_method(&mut self, did: &WasmDID) -> Result<(), JsValue> {
     self.0.remove_method(&did.0).map_err(err)
   }
 
@@ -235,10 +235,10 @@ impl WasmDocument {
   }
 
   #[wasm_bindgen(js_name = resolveKey)]
-  pub fn resolve_key(&mut self, query: &str) -> Result<Method, JsValue> {
+  pub fn resolve_key(&mut self, query: &str) -> Result<WasmMethod, JsValue> {
     let method: VerificationMethod = self.0.try_resolve(query).map_err(err)?.clone();
 
-    IotaMethod::try_from_core(method).map_err(err).map(Method)
+    IotaMethod::try_from_core(method).map_err(err).map(WasmMethod)
   }
 
   #[wasm_bindgen(js_name = revokeMerkleKey)]
@@ -276,15 +276,15 @@ impl WasmDocument {
     Ok(())
   }
 
-  /// Serializes a `Document` object as a JSON object.
+  /// Serializes a `WasmDocument` object as a JSON object.
   #[wasm_bindgen(js_name = toJSON)]
   pub fn to_json(&self) -> Result<JsValue, JsValue> {
     JsValue::from_serde(&self.0).map_err(err)
   }
 
-  /// Deserializes a `Document` object from a JSON object.
+  /// Deserializes a `WasmDocument` object from a JSON object.
   #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<Document, JsValue> {
+  pub fn from_json(json: &JsValue) -> Result<WasmDocument, JsValue> {
     json.into_serde().map_err(err).map(Self)
   }
 }

--- a/bindings/wasm/src/wasm_method.rs
+++ b/bindings/wasm/src/wasm_method.rs
@@ -13,19 +13,19 @@ use crate::utils::err;
 
 #[wasm_bindgen(inspectable)]
 #[derive(Clone, Debug, PartialEq)]
-pub struct Method(pub(crate) Method_);
+pub struct WasmMethod(pub(crate) Method_);
 
 #[wasm_bindgen]
-impl Method {
-  /// Creates a new `Method` object from the given `key`.
+impl WasmMethod {
+  /// Creates a new `WasmMethod` object from the given `key`.
   #[wasm_bindgen(constructor)]
-  pub fn new(key: &KeyPair, tag: Option<String>) -> Result<Method, JsValue> {
+  pub fn new(key: &KeyPair, tag: Option<String>) -> Result<WasmMethod, JsValue> {
     Method_::from_keypair(&key.0, tag.as_deref()).map_err(err).map(Self)
   }
 
-  /// Creates a new `Method` object from the given `did` and `key`.
+  /// Creates a new `WasmMethod` object from the given `did` and `key`.
   #[wasm_bindgen(js_name = fromDID)]
-  pub fn from_did(did: &DID, key: &KeyPair, tag: Option<String>) -> Result<Method, JsValue> {
+  pub fn from_did(did: &DID, key: &KeyPair, tag: Option<String>) -> Result<WasmMethod, JsValue> {
     Method_::from_did(did.0.clone(), &key.0, tag.as_deref())
       .map_err(err)
       .map(Self)
@@ -38,7 +38,7 @@ impl Method {
     did: &DID,
     keys: &KeyCollection,
     tag: Option<String>,
-  ) -> Result<Method, JsValue> {
+  ) -> Result<WasmMethod, JsValue> {
     match digest {
       Digest::Sha256 => Method_::create_merkle_key::<Sha256, _>(did.0.clone(), &keys.0, tag.as_deref())
         .map_err(err)
@@ -46,39 +46,39 @@ impl Method {
     }
   }
 
-  /// Returns the `id` DID of the `Method` object.
+  /// Returns the `id` DID of the `WasmMethod` object.
   #[wasm_bindgen(getter)]
   pub fn id(&self) -> DID {
     DID(self.0.id().clone())
   }
 
-  /// Returns the `controller` DID of the `Method` object.
+  /// Returns the `controller` DID of the `WasmMethod` object.
   #[wasm_bindgen(getter)]
   pub fn controller(&self) -> DID {
     DID(self.0.controller().clone())
   }
 
-  /// Returns the `Method` type.
+  /// Returns the `WasmMethod` type.
   #[wasm_bindgen(getter, js_name = type)]
   pub fn type_(&self) -> String {
     self.0.key_type().as_str().into()
   }
 
-  /// Returns the `Method` public key data.
+  /// Returns the `WasmMethod` public key data.
   #[wasm_bindgen(getter)]
   pub fn data(&self) -> Result<JsValue, JsValue> {
     JsValue::from_serde(self.0.key_data()).map_err(err)
   }
 
-  /// Serializes a `Method` object as a JSON object.
+  /// Serializes a `WasmMethod` object as a JSON object.
   #[wasm_bindgen(js_name = toJSON)]
   pub fn to_json(&self) -> Result<JsValue, JsValue> {
     JsValue::from_serde(&self.0).map_err(err)
   }
 
-  /// Deserializes a `Method` object from a JSON object.
+  /// Deserializes a `WasmMethod` object from a JSON object.
   #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(value: &JsValue) -> Result<Method, JsValue> {
+  pub fn from_json(value: &JsValue) -> Result<WasmMethod, JsValue> {
     value.into_serde().map_err(err).map(Self)
   }
 }

--- a/bindings/wasm/src/wasm_method.rs
+++ b/bindings/wasm/src/wasm_method.rs
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use identity::crypto::merkle_key::Sha256;
-use identity::iota::Method as Method_;
+use identity::iota::IotaMethod as Method_;
 use wasm_bindgen::prelude::*;
 
 use crate::crypto::Digest;
 use crate::crypto::KeyCollection;
 use crate::crypto::KeyPair;
-use crate::did::DID;
 use crate::utils::err;
+use crate::wasm_did::WasmDID;
 
 #[wasm_bindgen(inspectable)]
 #[derive(Clone, Debug, PartialEq)]
@@ -25,7 +25,7 @@ impl WasmMethod {
 
   /// Creates a new `WasmMethod` object from the given `did` and `key`.
   #[wasm_bindgen(js_name = fromDID)]
-  pub fn from_did(did: &DID, key: &KeyPair, tag: Option<String>) -> Result<WasmMethod, JsValue> {
+  pub fn from_did(did: &WasmDID, key: &KeyPair, tag: Option<String>) -> Result<WasmMethod, JsValue> {
     Method_::from_did(did.0.clone(), &key.0, tag.as_deref())
       .map_err(err)
       .map(Self)
@@ -35,7 +35,7 @@ impl WasmMethod {
   #[wasm_bindgen(js_name = createMerkleKey)]
   pub fn create_merkle_key(
     digest: Digest,
-    did: &DID,
+    did: &WasmDID,
     keys: &KeyCollection,
     tag: Option<String>,
   ) -> Result<WasmMethod, JsValue> {
@@ -48,14 +48,14 @@ impl WasmMethod {
 
   /// Returns the `id` DID of the `WasmMethod` object.
   #[wasm_bindgen(getter)]
-  pub fn id(&self) -> DID {
-    DID(self.0.id().clone())
+  pub fn id(&self) -> WasmDID {
+    WasmDID(self.0.id().clone())
   }
 
   /// Returns the `controller` DID of the `WasmMethod` object.
   #[wasm_bindgen(getter)]
-  pub fn controller(&self) -> DID {
-    DID(self.0.controller().clone())
+  pub fn controller(&self) -> WasmDID {
+    WasmDID(self.0.controller().clone())
   }
 
   /// Returns the `WasmMethod` type.

--- a/bindings/wasm/src/wasm_verification_method.rs
+++ b/bindings/wasm/src/wasm_verification_method.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use identity::crypto::merkle_key::Sha256;
-use identity::iota::IotaVerificationMethod as Method_;
+use identity::iota::IotaVerificationMethod;
 use wasm_bindgen::prelude::*;
 
 use crate::crypto::Digest;
@@ -13,7 +13,7 @@ use crate::wasm_did::WasmDID;
 
 #[wasm_bindgen(inspectable)]
 #[derive(Clone, Debug, PartialEq)]
-pub struct WasmVerificationMethod(pub(crate) Method_);
+pub struct WasmVerificationMethod(pub(crate) IotaVerificationMethod);
 
 #[wasm_bindgen]
 impl WasmVerificationMethod {

--- a/bindings/wasm/src/wasm_verification_method.rs
+++ b/bindings/wasm/src/wasm_verification_method.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use identity::crypto::merkle_key::Sha256;
-use identity::iota::IotaMethod as Method_;
+use identity::iota::IotaVerificationMethod as Method_;
 use wasm_bindgen::prelude::*;
 
 use crate::crypto::Digest;
@@ -13,19 +13,19 @@ use crate::wasm_did::WasmDID;
 
 #[wasm_bindgen(inspectable)]
 #[derive(Clone, Debug, PartialEq)]
-pub struct WasmMethod(pub(crate) Method_);
+pub struct WasmVerificationMethod(pub(crate) Method_);
 
 #[wasm_bindgen]
-impl WasmMethod {
-  /// Creates a new `WasmMethod` object from the given `key`.
+impl WasmVerificationMethod {
+  /// Creates a new `WasmVerificationMethod` object from the given `key`.
   #[wasm_bindgen(constructor)]
-  pub fn new(key: &KeyPair, tag: Option<String>) -> Result<WasmMethod, JsValue> {
+  pub fn new(key: &KeyPair, tag: Option<String>) -> Result<WasmVerificationMethod, JsValue> {
     Method_::from_keypair(&key.0, tag.as_deref()).map_err(err).map(Self)
   }
 
-  /// Creates a new `WasmMethod` object from the given `did` and `key`.
+  /// Creates a new `WasmVerificationMethod` object from the given `did` and `key`.
   #[wasm_bindgen(js_name = fromDID)]
-  pub fn from_did(did: &WasmDID, key: &KeyPair, tag: Option<String>) -> Result<WasmMethod, JsValue> {
+  pub fn from_did(did: &WasmDID, key: &KeyPair, tag: Option<String>) -> Result<WasmVerificationMethod, JsValue> {
     Method_::from_did(did.0.clone(), &key.0, tag.as_deref())
       .map_err(err)
       .map(Self)
@@ -38,7 +38,7 @@ impl WasmMethod {
     did: &WasmDID,
     keys: &KeyCollection,
     tag: Option<String>,
-  ) -> Result<WasmMethod, JsValue> {
+  ) -> Result<WasmVerificationMethod, JsValue> {
     match digest {
       Digest::Sha256 => Method_::create_merkle_key::<Sha256, _>(did.0.clone(), &keys.0, tag.as_deref())
         .map_err(err)
@@ -46,39 +46,39 @@ impl WasmMethod {
     }
   }
 
-  /// Returns the `id` DID of the `WasmMethod` object.
+  /// Returns the `id` DID of the `WasmVerificationMethod` object.
   #[wasm_bindgen(getter)]
   pub fn id(&self) -> WasmDID {
     WasmDID(self.0.id().clone())
   }
 
-  /// Returns the `controller` DID of the `WasmMethod` object.
+  /// Returns the `controller` DID of the `WasmVerificationMethod` object.
   #[wasm_bindgen(getter)]
   pub fn controller(&self) -> WasmDID {
     WasmDID(self.0.controller().clone())
   }
 
-  /// Returns the `WasmMethod` type.
+  /// Returns the `WasmVerificationMethod` type.
   #[wasm_bindgen(getter, js_name = type)]
   pub fn type_(&self) -> String {
     self.0.key_type().as_str().into()
   }
 
-  /// Returns the `WasmMethod` public key data.
+  /// Returns the `WasmVerificationMethod` public key data.
   #[wasm_bindgen(getter)]
   pub fn data(&self) -> Result<JsValue, JsValue> {
     JsValue::from_serde(self.0.key_data()).map_err(err)
   }
 
-  /// Serializes a `WasmMethod` object as a JSON object.
+  /// Serializes a `WasmVerificationMethod` object as a JSON object.
   #[wasm_bindgen(js_name = toJSON)]
   pub fn to_json(&self) -> Result<JsValue, JsValue> {
     JsValue::from_serde(&self.0).map_err(err)
   }
 
-  /// Deserializes a `WasmMethod` object from a JSON object.
+  /// Deserializes a `WasmVerificationMethod` object from a JSON object.
   #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(value: &JsValue) -> Result<WasmMethod, JsValue> {
+  pub fn from_json(value: &JsValue) -> Result<WasmVerificationMethod, JsValue> {
     value.into_serde().map_err(err).map(Self)
   }
 }

--- a/bindings/wasm/src/wasm_verification_method.rs
+++ b/bindings/wasm/src/wasm_verification_method.rs
@@ -20,13 +20,15 @@ impl WasmVerificationMethod {
   /// Creates a new `WasmVerificationMethod` object from the given `key`.
   #[wasm_bindgen(constructor)]
   pub fn new(key: &KeyPair, tag: Option<String>) -> Result<WasmVerificationMethod, JsValue> {
-    Method_::from_keypair(&key.0, tag.as_deref()).map_err(err).map(Self)
+    IotaVerificationMethod::from_keypair(&key.0, tag.as_deref())
+      .map_err(err)
+      .map(Self)
   }
 
   /// Creates a new `WasmVerificationMethod` object from the given `did` and `key`.
   #[wasm_bindgen(js_name = fromDID)]
   pub fn from_did(did: &WasmDID, key: &KeyPair, tag: Option<String>) -> Result<WasmVerificationMethod, JsValue> {
-    Method_::from_did(did.0.clone(), &key.0, tag.as_deref())
+    IotaVerificationMethod::from_did(did.0.clone(), &key.0, tag.as_deref())
       .map_err(err)
       .map(Self)
   }
@@ -40,7 +42,7 @@ impl WasmVerificationMethod {
     tag: Option<String>,
   ) -> Result<WasmVerificationMethod, JsValue> {
     match digest {
-      Digest::Sha256 => Method_::create_merkle_key::<Sha256, _>(did.0.clone(), &keys.0, tag.as_deref())
+      Digest::Sha256 => IotaVerificationMethod::create_merkle_key::<Sha256, _>(did.0.clone(), &keys.0, tag.as_deref())
         .map_err(err)
         .map(Self),
     }

--- a/bindings/wasm/tests/wasm.rs
+++ b/bindings/wasm/tests/wasm.rs
@@ -7,8 +7,8 @@ use identity_wasm::crypto::Digest;
 use identity_wasm::crypto::KeyCollection;
 use identity_wasm::crypto::KeyPair;
 use identity_wasm::crypto::KeyType;
-use identity_wasm::did::DID;
-use identity_wasm::document::Document;
+use identity_wasm::wasm_did::WasmDID;
+use identity_wasm::wasm_document::WasmDocument;
 
 #[wasm_bindgen_test]
 fn test_keypair() {
@@ -62,17 +62,17 @@ fn test_key_collection() {
 #[test]
 fn test_did() {
   let key = KeyPair::new(KeyType::Ed25519).unwrap();
-  let did = DID::new(&key, None, None).unwrap();
+  let did = WasmDID::new(&key, None, None).unwrap();
 
   assert_eq!(did.network(), "main");
   assert_eq!(did.shard(), None);
 
-  let parsed = DID::parse(&did.to_string()).unwrap();
+  let parsed = WasmDID::parse(&did.to_string()).unwrap();
 
   assert_eq!(did.to_string(), parsed.to_string());
 
   let public = key.public();
-  let base58 = DID::from_base58(&public, Some("com".to_string()), Some("xyz".to_string())).unwrap();
+  let base58 = WasmDID::from_base58(&public, Some("com".to_string()), Some("xyz".to_string())).unwrap();
 
   assert_eq!(base58.tag(), did.tag());
   assert_eq!(base58.network(), "com");
@@ -81,7 +81,7 @@ fn test_did() {
 
 #[test]
 fn test_document() {
-  let output = Document::new(KeyType::Ed25519, None).unwrap();
+  let output = WasmDocument::new(KeyType::Ed25519, None).unwrap();
 
   let mut doc = output.doc();
   let key = output.key();

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -13,17 +13,17 @@ use identity::credential::CredentialBuilder;
 use identity::credential::Subject;
 use identity::crypto::KeyPair;
 use identity::iota::Client;
-use identity::iota::Document;
+use identity::iota::IotaDocument;
 use identity::iota::Result;
 
 // A helper function to generate a new DID Document/KeyPair, sign the
 // document, publish it to the Tangle, and return the Document/KeyPair.
-pub async fn create_did_document(client: &Client) -> Result<(Document, KeyPair)> {
+pub async fn create_did_document(client: &Client) -> Result<(IotaDocument, KeyPair)> {
   // Generate a new DID Document and public/private key pair.
   // The generated document will have an authentication key associated with
   // the keypair.
   let keypair: KeyPair = KeyPair::new_ed25519()?;
-  let mut document: Document = Document::from_keypair(&keypair)?;
+  let mut document: IotaDocument = IotaDocument::from_keypair(&keypair)?;
 
   // Sign the DID Document with the default authentication key.
   document.sign(keypair.secret())?;
@@ -37,7 +37,7 @@ pub async fn create_did_document(client: &Client) -> Result<(Document, KeyPair)>
 
 // Helper that takes two DID Documents (identities) for issuer and subject, and
 // creates a credential with claims about subject by issuer.
-pub fn issue_degree(issuer: &Document, subject: &Document) -> Result<Credential> {
+pub fn issue_degree(issuer: &IotaDocument, subject: &IotaDocument) -> Result<Credential> {
   // Create VC "subject" field containing subject ID and claims about it.
   let subject: Subject = Subject::from_json_value(json!({
     "id": subject.id().as_str(),

--- a/examples/create_did_document.rs
+++ b/examples/create_did_document.rs
@@ -14,7 +14,7 @@ use identity::prelude::*;
 async fn main() -> Result<()> {
   // Create a DID Document (an identity).
   let keypair: KeyPair = KeyPair::new_ed25519()?;
-  let mut document: Document = Document::from_keypair(&keypair)?;
+  let mut document: IotaDocument = IotaDocument::from_keypair(&keypair)?;
 
   // Sign the DID Document with the default authentication key.
   document.sign(keypair.secret())?;

--- a/examples/diff_chain.rs
+++ b/examples/diff_chain.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
 
   {
     let keypair: KeyPair = KeyPair::new_ed25519()?;
-    let mut document: Document = Document::from_keypair(&keypair)?;
+    let mut document: IotaDocument = IotaDocument::from_keypair(&keypair)?;
     document.sign(keypair.secret())?;
     document.publish(&client).await?;
 
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
   sleep(Duration::from_secs(1));
 
   {
-    let mut new: Document = chain.current().clone();
+    let mut new: IotaDocument = chain.current().clone();
     let keypair: KeyPair = KeyPair::new_ed25519().unwrap();
 
     let authentication: MethodRef = MethodBuilder::default()
@@ -86,8 +86,8 @@ async fn main() -> Result<()> {
   sleep(Duration::from_secs(1));
 
   {
-    let new: Document = {
-      let mut this: Document = chain.current().clone();
+    let new: IotaDocument = {
+      let mut this: IotaDocument = chain.current().clone();
       this.properties_mut().insert("foo".into(), 123.into());
       this.properties_mut().insert("bar".into(), 456.into());
       this.set_updated(Timestamp::now());
@@ -113,7 +113,7 @@ async fn main() -> Result<()> {
   sleep(Duration::from_secs(1));
 
   {
-    let mut new: Document = chain.current().clone();
+    let mut new: IotaDocument = chain.current().clone();
     let keypair: KeyPair = KeyPair::new_ed25519().unwrap();
 
     let authentication: MethodRef = MethodBuilder::default()
@@ -145,8 +145,8 @@ async fn main() -> Result<()> {
   sleep(Duration::from_secs(1));
 
   {
-    let new: Document = {
-      let mut this: Document = chain.current().clone();
+    let new: IotaDocument = {
+      let mut this: IotaDocument = chain.current().clone();
       this.properties_mut().insert("baz".into(), 789.into());
       this.properties_mut().remove("bar");
       this.set_updated(Timestamp::now());
@@ -173,8 +173,8 @@ async fn main() -> Result<()> {
   println!("Chain (R) {:#}", remote);
   println!();
 
-  let a: &Document = chain.current();
-  let b: &Document = remote.current();
+  let a: &IotaDocument = chain.current();
+  let b: &IotaDocument = remote.current();
 
   // The current document in the resolved chain should be identical to the
   // current document in our local chain.
@@ -197,8 +197,8 @@ async fn main() -> Result<()> {
   println!("Chain (R) {:#}", remote);
   println!();
 
-  let a: &Document = chain.current();
-  let b: &Document = remote.current();
+  let a: &IotaDocument = chain.current();
+  let b: &IotaDocument = remote.current();
 
   // The current document in the resolved chain should be identical to the
   // current document in our local chain.
@@ -221,8 +221,8 @@ async fn main() -> Result<()> {
   println!("Chain (R) {:#}", remote);
   println!();
 
-  let a: &Document = chain.current();
-  let b: &Document = remote.current();
+  let a: &IotaDocument = chain.current();
+  let b: &IotaDocument = remote.current();
 
   // The current document in the resolved chain should not be identical to
   // the current document in our local chain because you read an outdated

--- a/examples/manipulate_did_document.rs
+++ b/examples/manipulate_did_document.rs
@@ -6,14 +6,14 @@
 //! cargo run --example manipulate_did_document
 
 use identity::crypto::KeyPair;
-use identity::iota::Document;
+use identity::iota::IotaDocument;
 use identity::iota::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
   // Create a DID Document out of an ed25519 keypair.
   let keypair: KeyPair = KeyPair::new_ed25519()?;
-  let mut document: identity::iota::Document = Document::from_keypair(&keypair)?;
+  let mut document: identity::iota::IotaDocument = IotaDocument::from_keypair(&keypair)?;
 
   // Sign the DID Document with the default authentication key.
   document.sign(keypair.secret())?;
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
   println!();
 
   // We can also add and remove methods from a DID Document using insert_method() and remove_method() respectively.
-  let method: &identity::did::Method = document.methods().next().unwrap();
+  let method: &identity::did::VerificationMethod = document.methods().next().unwrap();
   let _method_did: &identity::did::DID = method.id();
   // document.remove_method(identity::iota::DID::new(public: &[u8]));
 

--- a/examples/manipulate_did_document.rs
+++ b/examples/manipulate_did_document.rs
@@ -13,7 +13,7 @@ use identity::iota::Result;
 async fn main() -> Result<()> {
   // Create a DID Document out of an ed25519 keypair.
   let keypair: KeyPair = KeyPair::new_ed25519()?;
-  let mut document: identity::iota::IotaDocument = IotaDocument::from_keypair(&keypair)?;
+  let mut document: IotaDocument = IotaDocument::from_keypair(&keypair)?;
 
   // Sign the DID Document with the default authentication key.
   document.sign(keypair.secret())?;

--- a/examples/merkle_key.rs
+++ b/examples/merkle_key.rs
@@ -22,7 +22,7 @@ use identity::crypto::SecretKey;
 use identity::did::resolution::resolve;
 use identity::did::resolution::Resolution;
 use identity::did::MethodScope;
-use identity::iota::Method;
+use identity::iota::IotaMethod;
 use identity::iota::TangleRef;
 use identity::prelude::*;
 use rand::rngs::OsRng;
@@ -36,14 +36,14 @@ async fn main() -> Result<()> {
   let client: Client = Client::new().await?;
 
   // Create a new DID Document, signed and published.
-  let (mut doc, auth): (Document, KeyPair) = common::create_did_document(&client).await?;
+  let (mut doc, auth): (IotaDocument, KeyPair) = common::create_did_document(&client).await?;
 
   // Generate a collection of ed25519 keys for signing credentials
   let keys: KeyCollection = KeyCollection::new_ed25519(LEAVES)?;
 
   // Generate a Merkle Key Collection Verification Method
   // with SHA-256 as  the digest algorithm.
-  let method: Method = Method::create_merkle_key::<Sha256, _>(doc.id().clone(), &keys, "key-collection")?;
+  let method: IotaMethod = IotaMethod::create_merkle_key::<Sha256, _>(doc.id().clone(), &keys, "key-collection")?;
 
   // Append the new verification method to the set of existing methods
   doc.insert_method(MethodScope::VerificationMethod, method);
@@ -122,7 +122,11 @@ async fn main() -> Result<()> {
 
   // Resolve the DID and receive the latest document version
   let resolution: Resolution = resolve(doc.id().as_str(), Default::default(), &client).await?;
-  let document: Document = resolution.document.map(Document::try_from_core).transpose()?.unwrap();
+  let document: IotaDocument = resolution
+    .document
+    .map(IotaDocument::try_from_core)
+    .transpose()?
+    .unwrap();
 
   println!("metadata: {:#?}", resolution.metadata);
   println!("document: {:#?}", document);

--- a/examples/merkle_key.rs
+++ b/examples/merkle_key.rs
@@ -22,7 +22,7 @@ use identity::crypto::SecretKey;
 use identity::did::resolution::resolve;
 use identity::did::resolution::Resolution;
 use identity::did::MethodScope;
-use identity::iota::IotaMethod;
+use identity::iota::IotaVerificationMethod;
 use identity::iota::TangleRef;
 use identity::prelude::*;
 use rand::rngs::OsRng;
@@ -43,7 +43,8 @@ async fn main() -> Result<()> {
 
   // Generate a Merkle Key Collection Verification Method
   // with SHA-256 as  the digest algorithm.
-  let method: IotaMethod = IotaMethod::create_merkle_key::<Sha256, _>(doc.id().clone(), &keys, "key-collection")?;
+  let method: IotaVerificationMethod =
+    IotaVerificationMethod::create_merkle_key::<Sha256, _>(doc.id().clone(), &keys, "key-collection")?;
 
   // Append the new verification method to the set of existing methods
   doc.insert_method(MethodScope::VerificationMethod, method);

--- a/examples/resolution.rs
+++ b/examples/resolution.rs
@@ -12,7 +12,7 @@ use identity::core::SerdeInto;
 use identity::did::resolution;
 use identity::did::resolution::Resource;
 use identity::did::resolution::SecondaryResource;
-use identity::iota::DID;
+use identity::iota::IotaDID;
 use identity::prelude::*;
 
 #[tokio::main]
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
 
   // Create a DID Document using the Ed25519 public key as the authentication
   // method. The DID URL is also derived from the public key value.
-  let mut doc: Document = Document::from_keypair(&key)?;
+  let mut doc: IotaDocument = IotaDocument::from_keypair(&key)?;
 
   // Sign the document with our Ed25519 secret key.
   doc.sign(key.secret())?;
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
   // DID Dereferencing
   // ===========================================================================
 
-  let url: DID = doc.id().join("#authentication")?;
+  let url: IotaDID = doc.id().join("#authentication")?;
 
   // Retrieve a subset of the published DID Document properties.
   let future: _ = resolution::dereference(url.as_str(), Default::default(), &client);

--- a/examples/verifiable_credential.rs
+++ b/examples/verifiable_credential.rs
@@ -24,7 +24,7 @@ use identity::prelude::*;
 
 // Helper that takes two DID Documents (identities) for issuer and subject, and
 // creates a credential with claims about subject by issuer.
-fn issue_degree(issuer: &Document, subject: &Document) -> Result<Credential> {
+fn issue_degree(issuer: &IotaDocument, subject: &IotaDocument) -> Result<Credential> {
   // Create VC "subject" field containing subject ID and claims about it.
   let subject: Subject = Subject::from_json_value(json!({
     "id": subject.id().as_str(),
@@ -50,10 +50,10 @@ async fn main() -> Result<()> {
   let client: Client = Client::new().await?;
 
   // Create a signed DID Document/KeyPair for the credential issuer (see previous example).
-  let (doc_iss, key_iss): (Document, KeyPair) = common::create_did_document(&client).await?;
+  let (doc_iss, key_iss): (IotaDocument, KeyPair) = common::create_did_document(&client).await?;
 
   // Create a signed DID Document/KeyPair for the credential subject (see previous example).
-  let (doc_sub, _key_sub): (Document, KeyPair) = common::create_did_document(&client).await?;
+  let (doc_sub, _key_sub): (IotaDocument, KeyPair) = common::create_did_document(&client).await?;
 
   // Create an unsigned Credential with claims about `subject` specified by `issuer`.
   let mut credential: Credential = issue_degree(&doc_iss, &doc_sub)?;

--- a/examples/verifiable_presentation.rs
+++ b/examples/verifiable_presentation.rs
@@ -14,7 +14,7 @@ use identity::credential::Presentation;
 use identity::credential::PresentationBuilder;
 use identity::crypto::KeyPair;
 use identity::iota::Client;
-use identity::iota::Document;
+use identity::iota::IotaDocument;
 use identity::iota::Result;
 
 #[tokio::main]
@@ -23,10 +23,10 @@ async fn main() -> Result<()> {
   let client: Client = Client::new().await?;
 
   // Create a signed DID Document/KeyPair for the credential issuer (see previous example).
-  let (doc_iss, key_iss): (Document, KeyPair) = common::create_did_document(&client).await?;
+  let (doc_iss, key_iss): (IotaDocument, KeyPair) = common::create_did_document(&client).await?;
 
   // Create a signed DID Document/KeyPair for the credential subject (see previous example).
-  let (doc_sub, _key_sub): (Document, KeyPair) = common::create_did_document(&client).await?;
+  let (doc_sub, _key_sub): (IotaDocument, KeyPair) = common::create_did_document(&client).await?;
 
   // Create an unsigned Credential with claims about `subject` specified by `issuer`.
   let mut credential: Credential = common::issue_degree(&doc_iss, &doc_sub)?;

--- a/identity-credential/src/presentation/builder.rs
+++ b/identity-credential/src/presentation/builder.rs
@@ -139,12 +139,12 @@ mod tests {
   use identity_core::crypto::KeyPair;
   use identity_core::utils::encode_b58;
   use identity_did::did::DID;
-  use identity_did::document::Document;
+  use identity_did::document::CoreDocument;
   use identity_did::document::DocumentBuilder;
-  use identity_did::verification::Method;
   use identity_did::verification::MethodBuilder;
   use identity_did::verification::MethodData;
   use identity_did::verification::MethodType;
+  use identity_did::verification::VerificationMethod;
   use serde_json::json;
   use serde_json::Value;
 
@@ -175,7 +175,7 @@ mod tests {
     let keypair: KeyPair = KeyPair::new_ed25519().unwrap();
     let controller: DID = "did:example:1234".parse().unwrap();
 
-    let method: Method = MethodBuilder::default()
+    let method: VerificationMethod = MethodBuilder::default()
       .id(controller.join("#key-1").unwrap())
       .controller(controller.clone())
       .key_type(MethodType::Ed25519VerificationKey2018)
@@ -183,7 +183,7 @@ mod tests {
       .build()
       .unwrap();
 
-    let document: Document = DocumentBuilder::default()
+    let document: CoreDocument = DocumentBuilder::default()
       .id(controller)
       .verification_method(method)
       .build()

--- a/identity-did/src/diff/document.rs
+++ b/identity-did/src/diff/document.rs
@@ -12,12 +12,12 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::did::DID;
-use crate::document::Document;
+use crate::document::CoreDocument;
 use crate::service::Service;
 use crate::utils::DIDKey;
 use crate::utils::OrderedSet;
-use crate::verification::Method;
 use crate::verification::MethodRef;
+use crate::verification::VerificationMethod;
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(bound(deserialize = ""))]
@@ -34,7 +34,7 @@ where
   #[serde(skip_serializing_if = "Option::is_none")]
   also_known_as: Option<DiffVec<Url>>,
   #[serde(skip_serializing_if = "Option::is_none")]
-  verification_method: Option<DiffVec<DIDKey<Method<U>>>>,
+  verification_method: Option<DiffVec<DIDKey<VerificationMethod<U>>>>,
   #[serde(skip_serializing_if = "Option::is_none")]
   authentication: Option<DiffVec<DIDKey<MethodRef<U>>>>,
   #[serde(skip_serializing_if = "Option::is_none")]
@@ -51,7 +51,7 @@ where
   properties: Option<<T as Diff>::Type>,
 }
 
-impl<T, U, V> Diff for Document<T, U, V>
+impl<T, U, V> Diff for CoreDocument<T, U, V>
 where
   T: Diff + Serialize + for<'de> Deserialize<'de>,
   U: Diff + Serialize + for<'de> Deserialize<'de>,
@@ -143,7 +143,7 @@ where
       .transpose()?
       .unwrap_or_else(|| self.also_known_as().to_vec());
 
-    let verification_method: OrderedSet<DIDKey<Method<U>>> = diff
+    let verification_method: OrderedSet<DIDKey<VerificationMethod<U>>> = diff
       .verification_method
       .map(|value| self.verification_method().merge(value))
       .transpose()?
@@ -191,7 +191,7 @@ where
       .transpose()?
       .unwrap_or_else(|| self.properties().clone());
 
-    Ok(Document {
+    Ok(CoreDocument {
       id,
       controller,
       also_known_as,
@@ -228,7 +228,7 @@ where
       .transpose()?
       .ok_or_else(|| Error::convert("Missing field `also_known_as`"))?;
 
-    let verification_method: OrderedSet<DIDKey<Method<U>>> = diff
+    let verification_method: OrderedSet<DIDKey<VerificationMethod<U>>> = diff
       .verification_method
       .map(Diff::from_diff)
       .transpose()?
@@ -276,7 +276,7 @@ where
       .transpose()?
       .ok_or_else(|| Error::convert("Missing field `properties`"))?;
 
-    Ok(Document {
+    Ok(CoreDocument {
       id,
       controller,
       also_known_as,
@@ -322,7 +322,7 @@ mod test {
     "did:example:1234".parse().unwrap()
   }
 
-  fn method(controller: &DID, fragment: &str) -> Method {
+  fn method(controller: &DID, fragment: &str) -> VerificationMethod {
     MethodBuilder::default()
       .id(controller.join(fragment).unwrap())
       .controller(controller.clone())
@@ -339,12 +339,12 @@ mod test {
       .build()
       .unwrap()
   }
-  fn document() -> Document {
+  fn document() -> CoreDocument {
     let controller = controller();
     let mut properties: BTreeMap<String, Value> = BTreeMap::default();
     properties.insert("key1".to_string(), "value1".into());
 
-    Document::builder(properties)
+    CoreDocument::builder(properties)
       .id(controller.clone())
       .controller(controller.clone())
       .verification_method(method(&controller, "#key-1"))
@@ -742,7 +742,7 @@ mod test {
     let doc = document();
 
     let diff = doc.clone().into_diff().unwrap();
-    let new = Document::from_diff(diff).unwrap();
+    let new = CoreDocument::from_diff(diff).unwrap();
     assert_eq!(doc, new);
   }
 }

--- a/identity-did/src/diff/method.rs
+++ b/identity-did/src/diff/method.rs
@@ -11,9 +11,9 @@ use serde::Serialize;
 
 use crate::did::DID;
 use crate::diff::DiffMethodData;
-use crate::verification::Method;
 use crate::verification::MethodData;
 use crate::verification::MethodType;
+use crate::verification::VerificationMethod;
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct DiffMethod<T = Object>
@@ -32,7 +32,7 @@ where
   properties: Option<<T as Diff>::Type>,
 }
 
-impl<T> Diff for Method<T>
+impl<T> Diff for VerificationMethod<T>
 where
   T: Diff + Serialize + for<'de> Deserialize<'de>,
 {
@@ -99,7 +99,7 @@ where
       .transpose()?
       .unwrap_or_else(|| self.properties().clone());
 
-    Ok(Method {
+    Ok(VerificationMethod {
       id,
       controller,
       key_type,
@@ -139,7 +139,7 @@ where
       .transpose()?
       .ok_or_else(|| Error::convert("Missing field `properties`"))?;
 
-    Ok(Method {
+    Ok(VerificationMethod {
       id,
       controller,
       key_type,
@@ -165,8 +165,8 @@ mod test {
   use identity_core::common::Object;
   use identity_core::common::Value;
 
-  fn test_method() -> Method {
-    Method::builder(Default::default())
+  fn test_method() -> VerificationMethod {
+    VerificationMethod::builder(Default::default())
       .id("did:example:123".parse().unwrap())
       .controller("did:example:123".parse().unwrap())
       .key_type(MethodType::Ed25519VerificationKey2018)
@@ -314,7 +314,7 @@ mod test {
     let mut new = method.clone();
 
     let diff = method.diff(&new).unwrap();
-    let diff_method = Method::from_diff(diff);
+    let diff_method = VerificationMethod::from_diff(diff);
     assert!(diff_method.is_err());
 
     // add property
@@ -323,31 +323,31 @@ mod test {
     *new.properties_mut() = properties;
 
     let diff = method.diff(&new).unwrap();
-    let diff_method = Method::from_diff(diff);
+    let diff_method = VerificationMethod::from_diff(diff);
     assert!(diff_method.is_err());
 
     // add id
     *new.id_mut() = "did:diff:123".parse().unwrap();
     let diff = method.diff(&new).unwrap();
-    let diff_method = Method::from_diff(diff);
+    let diff_method = VerificationMethod::from_diff(diff);
     assert!(diff_method.is_err());
 
     // add controller
     *new.controller_mut() = "did:diff:123".parse().unwrap();
     let diff = method.diff(&new).unwrap();
-    let diff_method = Method::from_diff(diff);
+    let diff_method = VerificationMethod::from_diff(diff);
     assert!(diff_method.is_err());
 
     // add key_type
     *new.key_type_mut() = MethodType::MerkleKeyCollection2021;
     let diff = method.diff(&new).unwrap();
-    let diff_method = Method::from_diff(diff);
+    let diff_method = VerificationMethod::from_diff(diff);
     assert!(diff_method.is_err());
 
     // add key_data
     *new.key_data_mut() = MethodData::PublicKeyBase58("diff".into());
     let diff = method.diff(&new).unwrap();
-    let diff_method = Method::from_diff(diff.clone());
+    let diff_method = VerificationMethod::from_diff(diff.clone());
     assert!(diff_method.is_ok());
     let diff_method = diff_method.unwrap();
     assert_eq!(diff_method, new);

--- a/identity-did/src/document/builder.rs
+++ b/identity-did/src/document/builder.rs
@@ -5,12 +5,12 @@ use identity_core::common::Object;
 use identity_core::common::Url;
 
 use crate::did::DID;
-use crate::document::Document;
+use crate::document::CoreDocument;
 use crate::error::Result;
 use crate::service::Service;
 use crate::utils::DIDKey;
-use crate::verification::Method;
 use crate::verification::MethodRef;
+use crate::verification::VerificationMethod;
 
 /// A `DocumentBuilder` is used to generate a customized [Document].
 #[derive(Clone, Debug)]
@@ -18,7 +18,7 @@ pub struct DocumentBuilder<T = Object, U = Object, V = Object> {
   pub(crate) id: Option<DID>,
   pub(crate) controller: Option<DID>,
   pub(crate) also_known_as: Vec<Url>,
-  pub(crate) verification_method: Vec<DIDKey<Method<U>>>,
+  pub(crate) verification_method: Vec<DIDKey<VerificationMethod<U>>>,
   pub(crate) authentication: Vec<DIDKey<MethodRef<U>>>,
   pub(crate) assertion_method: Vec<DIDKey<MethodRef<U>>>,
   pub(crate) key_agreement: Vec<DIDKey<MethodRef<U>>>,
@@ -69,7 +69,7 @@ impl<T, U, V> DocumentBuilder<T, U, V> {
 
   /// Adds a value to the `verificationMethod` set.
   #[must_use]
-  pub fn verification_method(mut self, value: Method<U>) -> Self {
+  pub fn verification_method(mut self, value: VerificationMethod<U>) -> Self {
     self.verification_method.push(DIDKey::new(value));
     self
   }
@@ -117,8 +117,8 @@ impl<T, U, V> DocumentBuilder<T, U, V> {
   }
 
   /// Returns a new `Document` based on the `DocumentBuilder` configuration.
-  pub fn build(self) -> Result<Document<T, U, V>> {
-    Document::from_builder(self)
+  pub fn build(self) -> Result<CoreDocument<T, U, V>> {
+    CoreDocument::from_builder(self)
   }
 }
 
@@ -138,6 +138,6 @@ mod tests {
   #[test]
   #[should_panic = "InvalidDocumentId"]
   fn test_missing_id() {
-    let _: Document = DocumentBuilder::default().build().unwrap();
+    let _: CoreDocument = DocumentBuilder::default().build().unwrap();
   }
 }

--- a/identity-did/src/document/core_document.rs
+++ b/identity-did/src/document/core_document.rs
@@ -18,24 +18,24 @@ use crate::error::Result;
 use crate::service::Service;
 use crate::utils::DIDKey;
 use crate::utils::OrderedSet;
-use crate::verification::Method;
 use crate::verification::MethodQuery;
 use crate::verification::MethodRef;
 use crate::verification::MethodScope;
+use crate::verification::VerificationMethod;
 
 /// A DID Document.
 ///
 /// [Specification](https://www.w3.org/TR/did-core/#did-document-properties)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[rustfmt::skip]
-pub struct Document<T = Object, U = Object, V = Object> {
+pub struct CoreDocument<T = Object, U = Object, V = Object> {
   pub(crate) id: DID,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub(crate) controller: Option<DID>,
   #[serde(default = "Default::default", rename = "alsoKnownAs", skip_serializing_if = "Vec::is_empty")]
   pub(crate) also_known_as: Vec<Url>,
   #[serde(default = "Default::default", rename = "verificationMethod", skip_serializing_if = "OrderedSet::is_empty")]
-  pub(crate) verification_method: OrderedSet<DIDKey<Method<U>>>,
+  pub(crate) verification_method: OrderedSet<DIDKey<VerificationMethod<U>>>,
   #[serde(default = "Default::default", skip_serializing_if = "OrderedSet::is_empty")]
   pub(crate) authentication: OrderedSet<DIDKey<MethodRef<U>>>,
   #[serde(default = "Default::default", rename = "assertionMethod", skip_serializing_if = "OrderedSet::is_empty")]
@@ -52,15 +52,15 @@ pub struct Document<T = Object, U = Object, V = Object> {
   pub(crate) properties: T,
 }
 
-impl<T, U, V> Document<T, U, V> {
-  /// Creates a `DocumentBuilder` to configure a new `Document`.
+impl<T, U, V> CoreDocument<T, U, V> {
+  /// Creates a `DocumentBuilder` to configure a new `CoreDocument`.
   ///
   /// This is the same as `DocumentBuilder::new()`.
   pub fn builder(properties: T) -> DocumentBuilder<T, U, V> {
     DocumentBuilder::new(properties)
   }
 
-  /// Returns a new `Document` based on the `DocumentBuilder` configuration.
+  /// Returns a new `CoreDocument` based on the `DocumentBuilder` configuration.
   pub fn from_builder(builder: DocumentBuilder<T, U, V>) -> Result<Self> {
     Ok(Self {
       id: builder.id.ok_or(Error::BuilderInvalidDocumentId)?,
@@ -77,123 +77,123 @@ impl<T, U, V> Document<T, U, V> {
     })
   }
 
-  /// Returns a reference to the `Document` id.
+  /// Returns a reference to the `CoreDocument` id.
   pub fn id(&self) -> &DID {
     &self.id
   }
 
-  /// Returns a mutable reference to the `Document` id.
+  /// Returns a mutable reference to the `CoreDocument` id.
   pub fn id_mut(&mut self) -> &mut DID {
     &mut self.id
   }
 
-  /// Returns a reference to the `Document` controller.
+  /// Returns a reference to the `CoreDocument` controller.
   pub fn controller(&self) -> Option<&DID> {
     self.controller.as_ref()
   }
 
-  /// Returns a mutable reference to the `Document` controller.
+  /// Returns a mutable reference to the `CoreDocument` controller.
   pub fn controller_mut(&mut self) -> Option<&mut DID> {
     self.controller.as_mut()
   }
 
-  /// Returns a reference to the `Document` alsoKnownAs set.
+  /// Returns a reference to the `CoreDocument` alsoKnownAs set.
   pub fn also_known_as(&self) -> &[Url] {
     &self.also_known_as
   }
 
-  /// Returns a mutable reference to the `Document` alsoKnownAs set.
+  /// Returns a mutable reference to the `CoreDocument` alsoKnownAs set.
   pub fn also_known_as_mut(&mut self) -> &mut Vec<Url> {
     &mut self.also_known_as
   }
 
-  /// Returns a reference to the `Document` verificationMethod set.
-  pub fn verification_method(&self) -> &OrderedSet<DIDKey<Method<U>>> {
+  /// Returns a reference to the `CoreDocument` verificationMethod set.
+  pub fn verification_method(&self) -> &OrderedSet<DIDKey<VerificationMethod<U>>> {
     &self.verification_method
   }
 
-  /// Returns a mutable reference to the `Document` verificationMethod set.
-  pub fn verification_method_mut(&mut self) -> &mut OrderedSet<DIDKey<Method<U>>> {
+  /// Returns a mutable reference to the `CoreDocument` verificationMethod set.
+  pub fn verification_method_mut(&mut self) -> &mut OrderedSet<DIDKey<VerificationMethod<U>>> {
     &mut self.verification_method
   }
 
-  /// Returns a reference to the `Document` authentication set.
+  /// Returns a reference to the `CoreDocument` authentication set.
   pub fn authentication(&self) -> &OrderedSet<DIDKey<MethodRef<U>>> {
     &self.authentication
   }
 
-  /// Returns a mutable reference to the `Document` authentication set.
+  /// Returns a mutable reference to the `CoreDocument` authentication set.
   pub fn authentication_mut(&mut self) -> &mut OrderedSet<DIDKey<MethodRef<U>>> {
     &mut self.authentication
   }
 
-  /// Returns a reference to the `Document` assertionMethod set.
+  /// Returns a reference to the `CoreDocument` assertionMethod set.
   pub fn assertion_method(&self) -> &OrderedSet<DIDKey<MethodRef<U>>> {
     &self.assertion_method
   }
 
-  /// Returns a mutable reference to the `Document` assertionMethod set.
+  /// Returns a mutable reference to the `CoreDocument` assertionMethod set.
   pub fn assertion_method_mut(&mut self) -> &mut OrderedSet<DIDKey<MethodRef<U>>> {
     &mut self.assertion_method
   }
 
-  /// Returns a reference to the `Document` keyAgreement set.
+  /// Returns a reference to the `CoreDocument` keyAgreement set.
   pub fn key_agreement(&self) -> &OrderedSet<DIDKey<MethodRef<U>>> {
     &self.key_agreement
   }
 
-  /// Returns a mutable reference to the `Document` keyAgreement set.
+  /// Returns a mutable reference to the `CoreDocument` keyAgreement set.
   pub fn key_agreement_mut(&mut self) -> &mut OrderedSet<DIDKey<MethodRef<U>>> {
     &mut self.key_agreement
   }
 
-  /// Returns a reference to the `Document` capabilityDelegation set.
+  /// Returns a reference to the `CoreDocument` capabilityDelegation set.
   pub fn capability_delegation(&self) -> &OrderedSet<DIDKey<MethodRef<U>>> {
     &self.capability_delegation
   }
 
-  /// Returns a mutable reference to the `Document` capabilityDelegation set.
+  /// Returns a mutable reference to the `CoreDocument` capabilityDelegation set.
   pub fn capability_delegation_mut(&mut self) -> &mut OrderedSet<DIDKey<MethodRef<U>>> {
     &mut self.capability_delegation
   }
 
-  /// Returns a reference to the `Document` capabilityInvocation set.
+  /// Returns a reference to the `CoreDocument` capabilityInvocation set.
   pub fn capability_invocation(&self) -> &OrderedSet<DIDKey<MethodRef<U>>> {
     &self.capability_invocation
   }
 
-  /// Returns a mutable reference to the `Document` capabilityInvocation set.
+  /// Returns a mutable reference to the `CoreDocument` capabilityInvocation set.
   pub fn capability_invocation_mut(&mut self) -> &mut OrderedSet<DIDKey<MethodRef<U>>> {
     &mut self.capability_invocation
   }
 
-  /// Returns a reference to the `Document` service set.
+  /// Returns a reference to the `CoreDocument` service set.
   pub fn service(&self) -> &OrderedSet<DIDKey<Service<V>>> {
     &self.service
   }
 
-  /// Returns a mutable reference to the `Document` service set.
+  /// Returns a mutable reference to the `CoreDocument` service set.
   pub fn service_mut(&mut self) -> &mut OrderedSet<DIDKey<Service<V>>> {
     &mut self.service
   }
 
-  /// Returns a reference to the custom `Document` properties.
+  /// Returns a reference to the custom `CoreDocument` properties.
   pub fn properties(&self) -> &T {
     &self.properties
   }
 
-  /// Returns a mutable reference to the custom `Document` properties.
+  /// Returns a mutable reference to the custom `CoreDocument` properties.
   pub fn properties_mut(&mut self) -> &mut T {
     &mut self.properties
   }
 
-  /// Maps `Document<T>` to `Document<U>` by applying a function to the custom
+  /// Maps `CoreDocument<T>` to `CoreDocument<U>` by applying a function to the custom
   /// properties.
-  pub fn map<A, F>(self, f: F) -> Document<A, U, V>
+  pub fn map<A, F>(self, f: F) -> CoreDocument<A, U, V>
   where
     F: FnOnce(T) -> A,
   {
-    Document {
+    CoreDocument {
       id: self.id,
       controller: self.controller,
       also_known_as: self.also_known_as,
@@ -213,11 +213,11 @@ impl<T, U, V> Document<T, U, V> {
   /// # Errors
   ///
   /// `try_map` can fail if the provided function fails.
-  pub fn try_map<A, F, E>(self, f: F) -> Result<Document<A, U, V>, E>
+  pub fn try_map<A, F, E>(self, f: F) -> Result<CoreDocument<A, U, V>, E>
   where
     F: FnOnce(T) -> Result<A, E>,
   {
-    Ok(Document {
+    Ok(CoreDocument {
       id: self.id,
       controller: self.controller,
       also_known_as: self.also_known_as,
@@ -233,7 +233,7 @@ impl<T, U, V> Document<T, U, V> {
   }
 
   /// Adds a new [`Method<U>`][`Method`] to the Document.
-  pub fn insert_method(&mut self, scope: MethodScope, method: Method<U>) -> bool {
+  pub fn insert_method(&mut self, scope: MethodScope, method: VerificationMethod<U>) -> bool {
     match scope {
       MethodScope::VerificationMethod => self.verification_method.append(method.into()),
       MethodScope::Authentication => self.authentication.append(MethodRef::Embed(method).into()),
@@ -255,8 +255,8 @@ impl<T, U, V> Document<T, U, V> {
   }
 
   /// Returns an iterator over all verification methods in the DID Document.
-  pub fn methods(&self) -> impl Iterator<Item = &Method<U>> {
-    fn __filter_ref<T>(method: &DIDKey<MethodRef<T>>) -> Option<&Method<T>> {
+  pub fn methods(&self) -> impl Iterator<Item = &VerificationMethod<U>> {
+    fn __filter_ref<T>(method: &DIDKey<MethodRef<T>>) -> Option<&VerificationMethod<T>> {
       match &**method {
         MethodRef::Embed(method) => Some(method),
         MethodRef::Refer(_) => None,
@@ -276,7 +276,7 @@ impl<T, U, V> Document<T, U, V> {
 
   /// Returns the first verification [`method`][`Method`] with an `id` property
   /// matching the provided `query`.
-  pub fn resolve<'query, Q>(&self, query: Q) -> Option<&Method<U>>
+  pub fn resolve<'query, Q>(&self, query: Q) -> Option<&VerificationMethod<U>>
   where
     Q: Into<MethodQuery<'query>>,
   {
@@ -289,29 +289,29 @@ impl<T, U, V> Document<T, U, V> {
   /// # Errors
   ///
   /// Fails if no matching verification `Method` is found.
-  pub fn try_resolve<'query, Q>(&self, query: Q) -> Result<&Method<U>>
+  pub fn try_resolve<'query, Q>(&self, query: Q) -> Result<&VerificationMethod<U>>
   where
     Q: Into<MethodQuery<'query>>,
   {
     self.resolve(query).ok_or(Error::QueryMethodNotFound)
   }
 
-  /// Returns a mutable reference to the first verification [`method`][`Method`]
+  /// Returns a mutable reference to the first verification [`method`][`VerificationMethod`]
   /// with an `id` property matching the provided `query`.
-  pub fn resolve_mut<'query, Q>(&mut self, query: Q) -> Option<&mut Method<U>>
+  pub fn resolve_mut<'query, Q>(&mut self, query: Q) -> Option<&mut VerificationMethod<U>>
   where
     Q: Into<MethodQuery<'query>>,
   {
     self.resolve_method_mut(query.into())
   }
 
-  /// Returns a mutable reference to the first verification [`method`][`Method`]
+  /// Returns a mutable reference to the first verification [`method`][`VerificationMethod`]
   /// with an `id` property matching the provided `query`.
   ///
   /// # Errors
   ///
-  /// Fails if no matching verification `Method` is found.
-  pub fn try_resolve_mut<'query, Q>(&mut self, query: Q) -> Result<&mut Method<U>>
+  /// Fails if no matching `VerificationMethod` is found.
+  pub fn try_resolve_mut<'query, Q>(&mut self, query: Q) -> Result<&mut VerificationMethod<U>>
   where
     Q: Into<MethodQuery<'query>>,
   {
@@ -319,14 +319,14 @@ impl<T, U, V> Document<T, U, V> {
   }
 
   #[doc(hidden)]
-  pub fn resolve_ref<'a>(&'a self, method: &'a MethodRef<U>) -> Option<&'a Method<U>> {
+  pub fn resolve_ref<'a>(&'a self, method: &'a MethodRef<U>) -> Option<&'a VerificationMethod<U>> {
     match method {
       MethodRef::Embed(method) => Some(method),
       MethodRef::Refer(did) => self.verification_method.query(did.as_str()),
     }
   }
 
-  fn resolve_method(&self, query: MethodQuery<'_>) -> Option<&Method<U>> {
+  fn resolve_method(&self, query: MethodQuery<'_>) -> Option<&VerificationMethod<U>> {
     let mut method: Option<&MethodRef<U>> = None;
 
     if method.is_none() {
@@ -356,7 +356,7 @@ impl<T, U, V> Document<T, U, V> {
     }
   }
 
-  fn resolve_method_mut(&mut self, query: MethodQuery<'_>) -> Option<&mut Method<U>> {
+  fn resolve_method_mut(&mut self, query: MethodQuery<'_>) -> Option<&mut VerificationMethod<U>> {
     let mut method: Option<&mut MethodRef<U>> = None;
 
     if method.is_none() {
@@ -387,7 +387,7 @@ impl<T, U, V> Document<T, U, V> {
   }
 }
 
-impl<T, U, V> Display for Document<T, U, V>
+impl<T, U, V> Display for CoreDocument<T, U, V>
 where
   T: Serialize,
   U: Serialize,
@@ -405,17 +405,17 @@ where
 #[cfg(test)]
 mod tests {
   use crate::did::DID;
-  use crate::document::Document;
-  use crate::verification::Method;
+  use crate::document::CoreDocument;
   use crate::verification::MethodData;
   use crate::verification::MethodType;
+  use crate::verification::VerificationMethod;
 
   fn controller() -> DID {
     "did:example:1234".parse().unwrap()
   }
 
-  fn method(controller: &DID, fragment: &str) -> Method {
-    Method::builder(Default::default())
+  fn method(controller: &DID, fragment: &str) -> VerificationMethod {
+    VerificationMethod::builder(Default::default())
       .id(controller.join(fragment).unwrap())
       .controller(controller.clone())
       .key_type(MethodType::Ed25519VerificationKey2018)
@@ -424,10 +424,10 @@ mod tests {
       .unwrap()
   }
 
-  fn document() -> Document {
+  fn document() -> CoreDocument {
     let controller: DID = controller();
 
-    Document::builder(Default::default())
+    CoreDocument::builder(Default::default())
       .id(controller.clone())
       .verification_method(method(&controller, "#key-1"))
       .verification_method(method(&controller, "#key-2"))
@@ -441,7 +441,7 @@ mod tests {
 
   #[test]
   fn test_resolve_fragment_identifier() {
-    let document: Document = document();
+    let document: CoreDocument = document();
 
     // Resolve methods by fragment
     assert_eq!(document.resolve("#key-1").unwrap().id(), "did:example:1234#key-1");
@@ -456,7 +456,7 @@ mod tests {
 
   #[test]
   fn test_resolve_index_identifier() {
-    let document: Document = document();
+    let document: CoreDocument = document();
 
     // Resolve methods by index
     assert_eq!(document.methods().next().unwrap().id(), "did:example:1234#key-1");
@@ -465,7 +465,7 @@ mod tests {
 
   #[test]
   fn test_resolve_reference_missing() {
-    let document: Document = document();
+    let document: CoreDocument = document();
 
     // Resolving an existing reference to a missing method returns None
     assert_eq!(document.resolve("#key-4"), None);

--- a/identity-did/src/document/mod.rs
+++ b/identity-did/src/document/mod.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::module_inception)]
 
 mod builder;
-mod document;
+mod core_document;
 
 pub use self::builder::DocumentBuilder;
-pub use self::document::Document;
+pub use self::core_document::CoreDocument;

--- a/identity-did/src/resolution/impls.rs
+++ b/identity-did/src/resolution/impls.rs
@@ -5,7 +5,7 @@ use identity_core::common::Url;
 use std::time::Instant;
 
 use crate::did::DID;
-use crate::document::Document;
+use crate::document::CoreDocument;
 use crate::error::Error;
 use crate::error::Result;
 use crate::resolution::Dereference;
@@ -90,7 +90,8 @@ where
 
   // Extract the document and metadata - Both properties MUST exist as we
   // checked for resolution errors above.
-  let (document, metadata): (Document, DocumentMetadata) = match (resolution.document, resolution.document_metadata) {
+  let (document, metadata): (CoreDocument, DocumentMetadata) = match (resolution.document, resolution.document_metadata)
+  {
     (Some(document), Some(metadata)) => (document, metadata),
     (Some(_), None) => return Err(Error::MissingResolutionMetadata),
     (None, Some(_)) => return Err(Error::MissingResolutionDocument),
@@ -150,7 +151,7 @@ impl ResolveContext {
     Self(Resolution::new(), Instant::now())
   }
 
-  fn set_document(&mut self, value: Document) {
+  fn set_document(&mut self, value: CoreDocument) {
     self.0.document = Some(value);
   }
 
@@ -208,7 +209,7 @@ impl DerefContext {
   }
 }
 
-fn dereference_primary(document: Document, mut did: DID) -> Result<Option<PrimaryResource>> {
+fn dereference_primary(document: CoreDocument, mut did: DID) -> Result<Option<PrimaryResource>> {
   // Remove the DID fragment from the input DID URL.
   did.set_fragment(None);
 
@@ -238,7 +239,7 @@ fn dereference_primary(document: Document, mut did: DID) -> Result<Option<Primar
   }
 }
 
-fn dereference_document(document: Document, fragment: &str) -> Result<Option<SecondaryResource>> {
+fn dereference_document(document: CoreDocument, fragment: &str) -> Result<Option<SecondaryResource>> {
   #[inline]
   fn dereference<T>(base: &DID, query: &str, resources: &OrderedSet<DIDKey<T>>) -> Result<Option<SecondaryResource>>
   where

--- a/identity-did/src/resolution/resolution.rs
+++ b/identity-did/src/resolution/resolution.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::document::Document;
+use crate::document::CoreDocument;
 use crate::resolution::DocumentMetadata;
 use crate::resolution::ResolutionMetadata;
 
@@ -15,7 +15,7 @@ pub struct Resolution {
   pub metadata: ResolutionMetadata,
   /// The DID Document of a successful resolution.
   #[serde(rename = "did-document", skip_serializing_if = "Option::is_none")]
-  pub document: Option<Document>,
+  pub document: Option<CoreDocument>,
   /// Document-specific metadata.
   #[serde(rename = "did-document-metadata", skip_serializing_if = "Option::is_none")]
   pub document_metadata: Option<DocumentMetadata>,

--- a/identity-did/src/resolution/resource.rs
+++ b/identity-did/src/resolution/resource.rs
@@ -4,11 +4,11 @@
 use identity_core::common::Url;
 
 use crate::did::DID;
-use crate::document::Document;
+use crate::document::CoreDocument;
 use crate::service::Service;
 use crate::utils::DIDKey;
-use crate::verification::Method;
 use crate::verification::MethodRef;
+use crate::verification::VerificationMethod;
 
 /// A resource returned from a [DID URL dereferencing][SPEC] process.
 ///
@@ -40,13 +40,13 @@ impl From<SecondaryResource> for Resource {
 #[serde(untagged)]
 pub enum PrimaryResource {
   /// A dereferenced DID Document.
-  Document(Document),
+  Document(CoreDocument),
   /// A dereferenced DID Document service endpoint.
   Service(Url),
 }
 
-impl From<Document> for PrimaryResource {
-  fn from(other: Document) -> Self {
+impl From<CoreDocument> for PrimaryResource {
+  fn from(other: CoreDocument) -> Self {
     Self::Document(other)
   }
 }
@@ -67,7 +67,7 @@ pub enum SecondaryResource {
   /// A DID Document Method Id.
   VerificationDID(DID),
   /// A DID Document Verification Method.
-  VerificationKey(Method),
+  VerificationKey(VerificationMethod),
   /// A DID Document Service.
   Service(Service),
 }
@@ -78,8 +78,8 @@ impl From<DID> for SecondaryResource {
   }
 }
 
-impl From<Method> for SecondaryResource {
-  fn from(other: Method) -> Self {
+impl From<VerificationMethod> for SecondaryResource {
+  fn from(other: VerificationMethod) -> Self {
     Self::VerificationKey(other)
   }
 }

--- a/identity-did/src/resolution/traits.rs
+++ b/identity-did/src/resolution/traits.rs
@@ -4,7 +4,7 @@
 use async_trait::async_trait;
 
 use crate::did::DID;
-use crate::document::Document;
+use crate::document::CoreDocument;
 use crate::error::Result;
 use crate::resolution::DocumentMetadata;
 use crate::resolution::InputMetadata;
@@ -13,7 +13,7 @@ use crate::resolution::InputMetadata;
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct MetaDocument {
   /// A resolved DID Document.
-  pub data: Document,
+  pub data: CoreDocument,
   /// Information regarding the associated Documents resolution process.
   pub meta: DocumentMetadata,
 }

--- a/identity-did/src/verifiable/tests.rs
+++ b/identity-did/src/verifiable/tests.rs
@@ -16,13 +16,13 @@ use identity_core::crypto::TrySignature;
 use identity_core::crypto::TrySignatureMut;
 
 use crate::did::DID;
-use crate::document::Document;
+use crate::document::CoreDocument;
 use crate::verifiable::Properties;
-use crate::verification::Method;
 use crate::verification::MethodData;
 use crate::verification::MethodType;
 use crate::verification::MethodUriType;
 use crate::verification::TryMethod;
+use crate::verification::VerificationMethod;
 
 #[derive(Debug, Serialize)]
 struct That {
@@ -67,7 +67,7 @@ fn test_sign_verify_this_ed25519() {
   let key: KeyPair = KeyPair::new_ed25519().unwrap();
   let controller: DID = "did:example:1234".parse().unwrap();
 
-  let method: Method = Method::builder(Default::default())
+  let method: VerificationMethod = VerificationMethod::builder(Default::default())
     .id(controller.join("#key-1").unwrap())
     .controller(controller.clone())
     .key_type(MethodType::Ed25519VerificationKey2018)
@@ -75,7 +75,7 @@ fn test_sign_verify_this_ed25519() {
     .build()
     .unwrap();
 
-  let mut document: Document<Properties> = Document::builder(Default::default())
+  let mut document: CoreDocument<Properties> = CoreDocument::builder(Default::default())
     .id(controller)
     .verification_method(method)
     .build()
@@ -100,7 +100,7 @@ fn test_sign_verify_that_merkle_key_ed25519_sha256() {
   let proof: Proof<Sha256> = keys.merkle_proof(index).unwrap();
   let mkey: Vec<u8> = MerkleKey::encode_key::<Sha256, Ed25519>(&root);
 
-  let method: Method = Method::builder(Default::default())
+  let method: VerificationMethod = VerificationMethod::builder(Default::default())
     .id(controller.join("#key-collection").unwrap())
     .controller(controller.clone())
     .key_type(MethodType::MerkleKeyCollection2021)
@@ -108,7 +108,7 @@ fn test_sign_verify_that_merkle_key_ed25519_sha256() {
     .build()
     .unwrap();
 
-  let document: Document<Properties> = Document::builder(Default::default())
+  let document: CoreDocument<Properties> = CoreDocument::builder(Default::default())
     .id(controller)
     .verification_method(method)
     .build()

--- a/identity-did/src/verifiable/traits.rs
+++ b/identity-did/src/verifiable/traits.rs
@@ -6,7 +6,7 @@ use identity_core::common::Object;
 use identity_core::convert::FromJson;
 
 use crate::error::Result;
-use crate::verification::Method;
+use crate::verification::VerificationMethod;
 
 pub trait Revocation {
   /// Returns a [`set`][BitSet] of Merkle Key Collection revocation flags.
@@ -28,7 +28,7 @@ impl Revocation for Object {
   }
 }
 
-impl<T> Revocation for Method<T>
+impl<T> Revocation for VerificationMethod<T>
 where
   T: Revocation,
 {

--- a/identity-did/src/verification/builder.rs
+++ b/identity-did/src/verification/builder.rs
@@ -3,9 +3,9 @@
 
 use crate::did::DID;
 use crate::error::Result;
-use crate::verification::Method;
 use crate::verification::MethodData;
 use crate::verification::MethodType;
+use crate::verification::VerificationMethod;
 use identity_core::common::Object;
 
 /// A `MethodBuilder` is used to generate a customized `Method`.
@@ -30,37 +30,37 @@ impl<T> MethodBuilder<T> {
     }
   }
 
-  /// Sets the `id` value of the generated verification `Method`.
+  /// Sets the `id` value of the generated `VerificationMethod`.
   #[must_use]
   pub fn id(mut self, value: DID) -> Self {
     self.id = Some(value);
     self
   }
 
-  /// Sets the `controller` value of the generated verification `Method`.
+  /// Sets the `controller` value of the generated `VerificationMethod`.
   #[must_use]
   pub fn controller(mut self, value: DID) -> Self {
     self.controller = Some(value);
     self
   }
 
-  /// Sets the `type` value of the generated verification `Method`.
+  /// Sets the `type` value of the generated verification `VerificationMethod`.
   #[must_use]
   pub fn key_type(mut self, value: MethodType) -> Self {
     self.key_type = Some(value);
     self
   }
 
-  /// Sets the `data` value of the generated verification `Method`.
+  /// Sets the `data` value of the generated `VerificationMethod`.
   #[must_use]
   pub fn key_data(mut self, value: MethodData) -> Self {
     self.key_data = Some(value);
     self
   }
 
-  /// Returns a new `Method` based on the `MethodBuilder` configuration.
-  pub fn build(self) -> Result<Method<T>> {
-    Method::from_builder(self)
+  /// Returns a new `VerificationMethod` based on the `MethodBuilder` configuration.
+  pub fn build(self) -> Result<VerificationMethod<T>> {
+    VerificationMethod::from_builder(self)
   }
 }
 
@@ -71,7 +71,7 @@ mod tests {
   #[test]
   #[should_panic = "InvalidMethodId"]
   fn test_missing_id() {
-    let _: Method = MethodBuilder::default()
+    let _: VerificationMethod = MethodBuilder::default()
       .controller("did:example:123".parse().unwrap())
       .key_type(MethodType::Ed25519VerificationKey2018)
       .key_data(MethodData::PublicKeyBase58("".into()))
@@ -82,7 +82,7 @@ mod tests {
   #[test]
   #[should_panic = "InvalidMethodType"]
   fn test_missing_key_type() {
-    let _: Method = MethodBuilder::default()
+    let _: VerificationMethod = MethodBuilder::default()
       .id("did:example:123".parse().unwrap())
       .controller("did:example:123".parse().unwrap())
       .key_data(MethodData::PublicKeyBase58("".into()))
@@ -93,7 +93,7 @@ mod tests {
   #[test]
   #[should_panic = "InvalidMethodData"]
   fn test_missing_key_data() {
-    let _: Method = MethodBuilder::default()
+    let _: VerificationMethod = MethodBuilder::default()
       .id("did:example:123".parse().unwrap())
       .controller("did:example:123".parse().unwrap())
       .key_type(MethodType::Ed25519VerificationKey2018)
@@ -104,7 +104,7 @@ mod tests {
   #[test]
   #[should_panic = "InvalidMethodController"]
   fn test_missing_controller() {
-    let _: Method = MethodBuilder::default()
+    let _: VerificationMethod = MethodBuilder::default()
       .id("did:example:123".parse().unwrap())
       .key_type(MethodType::Ed25519VerificationKey2018)
       .key_data(MethodData::PublicKeyBase58("".into()))

--- a/identity-did/src/verification/method_ref.rs
+++ b/identity-did/src/verification/method_ref.rs
@@ -7,13 +7,13 @@ use core::fmt::Result as FmtResult;
 use identity_core::common::Object;
 
 use crate::did::DID;
-use crate::verification::Method;
+use crate::verification::VerificationMethod;
 
 /// A reference to a verification method, either a `DID` or embedded `Method`.
 #[derive(Clone, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum MethodRef<T = Object> {
-  Embed(Method<T>),
+  Embed(VerificationMethod<T>),
   Refer(DID),
 }
 
@@ -53,7 +53,7 @@ impl<T> MethodRef<T> {
   /// # Errors
   ///
   /// Fails if `MethodRef` is not an embedded method.
-  pub fn try_into_embedded(self) -> Result<Method<T>, Self> {
+  pub fn try_into_embedded(self) -> Result<VerificationMethod<T>, Self> {
     match self {
       Self::Embed(inner) => Ok(inner),
       Self::Refer(_) => Err(self),
@@ -87,9 +87,9 @@ where
   }
 }
 
-impl<T> From<Method<T>> for MethodRef<T> {
+impl<T> From<VerificationMethod<T>> for MethodRef<T> {
   #[inline]
-  fn from(other: Method<T>) -> Self {
+  fn from(other: VerificationMethod<T>) -> Self {
     Self::Embed(other)
   }
 }

--- a/identity-did/src/verification/mod.rs
+++ b/identity-did/src/verification/mod.rs
@@ -7,16 +7,15 @@
 //! crate.
 
 mod builder;
-mod method;
 mod method_data;
 mod method_query;
 mod method_ref;
 mod method_scope;
 mod method_type;
 mod traits;
+mod verification_method;
 
 pub use self::builder::MethodBuilder;
-pub use self::method::Method;
 pub use self::method_data::MethodData;
 pub use self::method_query::MethodQuery;
 pub use self::method_ref::MethodRef;
@@ -24,3 +23,4 @@ pub use self::method_scope::MethodScope;
 pub use self::method_type::MethodType;
 pub use self::traits::MethodUriType;
 pub use self::traits::TryMethod;
+pub use self::verification_method::VerificationMethod;

--- a/identity-did/src/verification/traits.rs
+++ b/identity-did/src/verification/traits.rs
@@ -3,7 +3,7 @@
 
 use crate::error::Error;
 use crate::error::Result;
-use crate::verification::Method;
+use crate::verification::VerificationMethod;
 
 /// Represents all possible verification method URI types
 ///
@@ -24,7 +24,7 @@ pub trait TryMethod {
   const TYPE: MethodUriType;
 
   /// Returns String representation of absolute or relative method URI, if any.
-  fn method<U>(method: &Method<U>) -> Option<String> {
+  fn method<U>(method: &VerificationMethod<U>) -> Option<String> {
     method.id().fragment()?;
 
     match Self::TYPE {
@@ -38,7 +38,7 @@ pub trait TryMethod {
   /// # Errors
   ///
   /// Fails if an unsupported verification method is used.
-  fn try_method<U>(method: &Method<U>) -> Result<String> {
+  fn try_method<U>(method: &VerificationMethod<U>) -> Result<String> {
     Self::method(method).ok_or(Error::InvalidMethodFragment)
   }
 }

--- a/identity-did/src/verification/verification_method.rs
+++ b/identity-did/src/verification/verification_method.rs
@@ -22,7 +22,7 @@ use crate::verification::MethodType;
 ///
 /// [Specification](https://www.w3.org/TR/did-core/#verification-method-properties)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub struct Method<T = Object> {
+pub struct VerificationMethod<T = Object> {
   pub(crate) id: DID,
   pub(crate) controller: DID,
   #[serde(rename = "type")]
@@ -33,7 +33,7 @@ pub struct Method<T = Object> {
   pub(crate) properties: T,
 }
 
-impl<T> Method<T> {
+impl<T> VerificationMethod<T> {
   /// Creates a `MethodBuilder` to configure a new `Method`.
   ///
   /// This is the same as `MethodBuilder::new()`.
@@ -43,7 +43,7 @@ impl<T> Method<T> {
 
   /// Returns a new `Method` based on the `MethodBuilder` configuration.
   pub fn from_builder(builder: MethodBuilder<T>) -> Result<Self> {
-    Ok(Method {
+    Ok(VerificationMethod {
       id: builder.id.ok_or(Error::BuilderInvalidMethodId)?,
       controller: builder.controller.ok_or(Error::BuilderInvalidMethodController)?,
       key_type: builder.key_type.ok_or(Error::BuilderInvalidMethodType)?,
@@ -116,7 +116,7 @@ impl<T> Method<T> {
   }
 }
 
-impl<T> Display for Method<T>
+impl<T> Display for VerificationMethod<T>
 where
   T: Serialize,
 {
@@ -129,7 +129,7 @@ where
   }
 }
 
-impl<T> AsRef<DID> for Method<T> {
+impl<T> AsRef<DID> for VerificationMethod<T> {
   fn as_ref(&self) -> &DID {
     self.id()
   }

--- a/identity-iota/src/chain/diff.rs
+++ b/identity-iota/src/chain/diff.rs
@@ -11,7 +11,7 @@ use identity_core::convert::ToJson;
 use crate::chain::DocumentChain;
 use crate::chain::IntegrationChain;
 use crate::did::DocumentDiff;
-use crate::did::DID;
+use crate::did::IotaDID;
 use crate::error::Error;
 use crate::error::Result;
 use crate::tangle::MessageExt;
@@ -34,7 +34,7 @@ impl DiffChain {
       return Ok(Self::new());
     }
 
-    let did: &DID = integration_chain.current().id();
+    let did: &IotaDID = integration_chain.current().id();
 
     let mut index: MessageIndex<DocumentDiff> = messages
       .iter()
@@ -171,8 +171,8 @@ impl Display for DiffChain {
 mod test {
   use crate::chain::DocumentChain;
   use crate::chain::IntegrationChain;
-  use crate::did::Document;
   use crate::did::DocumentDiff;
+  use crate::did::IotaDocument;
   use crate::tangle::TangleRef;
   use identity_core::common::Timestamp;
   use identity_core::crypto::KeyPair;
@@ -193,7 +193,7 @@ mod test {
 
     {
       let keypair: KeyPair = KeyPair::new_ed25519().unwrap();
-      let mut document: Document = Document::from_keypair(&keypair).unwrap();
+      let mut document: IotaDocument = IotaDocument::from_keypair(&keypair).unwrap();
       document.sign(keypair.secret()).unwrap();
       document.set_message_id(MessageId::new([8; 32]));
       chain = DocumentChain::new(IntegrationChain::new(document).unwrap());
@@ -209,7 +209,7 @@ mod test {
     // Push Integration Chain Update
     // =========================================================================
     {
-      let mut new: Document = chain.current().clone();
+      let mut new: IotaDocument = chain.current().clone();
       let keypair: KeyPair = KeyPair::new_ed25519().unwrap();
 
       let authentication: MethodRef = MethodBuilder::default()
@@ -243,8 +243,8 @@ mod test {
     // Push Diff Chain Update
     // =========================================================================
     {
-      let new: Document = {
-        let mut this: Document = chain.current().clone();
+      let new: IotaDocument = {
+        let mut this: IotaDocument = chain.current().clone();
         this.properties_mut().insert("foo".into(), 123.into());
         this.properties_mut().insert("bar".into(), 456.into());
         this.set_updated(Timestamp::now());

--- a/identity-iota/src/chain/integration.rs
+++ b/identity-iota/src/chain/integration.rs
@@ -8,8 +8,8 @@ use core::fmt::Result as FmtResult;
 use core::mem;
 use identity_core::convert::ToJson;
 
-use crate::did::Document;
-use crate::did::DID;
+use crate::did::IotaDID;
+use crate::did::IotaDocument;
 use crate::error::Error;
 use crate::error::Result;
 use crate::tangle::MessageExt;
@@ -22,19 +22,19 @@ use iota::MessageId;
 #[derive(Debug, Deserialize, Serialize)]
 pub struct IntegrationChain {
   #[serde(skip_serializing_if = "Option::is_none")]
-  pub(crate) history: Option<Vec<Document>>,
-  pub(crate) current: Document,
+  pub(crate) history: Option<Vec<IotaDocument>>,
+  pub(crate) current: IotaDocument,
 }
 
 impl IntegrationChain {
   /// Constructs a new `AuthChain` from a slice of `Message`s.
-  pub fn try_from_messages(did: &DID, messages: &[Message]) -> Result<Self> {
-    let mut index: MessageIndex<Document> = messages
+  pub fn try_from_messages(did: &IotaDID, messages: &[Message]) -> Result<Self> {
+    let mut index: MessageIndex<IotaDocument> = messages
       .iter()
       .flat_map(|message| message.try_extract_document(did))
       .collect();
 
-    let current: Document = index
+    let current: IotaDocument = index
       .remove_where(&MessageId::null(), |doc| doc.verify().is_ok())
       .ok_or(Error::ChainError {
         error: "Invalid Root Document",
@@ -53,8 +53,8 @@ impl IntegrationChain {
     Ok(this)
   }
 
-  /// Creates a new `AuthChain` with the given `Document` as the latest.
-  pub fn new(current: Document) -> Result<Self> {
+  /// Creates a new `AuthChain` with the given `IotaDocument` as the latest.
+  pub fn new(current: IotaDocument) -> Result<Self> {
     if current.verify().is_err() {
       return Err(Error::ChainError {
         error: "Invalid Signature",
@@ -70,13 +70,13 @@ impl IntegrationChain {
     Ok(Self { current, history: None })
   }
 
-  /// Returns a reference to the latest `Document`.
-  pub fn current(&self) -> &Document {
+  /// Returns a reference to the latest `IotaDocument`.
+  pub fn current(&self) -> &IotaDocument {
     &self.current
   }
 
-  /// Returns a mutable reference to the latest `Document`.
-  pub fn current_mut(&mut self) -> &mut Document {
+  /// Returns a mutable reference to the latest `IotaDocument`.
+  pub fn current_mut(&mut self) -> &mut IotaDocument {
     &mut self.current
   }
 
@@ -85,13 +85,13 @@ impl IntegrationChain {
     self.current.message_id()
   }
 
-  /// Adds a new `Document` to the `IntegrationChain`.
+  /// Adds a new `IotaDocument` to the `IntegrationChain`.
   ///
   /// # Errors
   ///
   /// Fails if the document signature is invalid or the Tangle message
-  /// references within the `Document` are invalid.
-  pub fn try_push(&mut self, document: Document) -> Result<()> {
+  /// references within the `IotaDocument` are invalid.
+  pub fn try_push(&mut self, document: IotaDocument) -> Result<()> {
     self.check_validity(&document)?;
 
     self
@@ -102,17 +102,17 @@ impl IntegrationChain {
     Ok(())
   }
 
-  /// Returns `true` if the `Document` can be added to the `AuthChain`.
-  pub fn is_valid(&self, document: &Document) -> bool {
+  /// Returns `true` if the `IotaDocument` can be added to the `AuthChain`.
+  pub fn is_valid(&self, document: &IotaDocument) -> bool {
     self.check_validity(document).is_ok()
   }
 
-  /// Checks if the `Document` can be added to the `AuthChain`.
+  /// Checks if the `IotaDocument` can be added to the `AuthChain`.
   ///
   /// # Errors
   ///
   /// Fails if the `Document` is not a valid addition.
-  pub fn check_validity(&self, document: &Document) -> Result<()> {
+  pub fn check_validity(&self, document: &IotaDocument) -> Result<()> {
     if self.current.verify_data(document).is_err() {
       return Err(Error::ChainError {
         error: "Invalid Signature",

--- a/identity-iota/src/client/client.rs
+++ b/identity-iota/src/client/client.rs
@@ -6,9 +6,9 @@ use crate::chain::DocumentChain;
 use crate::chain::IntegrationChain;
 use crate::client::ClientBuilder;
 use crate::client::Network;
-use crate::did::Document;
 use crate::did::DocumentDiff;
-use crate::did::DID;
+use crate::did::IotaDID;
+use crate::did::IotaDocument;
 use crate::error::Error;
 use crate::error::Result;
 use futures::stream::FuturesUnordered;
@@ -100,7 +100,7 @@ impl Client {
   ///
   /// Note: The only validation performed is to ensure the correct Tangle
   /// network is selected.
-  pub async fn publish_document(&self, document: &Document) -> Result<MessageId> {
+  pub async fn publish_document(&self, document: &IotaDocument) -> Result<MessageId> {
     trace!("Publish Document: {}", document.id());
 
     self.check_network(document.id())?;
@@ -128,7 +128,7 @@ impl Client {
     let message: Message = self
       .client
       .message()
-      .with_index(&Document::diff_address(message_id)?)
+      .with_index(&IotaDocument::diff_address(message_id)?)
       .with_data(diff.to_json()?.into_bytes())
       .finish()
       .await?;
@@ -136,11 +136,11 @@ impl Client {
     Ok(message.id().0)
   }
 
-  pub async fn read_document(&self, did: &DID) -> Result<Document> {
+  pub async fn read_document(&self, did: &IotaDID) -> Result<IotaDocument> {
     self.read_document_chain(did).await.and_then(DocumentChain::fold)
   }
 
-  pub async fn read_document_chain(&self, did: &DID) -> Result<DocumentChain> {
+  pub async fn read_document_chain(&self, did: &IotaDID) -> Result<DocumentChain> {
     trace!("Read Document Chain: {}", did);
     trace!("Integration Chain Address: {}", did.tag());
 
@@ -155,7 +155,7 @@ impl Client {
       DiffChain::new()
     } else {
       // Fetch all messages for the diff chain.
-      let address: String = Document::diff_address(integration_chain.current_message_id())?;
+      let address: String = IotaDocument::diff_address(integration_chain.current_message_id())?;
       let messages: Messages = self.read_messages(&address).await?;
 
       trace!("Tangle Messages: {:?}", messages);
@@ -179,7 +179,7 @@ impl Client {
     Ok(Messages { message_ids, messages })
   }
 
-  pub fn check_network(&self, did: &DID) -> Result<()> {
+  pub fn check_network(&self, did: &IotaDID) -> Result<()> {
     if !self.network.matches_did(did) {
       return Err(Error::InvalidDIDNetwork);
     }

--- a/identity-iota/src/client/network.rs
+++ b/identity-iota/src/client/network.rs
@@ -3,7 +3,7 @@
 
 use identity_core::common::Url;
 
-use crate::did::DID;
+use crate::did::IotaDID;
 
 const MAIN_NETWORK_NAME: &str = "main";
 const TEST_NETWORK_NAME: &str = "test";
@@ -33,13 +33,13 @@ impl Network {
     }
   }
 
-  /// Returns the `Network` the `DID` is associated with.
-  pub fn from_did(did: &DID) -> Self {
+  /// Returns the `Network` the `IotaDID` is associated with.
+  pub fn from_did(did: &IotaDID) -> Self {
     Self::from_name(did.network())
   }
 
   /// Returns true if this network is the same network as the DID.
-  pub fn matches_did(self, did: &DID) -> bool {
+  pub fn matches_did(self, did: &IotaDID) -> bool {
     did.network() == self.as_str()
   }
 
@@ -88,11 +88,11 @@ mod tests {
 
   #[test]
   fn test_matches_did() {
-    let did: DID = DID::new(b"").unwrap();
+    let did: IotaDID = IotaDID::new(b"").unwrap();
     assert!(Network::matches_did(Network::Mainnet, &did));
     assert!(!Network::matches_did(Network::Testnet, &did));
 
-    let did: DID = DID::with_network(b"", "test").unwrap();
+    let did: IotaDID = IotaDID::with_network(b"", "test").unwrap();
     assert!(Network::matches_did(Network::Testnet, &did));
     assert!(!Network::matches_did(Network::Mainnet, &did));
   }

--- a/identity-iota/src/client/resolver.rs
+++ b/identity-iota/src/client/resolver.rs
@@ -12,19 +12,19 @@ use identity_did::resolution::MetaDocument;
 use identity_did::resolution::ResolverMethod;
 
 use crate::client::Client;
-use crate::did::Document;
-use crate::did::DID;
+use crate::did::IotaDID;
+use crate::did::IotaDocument;
 
 #[async_trait(?Send)]
 impl ResolverMethod for Client {
   fn is_supported(&self, did: &CoreDID) -> bool {
-    DID::try_from_borrowed(did)
+    IotaDID::try_from_borrowed(did)
       .map(|did| self.check_network(did).is_ok())
       .unwrap_or(false)
   }
 
   async fn read(&self, did: &CoreDID, _input: InputMetadata) -> Result<Option<MetaDocument>> {
-    let document: Document = DID::try_from_borrowed(did)
+    let document: IotaDocument = IotaDID::try_from_borrowed(did)
       .map_err(|_| Error::MissingResolutionDID)
       .map(|did| self.read_document(&did))?
       .await

--- a/identity-iota/src/credential/validator.rs
+++ b/identity-iota/src/credential/validator.rs
@@ -10,8 +10,8 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 
 use crate::client::Client;
-use crate::did::Document;
-use crate::did::DID;
+use crate::did::IotaDID;
+use crate::did::IotaDocument;
 use crate::error::Error;
 use crate::error::Result;
 
@@ -33,8 +33,8 @@ pub struct PresentationValidation<T = Object, U = Object> {
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct DocumentValidation {
-  pub did: DID,
-  pub document: Document,
+  pub did: IotaDID,
+  pub document: IotaDocument,
   pub metadata: Object,
   pub verified: bool,
 }
@@ -156,8 +156,8 @@ impl<'a> CredentialValidator<'a> {
   }
 
   async fn validate_document(&self, did: &str) -> Result<DocumentValidation> {
-    let did: DID = did.parse()?;
-    let document: Document = self.client.read_document(&did).await?;
+    let did: IotaDID = did.parse()?;
+    let document: IotaDocument = self.client.read_document(&did).await?;
     let verified: bool = document.verify().is_ok();
 
     Ok(DocumentValidation {

--- a/identity-iota/src/did/doc/diff.rs
+++ b/identity-iota/src/did/doc/diff.rs
@@ -10,14 +10,14 @@ use identity_core::crypto::TrySignature;
 use identity_core::crypto::TrySignatureMut;
 use identity_core::diff::Diff;
 use identity_did::diff::DiffDocument;
-use identity_did::document::Document as CoreDocument;
+use identity_did::document::CoreDocument;
 use identity_did::verification::MethodUriType;
 use identity_did::verification::TryMethod;
 
 use crate::client::Client;
 use crate::client::Network;
-use crate::did::Document;
-use crate::did::DID;
+use crate::did::IotaDID;
+use crate::did::IotaDocument;
 use crate::error::Error;
 use crate::error::Result;
 use crate::tangle::MessageIdExt;
@@ -27,7 +27,7 @@ use iota::MessageId;
 /// Defines the difference between two DID [`Document`]s' JSON representations.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct DocumentDiff {
-  pub(crate) did: DID,
+  pub(crate) did: IotaDID,
   pub(crate) diff: String,
   #[serde(default = "MessageId::null", skip_serializing_if = "MessageIdExt::is_null")]
   pub(crate) previous_message_id: MessageId,
@@ -42,7 +42,7 @@ impl DocumentDiff {
   ///
   /// The `previous_message_id` is included verbatim in the output, and the `proof` is `None`. To
   /// set a proof, use the `set_signature()` method.
-  pub fn new(current: &Document, updated: &Document, previous_message_id: MessageId) -> Result<Self> {
+  pub fn new(current: &IotaDocument, updated: &IotaDocument, previous_message_id: MessageId) -> Result<Self> {
     let a: CoreDocument = current.serde_into()?;
     let b: CoreDocument = updated.serde_into()?;
     let diff: String = Diff::diff(&a, &b)?.to_json()?;
@@ -57,7 +57,7 @@ impl DocumentDiff {
   }
 
   /// Returns the DID of associated DID Document.
-  pub fn id(&self) -> &DID {
+  pub fn id(&self) -> &IotaDID {
     &self.did
   }
 
@@ -78,7 +78,7 @@ impl DocumentDiff {
 
   /// Returns a new DID Document which is the result of merging `self`
   /// with the given Document.
-  pub fn merge(&self, document: &Document) -> Result<Document> {
+  pub fn merge(&self, document: &IotaDocument) -> Result<IotaDocument> {
     let data: DiffDocument = DiffDocument::from_json(&self.diff)?;
     let core: CoreDocument = document.serde_into()?;
     let this: CoreDocument = Diff::merge(&core, data)?;

--- a/identity-iota/src/did/doc/iota_document.rs
+++ b/identity-iota/src/did/doc/iota_document.rs
@@ -16,27 +16,27 @@ use identity_core::crypto::SetSignature;
 use identity_core::crypto::Signature;
 use identity_core::crypto::TrySignature;
 use identity_core::crypto::TrySignatureMut;
-use identity_did::document::Document as CoreDocument;
+use identity_did::document::CoreDocument;
 use identity_did::service::Service;
 use identity_did::verifiable::DocumentSigner;
 use identity_did::verifiable::DocumentVerifier;
 use identity_did::verifiable::Properties as VerifiableProperties;
-use identity_did::verification::Method as CoreMethod;
 use identity_did::verification::MethodQuery;
 use identity_did::verification::MethodRef;
 use identity_did::verification::MethodScope;
 use identity_did::verification::MethodType;
 use identity_did::verification::MethodUriType;
 use identity_did::verification::TryMethod;
+use identity_did::verification::VerificationMethod;
 use iota::MessageId;
 use serde::Serialize;
 
 use crate::client::Client;
 use crate::client::Network;
 use crate::did::DocumentDiff;
-use crate::did::Method;
+use crate::did::IotaDID;
+use crate::did::IotaMethod;
 use crate::did::Properties as BaseProperties;
-use crate::did::DID;
 use crate::error::Error;
 use crate::error::Result;
 use crate::tangle::MessageIdExt;
@@ -50,20 +50,20 @@ pub type Verifier<'a> = DocumentVerifier<'a, Properties, Object, Object>;
 
 /// A DID Document adhering to the IOTA DID method specification.
 ///
-/// This is a thin wrapper around the [`Document`][CoreDocument] type from the
+/// This is a thin wrapper around the [`CoreDocument`][CoreDocument] type from the
 /// [identity_did] crate.
 #[derive(Clone, PartialEq, Deserialize, Serialize)]
 #[serde(try_from = "CoreDocument", into = "BaseDocument")]
-pub struct Document {
+pub struct IotaDocument {
   document: BaseDocument,
   message_id: MessageId,
 }
 
-impl TryMethod for Document {
+impl TryMethod for IotaDocument {
   const TYPE: MethodUriType = MethodUriType::Absolute;
 }
 
-impl Document {
+impl IotaDocument {
   /// Creates a new DID Document from the given KeyPair.
   ///
   /// The DID Document will be pre-populated with a single authentication
@@ -72,28 +72,28 @@ impl Document {
   /// The authentication method will have the DID URL fragment `#authentication`
   /// and can be easily retrieved with [Document::authentication].
   pub fn from_keypair(keypair: &KeyPair) -> Result<Self> {
-    let method: Method = Method::from_keypair(keypair, "authentication")?;
+    let method: IotaMethod = IotaMethod::from_keypair(keypair, "authentication")?;
 
     // SAFETY: We don't create invalid Methods.  Method::from_keypair() uses the MethodBuilder
     // internally which verifies correctness on construction.
     Ok(unsafe { Self::from_authentication_unchecked(method) })
   }
 
-  /// Creates a new DID Document from the given verification [`method`][Method].
-  pub fn from_authentication(method: Method) -> Result<Self> {
+  /// Creates a new DID Document from the given verification [`method`][VerificationMethod].
+  pub fn from_authentication(method: IotaMethod) -> Result<Self> {
     Self::check_authentication(&method)?;
 
     // SAFETY: We just checked the validity of the verification method.
     Ok(unsafe { Self::from_authentication_unchecked(method) })
   }
 
-  /// Creates a new DID Document from the given verification [`method`][Method]
+  /// Creates a new DID Document from the given verification [`method`][IotaMethod]
   /// without performing validation checks.
   ///
   /// # Safety
   ///
   /// This must be guaranteed safe by the caller.
-  pub unsafe fn from_authentication_unchecked(method: Method) -> Self {
+  pub unsafe fn from_authentication_unchecked(method: IotaMethod) -> Self {
     CoreDocument::builder(Default::default())
       .id(method.controller().clone().into())
       .authentication(method)
@@ -109,9 +109,9 @@ impl Document {
   ///
   /// Returns `Err` if the document is not a valid IOTA DID Document.
   pub fn try_from_core(document: CoreDocument) -> Result<Self> {
-    let did: &DID = DID::try_from_borrowed(document.id())?;
+    let did: &IotaDID = IotaDID::try_from_borrowed(document.id())?;
 
-    let method: &CoreMethod = document
+    let method: &VerificationMethod = document
       .authentication()
       .head()
       .and_then(|method| document.resolve_ref(method))
@@ -130,8 +130,8 @@ impl Document {
     })
   }
 
-  fn check_authentication(method: &CoreMethod) -> Result<()> {
-    Method::check_validity(method)?;
+  fn check_authentication(method: &VerificationMethod) -> Result<()> {
+    IotaMethod::check_validity(method)?;
 
     // Ensure the verification method type is supported
     match method.key_type() {
@@ -165,23 +165,23 @@ impl Document {
   // Properties
   // ===========================================================================
 
-  /// Returns the DID document [`id`][DID].
-  pub fn id(&self) -> &DID {
+  /// Returns the DID document [`id`][IotaDID].
+  pub fn id(&self) -> &IotaDID {
     // SAFETY: We checked the validity of the DID Document ID in the
     // DID Document constructors; we don't provide mutable references so
     // the value cannot change with typical "safe" Rust.
-    unsafe { DID::new_unchecked_ref(self.document.id()) }
+    unsafe { IotaDID::new_unchecked_ref(self.document.id()) }
   }
 
   /// Returns the default authentication method of the DID document.
-  pub fn authentication(&self) -> &Method {
+  pub fn authentication(&self) -> &IotaMethod {
     // This `unwrap` is "fine" - a valid document will
     // always have a resolvable authentication method.
     let method: &MethodRef = self.document.authentication().head().unwrap();
-    let method: &CoreMethod = self.document.resolve_ref(method).unwrap();
+    let method: &VerificationMethod = self.document.resolve_ref(method).unwrap();
 
     // SAFETY: We don't allow invalid authentication methods.
-    unsafe { Method::new_unchecked_ref(method) }
+    unsafe { IotaMethod::new_unchecked_ref(method) }
   }
 
   fn authentication_id(&self) -> &str {
@@ -235,12 +235,12 @@ impl Document {
   // ===========================================================================
 
   /// Adds a new Verification Method to the DID Document.
-  pub fn insert_method(&mut self, scope: MethodScope, method: Method) -> bool {
+  pub fn insert_method(&mut self, scope: MethodScope, method: IotaMethod) -> bool {
     self.document.insert_method(scope, method.into())
   }
 
   /// Removes all references to the specified Verification Method.
-  pub fn remove_method(&mut self, did: &DID) -> Result<()> {
+  pub fn remove_method(&mut self, did: &IotaDID) -> Result<()> {
     if self.authentication_id() == did.as_str() {
       return Err(Error::CannotRemoveAuthMethod);
     }
@@ -251,7 +251,7 @@ impl Document {
   }
 
   #[doc(hidden)]
-  pub fn try_resolve_mut<'query, Q>(&mut self, query: Q) -> Result<&mut CoreMethod>
+  pub fn try_resolve_mut<'query, Q>(&mut self, query: Q) -> Result<&mut VerificationMethod>
   where
     Q: Into<MethodQuery<'query>>,
   {
@@ -387,7 +387,7 @@ impl Document {
       return Err(Error::InvalidDocumentMessageId);
     }
 
-    Ok(DID::encode_key(message_id.encode_hex().as_bytes()))
+    Ok(IotaDID::encode_key(message_id.encode_hex().as_bytes()))
   }
 
   pub fn insert_service(&mut self, service: Service) -> bool {
@@ -398,25 +398,25 @@ impl Document {
     }
   }
 
-  pub fn remove_service(&mut self, did: &DID) -> Result<()> {
+  pub fn remove_service(&mut self, did: &IotaDID) -> Result<()> {
     self.document.service_mut().remove(did.as_ref());
     Ok(())
   }
 }
 
-impl Display for Document {
+impl Display for IotaDocument {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
     Display::fmt(&self.document, f)
   }
 }
 
-impl Debug for Document {
+impl Debug for IotaDocument {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
     Debug::fmt(&self.document, f)
   }
 }
 
-impl Deref for Document {
+impl Deref for IotaDocument {
   type Target = BaseDocument;
 
   fn deref(&self) -> &Self::Target {
@@ -424,7 +424,7 @@ impl Deref for Document {
   }
 }
 
-impl From<BaseDocument> for Document {
+impl From<BaseDocument> for IotaDocument {
   fn from(other: BaseDocument) -> Self {
     Self {
       document: other,
@@ -433,13 +433,13 @@ impl From<BaseDocument> for Document {
   }
 }
 
-impl From<Document> for BaseDocument {
-  fn from(other: Document) -> Self {
+impl From<IotaDocument> for BaseDocument {
+  fn from(other: IotaDocument) -> Self {
     other.document
   }
 }
 
-impl TryFrom<CoreDocument> for Document {
+impl TryFrom<CoreDocument> for IotaDocument {
   type Error = Error;
 
   fn try_from(other: CoreDocument) -> Result<Self, Self::Error> {
@@ -447,25 +447,25 @@ impl TryFrom<CoreDocument> for Document {
   }
 }
 
-impl TrySignature for Document {
+impl TrySignature for IotaDocument {
   fn signature(&self) -> Option<&Signature> {
     self.document.proof()
   }
 }
 
-impl TrySignatureMut for Document {
+impl TrySignatureMut for IotaDocument {
   fn signature_mut(&mut self) -> Option<&mut Signature> {
     self.document.proof_mut()
   }
 }
 
-impl SetSignature for Document {
+impl SetSignature for IotaDocument {
   fn set_signature(&mut self, signature: Signature) {
     self.document.set_proof(signature)
   }
 }
 
-impl TangleRef for Document {
+impl TangleRef for IotaDocument {
   fn message_id(&self) -> &MessageId {
     &self.message_id
   }
@@ -475,19 +475,19 @@ impl TangleRef for Document {
   }
 
   fn previous_message_id(&self) -> &MessageId {
-    Document::previous_message_id(self)
+    IotaDocument::previous_message_id(self)
   }
 
   fn set_previous_message_id(&mut self, message_id: MessageId) {
-    Document::set_previous_message_id(self, message_id)
+    IotaDocument::set_previous_message_id(self, message_id)
   }
 }
 
 #[cfg(test)]
 mod tests {
 
-  use crate::did::doc::Document;
-  use crate::did::url::DID;
+  use crate::did::doc::IotaDocument;
+  use crate::did::url::IotaDID;
   use identity_core::convert::FromJson;
   use identity_core::convert::SerdeInto;
   use identity_core::crypto::KeyPair;
@@ -517,7 +517,7 @@ mod tests {
     ))
   }
 
-  fn compare_document(document: &Document) {
+  fn compare_document(document: &IotaDocument) {
     assert_eq!(document.id().to_string(), DID_ID);
     assert_eq!(document.authentication_id(), DID_AUTH);
     assert_eq!(
@@ -534,51 +534,54 @@ mod tests {
   fn test_new() {
     //from keypair
     let keypair: KeyPair = generate_testkey();
-    let document: Document = Document::from_keypair(&keypair).unwrap();
+    let document: IotaDocument = IotaDocument::from_keypair(&keypair).unwrap();
     compare_document(&document);
 
     //from authentication
     let method = document.authentication().to_owned();
-    let document: Document = Document::from_authentication(method).unwrap();
+    let document: IotaDocument = IotaDocument::from_authentication(method).unwrap();
     compare_document(&document);
 
     //from core
-    let document: Document = Document::try_from_core(document.serde_into().unwrap()).unwrap();
+    let document: IotaDocument = IotaDocument::try_from_core(document.serde_into().unwrap()).unwrap();
     compare_document(&document);
   }
 
   #[test]
   fn test_json() {
     let keypair: KeyPair = generate_testkey();
-    let mut document: Document = Document::from_keypair(&keypair).unwrap();
+    let mut document: IotaDocument = IotaDocument::from_keypair(&keypair).unwrap();
 
     let json_doc: String = document.to_string();
-    let document2: Document = Document::from_json(&json_doc).unwrap();
+    let document2: IotaDocument = IotaDocument::from_json(&json_doc).unwrap();
     assert_eq!(document, document2);
 
     assert_eq!(document.sign(keypair.secret()).is_ok(), true);
 
     let json_doc: String = document.to_string();
-    let document2: Document = Document::from_json(&json_doc).unwrap();
+    let document2: IotaDocument = IotaDocument::from_json(&json_doc).unwrap();
     assert_eq!(document, document2);
   }
 
   #[test]
   fn test_authentication() {
     let keypair: KeyPair = generate_testkey();
-    let document: Document = Document::from_keypair(&keypair).unwrap();
+    let document: IotaDocument = IotaDocument::from_keypair(&keypair).unwrap();
 
-    assert_eq!(Document::check_authentication(document.authentication()).is_ok(), true);
+    assert_eq!(
+      IotaDocument::check_authentication(document.authentication()).is_ok(),
+      true
+    );
   }
 
   #[test]
   fn test_document_services() {
     let keypair: KeyPair = generate_testkey();
-    let mut document: Document = Document::from_keypair(&keypair).unwrap();
+    let mut document: IotaDocument = IotaDocument::from_keypair(&keypair).unwrap();
     let service: Service = Service::from_json(
       r#"{
       "id":"did:iota:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1N#linked-domain",
-      "type": "LinkedDomains", 
+      "type": "LinkedDomains",
       "serviceEndpoint": "https://bar.example.com"
     }"#,
     )
@@ -589,7 +592,7 @@ mod tests {
 
     document
       .remove_service(
-        &DID::parse("did:iota:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1N#linked-domain".to_string()).unwrap(),
+        &IotaDID::parse("did:iota:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1N#linked-domain".to_string()).unwrap(),
       )
       .ok();
     assert_eq!(0, document.service().len());
@@ -597,7 +600,7 @@ mod tests {
   #[test]
   fn test_relative_method_uri() {
     let keypair: KeyPair = generate_testkey();
-    let mut document: Document = Document::from_keypair(&keypair).unwrap();
+    let mut document: IotaDocument = IotaDocument::from_keypair(&keypair).unwrap();
 
     assert!(document.proof().is_none());
     assert_eq!(document.sign(keypair.secret()).is_ok(), true);

--- a/identity-iota/src/did/doc/iota_method.rs
+++ b/identity-iota/src/did/doc/iota_method.rs
@@ -16,34 +16,34 @@ use identity_core::crypto::KeyPair;
 use identity_core::crypto::KeyType;
 use identity_did::error::Result as DIDResult;
 use identity_did::verifiable::Revocation;
-use identity_did::verification::Method as CoreMethod;
 use identity_did::verification::MethodBuilder;
 use identity_did::verification::MethodData;
 use identity_did::verification::MethodRef;
 use identity_did::verification::MethodType;
+use identity_did::verification::VerificationMethod;
 
-use crate::did::DID;
+use crate::did::IotaDID;
 use crate::error::Error;
 use crate::error::Result;
 
 /// A DID Document verification method
 #[derive(Clone, PartialEq, Deserialize, Serialize)]
 #[repr(transparent)]
-#[serde(into = "CoreMethod", try_from = "CoreMethod")]
-pub struct Method(CoreMethod);
+#[serde(into = "VerificationMethod", try_from = "VerificationMethod")]
+pub struct IotaMethod(VerificationMethod);
 
-impl Method {
+impl IotaMethod {
   /// The default verification method tag.
   pub const TAG: &'static str = "key";
 
   /// Creates a new Merkle Key Collection Method from the given key collection.
-  pub fn create_merkle_key<'a, D, F>(did: DID, keys: &KeyCollection, fragment: F) -> Result<Self>
+  pub fn create_merkle_key<'a, D, F>(did: IotaDID, keys: &KeyCollection, fragment: F) -> Result<Self>
   where
     F: Into<Option<&'a str>>,
     D: MerkleDigest,
   {
     let tag: String = format!("#{}", fragment.into().unwrap_or(Self::TAG));
-    let key: DID = did.join(tag)?;
+    let key: IotaDID = did.join(tag)?;
 
     MethodBuilder::default()
       .id(key.into())
@@ -55,13 +55,13 @@ impl Method {
       .map(Self)
   }
 
-  /// Creates a new [`Method`] object from the given `keypair`.
+  /// Creates a new [`IotaMethod`] object from the given `keypair`.
   pub fn from_keypair<'a, F>(keypair: &KeyPair, fragment: F) -> Result<Self>
   where
     F: Into<Option<&'a str>>,
   {
     let key: &[u8] = keypair.public().as_ref();
-    let did: DID = DID::new(key)?;
+    let did: IotaDID = IotaDID::new(key)?;
 
     Self::from_did(did, keypair, fragment)
   }
@@ -70,12 +70,12 @@ impl Method {
   ///
   /// If the `fragment` resolves to `Option::None` then the default verification method tag will be
   /// used ("key").
-  pub fn from_did<'a, F>(did: DID, keypair: &KeyPair, fragment: F) -> Result<Self>
+  pub fn from_did<'a, F>(did: IotaDID, keypair: &KeyPair, fragment: F) -> Result<Self>
   where
     F: Into<Option<&'a str>>,
   {
     let tag: String = format!("#{}", fragment.into().unwrap_or(Self::TAG));
-    let key: DID = did.join(tag)?;
+    let key: IotaDID = did.join(tag)?;
 
     let mut builder: MethodBuilder = MethodBuilder::default().id(key.into()).controller(did.into());
 
@@ -94,7 +94,7 @@ impl Method {
   /// # Errors
   ///
   /// Returns `Err` if the document is not a valid IOTA Verification Method.
-  pub fn try_from_core(method: CoreMethod) -> Result<Self> {
+  pub fn try_from_core(method: VerificationMethod) -> Result<Self> {
     Self::check_validity(&method)?;
 
     Ok(Self(method))
@@ -102,11 +102,11 @@ impl Method {
 
   /// Converts a mutable `Method` reference to a mutable  IOTA Verification
   /// Method reference.
-  pub fn try_from_mut(method: &mut CoreMethod) -> Result<&mut Self> {
+  pub fn try_from_mut(method: &mut VerificationMethod) -> Result<&mut Self> {
     Self::check_validity(method)?;
 
     // SAFETY: We just checked the validity of the verification method.
-    Ok(unsafe { &mut *(method as *mut CoreMethod as *mut Method) })
+    Ok(unsafe { &mut *(method as *mut VerificationMethod as *mut IotaMethod) })
   }
 
   /// Converts a `Method` reference to an IOTA Verification Method reference
@@ -115,9 +115,9 @@ impl Method {
   /// # Safety
   ///
   /// This must be guaranteed safe by the caller.
-  pub unsafe fn new_unchecked_ref(method: &CoreMethod) -> &Self {
+  pub unsafe fn new_unchecked_ref(method: &VerificationMethod) -> &Self {
     // SAFETY: This is guaranteed safe by the caller.
-    &*(method as *const CoreMethod as *const Method)
+    &*(method as *const VerificationMethod as *const IotaMethod)
   }
 
   /// Checks if the given verification method is valid according to the IOTA
@@ -126,10 +126,10 @@ impl Method {
   /// # Errors
   ///
   /// Returns `Err` if the input is not a valid IOTA verification method.
-  pub fn check_validity(method: &CoreMethod) -> Result<()> {
+  pub fn check_validity(method: &VerificationMethod) -> Result<()> {
     // Ensure all associated DIDs are IOTA Identity DIDs
-    DID::check_validity(method.id())?;
-    DID::check_validity(method.controller())?;
+    IotaDID::check_validity(method.id())?;
+    IotaDID::check_validity(method.controller())?;
 
     // Ensure the authentication method has an identifying fragment
     if method.id().fragment().is_none() {
@@ -147,20 +147,20 @@ impl Method {
 
   /// Returns a `bool` indicating if the given verification method is valid
   /// according to the IOTA DID method specification.
-  pub fn is_valid(method: &CoreMethod) -> bool {
+  pub fn is_valid(method: &VerificationMethod) -> bool {
     Self::check_validity(method).is_ok()
   }
 
   /// Returns the method `id` property.
-  pub fn id(&self) -> &DID {
+  pub fn id(&self) -> &IotaDID {
     // SAFETY: We don't create methods with invalid DID's
-    unsafe { DID::new_unchecked_ref(self.0.id()) }
+    unsafe { IotaDID::new_unchecked_ref(self.0.id()) }
   }
 
   /// Returns the method `controller` property.
-  pub fn controller(&self) -> &DID {
+  pub fn controller(&self) -> &IotaDID {
     // SAFETY: We don't create methods with invalid DID's
-    unsafe { DID::new_unchecked_ref(self.0.controller()) }
+    unsafe { IotaDID::new_unchecked_ref(self.0.controller()) }
   }
 
   /// Revokes the public key of a Merkle Key Collection at the specified `index`.
@@ -182,47 +182,47 @@ impl Method {
   }
 }
 
-impl Display for Method {
+impl Display for IotaMethod {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
     Display::fmt(&self.0, f)
   }
 }
 
-impl Debug for Method {
+impl Debug for IotaMethod {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
     Debug::fmt(&self.0, f)
   }
 }
 
-impl Deref for Method {
-  type Target = CoreMethod;
+impl Deref for IotaMethod {
+  type Target = VerificationMethod;
 
   fn deref(&self) -> &Self::Target {
     &self.0
   }
 }
 
-impl From<Method> for CoreMethod {
-  fn from(other: Method) -> Self {
+impl From<IotaMethod> for VerificationMethod {
+  fn from(other: IotaMethod) -> Self {
     other.0
   }
 }
 
-impl From<Method> for MethodRef {
-  fn from(other: Method) -> Self {
+impl From<IotaMethod> for MethodRef {
+  fn from(other: IotaMethod) -> Self {
     other.0.into()
   }
 }
 
-impl TryFrom<CoreMethod> for Method {
+impl TryFrom<VerificationMethod> for IotaMethod {
   type Error = Error;
 
-  fn try_from(other: CoreMethod) -> Result<Self, Self::Error> {
+  fn try_from(other: VerificationMethod) -> Result<Self, Self::Error> {
     Self::try_from_core(other)
   }
 }
 
-impl Revocation for Method {
+impl Revocation for IotaMethod {
   fn revocation(&self) -> DIDResult<Option<BitSet>> {
     self.0.properties().revocation()
   }

--- a/identity-iota/src/did/doc/iota_verification_method.rs
+++ b/identity-iota/src/did/doc/iota_verification_method.rs
@@ -30,9 +30,9 @@ use crate::error::Result;
 #[derive(Clone, PartialEq, Deserialize, Serialize)]
 #[repr(transparent)]
 #[serde(into = "VerificationMethod", try_from = "VerificationMethod")]
-pub struct IotaMethod(VerificationMethod);
+pub struct IotaVerificationMethod(VerificationMethod);
 
-impl IotaMethod {
+impl IotaVerificationMethod {
   /// The default verification method tag.
   pub const TAG: &'static str = "key";
 
@@ -55,7 +55,7 @@ impl IotaMethod {
       .map(Self)
   }
 
-  /// Creates a new [`IotaMethod`] object from the given `keypair`.
+  /// Creates a new [`IotaVerificationMethod`] object from the given `keypair`.
   pub fn from_keypair<'a, F>(keypair: &KeyPair, fragment: F) -> Result<Self>
   where
     F: Into<Option<&'a str>>,
@@ -106,7 +106,7 @@ impl IotaMethod {
     Self::check_validity(method)?;
 
     // SAFETY: We just checked the validity of the verification method.
-    Ok(unsafe { &mut *(method as *mut VerificationMethod as *mut IotaMethod) })
+    Ok(unsafe { &mut *(method as *mut VerificationMethod as *mut IotaVerificationMethod) })
   }
 
   /// Converts a `Method` reference to an IOTA Verification Method reference
@@ -117,7 +117,7 @@ impl IotaMethod {
   /// This must be guaranteed safe by the caller.
   pub unsafe fn new_unchecked_ref(method: &VerificationMethod) -> &Self {
     // SAFETY: This is guaranteed safe by the caller.
-    &*(method as *const VerificationMethod as *const IotaMethod)
+    &*(method as *const VerificationMethod as *const IotaVerificationMethod)
   }
 
   /// Checks if the given verification method is valid according to the IOTA
@@ -182,19 +182,19 @@ impl IotaMethod {
   }
 }
 
-impl Display for IotaMethod {
+impl Display for IotaVerificationMethod {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
     Display::fmt(&self.0, f)
   }
 }
 
-impl Debug for IotaMethod {
+impl Debug for IotaVerificationMethod {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
     Debug::fmt(&self.0, f)
   }
 }
 
-impl Deref for IotaMethod {
+impl Deref for IotaVerificationMethod {
   type Target = VerificationMethod;
 
   fn deref(&self) -> &Self::Target {
@@ -202,19 +202,19 @@ impl Deref for IotaMethod {
   }
 }
 
-impl From<IotaMethod> for VerificationMethod {
-  fn from(other: IotaMethod) -> Self {
+impl From<IotaVerificationMethod> for VerificationMethod {
+  fn from(other: IotaVerificationMethod) -> Self {
     other.0
   }
 }
 
-impl From<IotaMethod> for MethodRef {
-  fn from(other: IotaMethod) -> Self {
+impl From<IotaVerificationMethod> for MethodRef {
+  fn from(other: IotaVerificationMethod) -> Self {
     other.0.into()
   }
 }
 
-impl TryFrom<VerificationMethod> for IotaMethod {
+impl TryFrom<VerificationMethod> for IotaVerificationMethod {
   type Error = Error;
 
   fn try_from(other: VerificationMethod) -> Result<Self, Self::Error> {
@@ -222,7 +222,7 @@ impl TryFrom<VerificationMethod> for IotaMethod {
   }
 }
 
-impl Revocation for IotaMethod {
+impl Revocation for IotaVerificationMethod {
   fn revocation(&self) -> DIDResult<Option<BitSet>> {
     self.0.properties().revocation()
   }

--- a/identity-iota/src/did/doc/mod.rs
+++ b/identity-iota/src/did/doc/mod.rs
@@ -3,12 +3,12 @@
 
 mod diff;
 mod iota_document;
-mod iota_method;
+mod iota_verification_method;
 mod properties;
 
 pub use self::diff::DocumentDiff;
 pub use self::iota_document::IotaDocument;
 pub use self::iota_document::Signer;
 pub use self::iota_document::Verifier;
-pub use self::iota_method::IotaMethod;
+pub use self::iota_verification_method::IotaVerificationMethod;
 pub use self::properties::Properties;

--- a/identity-iota/src/did/doc/mod.rs
+++ b/identity-iota/src/did/doc/mod.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod diff;
-mod document;
-mod method;
+mod iota_document;
+mod iota_method;
 mod properties;
 
 pub use self::diff::DocumentDiff;
-pub use self::document::Document;
-pub use self::document::Signer;
-pub use self::document::Verifier;
-pub use self::method::Method;
+pub use self::iota_document::IotaDocument;
+pub use self::iota_document::Signer;
+pub use self::iota_document::Verifier;
+pub use self::iota_method::IotaMethod;
 pub use self::properties::Properties;

--- a/identity-iota/src/did/macros.rs
+++ b/identity-iota/src/did/macros.rs
@@ -45,30 +45,30 @@ macro_rules! did {
 #[macro_export]
 macro_rules! try_did {
   ($public:expr, $network:expr, $shard:expr) => {
-    $crate::did::DID::parse(format!(
+    $crate::did::IotaDID::parse(format!(
       "{}:{}:{}:{}:{}",
-      $crate::did::DID::SCHEME,
-      $crate::did::DID::METHOD,
+      $crate::did::IotaDID::SCHEME,
+      $crate::did::IotaDID::METHOD,
       $network,
       $shard,
-      $crate::did::DID::encode_key($public),
+      $crate::did::IotaDID::encode_key($public),
     ))
   };
   ($public:expr, $network:expr) => {
-    $crate::did::DID::parse(format!(
+    $crate::did::IotaDID::parse(format!(
       "{}:{}:{}:{}",
-      $crate::did::DID::SCHEME,
-      $crate::did::DID::METHOD,
+      $crate::did::IotaDID::SCHEME,
+      $crate::did::IotaDID::METHOD,
       $network,
-      $crate::did::DID::encode_key($public),
+      $crate::did::IotaDID::encode_key($public),
     ))
   };
   ($public:expr) => {
-    $crate::did::DID::parse(format!(
+    $crate::did::IotaDID::parse(format!(
       "{}:{}:{}",
-      $crate::did::DID::SCHEME,
-      $crate::did::DID::METHOD,
-      $crate::did::DID::encode_key($public),
+      $crate::did::IotaDID::SCHEME,
+      $crate::did::IotaDID::METHOD,
+      $crate::did::IotaDID::encode_key($public),
     ))
   };
 }

--- a/identity-iota/src/did/mod.rs
+++ b/identity-iota/src/did/mod.rs
@@ -9,7 +9,7 @@ mod url;
 
 pub use self::doc::DocumentDiff;
 pub use self::doc::IotaDocument;
-pub use self::doc::IotaMethod;
+pub use self::doc::IotaVerificationMethod;
 pub use self::doc::Properties;
 pub use self::doc::Signer;
 pub use self::doc::Verifier;

--- a/identity-iota/src/did/mod.rs
+++ b/identity-iota/src/did/mod.rs
@@ -7,11 +7,11 @@ mod macros;
 mod doc;
 mod url;
 
-pub use self::doc::Document;
 pub use self::doc::DocumentDiff;
-pub use self::doc::Method;
+pub use self::doc::IotaDocument;
+pub use self::doc::IotaMethod;
 pub use self::doc::Properties;
 pub use self::doc::Signer;
 pub use self::doc::Verifier;
+pub use self::url::IotaDID;
 pub use self::url::Segments;
-pub use self::url::DID;

--- a/identity-iota/src/did/url/iota_did.rs
+++ b/identity-iota/src/did/url/iota_did.rs
@@ -29,9 +29,9 @@ const BLAKE2B_256_LEN: usize = 32;
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 #[repr(transparent)]
 #[serde(into = "CoreDID", try_from = "CoreDID")]
-pub struct DID(CoreDID);
+pub struct IotaDID(CoreDID);
 
-impl DID {
+impl IotaDID {
   /// The URL scheme for Decentralized Identifiers.
   pub const SCHEME: &'static str = CoreDID::SCHEME;
 
@@ -41,11 +41,11 @@ impl DID {
   /// The default Tangle network (`"main"`).
   pub const DEFAULT_NETWORK: &'static str = "main";
 
-  /// Converts a borrowed `DID` to an IOTA DID.
+  /// Converts a borrowed `DID` to an `IotaDID`.
   ///
   /// # Errors
   ///
-  /// Returns `Err` if the input is not a valid IOTA DID.
+  /// Returns `Err` if the input is not a valid `IotaDID`.
   pub fn try_from_borrowed(did: &CoreDID) -> Result<&Self> {
     Self::check_validity(did)?;
 
@@ -53,18 +53,18 @@ impl DID {
     Ok(unsafe { Self::new_unchecked_ref(did) })
   }
 
-  /// Converts an owned `DID` to an IOTA DID.
+  /// Converts an owned `DID` to an `IotaDID`.
   ///
   /// # Errors
   ///
-  /// Returns `Err` if the input is not a valid IOTA DID.
+  /// Returns `Err` if the input is not a valid `IotaDID`.
   pub fn try_from_owned(did: CoreDID) -> Result<Self> {
     Self::check_validity(&did)?;
 
     Ok(Self(Self::normalize(did)))
   }
 
-  /// Converts a `DID` reference to an IOTA DID reference without performing
+  /// Converts a `DID` reference to an `IotaDID` reference without performing
   /// validation checks.
   ///
   /// # Safety
@@ -72,41 +72,41 @@ impl DID {
   /// This must be guaranteed safe by the caller.
   pub unsafe fn new_unchecked_ref(did: &CoreDID) -> &Self {
     // SAFETY: This is guaranteed safe by the caller.
-    &*(did as *const CoreDID as *const DID)
+    &*(did as *const CoreDID as *const IotaDID)
   }
 
-  /// Parses an IOTA DID from the given `input`.
+  /// Parses an `IotaDID` from the given `input`.
   ///
   /// # Errors
   ///
-  /// Returns `Err` if the input is not a valid IOTA DID.
+  /// Returns `Err` if the input is not a valid `IotaDID`.
   pub fn parse(input: impl AsRef<str>) -> Result<Self> {
     CoreDID::parse(input).map_err(Into::into).and_then(Self::try_from_owned)
   }
 
-  /// Creates a new IOTA DID with a tag derived from the given `public` key.
+  /// Creates a new `IotaDID` with a tag derived from the given `public` key.
   ///
   /// # Errors
   ///
-  /// Returns `Err` if the input does not form a valid IOTA DID.
+  /// Returns `Err` if the input does not form a valid `IotaDID`.
   pub fn new(public: &[u8]) -> Result<Self> {
     try_did!(public)
   }
 
-  /// Creates a new IOTA DID from the given `public` key and `network`.
+  /// Creates a new `IotaDID` from the given `public` key and `network`.
   ///
   /// # Errors
   ///
-  /// Returns `Err` if the input does not form a valid IOTA DID.
+  /// Returns `Err` if the input does not form a valid `IotaDID`.
   pub fn with_network(public: &[u8], network: &str) -> Result<Self> {
     try_did!(public, network)
   }
 
-  /// Creates a new IOTA DID from the given `public` key, `network`, and `shard`.
+  /// Creates a new `IotaDID` from the given `public` key, `network`, and `shard`.
   ///
   /// # Errors
   ///
-  /// Returns `Err` if the input does not form a valid IOTA DID.
+  /// Returns `Err` if the input does not form a valid `IotaDID`.
   pub fn with_network_and_shard(public: &[u8], network: &str, shard: &str) -> Result<Self> {
     try_did!(public, network, shard)
   }
@@ -149,7 +149,7 @@ impl DID {
   ///
   /// # Errors
   ///
-  /// Returns `Err` if the input is not a valid IOTA DID.
+  /// Returns `Err` if the input is not a valid `IotaDID`.
   pub fn check_method(did: &CoreDID) -> Result<()> {
     if did.method() != Self::METHOD {
       Err(Error::InvalidDID(DIDError::InvalidMethodName))
@@ -158,11 +158,11 @@ impl DID {
     }
   }
 
-  /// Checks if the given `DID` has a valid IOTA DID `method_id`.
+  /// Checks if the given `DID` has a valid `IotaDID` `method_id`.
   ///
   /// # Errors
   ///
-  /// Returns `Err` if the input is not a valid IOTA DID.
+  /// Returns `Err` if the input is not a valid `IotaDID`.
   pub fn check_method_id(did: &CoreDID) -> Result<()> {
     let segments: Vec<&str> = did.method_id().split(':').collect();
 
@@ -181,12 +181,12 @@ impl DID {
     }
   }
 
-  /// Checks if the given `DID` is valid according to the IOTA DID method
+  /// Checks if the given `DID` is valid according to the `IotaDID` method
   /// specification.
   ///
   /// # Errors
   ///
-  /// Returns `Err` if the input is not a valid IOTA DID.
+  /// Returns `Err` if the input is not a valid `IotaDID`.
   pub fn check_validity(did: &CoreDID) -> Result<()> {
     Self::check_method(did)?;
     Self::check_method_id(did)?;
@@ -195,7 +195,7 @@ impl DID {
   }
 
   /// Returns a `bool` indicating if the given `DID` is valid according to the
-  /// IOTA DID method specification.
+  /// `IotaDID` method specification.
   pub fn is_valid(did: &CoreDID) -> bool {
     Self::check_validity(did).is_ok()
   }
@@ -238,19 +238,19 @@ impl DID {
   }
 }
 
-impl Display for DID {
+impl Display for IotaDID {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
     write!(f, "{}", self.0)
   }
 }
 
-impl Debug for DID {
+impl Debug for IotaDID {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
     write!(f, "{}", self.0)
   }
 }
 
-impl Deref for DID {
+impl Deref for IotaDID {
   type Target = CoreDID;
 
   fn deref(&self) -> &Self::Target {
@@ -258,19 +258,19 @@ impl Deref for DID {
   }
 }
 
-impl AsRef<CoreDID> for DID {
+impl AsRef<CoreDID> for IotaDID {
   fn as_ref(&self) -> &CoreDID {
     &self.0
   }
 }
 
-impl From<DID> for CoreDID {
-  fn from(other: DID) -> Self {
+impl From<IotaDID> for CoreDID {
+  fn from(other: IotaDID) -> Self {
     other.0
   }
 }
 
-impl TryFrom<CoreDID> for DID {
+impl TryFrom<CoreDID> for IotaDID {
   type Error = Error;
 
   fn try_from(other: CoreDID) -> Result<Self, Self::Error> {
@@ -278,15 +278,15 @@ impl TryFrom<CoreDID> for DID {
   }
 }
 
-impl<'a> TryFrom<&'a CoreDID> for &'a DID {
+impl<'a> TryFrom<&'a CoreDID> for &'a IotaDID {
   type Error = Error;
 
   fn try_from(other: &'a CoreDID) -> Result<Self, Self::Error> {
-    DID::try_from_borrowed(other)
+    IotaDID::try_from_borrowed(other)
   }
 }
 
-impl FromStr for DID {
+impl FromStr for IotaDID {
   type Err = Error;
 
   fn from_str(string: &str) -> Result<Self, Self::Err> {
@@ -299,102 +299,102 @@ mod tests {
   use identity_core::crypto::KeyPair;
   use identity_did::did::DID as CoreDID;
 
-  use crate::did::DID;
+  use crate::did::IotaDID;
 
   const TAG: &str = "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV";
 
   #[test]
   fn test_parse_valid() {
-    assert!(DID::parse(format!("did:iota:{}", TAG)).is_ok());
-    assert!(DID::parse(format!("did:iota:main:{}", TAG)).is_ok());
-    assert!(DID::parse(format!("did:iota:test:{}", TAG)).is_ok());
-    assert!(DID::parse(format!("did:iota:rainbow:{}", TAG)).is_ok());
-    assert!(DID::parse(format!("did:iota:rainbow:shard-1:{}", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:{}", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:main:{}", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:test:{}", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:rainbow:{}", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:rainbow:shard-1:{}", TAG)).is_ok());
   }
 
   #[test]
   fn test_parse_invalid() {
-    assert!(DID::parse("did:foo::").is_err());
-    assert!(DID::parse("did:::").is_err());
-    assert!(DID::parse("did:iota---::").is_err());
-    assert!(DID::parse("did:iota:").is_err());
+    assert!(IotaDID::parse("did:foo::").is_err());
+    assert!(IotaDID::parse("did:::").is_err());
+    assert!(IotaDID::parse("did:iota---::").is_err());
+    assert!(IotaDID::parse("did:iota:").is_err());
   }
 
   #[test]
   fn test_from_did() {
-    let key: String = DID::encode_key(b"123");
+    let key: String = IotaDID::encode_key(b"123");
 
     let did: CoreDID = format!("did:iota:{}", key).parse().unwrap();
-    assert!(DID::try_from_owned(did).is_ok());
+    assert!(IotaDID::try_from_owned(did).is_ok());
 
     let did: CoreDID = "did:iota:123".parse().unwrap();
-    assert!(DID::try_from_owned(did).is_err());
+    assert!(IotaDID::try_from_owned(did).is_err());
 
     let did: CoreDID = format!("did:web:{}", key).parse().unwrap();
-    assert!(DID::try_from_owned(did).is_err());
+    assert!(IotaDID::try_from_owned(did).is_err());
   }
 
   #[test]
   fn test_network() {
-    let key: String = DID::encode_key(b"123");
+    let key: String = IotaDID::encode_key(b"123");
 
-    let did: DID = format!("did:iota:test:{}", key).parse().unwrap();
+    let did: IotaDID = format!("did:iota:test:{}", key).parse().unwrap();
     assert_eq!(did.network(), "test");
 
-    let did: DID = format!("did:iota:{}", key).parse().unwrap();
+    let did: IotaDID = format!("did:iota:{}", key).parse().unwrap();
     assert_eq!(did.network(), "main");
 
-    let did: DID = format!("did:iota:rainbow:{}", key).parse().unwrap();
+    let did: IotaDID = format!("did:iota:rainbow:{}", key).parse().unwrap();
     assert_eq!(did.network(), "rainbow");
   }
 
   #[test]
   fn test_shard() {
-    let key: String = DID::encode_key(b"123");
+    let key: String = IotaDID::encode_key(b"123");
 
-    let did: DID = format!("did:iota:dev:{}", key).parse().unwrap();
+    let did: IotaDID = format!("did:iota:dev:{}", key).parse().unwrap();
     assert_eq!(did.shard(), None);
 
-    let did: DID = format!("did:iota:dev:shard:{}", key).parse().unwrap();
+    let did: IotaDID = format!("did:iota:dev:shard:{}", key).parse().unwrap();
     assert_eq!(did.shard(), Some("shard"));
   }
 
   #[test]
   fn test_tag() {
-    let did: DID = format!("did:iota:{}", TAG).parse().unwrap();
+    let did: IotaDID = format!("did:iota:{}", TAG).parse().unwrap();
     assert_eq!(did.tag(), TAG);
 
-    let did: DID = format!("did:iota:main:{}", TAG).parse().unwrap();
+    let did: IotaDID = format!("did:iota:main:{}", TAG).parse().unwrap();
     assert_eq!(did.tag(), TAG);
 
-    let did: DID = format!("did:iota:main:shard:{}", TAG).parse().unwrap();
+    let did: IotaDID = format!("did:iota:main:shard:{}", TAG).parse().unwrap();
     assert_eq!(did.tag(), TAG);
   }
 
   #[test]
   fn test_new() {
     let key: KeyPair = KeyPair::new_ed25519().unwrap();
-    let did: DID = DID::new(key.public().as_ref()).unwrap();
-    let tag: String = DID::encode_key(key.public().as_ref());
+    let did: IotaDID = IotaDID::new(key.public().as_ref()).unwrap();
+    let tag: String = IotaDID::encode_key(key.public().as_ref());
 
     assert_eq!(did.tag(), tag);
-    assert_eq!(did.network(), DID::DEFAULT_NETWORK);
+    assert_eq!(did.network(), IotaDID::DEFAULT_NETWORK);
     assert_eq!(did.shard(), None);
 
-    let did = DID::from_components(key.public().as_ref(), None, None).unwrap();
+    let did = IotaDID::from_components(key.public().as_ref(), None, None).unwrap();
     assert_eq!(did.tag(), tag);
-    assert_eq!(did.network(), DID::DEFAULT_NETWORK);
+    assert_eq!(did.network(), IotaDID::DEFAULT_NETWORK);
     assert_eq!(did.shard(), None);
 
-    let did = DID::from_components(key.public().as_ref(), Some(DID::DEFAULT_NETWORK), None).unwrap();
-    assert_eq!(did.network(), DID::DEFAULT_NETWORK);
+    let did = IotaDID::from_components(key.public().as_ref(), Some(IotaDID::DEFAULT_NETWORK), None).unwrap();
+    assert_eq!(did.network(), IotaDID::DEFAULT_NETWORK);
   }
 
   #[test]
   fn test_with_network() {
     let key: KeyPair = KeyPair::new_ed25519().unwrap();
-    let did: DID = DID::with_network(key.public().as_ref(), "foo").unwrap();
-    let tag: String = DID::encode_key(key.public().as_ref());
+    let did: IotaDID = IotaDID::with_network(key.public().as_ref(), "foo").unwrap();
+    let tag: String = IotaDID::encode_key(key.public().as_ref());
 
     assert_eq!(did.tag(), tag);
     assert_eq!(did.network(), "foo");
@@ -404,8 +404,8 @@ mod tests {
   #[test]
   fn test_with_network_and_shard() {
     let key: KeyPair = KeyPair::new_ed25519().unwrap();
-    let did: DID = DID::with_network_and_shard(key.public().as_ref(), "foo", "shard-1").unwrap();
-    let tag: String = DID::encode_key(key.public().as_ref());
+    let did: IotaDID = IotaDID::with_network_and_shard(key.public().as_ref(), "foo", "shard-1").unwrap();
+    let tag: String = IotaDID::encode_key(key.public().as_ref());
 
     assert_eq!(did.tag(), tag);
     assert_eq!(did.network(), "foo");
@@ -415,16 +415,16 @@ mod tests {
   #[test]
   fn test_normalize() {
     let key: KeyPair = KeyPair::new_ed25519().unwrap();
-    let tag: String = DID::encode_key(key.public().as_ref());
+    let tag: String = IotaDID::encode_key(key.public().as_ref());
 
-    // A DID with "main" as the network can be normalized ("main" removed)
-    let did1: DID = format!("did:iota:{}", tag).parse().unwrap();
-    let did2: DID = format!("did:iota:main:{}", tag).parse().unwrap();
+    // A IotaDID with "main" as the network can be normalized ("main" removed)
+    let did1: IotaDID = format!("did:iota:{}", tag).parse().unwrap();
+    let did2: IotaDID = format!("did:iota:main:{}", tag).parse().unwrap();
     assert_eq!(did1, did2);
 
-    // A DID with a shard cannot be normalized
+    // A IotaDID with a shard cannot be normalized
     let did_str: String = format!("did:iota:main:shard:{}", tag);
-    let did: DID = did_str.parse().unwrap();
+    let did: IotaDID = did_str.parse().unwrap();
 
     assert_eq!(did.as_str(), did_str);
   }
@@ -432,7 +432,7 @@ mod tests {
   #[test]
   fn test_setter() {
     let key: KeyPair = KeyPair::new_ed25519().unwrap();
-    let mut did: DID = DID::new(key.public().as_ref()).unwrap();
+    let mut did: IotaDID = IotaDID::new(key.public().as_ref()).unwrap();
 
     did.set_path("#foo");
     did.set_query(Some("diff=true"));

--- a/identity-iota/src/did/url/mod.rs
+++ b/identity-iota/src/did/url/mod.rs
@@ -1,8 +1,8 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-mod did;
+mod iota_did;
 mod segments;
 
-pub use self::did::DID;
+pub use self::iota_did::IotaDID;
 pub use self::segments::Segments;

--- a/identity-iota/src/did/url/segments.rs
+++ b/identity-iota/src/did/url/segments.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::did::DID;
+use crate::did::IotaDID;
 
 macro_rules! get {
   (@network $this:expr) => {
@@ -31,14 +31,14 @@ impl<'id> Segments<'id> {
   pub fn is_default_network(&self) -> bool {
     match self.count() {
       1 => true,
-      2 | 3 => get!(@network self) == DID::DEFAULT_NETWORK,
+      2 | 3 => get!(@network self) == IotaDID::DEFAULT_NETWORK,
       _ => unreachable!("Segments::is_default_network called for invalid IOTA DID"),
     }
   }
 
   pub fn network(&self) -> &'id str {
     match self.count() {
-      1 => DID::DEFAULT_NETWORK,
+      1 => IotaDID::DEFAULT_NETWORK,
       2 | 3 => get!(@network self),
       _ => unreachable!("Segments::network called for invalid IOTA DID"),
     }

--- a/identity-iota/src/tangle/message_ext.rs
+++ b/identity-iota/src/tangle/message_ext.rs
@@ -6,9 +6,9 @@ use iota::Message;
 use iota::MessageId;
 use iota::Payload;
 
-use crate::did::Document;
 use crate::did::DocumentDiff;
-use crate::did::DID;
+use crate::did::IotaDID;
+use crate::did::IotaDocument;
 use crate::error::Result;
 use crate::tangle::TangleRef;
 
@@ -53,17 +53,17 @@ impl MessageIdExt for MessageId {
 }
 
 pub trait MessageExt {
-  fn try_extract_document(&self, did: &DID) -> Option<Document>;
+  fn try_extract_document(&self, did: &IotaDID) -> Option<IotaDocument>;
 
-  fn try_extract_diff(&self, did: &DID) -> Option<DocumentDiff>;
+  fn try_extract_diff(&self, did: &IotaDID) -> Option<DocumentDiff>;
 }
 
 impl MessageExt for Message {
-  fn try_extract_document(&self, did: &DID) -> Option<Document> {
-    try_extract!(Document, self, did)
+  fn try_extract_document(&self, did: &IotaDID) -> Option<IotaDocument> {
+    try_extract!(IotaDocument, self, did)
   }
 
-  fn try_extract_diff(&self, did: &DID) -> Option<DocumentDiff> {
+  fn try_extract_diff(&self, did: &IotaDID) -> Option<DocumentDiff> {
     try_extract!(DocumentDiff, self, did)
   }
 }

--- a/identity/src/lib.rs
+++ b/identity/src/lib.rs
@@ -95,6 +95,6 @@ pub mod prelude {
 
   pub use identity_core::crypto::KeyPair;
   pub use identity_iota::client::Client;
-  pub use identity_iota::did::Document;
+  pub use identity_iota::did::IotaDocument;
   pub use identity_iota::Result;
 }


### PR DESCRIPTION
# Description of change

Rename types with common names to contain prefixes.

- `identity-did/src/document/document.rs` -> `identity-did/src/document/core_document.rs`
  - `Document` -> `CoreDocument`
- `identity-did/src/verification/method.rs` -> `identity-did/src/verification/verification_method.rs`
  - `Method` -> `VerificationMethod`
- `identity-iota/src/did/doc/document.rs` -> `identity-iota/src/did/doc/iota_document.rs`
  - `Document` -> `IotaDocument`
- `identity-iota/src/did/doc/method.rs` -> `identity-iota/src/did/doc/iota_method.rs`
  - `Method` -> `IotaMethod`
- `identity-iota/src/did/url/did.rs` -> `identity-iota/src/did/url/iota_did.rs`
  - `DID` -> `IotaDID`
- `bindings/wasm/src/document.rs` -> `bindings/wasm/src/wasm_document.rs`
  - `Document` -> `WasmDocument`
- `bindings/wasm/src/method.rs` -> `bindings/wasm/src/wasm_method.rs`
  - `Method` -> `WasmMethod`
- `bindings/wasm/src/did.rs` -> `bindings/wasm/src/wasm_did.rs`
  - `DID` -> `WasmDID`

Discussion in #218 

## Links to any relevant issues

#218 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

This PR contains type renames and file moves only. Thankfully Rust has a great type system so if it compiles, it _should_ work :)

`cargo build` and `cargo test` both succeed.

`cargo clippy` for target `aarch64-apple-darwin` passes locally, but for some reason is failing in GitHub actions.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
