### PR TITLE
Update README example to use IotaDocument instead of Document

### DIFF
--- a/identity/README.md
+++ b/identity/README.md
@@ -7,7 +7,7 @@ IOTA Identity is a [Rust](https://www.rust-lang.org/) implementation of decentra
 ```rust
 use identity::crypto::KeyPair;
 use identity::iota::Client;
-use identity::iota::Document;
+use identity::iota::IotaDocument;
 use identity::iota::Network;
 use identity::iota::Result;
 use identity::iota::TangleRef;
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
 
   // Create a DID Document (an identity).
   let keypair: KeyPair = KeyPair::new_ed25519()?;
-  let mut document: Document = Document::from_keypair(&keypair)?;
+  let mut document: IotaDocument = IotaDocument::from_keypair(&keypair)?;
 
   // Sign the DID Document with the default authentication key.
   document.sign(keypair.secret())?;


### PR DESCRIPTION
# Description of change

Update README example to use `IotaDocument` instead of `Document`. I missed updating this README in #219.

## Links to any relevant issues

Follow-up to #219.

## Type of change

- [x] Documentation Fix

## How the change has been tested

N/A - documentation change only

## Change checklist

- [x] I have made corresponding changes to the documentation
