### PR TITLE
Rename previous_message_id field to use camelCase in JSON output.

### DIFF
--- a/identity-iota/src/did/doc/diff.rs
+++ b/identity-iota/src/did/doc/diff.rs
@@ -29,7 +29,11 @@ use iota_client::bee_message::MessageId;
 pub struct DocumentDiff {
   pub(crate) did: IotaDID,
   pub(crate) diff: String,
-  #[serde(default = "MessageId::null", skip_serializing_if = "MessageIdExt::is_null")]
+  #[serde(
+    rename = "previousMessageId",
+    default = "MessageId::null",
+    skip_serializing_if = "MessageIdExt::is_null"
+  )]
   pub(crate) previous_message_id: MessageId,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub(crate) proof: Option<Signature>,

--- a/identity-iota/src/did/doc/properties.rs
+++ b/identity-iota/src/did/doc/properties.rs
@@ -11,7 +11,11 @@ use iota_client::bee_message::MessageId;
 pub struct Properties {
   pub(crate) created: Timestamp,
   pub(crate) updated: Timestamp,
-  #[serde(default = "MessageId::null", skip_serializing_if = "MessageIdExt::is_null")]
+  #[serde(
+    rename = "previousMessageId",
+    default = "MessageId::null",
+    skip_serializing_if = "MessageIdExt::is_null"
+  )]
   pub(crate) previous_message_id: MessageId,
   #[serde(flatten)]
   pub(crate) properties: Object,


### PR DESCRIPTION
# Description of change

Rename `previous_message_id` field to `previousMessageId` (camelCase) as per JSON and IOTA DID spec.

The rename was made in:
- `identity-iota/src/did/doc/diff.rs`: `DocumentDiff.previous_message_id`
- `identity-iota/src/did/doc/properties.rs`: `Properties.previous_message_id`

The in-code name remains the same (snake_case).

## Links to any relevant issues

#222 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Previously serialized message structures will now fail to parse due to field rename.

## How the change has been tested

`cargo test`

Nothing failed, maybe we should have some golden parse & structure tests 🤔 

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
