### PR TITLE
Add features to account to allow wasm compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
 resolver = "2"
-
 members = [
   "identity",
   "identity-comm",

--- a/identity-account/Cargo.toml
+++ b/identity-account/Cargo.toml
@@ -17,16 +17,19 @@ hashbrown = { version = "0.9", features = ["serde"] }
 identity-core = { version = "=0.3.0", path = "../identity-core" }
 identity-credential = { version = "=0.3.0", path = "../identity-credential" }
 identity-did = { version = "=0.3.0", path = "../identity-did" }
-identity-iota = { version = "=0.3.0", path = "../identity-iota" }
+identity-iota = { version = "=0.3.0", path = "../identity-iota", default-features = false }
 itoa = { version = "0.4" }
 log = { version = "0.4", default-features = false }
 once_cell = { version = "1.7", default-features = false, features = ["std"] }
 paste = { version = "1.0" }
-riker = { version = "0.4" }
-serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+riker = { version = "0.4", optional = true }
+serde = { version = "1.0", default-features = false, features = [
+    "alloc",
+    "derive"
+] }
 slog = { version = "2.7" }
 thiserror = { version = "1.0" }
-tokio = { version = "1.5", default-features = false, features = ["rt", "rt-multi-thread", "sync"] }
+tokio = { version = "1.5", features = ["sync"] }
 zeroize = { version = "1.3" }
 
 [dependencies.iota-crypto]
@@ -36,15 +39,31 @@ features = ["blake2b", "ed25519", "hmac", "pbkdf", "sha", "slip10", "std"]
 [dependencies.iota_stronghold]
 git = "https://github.com/iotaledger/stronghold.rs"
 rev = "6dd92dc9743eba2f3b4126425e7572470d92c80b"
+optional = true
 
 [dependencies.stronghold_engine]
 git = "https://github.com/iotaledger/stronghold.rs"
 rev = "6dd92dc9743eba2f3b4126425e7572470d92c80b"
+optional = true
 
 [dev-dependencies]
 rand = { version = "0.8" }
 rusty-fork = { version = "0.3" }
-tokio = { version = "1.5", features = ["macros", "rt", "rt-multi-thread", "sync"] }
+tokio = { version = "1.5", features = [
+    "macros",
+    "rt",
+    "rt-multi-thread",
+    "sync"
+] }
 
 [features]
 mem-client = []
+stronghold = [
+    "iota_stronghold",
+    "stronghold_engine",
+    "riker",
+    "tokio/rt-multi-thread",
+]
+wasm = ["identity-iota/wasm"]
+async = ["identity-iota/async"]
+default = ["stronghold", "async"]

--- a/identity-account/src/account/builder.rs
+++ b/identity-account/src/account/builder.rs
@@ -4,7 +4,9 @@
 use hashbrown::HashMap;
 use identity_iota::tangle::ClientBuilder;
 use identity_iota::tangle::Network;
+#[cfg(feature = "stronghold")]
 use std::path::PathBuf;
+#[cfg(feature = "stronghold")]
 use zeroize::Zeroize;
 
 use crate::account::Account;
@@ -13,12 +15,17 @@ use crate::account::Config;
 use crate::error::Result;
 use crate::storage::MemStore;
 use crate::storage::Storage;
+#[cfg(feature = "stronghold")]
 use crate::storage::Stronghold;
 
 /// The storage adapter used by an [Account].
+///
+/// Note that [AccountStorage::Stronghold] is only available if the `stronghold` feature is activated, which it is by
+/// default.
 #[derive(Debug)]
 pub enum AccountStorage {
   Memory,
+  #[cfg(feature = "stronghold")]
   Stronghold(PathBuf, Option<String>),
   Custom(Box<dyn Storage>),
 }
@@ -81,6 +88,7 @@ impl AccountBuilder {
   pub async fn build(mut self) -> Result<Account> {
     let account: Account = match self.storage {
       AccountStorage::Memory => Account::with_config(MemStore::new(), self.config).await?,
+      #[cfg(feature = "stronghold")]
       AccountStorage::Stronghold(snapshot, password) => {
         let passref: Option<&str> = password.as_deref();
         let adapter: Stronghold = Stronghold::new(&snapshot, passref).await?;

--- a/identity-account/src/error.rs
+++ b/identity-account/src/error.rs
@@ -28,9 +28,11 @@ pub enum Error {
   #[error(transparent)]
   IoError(#[from] std::io::Error),
   /// Caused by an internal failure of the riker actor system.
+  #[cfg(feature = "stronghold")]
   #[error(transparent)]
   ActorSystemError(#[from] riker::system::SystemError),
   /// Caused by errors from the [iota_stronghold] crate.
+  #[cfg(feature = "stronghold")]
   #[error(transparent)]
   StrongholdError(#[from] iota_stronghold::Error),
   /// Caused by errors from an invalid Stronghold procedure.

--- a/identity-account/src/lib.rs
+++ b/identity-account/src/lib.rs
@@ -26,6 +26,7 @@ pub mod error;
 pub mod events;
 pub mod identity;
 pub mod storage;
+#[cfg(feature = "stronghold")]
 pub mod stronghold;
 pub mod types;
 pub mod utils;

--- a/identity-account/src/storage/mod.rs
+++ b/identity-account/src/storage/mod.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod memstore;
+#[cfg(feature = "stronghold")]
 mod stronghold;
 mod traits;
 
 pub use self::memstore::*;
+#[cfg(feature = "stronghold")]
 pub use self::stronghold::*;
 pub use self::traits::*;


### PR DESCRIPTION
# Description of change

It should be possible to compile the upcoming identity actor to WebAssembly. It will use types from the account crate, and the account crate is not Wasm compatible due to a dependency on stronghold. This PR adds features to the account crate to opt-in to stronghold support - which is enabled by default - but can be opted out of to enable compilation to Wasm.

There is a weird issue with `tokio`, where even if we specify it to only use feature `sync` for example, it will still depend on the `mio` crate, even though it shouldn't. This may be happening due to how cargo selects features, and I've described the issue in some detail in the `toml` file. Fortunately, this can be worked around by specifying dependencies via git rather than crates.io. Makes it a bit less ergonomic to work with, i.e. we have to explicitly specify when we want to update `tokio` by updating the revision, but that shouldn't be too much of a hassle.

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
