### PR TITLE
Reimpl `Key` with generics

### DIFF
--- a/identity-core/src/crypto/key/key.rs
+++ b/identity-core/src/crypto/key/key.rs
@@ -5,57 +5,85 @@ use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
 use core::fmt::Result;
+use std::marker::PhantomData;
 use zeroize::Zeroize;
 
-macro_rules! impl_key {
-  ($ident:ident, $doc:expr) => {
-    #[derive(Clone)]
-    #[doc = $doc]
-    pub struct $ident(Box<[u8]>);
+/// A cryptographic key with `Public` components.
+pub type PublicKey = Key<Public>;
 
-    impl Debug for $ident {
-      fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        f.write_str(stringify!($ident))
-      }
-    }
+/// A cryptographic key with `Secret` components.
+pub type SecretKey = Key<Secret>;
 
-    impl Display for $ident {
-      fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        f.write_str(stringify!($ident))
-      }
-    }
+// =============================================================================
+// =============================================================================
 
-    impl Drop for $ident {
-      fn drop(&mut self) {
-        self.0.zeroize();
-      }
-    }
-
-    impl Zeroize for $ident {
-      fn zeroize(&mut self) {
-        self.0.zeroize();
-      }
-    }
-
-    impl AsRef<[u8]> for $ident {
-      fn as_ref(&self) -> &[u8] {
-        &self.0
-      }
-    }
-
-    impl From<Box<[u8]>> for $ident {
-      fn from(other: Box<[u8]>) -> Self {
-        Self(other)
-      }
-    }
-
-    impl From<Vec<u8>> for $ident {
-      fn from(other: Vec<u8>) -> Self {
-        other.into_boxed_slice().into()
-      }
-    }
-  };
+mod private {
+  pub trait Sealed {}
 }
 
-impl_key!(PublicKey, "A public key object.");
-impl_key!(SecretKey, "A secret key object.");
+// A marker type for the `Public` components of a cryptographic key.
+#[derive(Clone, Copy, Debug)]
+pub enum Public {}
+
+// A marker type for the `Secret` components of a cryptographic key.
+#[derive(Clone, Copy, Debug)]
+pub enum Secret {}
+
+impl private::Sealed for Public {}
+
+impl private::Sealed for Secret {}
+
+// =============================================================================
+// =============================================================================
+
+/// A cryptographic key.
+#[derive(Clone)]
+pub struct Key<V: private::Sealed> {
+  key: Box<[u8]>,
+  vis: PhantomData<V>,
+}
+
+impl<V: private::Sealed> Debug for Key<V> {
+  fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    f.write_str("Key")
+  }
+}
+
+impl<V: private::Sealed> Display for Key<V> {
+  fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    f.write_str("Key")
+  }
+}
+
+impl<V: private::Sealed> Drop for Key<V> {
+  fn drop(&mut self) {
+    self.key.zeroize();
+  }
+}
+
+impl<V: private::Sealed> Zeroize for Key<V> {
+  fn zeroize(&mut self) {
+    self.key.zeroize();
+  }
+}
+
+impl<V: private::Sealed> AsRef<[u8]> for Key<V> {
+  fn as_ref(&self) -> &[u8] {
+    &self.key
+  }
+}
+
+impl<V: private::Sealed> From<Box<[u8]>> for Key<V> {
+  fn from(other: Box<[u8]>) -> Self {
+    Self {
+      key: other,
+      vis: PhantomData,
+    }
+  }
+}
+
+impl<V: private::Sealed> From<Vec<u8>> for Key<V> {
+  fn from(other: Vec<u8>) -> Self {
+    other.into_boxed_slice().into()
+  }
+}


### PR DESCRIPTION
# Description of change

Based on a conversation with and code from @l1h3r, this reimplements `PublicKey` and `SecretKey` using generics rather than a macro.

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
