### PR TITLE
Add IotaDocument unit tests for methods and controller.

### DIFF
--- a/identity-iota/src/did/doc/iota_document.rs
+++ b/identity-iota/src/did/doc/iota_document.rs
@@ -649,9 +649,6 @@ mod tests {
   }
 
   #[test]
-  fn test_signer() {}
-
-  #[test]
   fn test_json() {
     let keypair: KeyPair = generate_testkey();
     let mut document: IotaDocument = IotaDocument::from_keypair(&keypair).unwrap();


### PR DESCRIPTION
# Description of change

Add `IotaDocument` unit tests for `methods()` and `controller()`.

This is in preparation to address #172, which I discovered doesn't have any unit tests that call `IotaDocument::controller()` or `IotaDocument::methods()`. These tests are relatively straightforward, but will now clearly show changes in types after returning the "correct" (aka. Iota-specific types) for these methods.

## Links to any relevant issues

#172

## Type of change

- [x] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo test`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
