### PR TITLE
Add missing wasm accessors

### DIFF
--- a/bindings/wasm/.license_template
+++ b/bindings/wasm/.license_template
@@ -1,1 +1,2 @@
-../../.license_template
+// Copyright {20\d{2}(-20\d{2})?} IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -132,10 +132,12 @@ Parses a `DID` from the input string.
 **Kind**: global class  
 
 * [Document](#Document)
-    * [new Document(type_, tag)](#new_Document_new)
+    * [new Document(type_, network, tag)](#new_Document_new)
     * _instance_
         * [.id](#Document+id) ⇒ [<code>DID</code>](#DID)
         * [.proof](#Document+proof) ⇒ <code>any</code>
+        * [.previousMessageId](#Document+previousMessageId) ⇒ <code>string</code>
+        * [.setPreviousMessageId](#Document+setPreviousMessageId)
         * [.insertMethod(method, scope)](#Document+insertMethod) ⇒ <code>boolean</code>
         * [.removeMethod(did)](#Document+removeMethod)
         * [.insertService(service)](#Document+insertService) ⇒ <code>boolean</code>
@@ -158,13 +160,14 @@ Parses a `DID` from the input string.
 
 <a name="new_Document_new"></a>
 
-### new Document(type_, tag)
+### new Document(type_, network, tag)
 Creates a new DID Document from the given KeyPair.
 
 
 | Param | Type |
 | --- | --- |
 | type_ | <code>number</code> | 
+| network | <code>string</code> \| <code>undefined</code> |
 | tag | <code>string</code> \| <code>undefined</code> | 
 
 <a name="Document+id"></a>
@@ -179,6 +182,19 @@ Returns the DID Document `id`.
 Returns the DID Document `proof` object.
 
 **Kind**: instance property of [<code>Document</code>](#Document)  
+<a name="Document+previousMessageId"></a>
+
+### document.previousMessageId ⇒ <code>string</code>
+**Kind**: instance property of [<code>Document</code>](#Document)
+<a name="Document+setPreviousMessageId"></a>
+
+### document.setPreviousMessageId
+**Kind**: instance property of [<code>Document</code>](#Document)
+
+| Param | Type |
+| --- | --- |
+| value | <code>string</code> |
+
 <a name="Document+insertMethod"></a>
 
 ### document.insertMethod(method, scope) ⇒ <code>boolean</code>

--- a/bindings/wasm/rustfmt.toml
+++ b/bindings/wasm/rustfmt.toml
@@ -1,1 +1,8 @@
-../../rustfmt.toml
+comment_width = 120
+format_code_in_doc_comments = true
+license_template_path = ".license_template"
+max_width = 120
+normalize_comments = false
+normalize_doc_attributes = false
+tab_spaces = 2
+wrap_comments = true

--- a/bindings/wasm/src/wasm_document.rs
+++ b/bindings/wasm/src/wasm_document.rs
@@ -13,6 +13,7 @@ use identity::did::verifiable;
 use identity::did::MethodScope;
 use identity::did::VerificationMethod;
 use identity::iota::DocumentDiff;
+use identity::iota::IotaDID;
 use identity::iota::IotaDocument;
 use identity::iota::IotaVerificationMethod;
 use identity::iota::MessageId;
@@ -59,13 +60,22 @@ impl WasmDocument {
   /// Creates a new DID Document from the given KeyPair.
   #[wasm_bindgen(constructor)]
   #[allow(clippy::new_ret_no_self)]
-  pub fn new(type_: KeyType, tag: Option<String>) -> Result<NewDocument, JsValue> {
-    let key: KeyPair = KeyPair::new(type_)?;
-    let method: IotaVerificationMethod = IotaVerificationMethod::from_keypair(&key.0, tag.as_deref()).map_err(err)?;
+  pub fn new(type_: KeyType, network: Option<String>, tag: Option<String>) -> Result<NewDocument, JsValue> {
+    let keypair: KeyPair = KeyPair::new(type_)?;
+    let public: &PublicKey = keypair.0.public();
+
+    let did: IotaDID = if let Some(network) = network.as_deref() {
+      IotaDID::with_network(public.as_ref(), network).map_err(err)?
+    } else {
+      IotaDID::new(public.as_ref()).map_err(err)?
+    };
+
+    let method: IotaVerificationMethod =
+      IotaVerificationMethod::from_did(did, &keypair.0, tag.as_deref()).map_err(err)?;
     let document: IotaDocument = IotaDocument::from_authentication(method).map_err(err)?;
 
     Ok(NewDocument {
-      key,
+      key: keypair,
       doc: Self(document),
     })
   }
@@ -101,6 +111,20 @@ impl WasmDocument {
       Some(proof) => JsValue::from_serde(proof).map_err(err),
       None => Ok(JsValue::NULL),
     }
+  }
+
+  #[wasm_bindgen(getter = previousMessageId)]
+  pub fn previous_message_id(&self) -> String {
+    self.0.previous_message_id().to_string()
+  }
+
+  #[wasm_bindgen(setter = setPreviousMessageId)]
+  pub fn set_previous_message_id(&mut self, value: &str) -> Result<(), JsValue> {
+    let message: MessageId = MessageId::from_str(value).map_err(err)?;
+
+    self.0.set_previous_message_id(message);
+
+    Ok(())
   }
 
   // ===========================================================================

--- a/bindings/wasm/tests/wasm.rs
+++ b/bindings/wasm/tests/wasm.rs
@@ -72,16 +72,16 @@ fn test_did() {
   assert_eq!(did.to_string(), parsed.to_string());
 
   let public = key.public();
-  let base58 = WasmDID::from_base58(&public, Some("com".to_string()), Some("xyz".to_string())).unwrap();
+  let base58 = WasmDID::from_base58(&public, Some("test".to_string()), Some("xyz".to_string())).unwrap();
 
   assert_eq!(base58.tag(), did.tag());
-  assert_eq!(base58.network(), "com");
+  assert_eq!(base58.network(), "test");
   assert_eq!(base58.shard().unwrap(), "xyz");
 }
 
 #[test]
 fn test_document() {
-  let output = WasmDocument::new(KeyType::Ed25519, None).unwrap();
+  let output = WasmDocument::new(KeyType::Ed25519, None, None).unwrap();
 
   let mut doc = output.doc();
   let key = output.key();


### PR DESCRIPTION
# Description of change

Adds `network` to the `WasmDocument` constructor / `previousMessageId` accessor

## Type of change

- [x] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
