### PR TITLE
Fix log for manipulate_did.js example

### DIFF
--- a/bindings/wasm/examples/manipulate_did.js
+++ b/bindings/wasm/examples/manipulate_did.js
@@ -52,7 +52,7 @@ async function manipulateIdentity(clientConfig) {
     const nextMessageId = await client.publishDocument(doc.toJSON());
 
     // Log the results.
-    logExplorerUrl("Identity Update:", clientConfig.network.toString(), messageId);
+    logExplorerUrl("Identity Update:", clientConfig.network.toString(), nextMessageId);
     return {key, newKey, doc, nextMessageId};
 }
 


### PR DESCRIPTION
# Description of change
- This PR fixes the wasm example manipulate_did.js
- The last Explorer Url needs to be build with "nextMessageId" instead of "messageId"
- Otherwise the output of the example will be the same Explorer Url twice

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
