### PR TITLE
Fix message_ext.rs incomplete match expression error.

### DIFF
--- a/identity-iota/src/tangle/message_ext.rs
+++ b/identity-iota/src/tangle/message_ext.rs
@@ -46,6 +46,7 @@ macro_rules! try_extract {
           }
           _ => None,
         },
+        _ => None,
       },
       _ => None,
     }


### PR DESCRIPTION
# Description of change

**Edit:** I'm actually not sure what's going on here. It looks like `Essence` only has one enum value, so this _should_ be fine, but compilation fails...

Fix compilation error in `dev` branch.


```
❯ rustup toolchain list
stable-aarch64-apple-darwin (default)
❯ cargo version
cargo 1.51.0 (43b129a20 2021-03-16)
❯ git checkout dev
❯ git fetch upstream
❯ git merge upstream/dev
Already up to date.
❯ cargo test --manifest-path ./bindings/wasm/Cargo.toml
   Compiling identity-iota v0.3.0 (/Users/mrenaud/iota/m-renaud/identity.rs/identity-iota)
error[E0004]: non-exhaustive patterns: `&_` not covered
  --> /Users/mrenaud/iota/m-renaud/identity.rs/identity-iota/src/tangle/message_ext.rs:34:55
   |
34 |       Some(Payload::Transaction(tx_payload)) => match tx_payload.essence() {
   |                                                       ^^^^^^^^^^^^^^^^^^^^ pattern `&_` not covered
...
85 |     try_extract!(IotaDocument, self, did)
   |     ------------------------------------- in this macro invocation
   |
   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
   = note: the matched value is of type `&Essence`
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

This change fixes the test, but fails clippy 😕 

```
❯ cargo clippy
warning: unreachable pattern
  --> identity-iota/src/tangle/message_ext.rs:49:9
   |
49 |         _ => None,
   |         ^
...
86 |     try_extract!(IotaDocument, self, did)
   |     ------------------------------------- in this macro invocation
   |
   = note: `#[warn(unreachable_patterns)]` on by default
   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

## Links to any relevant issues

Not reported.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo test`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
