### PR TITLE
Rename JS types

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -9,13 +9,15 @@
 <dd></dd>
 <dt><a href="#KeyPair">KeyPair</a></dt>
 <dd></dd>
-<dt><a href="#Method">Method</a></dt>
-<dd></dd>
 <dt><a href="#NewDocument">NewDocument</a></dt>
+<dd></dd>
+<dt><a href="#Service">Service</a></dt>
 <dd></dd>
 <dt><a href="#VerifiableCredential">VerifiableCredential</a></dt>
 <dd></dd>
 <dt><a href="#VerifiablePresentation">VerifiablePresentation</a></dt>
+<dd></dd>
+<dt><a href="#VerificationMethod">VerificationMethod</a></dt>
 <dd></dd>
 </dl>
 
@@ -59,7 +61,6 @@
         * [.network](#DID+network) ⇒ <code>string</code>
         * [.shard](#DID+shard) ⇒ <code>string</code> \| <code>undefined</code>
         * [.tag](#DID+tag) ⇒ <code>string</code>
-        * [.address](#DID+address) ⇒ <code>string</code>
         * [.toString()](#DID+toString) ⇒ <code>string</code>
     * _static_
         * [.fromBase58(key, network, shard)](#DID.fromBase58) ⇒ [<code>DID</code>](#DID)
@@ -93,12 +94,6 @@ Returns the IOTA tangle shard of the `DID` (if any).
 
 ### did.tag ⇒ <code>string</code>
 Returns the unique tag of the `DID`.
-
-**Kind**: instance property of [<code>DID</code>](#DID)  
-<a name="DID+address"></a>
-
-### did.address ⇒ <code>string</code>
-Returns the IOTA tangle address of the `DID`.
 
 **Kind**: instance property of [<code>DID</code>](#DID)  
 <a name="DID+toString"></a>
@@ -143,13 +138,15 @@ Parses a `DID` from the input string.
         * [.proof](#Document+proof) ⇒ <code>any</code>
         * [.insertMethod(method, scope)](#Document+insertMethod) ⇒ <code>boolean</code>
         * [.removeMethod(did)](#Document+removeMethod)
+        * [.insertService(service)](#Document+insertService) ⇒ <code>boolean</code>
+        * [.removeService(did)](#Document+removeService)
         * [.sign(key)](#Document+sign)
         * [.verify()](#Document+verify) ⇒ <code>boolean</code>
         * [.signCredential(data, args)](#Document+signCredential) ⇒ [<code>VerifiableCredential</code>](#VerifiableCredential)
         * [.signPresentation(data, args)](#Document+signPresentation) ⇒ [<code>VerifiablePresentation</code>](#VerifiablePresentation)
         * [.signData(data, args)](#Document+signData) ⇒ <code>any</code>
         * [.verifyData(data)](#Document+verifyData) ⇒ <code>boolean</code>
-        * [.resolveKey(query)](#Document+resolveKey) ⇒ [<code>Method</code>](#Method)
+        * [.resolveKey(query)](#Document+resolveKey) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
         * [.revokeMerkleKey(query, index)](#Document+revokeMerkleKey) ⇒ <code>boolean</code>
         * [.diff(other, message, key)](#Document+diff) ⇒ <code>any</code>
         * [.merge(diff)](#Document+merge)
@@ -189,12 +186,30 @@ Returns the DID Document `proof` object.
 
 | Param | Type |
 | --- | --- |
-| method | [<code>Method</code>](#Method) | 
+| method | [<code>VerificationMethod</code>](#VerificationMethod) | 
 | scope | <code>string</code> \| <code>undefined</code> | 
 
 <a name="Document+removeMethod"></a>
 
 ### document.removeMethod(did)
+**Kind**: instance method of [<code>Document</code>](#Document)  
+
+| Param | Type |
+| --- | --- |
+| did | [<code>DID</code>](#DID) | 
+
+<a name="Document+insertService"></a>
+
+### document.insertService(service) ⇒ <code>boolean</code>
+**Kind**: instance method of [<code>Document</code>](#Document)  
+
+| Param | Type |
+| --- | --- |
+| service | [<code>Service</code>](#Service) | 
+
+<a name="Document+removeService"></a>
+
+### document.removeService(did)
 **Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
@@ -267,7 +282,7 @@ Verifies the authenticity of `data` using the target verification method.
 
 <a name="Document+resolveKey"></a>
 
-### document.resolveKey(query) ⇒ [<code>Method</code>](#Method)
+### document.resolveKey(query) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
 **Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
@@ -334,7 +349,7 @@ Creates a new DID Document from the given verification [`method`][`Method`].
 
 | Param | Type |
 | --- | --- |
-| method | [<code>Method</code>](#Method) | 
+| method | [<code>VerificationMethod</code>](#VerificationMethod) | 
 
 <a name="Document.fromJSON"></a>
 
@@ -525,103 +540,6 @@ Deserializes a `KeyPair` object from a JSON object.
 | --- | --- |
 | json | <code>any</code> | 
 
-<a name="Method"></a>
-
-## Method
-**Kind**: global class  
-
-* [Method](#Method)
-    * [new Method(key, tag)](#new_Method_new)
-    * _instance_
-        * [.id](#Method+id) ⇒ [<code>DID</code>](#DID)
-        * [.controller](#Method+controller) ⇒ [<code>DID</code>](#DID)
-        * [.type](#Method+type) ⇒ <code>string</code>
-        * [.data](#Method+data) ⇒ <code>any</code>
-        * [.toJSON()](#Method+toJSON) ⇒ <code>any</code>
-    * _static_
-        * [.fromDID(did, key, tag)](#Method.fromDID) ⇒ [<code>Method</code>](#Method)
-        * [.createMerkleKey(digest, did, keys, tag)](#Method.createMerkleKey) ⇒ [<code>Method</code>](#Method)
-        * [.fromJSON(value)](#Method.fromJSON) ⇒ [<code>Method</code>](#Method)
-
-<a name="new_Method_new"></a>
-
-### new Method(key, tag)
-Creates a new `Method` object from the given `key`.
-
-
-| Param | Type |
-| --- | --- |
-| key | [<code>KeyPair</code>](#KeyPair) | 
-| tag | <code>string</code> \| <code>undefined</code> | 
-
-<a name="Method+id"></a>
-
-### method.id ⇒ [<code>DID</code>](#DID)
-Returns the `id` DID of the `Method` object.
-
-**Kind**: instance property of [<code>Method</code>](#Method)  
-<a name="Method+controller"></a>
-
-### method.controller ⇒ [<code>DID</code>](#DID)
-Returns the `controller` DID of the `Method` object.
-
-**Kind**: instance property of [<code>Method</code>](#Method)  
-<a name="Method+type"></a>
-
-### method.type ⇒ <code>string</code>
-Returns the `Method` type.
-
-**Kind**: instance property of [<code>Method</code>](#Method)  
-<a name="Method+data"></a>
-
-### method.data ⇒ <code>any</code>
-Returns the `Method` public key data.
-
-**Kind**: instance property of [<code>Method</code>](#Method)  
-<a name="Method+toJSON"></a>
-
-### method.toJSON() ⇒ <code>any</code>
-Serializes a `Method` object as a JSON object.
-
-**Kind**: instance method of [<code>Method</code>](#Method)  
-<a name="Method.fromDID"></a>
-
-### Method.fromDID(did, key, tag) ⇒ [<code>Method</code>](#Method)
-Creates a new `Method` object from the given `did` and `key`.
-
-**Kind**: static method of [<code>Method</code>](#Method)  
-
-| Param | Type |
-| --- | --- |
-| did | [<code>DID</code>](#DID) | 
-| key | [<code>KeyPair</code>](#KeyPair) | 
-| tag | <code>string</code> \| <code>undefined</code> | 
-
-<a name="Method.createMerkleKey"></a>
-
-### Method.createMerkleKey(digest, did, keys, tag) ⇒ [<code>Method</code>](#Method)
-Creates a new Merkle Key Collection Method from the given key collection.
-
-**Kind**: static method of [<code>Method</code>](#Method)  
-
-| Param | Type |
-| --- | --- |
-| digest | <code>number</code> | 
-| did | [<code>DID</code>](#DID) | 
-| keys | [<code>KeyCollection</code>](#KeyCollection) | 
-| tag | <code>string</code> \| <code>undefined</code> | 
-
-<a name="Method.fromJSON"></a>
-
-### Method.fromJSON(value) ⇒ [<code>Method</code>](#Method)
-Deserializes a `Method` object from a JSON object.
-
-**Kind**: static method of [<code>Method</code>](#Method)  
-
-| Param | Type |
-| --- | --- |
-| value | <code>any</code> | 
-
 <a name="NewDocument"></a>
 
 ## NewDocument
@@ -639,6 +557,34 @@ Deserializes a `Method` object from a JSON object.
 
 ### newDocument.doc ⇒ [<code>Document</code>](#Document)
 **Kind**: instance property of [<code>NewDocument</code>](#NewDocument)  
+<a name="Service"></a>
+
+## Service
+**Kind**: global class  
+
+* [Service](#Service)
+    * _instance_
+        * [.toJSON()](#Service+toJSON) ⇒ <code>any</code>
+    * _static_
+        * [.fromJSON(value)](#Service.fromJSON) ⇒ [<code>Service</code>](#Service)
+
+<a name="Service+toJSON"></a>
+
+### service.toJSON() ⇒ <code>any</code>
+Serializes a `Service` object as a JSON object.
+
+**Kind**: instance method of [<code>Service</code>](#Service)  
+<a name="Service.fromJSON"></a>
+
+### Service.fromJSON(value) ⇒ [<code>Service</code>](#Service)
+Deserializes a `Method` object from a JSON object.
+
+**Kind**: static method of [<code>Service</code>](#Service)  
+
+| Param | Type |
+| --- | --- |
+| value | <code>any</code> | 
+
 <a name="VerifiableCredential"></a>
 
 ## VerifiableCredential
@@ -729,6 +675,103 @@ Deserializes a `VerifiablePresentation` object from a JSON object.
 | Param | Type |
 | --- | --- |
 | json | <code>any</code> | 
+
+<a name="VerificationMethod"></a>
+
+## VerificationMethod
+**Kind**: global class  
+
+* [VerificationMethod](#VerificationMethod)
+    * [new VerificationMethod(key, tag)](#new_VerificationMethod_new)
+    * _instance_
+        * [.id](#VerificationMethod+id) ⇒ [<code>DID</code>](#DID)
+        * [.controller](#VerificationMethod+controller) ⇒ [<code>DID</code>](#DID)
+        * [.type](#VerificationMethod+type) ⇒ <code>string</code>
+        * [.data](#VerificationMethod+data) ⇒ <code>any</code>
+        * [.toJSON()](#VerificationMethod+toJSON) ⇒ <code>any</code>
+    * _static_
+        * [.fromDID(did, key, tag)](#VerificationMethod.fromDID) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
+        * [.createMerkleKey(digest, did, keys, tag)](#VerificationMethod.createMerkleKey) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
+        * [.fromJSON(value)](#VerificationMethod.fromJSON) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
+
+<a name="new_VerificationMethod_new"></a>
+
+### new VerificationMethod(key, tag)
+Creates a new `VerificationMethod` object from the given `key`.
+
+
+| Param | Type |
+| --- | --- |
+| key | [<code>KeyPair</code>](#KeyPair) | 
+| tag | <code>string</code> \| <code>undefined</code> | 
+
+<a name="VerificationMethod+id"></a>
+
+### verificationMethod.id ⇒ [<code>DID</code>](#DID)
+Returns the `id` DID of the `VerificationMethod` object.
+
+**Kind**: instance property of [<code>VerificationMethod</code>](#VerificationMethod)  
+<a name="VerificationMethod+controller"></a>
+
+### verificationMethod.controller ⇒ [<code>DID</code>](#DID)
+Returns the `controller` DID of the `VerificationMethod` object.
+
+**Kind**: instance property of [<code>VerificationMethod</code>](#VerificationMethod)  
+<a name="VerificationMethod+type"></a>
+
+### verificationMethod.type ⇒ <code>string</code>
+Returns the `VerificationMethod` type.
+
+**Kind**: instance property of [<code>VerificationMethod</code>](#VerificationMethod)  
+<a name="VerificationMethod+data"></a>
+
+### verificationMethod.data ⇒ <code>any</code>
+Returns the `VerificationMethod` public key data.
+
+**Kind**: instance property of [<code>VerificationMethod</code>](#VerificationMethod)  
+<a name="VerificationMethod+toJSON"></a>
+
+### verificationMethod.toJSON() ⇒ <code>any</code>
+Serializes a `VerificationMethod` object as a JSON object.
+
+**Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)  
+<a name="VerificationMethod.fromDID"></a>
+
+### VerificationMethod.fromDID(did, key, tag) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
+Creates a new `VerificationMethod` object from the given `did` and `key`.
+
+**Kind**: static method of [<code>VerificationMethod</code>](#VerificationMethod)  
+
+| Param | Type |
+| --- | --- |
+| did | [<code>DID</code>](#DID) | 
+| key | [<code>KeyPair</code>](#KeyPair) | 
+| tag | <code>string</code> \| <code>undefined</code> | 
+
+<a name="VerificationMethod.createMerkleKey"></a>
+
+### VerificationMethod.createMerkleKey(digest, did, keys, tag) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
+Creates a new Merkle Key Collection Method from the given key collection.
+
+**Kind**: static method of [<code>VerificationMethod</code>](#VerificationMethod)  
+
+| Param | Type |
+| --- | --- |
+| digest | <code>number</code> | 
+| did | [<code>DID</code>](#DID) | 
+| keys | [<code>KeyCollection</code>](#KeyCollection) | 
+| tag | <code>string</code> \| <code>undefined</code> | 
+
+<a name="VerificationMethod.fromJSON"></a>
+
+### VerificationMethod.fromJSON(value) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
+Deserializes a `VerificationMethod` object from a JSON object.
+
+**Kind**: static method of [<code>VerificationMethod</code>](#VerificationMethod)  
+
+| Param | Type |
+| --- | --- |
+| value | <code>any</code> | 
 
 <a name="Digest"></a>
 

--- a/bindings/wasm/examples/node.js
+++ b/bindings/wasm/examples/node.js
@@ -16,7 +16,7 @@ const {
   KeyCollection,
   KeyPair,
   KeyType,
-  Method,
+  VerificationMethod,
   VerifiableCredential,
   VerifiablePresentation,
 } = Identity
@@ -46,7 +46,7 @@ async function run() {
 
   // Add a Merkle Key Collection method for Bob, so compromised keys can be revoked.
   const keys = new KeyCollection(KeyType.Ed25519, 8)
-  const method = Method.createMerkleKey(Digest.Sha256, user2.doc.id, keys, "key-collection")
+  const method = VerificationMethod.createMerkleKey(Digest.Sha256, user2.doc.id, keys, "key-collection")
 
   // Add to the DID Document as a general-purpose verification method
   user2.doc.insertMethod(method, "VerificationMethod")

--- a/bindings/wasm/examples/web.js
+++ b/bindings/wasm/examples/web.js
@@ -8,7 +8,7 @@ async function run(Identity) {
     KeyCollection,
     KeyPair,
     KeyType,
-    Method,
+    VerificationMethod,
     VerifiableCredential,
     VerifiablePresentation,
   } = Identity
@@ -37,7 +37,7 @@ async function run(Identity) {
 
   // Add a Merkle Key Collection method for Bob, so compromised keys can be revoked.
   const keys = new KeyCollection(KeyType.Ed25519, 8)
-  const method = Method.createMerkleKey(Digest.Sha256, user2.doc.id, keys, "key-collection")
+  const method = VerificationMethod.createMerkleKey(Digest.Sha256, user2.doc.id, keys, "key-collection")
 
   // Add to the DID Document as a general-purpose verification method
   user2.doc.insertMethod(method, "VerificationMethod")

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iota/identity-wasm",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "WASM bindings for IOTA Identity - A Self Sovereign Identity Framework implementing the DID and VC standards from W3C. To be used in Javascript/Typescript",
   "repository": {
     "type": "git",

--- a/bindings/wasm/src/wasm_did.rs
+++ b/bindings/wasm/src/wasm_did.rs
@@ -13,7 +13,7 @@ use crate::utils::err;
 #[derive(Clone, Debug, PartialEq)]
 pub struct WasmDID(pub(crate) IotaDID);
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_class = DID)]
 impl WasmDID {
   /// Creates a new `WasmDID` from a `KeyPair` object.
   #[wasm_bindgen(constructor)]

--- a/bindings/wasm/src/wasm_did.rs
+++ b/bindings/wasm/src/wasm_did.rs
@@ -15,7 +15,7 @@ pub struct WasmDID(pub(crate) IotaDID);
 
 #[wasm_bindgen(js_class = DID)]
 impl WasmDID {
-  /// Creates a new `WasmDID` from a `KeyPair` object.
+  /// Creates a new `DID` from a `KeyPair` object.
   #[wasm_bindgen(constructor)]
   pub fn new(key: &KeyPair, network: Option<String>, shard: Option<String>) -> Result<WasmDID, JsValue> {
     let public: &[u8] = key.0.public().as_ref();
@@ -25,7 +25,7 @@ impl WasmDID {
     IotaDID::from_components(public, network, shard).map_err(err).map(Self)
   }
 
-  /// Creates a new `WasmDID` from a base58-encoded public key.
+  /// Creates a new `DID` from a base58-encoded public key.
   #[wasm_bindgen(js_name = fromBase58)]
   pub fn from_base58(key: &str, network: Option<String>, shard: Option<String>) -> Result<WasmDID, JsValue> {
     let public: Vec<u8> = decode_b58(key).map_err(err)?;
@@ -35,25 +35,25 @@ impl WasmDID {
     IotaDID::from_components(&public, network, shard).map_err(err).map(Self)
   }
 
-  /// Parses a `WasmDID` from the input string.
+  /// Parses a `DID` from the input string.
   #[wasm_bindgen]
   pub fn parse(input: &str) -> Result<WasmDID, JsValue> {
     IotaDID::parse(input).map_err(err).map(Self)
   }
 
-  /// Returns the IOTA tangle network of the `WasmDID`.
+  /// Returns the IOTA tangle network of the `DID`.
   #[wasm_bindgen(getter)]
   pub fn network(&self) -> String {
     self.0.network().into()
   }
 
-  /// Returns the IOTA tangle shard of the `WasmDID` (if any).
+  /// Returns the IOTA tangle shard of the `DID` (if any).
   #[wasm_bindgen(getter)]
   pub fn shard(&self) -> Option<String> {
     self.0.shard().map(Into::into)
   }
 
-  /// Returns the unique tag of the `WasmDID`.
+  /// Returns the unique tag of the `DID`.
   #[wasm_bindgen(getter)]
   pub fn tag(&self) -> String {
     self.0.tag().into()

--- a/bindings/wasm/src/wasm_document.rs
+++ b/bindings/wasm/src/wasm_document.rs
@@ -278,13 +278,13 @@ impl WasmDocument {
     Ok(())
   }
 
-  /// Serializes a `WasmDocument` object as a JSON object.
+  /// Serializes a `Document` object as a JSON object.
   #[wasm_bindgen(js_name = toJSON)]
   pub fn to_json(&self) -> Result<JsValue, JsValue> {
     JsValue::from_serde(&self.0).map_err(err)
   }
 
-  /// Deserializes a `WasmDocument` object from a JSON object.
+  /// Deserializes a `Document` object from a JSON object.
   #[wasm_bindgen(js_name = fromJSON)]
   pub fn from_json(json: &JsValue) -> Result<WasmDocument, JsValue> {
     json.into_serde().map_err(err).map(Self)

--- a/bindings/wasm/src/wasm_document.rs
+++ b/bindings/wasm/src/wasm_document.rs
@@ -50,7 +50,7 @@ impl NewDocument {
 // =============================================================================
 // =============================================================================
 
-#[wasm_bindgen(inspectable)]
+#[wasm_bindgen(js_name = Document, inspectable)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct WasmDocument(pub(crate) IotaDocument);
 

--- a/bindings/wasm/src/wasm_document.rs
+++ b/bindings/wasm/src/wasm_document.rs
@@ -54,7 +54,7 @@ impl NewDocument {
 #[derive(Clone, Debug, PartialEq)]
 pub struct WasmDocument(pub(crate) IotaDocument);
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_class = Document)]
 impl WasmDocument {
   /// Creates a new DID Document from the given KeyPair.
   #[wasm_bindgen(constructor)]

--- a/bindings/wasm/src/wasm_verification_method.rs
+++ b/bindings/wasm/src/wasm_verification_method.rs
@@ -15,7 +15,7 @@ use crate::wasm_did::WasmDID;
 #[derive(Clone, Debug, PartialEq)]
 pub struct WasmVerificationMethod(pub(crate) IotaVerificationMethod);
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_class = VerificationMethod)]
 impl WasmVerificationMethod {
   /// Creates a new `WasmVerificationMethod` object from the given `key`.
   #[wasm_bindgen(constructor)]

--- a/bindings/wasm/src/wasm_verification_method.rs
+++ b/bindings/wasm/src/wasm_verification_method.rs
@@ -17,7 +17,7 @@ pub struct WasmVerificationMethod(pub(crate) IotaVerificationMethod);
 
 #[wasm_bindgen(js_class = VerificationMethod)]
 impl WasmVerificationMethod {
-  /// Creates a new `WasmVerificationMethod` object from the given `key`.
+  /// Creates a new `VerificationMethod` object from the given `key`.
   #[wasm_bindgen(constructor)]
   pub fn new(key: &KeyPair, tag: Option<String>) -> Result<WasmVerificationMethod, JsValue> {
     IotaVerificationMethod::from_keypair(&key.0, tag.as_deref())
@@ -25,7 +25,7 @@ impl WasmVerificationMethod {
       .map(Self)
   }
 
-  /// Creates a new `WasmVerificationMethod` object from the given `did` and `key`.
+  /// Creates a new `VerificationMethod` object from the given `did` and `key`.
   #[wasm_bindgen(js_name = fromDID)]
   pub fn from_did(did: &WasmDID, key: &KeyPair, tag: Option<String>) -> Result<WasmVerificationMethod, JsValue> {
     IotaVerificationMethod::from_did(did.0.clone(), &key.0, tag.as_deref())
@@ -48,37 +48,37 @@ impl WasmVerificationMethod {
     }
   }
 
-  /// Returns the `id` DID of the `WasmVerificationMethod` object.
+  /// Returns the `id` DID of the `VerificationMethod` object.
   #[wasm_bindgen(getter)]
   pub fn id(&self) -> WasmDID {
     WasmDID(self.0.id().clone())
   }
 
-  /// Returns the `controller` DID of the `WasmVerificationMethod` object.
+  /// Returns the `controller` DID of the `VerificationMethod` object.
   #[wasm_bindgen(getter)]
   pub fn controller(&self) -> WasmDID {
     WasmDID(self.0.controller().clone())
   }
 
-  /// Returns the `WasmVerificationMethod` type.
+  /// Returns the `VerificationMethod` type.
   #[wasm_bindgen(getter, js_name = type)]
   pub fn type_(&self) -> String {
     self.0.key_type().as_str().into()
   }
 
-  /// Returns the `WasmVerificationMethod` public key data.
+  /// Returns the `VerificationMethod` public key data.
   #[wasm_bindgen(getter)]
   pub fn data(&self) -> Result<JsValue, JsValue> {
     JsValue::from_serde(self.0.key_data()).map_err(err)
   }
 
-  /// Serializes a `WasmVerificationMethod` object as a JSON object.
+  /// Serializes a `VerificationMethod` object as a JSON object.
   #[wasm_bindgen(js_name = toJSON)]
   pub fn to_json(&self) -> Result<JsValue, JsValue> {
     JsValue::from_serde(&self.0).map_err(err)
   }
 
-  /// Deserializes a `WasmVerificationMethod` object from a JSON object.
+  /// Deserializes a `VerificationMethod` object from a JSON object.
   #[wasm_bindgen(js_name = fromJSON)]
   pub fn from_json(value: &JsValue) -> Result<WasmVerificationMethod, JsValue> {
     value.into_serde().map_err(err).map(Self)

--- a/bindings/wasm/src/wasm_verification_method.rs
+++ b/bindings/wasm/src/wasm_verification_method.rs
@@ -11,7 +11,7 @@ use crate::crypto::KeyPair;
 use crate::utils::err;
 use crate::wasm_did::WasmDID;
 
-#[wasm_bindgen(inspectable)]
+#[wasm_bindgen(js_name = VerificationMethod, inspectable)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct WasmVerificationMethod(pub(crate) IotaVerificationMethod);
 


### PR DESCRIPTION
# Description of change

- Rename `WasmDocument` -> `Document`
- Rename `WasmVerificationMethod` -> `VerificationMethod`
- Update rustdoc comments to use JS types
- Ensure functions are associated with renamed JS types

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

## How the change has been tested

Ran examples

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
