### PR TITLE
Expand unit test coverage in bitset.rs, iota_did.rs, and iota_document.rs

### DIFF
--- a/identity-core/src/common/bitset.rs
+++ b/identity-core/src/common/bitset.rs
@@ -18,7 +18,7 @@ use crate::utils::decode_b64;
 use crate::utils::encode_b64;
 
 /// A general-purpose compressed bitset.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct BitSet(RoaringBitmap);
 
 impl BitSet {
@@ -178,5 +178,33 @@ mod tests {
     set.clear();
 
     assert_eq!(set.len(), 0);
+  }
+
+  // Validate that a `deserialize_b64` ∘ `serialize_b64` round-trip results in the original bitset.
+  #[test]
+  fn test_serialize_b64_round_trip() {
+    let mut set = BitSet::new();
+    for index in 0..10 {
+      assert!(set.insert(index));
+    }
+
+    assert_eq!(
+      BitSet::deserialize_b64(set.serialize_b64().unwrap().as_str()).unwrap(),
+      set
+    );
+  }
+
+  // Validate that a `deserialize_slice` ∘ `serialize_vec` round-trip results in the original bitset.
+  #[test]
+  fn test_serialize_slice_round_trip() {
+    let mut set = BitSet::new();
+    for index in 0..10 {
+      assert!(set.insert(index));
+    }
+
+    assert_eq!(
+      BitSet::deserialize_slice(set.serialize_vec().unwrap().as_slice()).unwrap(),
+      set
+    );
   }
 }

--- a/identity-core/src/common/one_or_many.rs
+++ b/identity-core/src/common/one_or_many.rs
@@ -10,13 +10,13 @@ use core::mem::replace;
 use core::ops::Deref;
 use core::slice::from_ref;
 
-/// A generic container that stores one or many values of a given type.
+/// A generic container that stores exactly one or many (0+) values of a given type.
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum OneOrMany<T> {
   /// A single instance of `T`.
   One(T),
-  /// Multiple instances of `T`.
+  /// Multiple (zero or more) instances of `T`.
   Many(Vec<T>),
 }
 

--- a/identity-iota/src/did/doc/iota_document.rs
+++ b/identity-iota/src/did/doc/iota_document.rs
@@ -724,7 +724,7 @@ mod tests {
     let doc = IotaDocument::try_from_core(
       CoreDocument::builder(valid_properties())
         // INVALID
-        .id(invalid_did.clone())
+        .id(invalid_did)
         .authentication(core_verification_method(&valid_did(), "#auth-key"))
         .build()
         .unwrap(),

--- a/identity-iota/src/did/url/iota_did.rs
+++ b/identity-iota/src/did/url/iota_did.rs
@@ -306,18 +306,44 @@ mod tests {
   #[test]
   fn test_parse_valid() {
     assert!(IotaDID::parse(format!("did:iota:{}", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:{}#fragment", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:{}?somequery=somevalue", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:{}?somequery=somevalue#fragment", TAG)).is_ok());
+
     assert!(IotaDID::parse(format!("did:iota:main:{}", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:main:{}#fragment", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:main:{}?somequery=somevalue", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:main:{}?somequery=somevalue#fragment", TAG)).is_ok());
+
     assert!(IotaDID::parse(format!("did:iota:test:{}", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:test:{}#fragment", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:test:{}?somequery=somevalue", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:test:{}?somequery=somevalue#fragment", TAG)).is_ok());
+
     assert!(IotaDID::parse(format!("did:iota:rainbow:{}", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:rainbow:{}#fragment", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:rainbow:{}?somequery=somevalue", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:rainbow:{}?somequery=somevalue#fragment", TAG)).is_ok());
+
     assert!(IotaDID::parse(format!("did:iota:rainbow:shard-1:{}", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:rainbow:shard-1:{}#fragment", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:rainbow:shard-1:{}?somequery=somevalue", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:rainbow:shard-1:{}?somequery=somevalue#fragment", TAG)).is_ok());
   }
 
   #[test]
   fn test_parse_invalid() {
+    // A non-"iota" DID method is invalid.
     assert!(IotaDID::parse("did:foo::").is_err());
+    // An empty DID method is invalid.
     assert!(IotaDID::parse("did:::").is_err());
+    assert!(IotaDID::parse(format!("did::rainbow:shard-1:{}", TAG)).is_err());
+    // A non-"iota" DID method is invalid.
     assert!(IotaDID::parse("did:iota---::").is_err());
+    // An empty `iota-specific-idstring` is invalid.
     assert!(IotaDID::parse("did:iota:").is_err());
+    // Too many components is invalid.
+    assert!(IotaDID::parse(format!("did:iota:rainbow:shard-1:random:{}", TAG)).is_err());
   }
 
   #[test]
@@ -325,7 +351,12 @@ mod tests {
     let key: String = IotaDID::encode_key(b"123");
 
     let did: CoreDID = format!("did:iota:{}", key).parse().unwrap();
-    assert!(IotaDID::try_from_owned(did).is_ok());
+    let iota_did = IotaDID::try_from_owned(did).unwrap();
+    assert_eq!(iota_did.network(), "main");
+    assert_eq!(iota_did.shard(), None);
+    assert_eq!(iota_did.tag(), key);
+    assert_eq!(iota_did.path(), "");
+    assert_eq!(iota_did.query(), None);
 
     let did: CoreDID = "did:iota:123".parse().unwrap();
     assert!(IotaDID::try_from_owned(did).is_err());
@@ -351,6 +382,9 @@ mod tests {
   #[test]
   fn test_shard() {
     let key: String = IotaDID::encode_key(b"123");
+
+    let did: IotaDID = format!("did:iota:{}", key).parse().unwrap();
+    assert_eq!(did.shard(), None);
 
     let did: IotaDID = format!("did:iota:dev:{}", key).parse().unwrap();
     assert_eq!(did.shard(), None);


### PR DESCRIPTION
# Description of change

Test the non-happy paths of `IotaDocument::try_from_core()`, `IotaDID::parse()`, and bitset serialize round trips.

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

- [x] Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo test`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
