### PR TITLE
Add IotaDocument::from_keypair_with_network() and WASM binding.

### DIFF
--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -7,6 +7,7 @@
 ## Install the library:
 
 Latest Release: This version matches the main branch of this repository, is stable and will have changelogs.
+
 ```bash
 $ npm install @iota/identity-wasm
 // or using yarn
@@ -14,6 +15,7 @@ $ yarn add @iota/identity-wasm
 ```
 
 Development Release: This version matches the dev branch of this repository, may see frequent breaking changes and has the latest code changes.
+
 ```bash
 $ npm install @iota/identity-wasm@dev
 // or using yarn
@@ -23,25 +25,30 @@ $ yarn add @iota/identity-wasm@dev
 ## NodeJS Setup
 
 ```js
-const identity = require('@iota/identity-wasm/node')
+const identity = require("@iota/identity-wasm/node");
 
 // Generate a new KeyPair
-const key = new identity.KeyPair(identity.KeyType.Ed25519)
+const key = new identity.KeyPair(identity.KeyType.Ed25519);
 
 // Create a new DID Document with the KeyPair as the default authentication method
-const doc = identity.Document.fromKeyPair(key)
+const doc = identity.Document.fromKeyPair(key);
 
 // Sign the DID Document with the sceret key
-doc.sign(key)
+doc.sign(key);
 
 // Publish the DID Document to the IOTA Tangle
-identity.publish(doc.toJSON(), { node: "https://nodes.thetangle.org:443" })
+identity
+  .publish(doc.toJSON(), { node: "https://nodes.thetangle.org:443" })
   .then((message) => {
-    console.log("Tangle Message Id: ", message)
-    console.log("Tangle Message Url", `https://explorer.iota.org/mainnet/transaction/${message}`)
-  }).catch((error) => {
-    console.error("Error: ", error)
+    console.log("Tangle Message Id: ", message);
+    console.log(
+      "Tangle Message Url",
+      `https://explorer.iota.org/mainnet/transaction/${message}`,
+    );
   })
+  .catch((error) => {
+    console.error("Error: ", error);
+  });
 ```
 
 ## Web Setup
@@ -62,16 +69,18 @@ $ yarn add rollup-plugin-copy --dev
 
 ```js
 // Include the copy plugin
-import copy from 'rollup-plugin-copy'
+import copy from "rollup-plugin-copy";
 
 // Add the copy plugin to the `plugins` array of your rollup config:
 copy({
-  targets: [{
-    src: 'node_modules/@iota/identity-wasm/web/identity_wasm_bg.wasm',
-    dest: 'public',
-    rename: 'identity_wasm_bg.wasm'
-  }]
-})
+  targets: [
+    {
+      src: "node_modules/@iota/identity-wasm/web/identity_wasm_bg.wasm",
+      dest: "public",
+      rename: "identity_wasm_bg.wasm",
+    },
+  ],
+});
 ```
 
 ### Webpack
@@ -106,21 +115,25 @@ new CopyWebPlugin({
 import * as identity from "@iota/identity-wasm/web";
 
 identity.init().then(() => {
-  const key = new identity.KeyPair(identity.KeyType.Ed25519)
-  const doc = identity.Document.fromKeyPair(key)
-  console.log("Key Pair", key)
-  console.log("DID Document: ", doc)
+  const key = new identity.KeyPair(identity.KeyType.Ed25519);
+  const doc = identity.Document.fromKeyPair(key);
+  // Or, if using the testnet:
+  // const doc = identity.Document.fromKeyPairWithNetwork(key, "test")
+  console.log("Key Pair", key);
+  console.log("DID Document: ", doc);
 });
 
 // or
 
 (async () => {
-  await identity.init()
-  const key = new identity.KeyPair(identity.KeyType.Ed25519)
-  const doc = identity.Document.fromKeyPair(key)
-  console.log("Key Pair", key)
-  console.log("DID Document: ", doc)
-})()
+  await identity.init();
+  const key = new identity.KeyPair(identity.KeyType.Ed25519);
+  const doc = identity.Document.fromKeyPair(key);
+  // Or, if using the testnet:
+  // const doc = identity.Document.fromKeyPairWithNetwork(key, "test")
+  console.log("Key Pair", key);
+  console.log("DID Document: ", doc);
+})();
 
 // Default path is "identity_wasm_bg.wasm", but you can override it like this
 await identity.init("./static/identity_wasm_bg.wasm");

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -109,7 +109,7 @@ identity.init().then(() => {
   const key = new identity.KeyPair(identity.KeyType.Ed25519)
   const doc = identity.Document.fromKeyPair(key)
   // Or, if using the testnet:
-  // const doc = identity.Document.fromKeyPairWithNetwork(key, "test")  
+  // const doc = identity.Document.fromKeyPair(key, "test")  
   console.log("Key Pair", key)
   console.log("DID Document: ", doc)
 });
@@ -121,7 +121,7 @@ identity.init().then(() => {
   const key = new identity.KeyPair(identity.KeyType.Ed25519)
   const doc = identity.Document.fromKeyPair(key)
   // Or, if using the testnet:
-  // const doc = identity.Document.fromKeyPairWithNetwork(key, "test")
+  // const doc = identity.Document.fromKeyPair(key, "test")
   console.log("Key Pair", key)
   console.log("DID Document: ", doc)
 })()

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -7,7 +7,6 @@
 ## Install the library:
 
 Latest Release: This version matches the main branch of this repository, is stable and will have changelogs.
-
 ```bash
 $ npm install @iota/identity-wasm
 // or using yarn
@@ -15,7 +14,6 @@ $ yarn add @iota/identity-wasm
 ```
 
 Development Release: This version matches the dev branch of this repository, may see frequent breaking changes and has the latest code changes.
-
 ```bash
 $ npm install @iota/identity-wasm@dev
 // or using yarn
@@ -25,30 +23,25 @@ $ yarn add @iota/identity-wasm@dev
 ## NodeJS Setup
 
 ```js
-const identity = require("@iota/identity-wasm/node");
+const identity = require('@iota/identity-wasm/node')
 
 // Generate a new KeyPair
-const key = new identity.KeyPair(identity.KeyType.Ed25519);
+const key = new identity.KeyPair(identity.KeyType.Ed25519)
 
 // Create a new DID Document with the KeyPair as the default authentication method
-const doc = identity.Document.fromKeyPair(key);
+const doc = identity.Document.fromKeyPair(key)
 
 // Sign the DID Document with the sceret key
-doc.sign(key);
+doc.sign(key)
 
 // Publish the DID Document to the IOTA Tangle
-identity
-  .publish(doc.toJSON(), { node: "https://nodes.thetangle.org:443" })
+identity.publish(doc.toJSON(), { node: "https://nodes.thetangle.org:443" })
   .then((message) => {
-    console.log("Tangle Message Id: ", message);
-    console.log(
-      "Tangle Message Url",
-      `https://explorer.iota.org/mainnet/transaction/${message}`,
-    );
+    console.log("Tangle Message Id: ", message)
+    console.log("Tangle Message Url", `https://explorer.iota.org/mainnet/transaction/${message}`)
+  }).catch((error) => {
+    console.error("Error: ", error)
   })
-  .catch((error) => {
-    console.error("Error: ", error);
-  });
 ```
 
 ## Web Setup
@@ -69,18 +62,16 @@ $ yarn add rollup-plugin-copy --dev
 
 ```js
 // Include the copy plugin
-import copy from "rollup-plugin-copy";
+import copy from 'rollup-plugin-copy'
 
 // Add the copy plugin to the `plugins` array of your rollup config:
 copy({
-  targets: [
-    {
-      src: "node_modules/@iota/identity-wasm/web/identity_wasm_bg.wasm",
-      dest: "public",
-      rename: "identity_wasm_bg.wasm",
-    },
-  ],
-});
+  targets: [{
+    src: 'node_modules/@iota/identity-wasm/web/identity_wasm_bg.wasm',
+    dest: 'public',
+    rename: 'identity_wasm_bg.wasm'
+  }]
+})
 ```
 
 ### Webpack
@@ -115,25 +106,25 @@ new CopyWebPlugin({
 import * as identity from "@iota/identity-wasm/web";
 
 identity.init().then(() => {
-  const key = new identity.KeyPair(identity.KeyType.Ed25519);
-  const doc = identity.Document.fromKeyPair(key);
+  const key = new identity.KeyPair(identity.KeyType.Ed25519)
+  const doc = identity.Document.fromKeyPair(key)
   // Or, if using the testnet:
-  // const doc = identity.Document.fromKeyPairWithNetwork(key, "test")
-  console.log("Key Pair", key);
-  console.log("DID Document: ", doc);
+  // const doc = identity.Document.fromKeyPairWithNetwork(key, "test")  
+  console.log("Key Pair", key)
+  console.log("DID Document: ", doc)
 });
 
 // or
 
 (async () => {
-  await identity.init();
-  const key = new identity.KeyPair(identity.KeyType.Ed25519);
-  const doc = identity.Document.fromKeyPair(key);
+  await identity.init()
+  const key = new identity.KeyPair(identity.KeyType.Ed25519)
+  const doc = identity.Document.fromKeyPair(key)
   // Or, if using the testnet:
   // const doc = identity.Document.fromKeyPairWithNetwork(key, "test")
-  console.log("Key Pair", key);
-  console.log("DID Document: ", doc);
-})();
+  console.log("Key Pair", key)
+  console.log("DID Document: ", doc)
+})()
 
 // Default path is "identity_wasm_bg.wasm", but you can override it like this
 await identity.init("./static/identity_wasm_bg.wasm");

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -532,6 +532,7 @@ Parses a `DID` from the input string.
         * [.toJSON()](#Document+toJSON) ⇒ <code>any</code>
     * _static_
         * [.fromKeyPair(key)](#Document.fromKeyPair) ⇒ [<code>Document</code>](#Document)
+        * [.fromKeyPairWithNetwork(key, network)](#Document.fromKeyPairWithNetwork) ⇒ [<code>Document</code>](#Document)
         * [.fromAuthentication(method)](#Document.fromAuthentication) ⇒ [<code>Document</code>](#Document)
         * [.fromJSON(json)](#Document.fromJSON) ⇒ [<code>Document</code>](#Document)
 
@@ -732,6 +733,18 @@ Creates a new DID Document from the given KeyPair.
 | Param | Type |
 | --- | --- |
 | key | [<code>KeyPair</code>](#KeyPair) | 
+
+<a name="Document.fromKeyPairWithNetwork"></a>
+
+### Document.fromKeyPairWithNetwork(key, network) ⇒ [<code>Document</code>](#Document)
+Creates a new DID Document from the given KeyPair on the specified network.
+
+**Kind**: static method of [<code>Document</code>](#Document)  
+
+| Param | Type |
+| --- | --- |
+| key | [<code>KeyPair</code>](#KeyPair) | 
+| network | <code>string</code> | 
 
 <a name="Document.fromAuthentication"></a>
 

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -532,7 +532,6 @@ Parses a `DID` from the input string.
         * [.toJSON()](#Document+toJSON) ⇒ <code>any</code>
     * _static_
         * [.fromKeyPair(key)](#Document.fromKeyPair) ⇒ [<code>Document</code>](#Document)
-        * [.fromKeyPairWithNetwork(key, network)](#Document.fromKeyPairWithNetwork) ⇒ [<code>Document</code>](#Document)
         * [.fromAuthentication(method)](#Document.fromAuthentication) ⇒ [<code>Document</code>](#Document)
         * [.fromJSON(json)](#Document.fromJSON) ⇒ [<code>Document</code>](#Document)
 
@@ -726,25 +725,16 @@ Serializes a `Document` object as a JSON object.
 <a name="Document.fromKeyPair"></a>
 
 ### Document.fromKeyPair(key) ⇒ [<code>Document</code>](#Document)
-Creates a new DID Document from the given KeyPair.
+Creates a new DID Document from the given KeyPair and optional network.
+
+If unspecified, the network defaults to the mainnet.
 
 **Kind**: static method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
 | key | [<code>KeyPair</code>](#KeyPair) | 
-
-<a name="Document.fromKeyPairWithNetwork"></a>
-
-### Document.fromKeyPairWithNetwork(key, network) ⇒ [<code>Document</code>](#Document)
-Creates a new DID Document from the given KeyPair on the specified network.
-
-**Kind**: static method of [<code>Document</code>](#Document)  
-
-| Param | Type |
-| --- | --- |
-| key | [<code>KeyPair</code>](#KeyPair) | 
-| network | <code>string</code> | 
+| network | <code>string</code> \| <code>undefined</code> |
 
 <a name="Document.fromAuthentication"></a>
 

--- a/bindings/wasm/src/wasm_document.rs
+++ b/bindings/wasm/src/wasm_document.rs
@@ -86,6 +86,14 @@ impl WasmDocument {
     IotaDocument::from_keypair(&key.0).map_err(err).map(Self)
   }
 
+  /// Creates a new DID Document from the given KeyPair on the specified network.
+  #[wasm_bindgen(js_name = fromKeyPairWithNetwork)]
+  pub fn from_keypair_with_network(key: &KeyPair, network: &str) -> Result<WasmDocument, JsValue> {
+    IotaDocument::from_keypair_with_network(&key.0, &network)
+      .map_err(err)
+      .map(Self)
+  }
+
   /// Creates a new DID Document from the given verification [`method`][`Method`].
   #[wasm_bindgen(js_name = fromAuthentication)]
   pub fn from_authentication(method: &WasmVerificationMethod) -> Result<WasmDocument, JsValue> {

--- a/bindings/wasm/src/wasm_document.rs
+++ b/bindings/wasm/src/wasm_document.rs
@@ -88,7 +88,7 @@ impl WasmDocument {
     let doc = match network {
       Some(net) => IotaDocument::from_keypair_with_network(&key.0, &net),
       None => IotaDocument::from_keypair(&key.0)
-    }
+    };
     doc.map_err(err).map(Self)
   }
 

--- a/bindings/wasm/src/wasm_document.rs
+++ b/bindings/wasm/src/wasm_document.rs
@@ -80,18 +80,16 @@ impl WasmDocument {
     })
   }
 
-  /// Creates a new DID Document from the given KeyPair.
+  /// Creates a new DID Document from the given KeyPair and optional network.
+  ///
+  /// If unspecified, network defaults to the mainnet.
   #[wasm_bindgen(js_name = fromKeyPair)]
-  pub fn from_keypair(key: &KeyPair) -> Result<WasmDocument, JsValue> {
-    IotaDocument::from_keypair(&key.0).map_err(err).map(Self)
-  }
-
-  /// Creates a new DID Document from the given KeyPair on the specified network.
-  #[wasm_bindgen(js_name = fromKeyPairWithNetwork)]
-  pub fn from_keypair_with_network(key: &KeyPair, network: &str) -> Result<WasmDocument, JsValue> {
-    IotaDocument::from_keypair_with_network(&key.0, &network)
-      .map_err(err)
-      .map(Self)
+  pub fn from_keypair(key: &KeyPair, network: Option<String>) -> Result<WasmDocument, JsValue> {
+    let doc = match network {
+      Some(net) => IotaDocument::from_keypair_with_network(&key.0, &net),
+      None => IotaDocument::from_keypair(&key.0)
+    }
+    doc.map_err(err).map(Self)
   }
 
   /// Creates a new DID Document from the given verification [`method`][`Method`].

--- a/identity-iota/src/did/doc/iota_document.rs
+++ b/identity-iota/src/did/doc/iota_document.rs
@@ -82,6 +82,22 @@ impl IotaDocument {
     Ok(unsafe { Self::from_authentication_unchecked(method) })
   }
 
+  /// Creates a new DID Document from the given KeyPair and network.
+  ///
+  /// The DID Document will be pre-populated with a single authentication
+  /// method based on the provided [KeyPair].
+  ///
+  /// The authentication method will have the DID URL fragment `#authentication`
+  /// and can be easily retrieved with [Document::authentication].
+  pub fn from_keypair_with_network(keypair: &KeyPair, network: &str) -> Result<Self> {
+    let method: IotaVerificationMethod =
+      IotaVerificationMethod::from_keypair_with_network(keypair, "authentication", network)?;
+
+    // SAFETY: We don't create invalid Methods.  Method::from_keypair() uses the MethodBuilder
+    // internally which verifies correctness on construction.
+    Ok(unsafe { Self::from_authentication_unchecked(method) })
+  }
+
   /// Creates a new DID Document from the given verification [`method`][VerificationMethod].
   pub fn from_authentication(method: IotaVerificationMethod) -> Result<Self> {
     Self::check_authentication(&method)?;
@@ -631,6 +647,8 @@ mod tests {
 
   const DID_ID: &str = "did:iota:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1M";
   const DID_AUTH: &str = "did:iota:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1M#authentication";
+  const DID_TESTNET_ID: &str = "did:iota:test:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1M";
+  const DID_TESTNET_AUTH: &str = "did:iota:test:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1M#authentication";
 
   fn valid_did() -> DID {
     DID_ID.parse().unwrap()
@@ -706,6 +724,19 @@ mod tests {
   fn compare_document(document: &IotaDocument) {
     assert_eq!(document.id().to_string(), DID_ID);
     assert_eq!(document.authentication_id(), DID_AUTH);
+    assert_eq!(
+      document.authentication().key_type(),
+      MethodType::Ed25519VerificationKey2018
+    );
+    assert_eq!(
+      document.authentication().key_data(),
+      &MethodData::PublicKeyBase58(String::from("FJsXMk9UqpJf3ZTKnfEQAhvBrVLKMSx9ZeYwQME6c6tT"))
+    );
+  }
+
+  fn compare_document_testnet(document: &IotaDocument) {
+    assert_eq!(document.id().to_string(), DID_TESTNET_ID);
+    assert_eq!(document.authentication_id(), DID_TESTNET_AUTH);
     assert_eq!(
       document.authentication().key_type(),
       MethodType::Ed25519VerificationKey2018
@@ -889,6 +920,14 @@ mod tests {
     //from core
     let document: IotaDocument = IotaDocument::try_from_core(document.serde_into().unwrap()).unwrap();
     compare_document(&document);
+  }
+
+  #[test]
+  fn test_from_keypair_with_network() {
+    //from keypair
+    let keypair: KeyPair = generate_testkey();
+    let document: IotaDocument = IotaDocument::from_keypair_with_network(&keypair, "test").unwrap();
+    compare_document_testnet(&document);
   }
 
   #[test]

--- a/identity-iota/src/did/doc/iota_verification_method.rs
+++ b/identity-iota/src/did/doc/iota_verification_method.rs
@@ -66,6 +66,17 @@ impl IotaVerificationMethod {
     Self::from_did(did, keypair, fragment)
   }
 
+  /// Creates a new [`IotaVerificationMethod`] object from the given `keypair` on the specified `network`.
+  pub fn from_keypair_with_network<'a, F>(keypair: &KeyPair, fragment: F, network: &str) -> Result<Self>
+  where
+    F: Into<Option<&'a str>>,
+  {
+    let key: &[u8] = keypair.public().as_ref();
+    let did: IotaDID = IotaDID::with_network(key, &network)?;
+
+    Self::from_did(did, keypair, fragment)
+  }
+
   /// Creates a new [`Method`] object from the given `did` and `keypair`.
   ///
   /// If the `fragment` resolves to `Option::None` then the default verification method tag will be


### PR DESCRIPTION
# Description of change

Add `IotaDocument::from_keypair_with_network(key, network)` and expose in WASM bindings (via optional `network` param in `fromKeyPair`).

This was a missing API which required a workaround (see https://github.com/iotaledger/identity.rs/issues/264#issuecomment-843364038).

This PR also include an example in the WASM examples README alongside the `identity.Document.fromKeyPair()` call (in comments).

## Links to any relevant issues

#264 root cause was from a mismatch in network between document and node, and it wasn't obvious how to create a document from a keypair on the test network.

## Type of change

- [x] Enhancement (a non-breaking change which adds functionality)
- [x] Documentation Fix

## How the change has been tested

`cargo test`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
