### PR TITLE
Return IOTA specific types for methods on IotaDocument

### DIFF
--- a/bindings/wasm/src/wasm_document.rs
+++ b/bindings/wasm/src/wasm_document.rs
@@ -11,8 +11,8 @@ use identity::crypto::PublicKey;
 use identity::crypto::SecretKey;
 use identity::did::verifiable;
 use identity::did::MethodScope;
-use identity::did::VerificationMethod;
 use identity::iota::DocumentDiff;
+use identity::iota::Error;
 use identity::iota::IotaDID;
 use identity::iota::IotaDocument;
 use identity::iota::IotaVerificationMethod;
@@ -220,7 +220,7 @@ impl WasmDocument {
         let merkle_key: Vec<u8> = self
           .0
           .try_resolve(&*method)
-          .and_then(|method| method.key_data().try_decode())
+          .and_then(|method| method.key_data().try_decode().map_err(Error::InvalidDoc))
           .map_err(err)?;
 
         let public: PublicKey = decode_b58(&public).map_err(err).map(Into::into)?;
@@ -260,11 +260,7 @@ impl WasmDocument {
 
   #[wasm_bindgen(js_name = resolveKey)]
   pub fn resolve_key(&mut self, query: &str) -> Result<WasmVerificationMethod, JsValue> {
-    let method: VerificationMethod = self.0.try_resolve(query).map_err(err)?.clone();
-
-    IotaVerificationMethod::try_from_core(method)
-      .map_err(err)
-      .map(WasmVerificationMethod)
+    Ok(WasmVerificationMethod(self.0.try_resolve(query).map_err(err)?.clone()))
   }
 
   #[wasm_bindgen(js_name = revokeMerkleKey)]

--- a/examples/manipulate_did_document.rs
+++ b/examples/manipulate_did_document.rs
@@ -6,7 +6,9 @@
 //! cargo run --example manipulate_did_document
 
 use identity::crypto::KeyPair;
+use identity::iota::IotaDID;
 use identity::iota::IotaDocument;
+use identity::iota::IotaVerificationMethod;
 use identity::iota::Result;
 
 #[tokio::main]
@@ -21,22 +23,22 @@ async fn main() -> Result<()> {
   println!();
 
   // We can access individual fields of the DID Document as defined below using the appropriate getters:
-  let _did: &identity::did::DID = document.id(); // The Document ID.
-  let _controller: Option<&identity::did::DID> = document.controller(); // The Document controller.
+  let _did: &IotaDID = document.id(); // The Document ID.
+  let _controller: Option<&IotaDID> = document.controller(); // The Document controller.
   let _aka: &[identity::core::Url] = document.also_known_as(); // AKA: Subject of this identifier is also identified by one or more other identifiers.
                                                                // ... etc. Each getter also has a _mut variant returning a mutable reference instead of an immutable one, e.g.
                                                                // .id_mut() See also https://identity.docs.iota.org/docs/identity/did/struct.Document.html
 
   // We can iterate over a DID Document's verification methods using document.methods(), which returns an iterator:
   for m in document.methods() {
-    // m is of type &identity::did::Method
+    // m is of type &IotaVerificationMethod
     println!("Method > {:#}", m);
   }
   println!();
 
   // We can also add and remove methods from a DID Document using insert_method() and remove_method() respectively.
-  let method: &identity::did::VerificationMethod = document.methods().next().unwrap();
-  let _method_did: &identity::did::DID = method.id();
+  let method: &IotaVerificationMethod = document.methods().next().unwrap();
+  let _method_did: &IotaDID = method.id();
   // document.remove_method(identity::iota::DID::new(public: &[u8]));
 
   // We can search for a specific method using .resolve(), for instance if we want to have the first #authentication

--- a/identity-did/src/document/core_document.rs
+++ b/identity-did/src/document/core_document.rs
@@ -254,7 +254,9 @@ impl<T, U, V> CoreDocument<T, U, V> {
     self.verification_method.remove(did);
   }
 
-  /// Returns an iterator over all verification methods in the DID Document.
+  /// Returns an iterator over all embedded verification methods in the DID Document.
+  ///
+  /// This excludes verification methods that are referenced by the DID Document.
   pub fn methods(&self) -> impl Iterator<Item = &VerificationMethod<U>> {
     fn __filter_ref<T>(method: &DIDKey<MethodRef<T>>) -> Option<&VerificationMethod<T>> {
       match &**method {
@@ -272,6 +274,23 @@ impl<T, U, V> CoreDocument<T, U, V> {
       .chain(self.key_agreement.iter().filter_map(__filter_ref))
       .chain(self.capability_delegation.iter().filter_map(__filter_ref))
       .chain(self.capability_invocation.iter().filter_map(__filter_ref))
+  }
+
+  /// Returns an iterator over all verification relationships.
+  ///
+  /// This includes embeded and referenced verification methods.
+  pub fn verification_relationships(&self) -> impl Iterator<Item = &MethodRef<U>> {
+    fn __method_ref<T>(method: &DIDKey<MethodRef<T>>) -> &MethodRef<T> {
+      &**method
+    }
+    self
+      .authentication
+      .iter()
+      .map(__method_ref)
+      .chain(self.assertion_method.iter().map(__method_ref))
+      .chain(self.key_agreement.iter().map(__method_ref))
+      .chain(self.capability_delegation.iter().map(__method_ref))
+      .chain(self.capability_invocation.iter().map(__method_ref))
   }
 
   /// Returns the first verification [`method`][`Method`] with an `id` property

--- a/identity-iota/src/did/doc/iota_document.rs
+++ b/identity-iota/src/did/doc/iota_document.rs
@@ -135,6 +135,11 @@ impl IotaDocument {
     })
   }
 
+  /// Performs validation that a `CoreDocument` adheres to the IOTA spec.
+  ///
+  /// # Errors
+  ///
+  /// Returns `Err` if the document is not a valid IOTA DID Document.
   fn validate_core_document<T, U, V>(document: &CoreDocument<T, U, V>) -> Result<()> {
     // Validate that the DID conforms to the IotaDID specification.
     // This check is required to ensure the correctness of the `IotaDocument::id()` method which

--- a/identity-iota/src/did/doc/iota_document.rs
+++ b/identity-iota/src/did/doc/iota_document.rs
@@ -261,7 +261,7 @@ impl IotaDocument {
 
   /// Returns a reference to the [`proof`][`Signature`], if one exists.
   pub fn proof(&self) -> Option<&Signature> {
-    return self.document.proof();
+    self.document.proof()
   }
 
   // ===========================================================================
@@ -323,7 +323,7 @@ impl IotaDocument {
         .document
         .try_resolve(query)
         .map(|m| IotaVerificationMethod::new_unchecked_ref(m))
-        .map_err(|e| Error::InvalidDoc(e))
+        .map_err(Error::InvalidDoc)
     }
   }
 

--- a/identity-iota/src/did/doc/iota_document.rs
+++ b/identity-iota/src/did/doc/iota_document.rs
@@ -6,7 +6,6 @@ use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
 use core::fmt::Result as FmtResult;
-use core::ops::Deref;
 use identity_core::common::Object;
 use identity_core::common::Timestamp;
 use identity_core::convert::SerdeInto;
@@ -413,14 +412,6 @@ impl Display for IotaDocument {
 impl Debug for IotaDocument {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
     Debug::fmt(&self.document, f)
-  }
-}
-
-impl Deref for IotaDocument {
-  type Target = BaseDocument;
-
-  fn deref(&self) -> &Self::Target {
-    &self.document
   }
 }
 

--- a/identity-iota/src/did/doc/iota_document.rs
+++ b/identity-iota/src/did/doc/iota_document.rs
@@ -220,6 +220,7 @@ impl IotaDocument {
 
   /// Returns a reference to the `IotaDocument` controller.
   pub fn controller(&self) -> Option<&IotaDID> {
+    // SAFETY: Validity of controller checked in DID Document constructors.
     unsafe { self.document.controller().map(|d| IotaDID::new_unchecked_ref(d)) }
   }
 
@@ -296,6 +297,7 @@ impl IotaDocument {
 
   /// Returns an iterator over all verification methods in the DID Document.
   pub fn methods(&self) -> impl Iterator<Item = &IotaVerificationMethod> {
+    // SAFETY: Validity of verification methods checked in `IotaDocument::check_authentication`.
     unsafe {
       self
         .document
@@ -326,6 +328,7 @@ impl IotaDocument {
   where
     Q: Into<MethodQuery<'query>>,
   {
+    // SAFETY: Validity of verification methods checked in `IotaDocument::check_authentication`.
     unsafe {
       self
         .document
@@ -344,6 +347,7 @@ impl IotaDocument {
   where
     Q: Into<MethodQuery<'query>>,
   {
+    // SAFETY: Validity of verification methods checked in `IotaDocument::check_authentication`.
     unsafe {
       self
         .document

--- a/identity-iota/src/did/doc/iota_verification_method.rs
+++ b/identity-iota/src/did/doc/iota_verification_method.rs
@@ -126,7 +126,7 @@ impl IotaVerificationMethod {
   /// # Errors
   ///
   /// Returns `Err` if the input is not a valid IOTA verification method.
-  pub fn check_validity(method: &VerificationMethod) -> Result<()> {
+  pub fn check_validity<T>(method: &VerificationMethod<T>) -> Result<()> {
     // Ensure all associated DIDs are IOTA Identity DIDs
     IotaDID::check_validity(method.id())?;
     IotaDID::check_validity(method.controller())?;


### PR DESCRIPTION
# Description of change

## Summary

Remove the `impl Deref for IotaDocument` and re-implement `CoreDocument` methods on `IotaDocument` returning the correct (ie. IOTA-specific) types.

## Details

Specifically, the following functions have been linked to the `IotaDocument` type:

- `IotaDocument::controller()` - "unsafe", see Safety section below
- `IotaDocument::also_known_as()` - "safe"
- `IotaDocument::proof()` - "safe"
- `IotaDocument::methods()` - "unsafe", see Safety section below
- `IotaDocument::resolve()` - "unsafe", see Safety section below
- `IotaDocument::try_resolve()` - "unsafe, see Safety section below
- `IotaDocument::verifier()` - "safe"
- `IotaDocument::signer()` - "safe"
- `IotaDocument::services()` - "safe"

## Safety / Verification

The `IotaDocument::try_from_core()` method has been updated to include validity checks for:
- `document.controller()` - needed for `IotaDocument::controller()`
- `document.methods()` - needed for `IotaDocument::methods()`, `IotaDocument::resolve()`, `IotaDocument::try_resolve()`

Reviewers, please triple check that there aren't other ways non-conformant documents can slip in.

As a side note, I noticed that the `impl From<BaseDocument> for IotaDocument` instance may not be "safe", since `BaseDocument` is simply `CoreDocument<Properties, Object, Object>` which I think someone could construct themself (and not conform to the spec), and then convert this to an `IotaDocument`.

## Breaking Change

This is a breaking change, any code that was previously relying on the `Deref` instance for `IotaDocument`->`CoreDocument` will need to update. Hopefully the breakages are minimal since the most common functions that are used via `Deref` have been re-implemented on `IotaDocument`.

## Links to any relevant issues

fixes issue #172

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

`cargo test`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
