### PR TITLE
Fix pipeline download failures

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-07-05
           override: true
           components: llvm-tools-preview
       - uses: actions-rs/install@v0.1

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-07-05
           override: true
           components: rustfmt
       - name: core fmt check

--- a/.github/workflows/scripts/coverage.sh
+++ b/.github/workflows/scripts/coverage.sh
@@ -5,9 +5,11 @@ set -e
 rm -rf coverage
 mkdir coverage
 
+NIGHTLY="+nightly-2021-07-05"
+
 # Run tests with profiling instrumentation
 echo "Running instrumented unit tests..."
-RUSTFLAGS="-Zinstrument-coverage" LLVM_PROFILE_FILE="identity-%m.profraw" cargo +nightly test --tests --all --all-features
+RUSTFLAGS="-Zinstrument-coverage" LLVM_PROFILE_FILE="identity-%m.profraw" cargo $NIGHTLY test --tests --all --all-features
 
 # Merge all .profraw files into "identity.profdata"
 echo "Merging coverage data..."
@@ -18,7 +20,7 @@ do
   PROFRAW="${PROFRAW} $file"
 done
 
-cargo +nightly profdata -- merge ${PROFRAW} -o identity.profdata
+cargo $NIGHTLY profdata -- merge ${PROFRAW} -o identity.profdata
 
 # List the test binaries
 echo "Locating test binaries..."
@@ -27,7 +29,7 @@ BINARIES=""
 for file in \
   $( \
     RUSTFLAGS="-Zinstrument-coverage" \
-      cargo +nightly test --tests --all --all-features --no-run --message-format=json \
+      cargo $NIGHTLY test --tests --all --all-features --no-run --message-format=json \
         | jq -r "select(.profile.test == true) | .filenames[]" \
         | grep -v dSYM - \
   ); \
@@ -38,7 +40,7 @@ done
 
 # Generate and export the coverage report to lcov format
 echo "Generating lcov file..."
-cargo +nightly cov -- export ${BINARIES} \
+cargo $NIGHTLY cov -- export ${BINARIES} \
   --instr-profile=identity.profdata \
   --ignore-filename-regex="/.cargo|rustc|target|tests|/.rustup" \
   --format=lcov --Xdemangler=rustfilt \


### PR DESCRIPTION
Fix attempt for inconsistent Github Actions failures when downloading crates.

# Description of change
Pin the nightly Rust toolchain version in the `coverage` and `format` actions to `nightly-2021-07-05`.

The fix was suggested at the following link: https://github.community/t/failed-sending-data-to-the-peer-connection-died-tried-5-times-before-giving-up/189130

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

Github Actions pipeline tested against this PR.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
