### PR TITLE
Rename AuthChain references

### DIFF
--- a/examples/diff_chain.rs
+++ b/examples/diff_chain.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<()> {
     }
 
     new.set_updated(Timestamp::now());
-    new.set_previous_message_id(*chain.auth_message_id());
+    new.set_previous_message_id(*chain.integration_message_id());
 
     chain.current().sign_data(&mut new, keys[0].secret())?;
     new.publish(&client).await?;
@@ -97,7 +97,7 @@ async fn main() -> Result<()> {
     let message_id = *chain.diff_message_id();
     let mut diff: DocumentDiff = chain.current().diff(&new, message_id, keys[1].secret())?;
 
-    diff.publish(chain.auth_message_id(), &client).await?;
+    diff.publish(chain.integration_message_id(), &client).await?;
     chain.try_push_diff(diff)?;
     let message_id2 = *chain.diff_message_id();
 
@@ -130,7 +130,7 @@ async fn main() -> Result<()> {
     }
 
     new.set_updated(Timestamp::now());
-    new.set_previous_message_id(*chain.auth_message_id());
+    new.set_previous_message_id(*chain.integration_message_id());
 
     new.sign(keypair.secret())?;
     new.publish(&client).await?;
@@ -156,7 +156,7 @@ async fn main() -> Result<()> {
     let message_id = *chain.diff_message_id();
     let mut diff: DocumentDiff = chain.current().diff(&new, message_id, keys[1].secret())?;
 
-    diff.publish(chain.auth_message_id(), &client).await?;
+    diff.publish(chain.integration_message_id(), &client).await?;
     chain.try_push_diff(diff)?;
 
     println!("Chain (4) > {:#}", chain);

--- a/identity-core/Cargo.toml
+++ b/identity-core/Cargo.toml
@@ -27,8 +27,7 @@ url = { version = "2.2", default-features = false, features = ["serde"] }
 zeroize = { version = "1.2", default-features = false }
 
 [dependencies.iota-crypto]
-git = "https://github.com/iotaledger/crypto.rs"
-rev = "b849861b86c3f7357b7477de4253b7352b363627"
+version = "0.5"
 default-features = false
 features = ["blake2b", "ed25519", "random", "sha"]
 

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -30,8 +30,7 @@ default-features = false
 features = ["wasm"]
 
 [dependencies.iota-crypto]
-git = "https://github.com/iotaledger/crypto.rs"
-rev = "c3bf565eba62d0b81144174c2ff917bfde282e49"
+version = "0.5"
 default-features = false
 features = ["blake2b"]
 

--- a/identity-iota/src/chain/diff.rs
+++ b/identity-iota/src/chain/diff.rs
@@ -227,7 +227,7 @@ mod test {
       }
 
       new.set_updated(Timestamp::now());
-      new.set_previous_message_id(*chain.auth_message_id());
+      new.set_previous_message_id(*chain.integration_message_id());
 
       assert!(chain.current().sign_data(&mut new, keys[0].secret()).is_ok());
       assert_eq!(

--- a/identity-iota/src/chain/document.rs
+++ b/identity-iota/src/chain/document.rs
@@ -32,8 +32,8 @@ impl DocumentChain {
       .unwrap_or_else(|| integration_chain.current_message_id())
   }
 
-  pub(crate) fn __fold(auth_chain: &IntegrationChain, diff_chain: &DiffChain) -> Result<IotaDocument> {
-    let mut this: IotaDocument = auth_chain.current.clone();
+  pub(crate) fn __fold(integration_chain: &IntegrationChain, diff_chain: &DiffChain) -> Result<IotaDocument> {
+    let mut this: IotaDocument = integration_chain.current.clone();
 
     for diff in diff_chain.iter() {
       this.merge(diff)?;
@@ -42,25 +42,25 @@ impl DocumentChain {
     Ok(this)
   }
 
-  /// Creates a new `DocumentChain` from given the `AuthChain`.
-  pub fn new(auth_chain: IntegrationChain) -> Self {
+  /// Creates a new `DocumentChain` from given the `IntegrationChain`.
+  pub fn new(integration_chain: IntegrationChain) -> Self {
     Self {
-      integration_chain: auth_chain,
+      integration_chain,
       diff_chain: DiffChain::new(),
       document: None,
     }
   }
 
-  /// Creates a new `DocumentChain` from given the `AuthChain` and `DiffChain`.
-  pub fn with_diff_chain(auth_chain: IntegrationChain, diff_chain: DiffChain) -> Result<Self> {
+  /// Creates a new `DocumentChain` from given the `IntegrationChain` and `DiffChain`.
+  pub fn with_diff_chain(integration_chain: IntegrationChain, diff_chain: DiffChain) -> Result<Self> {
     let document: Option<IotaDocument> = if diff_chain.is_empty() {
       None
     } else {
-      Some(Self::__fold(&auth_chain, &diff_chain)?)
+      Some(Self::__fold(&integration_chain, &diff_chain)?)
     };
 
     Ok(Self {
-      integration_chain: auth_chain,
+      integration_chain,
       diff_chain,
       document,
     })
@@ -71,12 +71,12 @@ impl DocumentChain {
     self.integration_chain.current.id()
   }
 
-  /// Returns a reference to the `AuthChain`.
+  /// Returns a reference to the `IntegrationChain`.
   pub fn integration_chain(&self) -> &IntegrationChain {
     &self.integration_chain
   }
 
-  /// Returns a mutable reference to the `AuthChain`.
+  /// Returns a mutable reference to the `IntegrationChain`.
   pub fn integration_chain_mut(&mut self) -> &mut IntegrationChain {
     &mut self.integration_chain
   }
@@ -117,7 +117,7 @@ impl DocumentChain {
   }
 
   /// Returns the Tangle message Id of the latest integration document.
-  pub fn auth_message_id(&self) -> &MessageId {
+  pub fn integration_message_id(&self) -> &MessageId {
     self.integration_chain.current_message_id()
   }
 

--- a/identity-iota/src/chain/document.rs
+++ b/identity-iota/src/chain/document.rs
@@ -17,25 +17,23 @@ use iota::MessageId;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct DocumentChain {
-  #[serde(rename = "diff")]
-  diff_chain: DiffChain,
-  #[serde(rename = "integration")]
-  integration_chain: IntegrationChain,
-  #[serde(rename = "latest", skip_serializing_if = "Option::is_none")]
+  chain_d: DiffChain,
+  chain_i: IntegrationChain,
+  #[serde(skip_serializing_if = "Option::is_none")]
   document: Option<IotaDocument>,
 }
 
 impl DocumentChain {
-  pub(crate) fn __diff_message_id<'a>(integration_chain: &'a IntegrationChain, diff: &'a DiffChain) -> &'a MessageId {
+  pub(crate) fn __diff_message_id<'a>(chain_i: &'a IntegrationChain, diff: &'a DiffChain) -> &'a MessageId {
     diff
       .current_message_id()
-      .unwrap_or_else(|| integration_chain.current_message_id())
+      .unwrap_or_else(|| chain_i.current_message_id())
   }
 
-  pub(crate) fn __fold(integration_chain: &IntegrationChain, diff_chain: &DiffChain) -> Result<IotaDocument> {
-    let mut this: IotaDocument = integration_chain.current.clone();
+  pub(crate) fn __fold(chain_i: &IntegrationChain, chain_d: &DiffChain) -> Result<IotaDocument> {
+    let mut this: IotaDocument = chain_i.current.clone();
 
-    for diff in diff_chain.iter() {
+    for diff in chain_d.iter() {
       this.merge(diff)?;
     }
 
@@ -43,60 +41,60 @@ impl DocumentChain {
   }
 
   /// Creates a new `DocumentChain` from given the `IntegrationChain`.
-  pub fn new(integration_chain: IntegrationChain) -> Self {
+  pub fn new(chain_i: IntegrationChain) -> Self {
     Self {
-      integration_chain,
-      diff_chain: DiffChain::new(),
+      chain_i,
+      chain_d: DiffChain::new(),
       document: None,
     }
   }
 
   /// Creates a new `DocumentChain` from given the `IntegrationChain` and `DiffChain`.
-  pub fn with_diff_chain(integration_chain: IntegrationChain, diff_chain: DiffChain) -> Result<Self> {
-    let document: Option<IotaDocument> = if diff_chain.is_empty() {
+  pub fn with_diff_chain(chain_i: IntegrationChain, chain_d: DiffChain) -> Result<Self> {
+    let document: Option<IotaDocument> = if chain_d.is_empty() {
       None
     } else {
-      Some(Self::__fold(&integration_chain, &diff_chain)?)
+      Some(Self::__fold(&chain_i, &chain_d)?)
     };
 
     Ok(Self {
-      integration_chain,
-      diff_chain,
+      chain_i,
+      chain_d,
       document,
     })
   }
 
   /// Returns a reference to the DID identifying the document chain.
   pub fn id(&self) -> &IotaDID {
-    self.integration_chain.current.id()
+    self.chain_i.current.id()
   }
 
   /// Returns a reference to the `IntegrationChain`.
   pub fn integration_chain(&self) -> &IntegrationChain {
-    &self.integration_chain
+    &self.chain_i
   }
 
   /// Returns a mutable reference to the `IntegrationChain`.
   pub fn integration_chain_mut(&mut self) -> &mut IntegrationChain {
-    &mut self.integration_chain
+    &mut self.chain_i
   }
 
   /// Returns a reference to the `DiffChain`.
   pub fn diff(&self) -> &DiffChain {
-    &self.diff_chain
+    &self.chain_d
   }
 
   /// Returns a mutable reference to the `DiffChain`.
   pub fn diff_mut(&mut self) -> &mut DiffChain {
-    &mut self.diff_chain
+    &mut self.chain_d
   }
 
   pub fn fold(mut self) -> Result<IotaDocument> {
-    for diff in self.diff_chain.iter() {
-      self.integration_chain.current.merge(diff)?;
+    for diff in self.chain_d.iter() {
+      self.chain_i.current.merge(diff)?;
     }
 
-    Ok(self.integration_chain.current)
+    Ok(self.chain_i.current)
   }
 
   /// Returns a reference to the latest document.
@@ -104,7 +102,7 @@ impl DocumentChain {
     self
       .document
       .as_ref()
-      .unwrap_or_else(|| self.integration_chain.current())
+      .unwrap_or_else(|| self.chain_i.current())
   }
 
   /// Returns a mutable reference to the latest document.
@@ -112,18 +110,18 @@ impl DocumentChain {
     if let Some(document) = self.document.as_mut() {
       document
     } else {
-      self.integration_chain.current_mut()
+      self.chain_i.current_mut()
     }
   }
 
   /// Returns the Tangle message Id of the latest integration document.
   pub fn integration_message_id(&self) -> &MessageId {
-    self.integration_chain.current_message_id()
+    self.chain_i.current_message_id()
   }
 
   /// Returns the Tangle message Id of the latest diff or integration document.
   pub fn diff_message_id(&self) -> &MessageId {
-    Self::__diff_message_id(&self.integration_chain, &self.diff_chain)
+    Self::__diff_message_id(&self.chain_i, &self.chain_d)
   }
 
   /// Adds a new integration document to the chain.
@@ -132,8 +130,8 @@ impl DocumentChain {
   ///
   /// Fails if the document is not a valid integration document.
   pub fn try_push_integration(&mut self, document: IotaDocument) -> Result<()> {
-    self.integration_chain.try_push(document)?;
-    self.diff_chain.clear();
+    self.chain_i.try_push(document)?;
+    self.chain_d.clear();
 
     self.document = None;
 
@@ -146,12 +144,12 @@ impl DocumentChain {
   ///
   /// Fails if the document diff is invalid.
   pub fn try_push_diff(&mut self, diff: DocumentDiff) -> Result<()> {
-    self.diff_chain.check_validity(&self.integration_chain, &diff)?;
+    self.chain_d.check_validity(&self.chain_i, &diff)?;
 
     let mut document: IotaDocument = self
       .document
       .take()
-      .unwrap_or_else(|| self.integration_chain.current().clone());
+      .unwrap_or_else(|| self.chain_i.current().clone());
 
     document.merge(&diff)?;
 
@@ -159,7 +157,7 @@ impl DocumentChain {
 
     // SAFETY: we performed the necessary validation in `DiffChain::check_validity`.
     unsafe {
-      self.diff_chain.push_unchecked(diff);
+      self.chain_d.push_unchecked(diff);
     }
 
     Ok(())

--- a/identity-iota/src/chain/document.rs
+++ b/identity-iota/src/chain/document.rs
@@ -99,10 +99,7 @@ impl DocumentChain {
 
   /// Returns a reference to the latest document.
   pub fn current(&self) -> &IotaDocument {
-    self
-      .document
-      .as_ref()
-      .unwrap_or_else(|| self.chain_i.current())
+    self.document.as_ref().unwrap_or_else(|| self.chain_i.current())
   }
 
   /// Returns a mutable reference to the latest document.
@@ -146,10 +143,7 @@ impl DocumentChain {
   pub fn try_push_diff(&mut self, diff: DocumentDiff) -> Result<()> {
     self.chain_d.check_validity(&self.chain_i, &diff)?;
 
-    let mut document: IotaDocument = self
-      .document
-      .take()
-      .unwrap_or_else(|| self.chain_i.current().clone());
+    let mut document: IotaDocument = self.document.take().unwrap_or_else(|| self.chain_i.current().clone());
 
     document.merge(&diff)?;
 

--- a/identity-iota/src/chain/integration.rs
+++ b/identity-iota/src/chain/integration.rs
@@ -27,7 +27,7 @@ pub struct IntegrationChain {
 }
 
 impl IntegrationChain {
-  /// Constructs a new `AuthChain` from a slice of `Message`s.
+  /// Constructs a new `IntegrationChain` from a slice of `Message`s.
   pub fn try_from_messages(did: &IotaDID, messages: &[Message]) -> Result<Self> {
     let mut index: MessageIndex<IotaDocument> = messages
       .iter()
@@ -53,7 +53,7 @@ impl IntegrationChain {
     Ok(this)
   }
 
-  /// Creates a new `AuthChain` with the given `IotaDocument` as the latest.
+  /// Creates a new `IntegrationChain` with the given `IotaDocument` as the latest.
   pub fn new(current: IotaDocument) -> Result<Self> {
     if current.verify().is_err() {
       return Err(Error::ChainError {
@@ -102,12 +102,12 @@ impl IntegrationChain {
     Ok(())
   }
 
-  /// Returns `true` if the `IotaDocument` can be added to the `AuthChain`.
+  /// Returns `true` if the `IotaDocument` can be added to the `IntegrationChain`.
   pub fn is_valid(&self, document: &IotaDocument) -> bool {
     self.check_validity(document).is_ok()
   }
 
-  /// Checks if the `IotaDocument` can be added to the `AuthChain`.
+  /// Checks if the `IotaDocument` can be added to the `IntegrationChain`.
   ///
   /// # Errors
   ///


### PR DESCRIPTION
# Description of change

Renames a few AuthChain references that were missed in https://github.com/iotaledger/identity.rs/pull/230

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

## How the change has been tested

Ran tests

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
