### PR TITLE
Fix cyclic dependency

### DIFF
--- a/identity-core/Cargo.toml
+++ b/identity-core/Cargo.toml
@@ -20,7 +20,7 @@ identity-diff = { version = "=0.3.0", path = "../identity-diff", default-feature
 roaring = { version = "0.7", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
 serde_jcs = { version = "0.1", default-features = false }
-serde_json = { version = "1.0", default-features = false, features = ["preserve_order", "std"] }
+serde_json = { version = "1.0", default-features = false, features = ["std"] }
 subtle = { version = "2.4", default-features = false }
 thiserror = { version = "1.0", default-features = false }
 typenum = { version = "1.13", default-features = false }


### PR DESCRIPTION
Fix cyclic dependency when an updated version of [iota.rs](https://github.com/iotaledger/iota.rs) is in the dependency tree.

# Description of change
Remove unused `"preserve_order"` feature flag for `serde_json` which was causing a cyclic dependency, see issue #315 for context. Turns out we no longer need this feature to ensure the ordering of JSON-serialised data, as it was replaced by [`serde_jcs`](https://github.com/l1h3r/serde_jcs). Credit to @l1h3r for this.

NOTE: this PR does not update the version of [iota.rs](https://github.com/iotaledger/iota.rs) we use as there are errors compiling the wasm bindings with it, unrelated to the cyclic dependency which this fixes - PR #291 may address those issues.

## Links to any relevant issues
Fixes issue #315

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

Compiled and ran the test suite successfully with the latest version of [iota.rs](https://github.com/iotaledger/iota.rs) on the dev branch, which had the problem. 

```
[dependencies.iota-client]
git = "https://github.com/iotaledger/iota.rs"
rev = "7407b957efe0136e04c61eef1b30f6873ee3eb67"
default-features = false
```

No cyclic dependency when including [iota streams](https://github.com/iotaledger/streams) in the same project as identity either, which was reported as a problem on Discord (due to it pulling in a later version of iota.rs).

```
iota-streams = { git = "https://github.com/iotaledger/streams", branch  = "develop"}
```

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
