### PR TITLE
Use u32 for message delays

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -75,6 +75,9 @@
 ## Functions
 
 <dl>
+<dt><a href="#start">start()</a></dt>
+<dd><p>Initializes the console error panic hook for better error messages</p>
+</dd>
 <dt><a href="#publish">publish(document, params)</a> ⇒ <code>any</code></dt>
 <dd><p>Publishes a DID Document to the Tangle, params looks like { node: &quot;<a href="http://localhost:14265&quot;">http://localhost:14265&quot;</a>, network: &quot;main&quot; }</p>
 </dd>
@@ -87,9 +90,6 @@
 <dt><a href="#checkPresentation">checkPresentation(data, params)</a> ⇒ <code>any</code></dt>
 <dd><p>Validates a presentation with the DID Document from the Tangle, params looks like { node: &quot;<a href="http://localhost:14265&quot;">http://localhost:14265&quot;</a>, network: &quot;main&quot; }</p>
 </dd>
-<dt><a href="#start">start()</a></dt>
-<dd><p>Initializes the console error panic hook for better error messages</p>
-</dd>
 </dl>
 
 <a name="AuthenticationRequest"></a>
@@ -99,114 +99,9 @@
 
 * [AuthenticationRequest](#AuthenticationRequest)
     * _instance_
-        * [.context](#AuthenticationRequest+context) ⇒ <code>string</code>
-        * [.context](#AuthenticationRequest+context)
-        * [.thread](#AuthenticationRequest+thread) ⇒ <code>string</code>
-        * [.thread](#AuthenticationRequest+thread)
-        * [.callbackURL](#AuthenticationRequest+callbackURL) ⇒ <code>string</code>
-        * [.callbackURL](#AuthenticationRequest+callbackURL)
-        * [.challenge](#AuthenticationRequest+challenge) ⇒ <code>string</code>
-        * [.challenge](#AuthenticationRequest+challenge)
-        * [.responseRequested](#AuthenticationRequest+responseRequested) ⇒ <code>boolean</code> \| <code>undefined</code>
-        * [.responseRequested](#AuthenticationRequest+responseRequested)
-        * [.id](#AuthenticationRequest+id) ⇒ [<code>DID</code>](#DID) \| <code>undefined</code>
-        * [.id](#AuthenticationRequest+id)
-        * [.timing](#AuthenticationRequest+timing) ⇒ [<code>Timing</code>](#Timing) \| <code>undefined</code>
-        * [.timing](#AuthenticationRequest+timing)
         * [.toJSON()](#AuthenticationRequest+toJSON) ⇒ <code>any</code>
     * _static_
         * [.fromJSON(value)](#AuthenticationRequest.fromJSON) ⇒ [<code>AuthenticationRequest</code>](#AuthenticationRequest)
-
-<a name="AuthenticationRequest+context"></a>
-
-### authenticationRequest.context ⇒ <code>string</code>
-**Kind**: instance property of [<code>AuthenticationRequest</code>](#AuthenticationRequest)
-<a name="AuthenticationRequest+context"></a>
-
-### authenticationRequest.context
-**Kind**: instance property of [<code>AuthenticationRequest</code>](#AuthenticationRequest)
-
-| Param | Type |
-| --- | --- |
-| value | <code>string</code> |
-
-<a name="AuthenticationRequest+thread"></a>
-
-### authenticationRequest.thread ⇒ <code>string</code>
-**Kind**: instance property of [<code>AuthenticationRequest</code>](#AuthenticationRequest)
-<a name="AuthenticationRequest+thread"></a>
-
-### authenticationRequest.thread
-**Kind**: instance property of [<code>AuthenticationRequest</code>](#AuthenticationRequest)
-
-| Param | Type |
-| --- | --- |
-| value | <code>string</code> |
-
-<a name="AuthenticationRequest+callbackURL"></a>
-
-### authenticationRequest.callbackURL ⇒ <code>string</code>
-**Kind**: instance property of [<code>AuthenticationRequest</code>](#AuthenticationRequest)
-<a name="AuthenticationRequest+callbackURL"></a>
-
-### authenticationRequest.callbackURL
-**Kind**: instance property of [<code>AuthenticationRequest</code>](#AuthenticationRequest)
-
-| Param | Type |
-| --- | --- |
-| value | <code>string</code> |
-
-<a name="AuthenticationRequest+challenge"></a>
-
-### authenticationRequest.challenge ⇒ <code>string</code>
-**Kind**: instance property of [<code>AuthenticationRequest</code>](#AuthenticationRequest)
-<a name="AuthenticationRequest+challenge"></a>
-
-### authenticationRequest.challenge
-**Kind**: instance property of [<code>AuthenticationRequest</code>](#AuthenticationRequest)
-
-| Param | Type |
-| --- | --- |
-| value | <code>string</code> |
-
-<a name="AuthenticationRequest+responseRequested"></a>
-
-### authenticationRequest.responseRequested ⇒ <code>boolean</code> \| <code>undefined</code>
-**Kind**: instance property of [<code>AuthenticationRequest</code>](#AuthenticationRequest)
-<a name="AuthenticationRequest+responseRequested"></a>
-
-### authenticationRequest.responseRequested
-**Kind**: instance property of [<code>AuthenticationRequest</code>](#AuthenticationRequest)
-
-| Param | Type |
-| --- | --- |
-| value | <code>boolean</code> |
-
-<a name="AuthenticationRequest+id"></a>
-
-### authenticationRequest.id ⇒ [<code>DID</code>](#DID) \| <code>undefined</code>
-**Kind**: instance property of [<code>AuthenticationRequest</code>](#AuthenticationRequest)
-<a name="AuthenticationRequest+id"></a>
-
-### authenticationRequest.id
-**Kind**: instance property of [<code>AuthenticationRequest</code>](#AuthenticationRequest)
-
-| Param | Type |
-| --- | --- |
-| value | <code>string</code> |
-
-<a name="AuthenticationRequest+timing"></a>
-
-### authenticationRequest.timing ⇒ [<code>Timing</code>](#Timing) \| <code>undefined</code>
-**Kind**: instance property of [<code>AuthenticationRequest</code>](#AuthenticationRequest)
-<a name="AuthenticationRequest+timing"></a>
-
-### authenticationRequest.timing
-**Kind**: instance property of [<code>AuthenticationRequest</code>](#AuthenticationRequest)
-
-| Param | Type |
-| --- | --- |
-| value | [<code>Timing</code>](#Timing) |
 
 <a name="AuthenticationRequest+toJSON"></a>
 
@@ -531,7 +426,7 @@ Parses a `DID` from the input string.
         * [.merge(diff)](#Document+merge)
         * [.toJSON()](#Document+toJSON) ⇒ <code>any</code>
     * _static_
-        * [.fromKeyPair(key)](#Document.fromKeyPair) ⇒ [<code>Document</code>](#Document)
+        * [.fromKeyPair(key, network)](#Document.fromKeyPair) ⇒ [<code>Document</code>](#Document)
         * [.fromAuthentication(method)](#Document.fromAuthentication) ⇒ [<code>Document</code>](#Document)
         * [.fromJSON(json)](#Document.fromJSON) ⇒ [<code>Document</code>](#Document)
 
@@ -724,10 +619,10 @@ Serializes a `Document` object as a JSON object.
 **Kind**: instance method of [<code>Document</code>](#Document)  
 <a name="Document.fromKeyPair"></a>
 
-### Document.fromKeyPair(key) ⇒ [<code>Document</code>](#Document)
+### Document.fromKeyPair(key, network) ⇒ [<code>Document</code>](#Document)
 Creates a new DID Document from the given KeyPair and optional network.
 
-If unspecified, the network defaults to the mainnet.
+If unspecified, network defaults to the mainnet.
 
 **Kind**: static method of [<code>Document</code>](#Document)  
 
@@ -1189,7 +1084,7 @@ Serializes a `Service` object as a JSON object.
 <a name="Service.fromJSON"></a>
 
 ### Service.fromJSON(value) ⇒ [<code>Service</code>](#Service)
-Deserializes a `Method` object from a JSON object.
+Deserializes a `Service` object from a JSON object.
 
 **Kind**: static method of [<code>Service</code>](#Service)  
 
@@ -1214,7 +1109,7 @@ Deserializes a `Method` object from a JSON object.
         * [.expiresTime](#Timing+expiresTime)
         * [.waitUntilTime](#Timing+waitUntilTime) ⇒ <code>string</code> \| <code>undefined</code>
         * [.waitUntilTime](#Timing+waitUntilTime)
-        * [.delayMilli](#Timing+delayMilli) ⇒ <code>BigInt</code> \| <code>undefined</code>
+        * [.delayMilli](#Timing+delayMilli) ⇒ <code>number</code> \| <code>undefined</code>
         * [.delayMilli](#Timing+delayMilli)
         * [.toJSON()](#Timing+toJSON) ⇒ <code>any</code>
     * _static_
@@ -1287,7 +1182,7 @@ Deserializes a `Method` object from a JSON object.
 
 <a name="Timing+delayMilli"></a>
 
-### timing.delayMilli ⇒ <code>BigInt</code> \| <code>undefined</code>
+### timing.delayMilli ⇒ <code>number</code> \| <code>undefined</code>
 **Kind**: instance property of [<code>Timing</code>](#Timing)
 <a name="Timing+delayMilli"></a>
 
@@ -1296,7 +1191,7 @@ Deserializes a `Method` object from a JSON object.
 
 | Param | Type |
 | --- | --- |
-| value | <code>BigInt</code> |
+| value | <code>number</code> |
 
 <a name="Timing+toJSON"></a>
 
@@ -1555,6 +1450,12 @@ Deserializes a `VerificationMethod` object from a JSON object.
 
 ## KeyType
 **Kind**: global variable  
+<a name="start"></a>
+
+## start()
+Initializes the console error panic hook for better error messages
+
+**Kind**: global function
 <a name="publish"></a>
 
 ## publish(document, params) ⇒ <code>any</code>
@@ -1603,9 +1504,3 @@ Validates a presentation with the DID Document from the Tangle, params looks lik
 | data | <code>string</code> | 
 | params | <code>any</code> | 
 
-<a name="start"></a>
-
-## start()
-Initializes the console error panic hook for better error messages
-
-**Kind**: global function

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iota/identity-wasm",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "WASM bindings for IOTA Identity - A Self Sovereign Identity Framework implementing the DID and VC standards from W3C. To be used in Javascript/Typescript",
   "repository": {
     "type": "git",

--- a/bindings/wasm/src/message/timing.rs
+++ b/bindings/wasm/src/message/timing.rs
@@ -64,12 +64,12 @@ impl Timing {
   }
 
   #[wasm_bindgen(getter = delayMilli)]
-  pub fn delay_milli(&self) -> Option<u64> {
+  pub fn delay_milli(&self) -> Option<u32> {
     self.0.delay_milli()
   }
 
   #[wasm_bindgen(setter = delayMilli)]
-  pub fn set_delay_milli(&mut self, value: u64) {
+  pub fn set_delay_milli(&mut self, value: u32) {
     self.0.set_delay_milli(value);
   }
 

--- a/bindings/wasm/src/wasm_document.rs
+++ b/bindings/wasm/src/wasm_document.rs
@@ -87,7 +87,7 @@ impl WasmDocument {
   pub fn from_keypair(key: &KeyPair, network: Option<String>) -> Result<WasmDocument, JsValue> {
     let doc = match network {
       Some(net) => IotaDocument::from_keypair_with_network(&key.0, &net),
-      None => IotaDocument::from_keypair(&key.0)
+      None => IotaDocument::from_keypair(&key.0),
     };
     doc.map_err(err).map(Self)
   }

--- a/identity-comm/src/message/timing.rs
+++ b/identity-comm/src/message/timing.rs
@@ -19,7 +19,7 @@ pub struct Timing {
   #[serde(skip_serializing_if = "Option::is_none")]
   wait_until_time: Option<Timestamp>,
   #[serde(skip_serializing_if = "Option::is_none")]
-  delay_milli: Option<u64>,
+  delay_milli: Option<u32>,
 }
 
 impl Timing {
@@ -111,12 +111,12 @@ impl Timing {
   }
 
   /// Returns the value of the `delay_milli` field.
-  pub fn delay_milli(&self) -> Option<u64> {
+  pub fn delay_milli(&self) -> Option<u32> {
     self.delay_milli
   }
 
   /// Sets the value of the `delay_milli` field.
-  pub fn set_delay_milli<T: Into<Option<u64>>>(&mut self, value: T) {
+  pub fn set_delay_milli<T: Into<Option<u32>>>(&mut self, value: T) {
     self.delay_milli = value.into();
   }
 }


### PR DESCRIPTION
# Description of change

Prevents adding the `BigUint64Array` type to WASM bindings

## Links to any relevant issues

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

## How the change has been tested

CI

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
