### PR TITLE
Fix inconsistent stronghold storage test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ Cargo.lock
 .idea/
 .vscode/
 
+# Ignore temporary test files
+test-storage/
+
 # remove book
 book
 


### PR DESCRIPTION
# Description of change

The `test_password_persistence` and `test_password_expiration` tests were inconsistently failing in the CI pipeline, and consistently failing when run inside a slow VM.

This PR raises the stronghold test password timeouts which were reduced in 4e4bd0ecc535c370677719b538a1cf13df3916b7 and improves handling on slow systems. The tests will still legitimately fail if e.g. the password clearing task never runs or runs too early.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

All tests pass locally on Windows and Linux, and should pass the CI pipeline consistently.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
