### PR TITLE
Fix import.meta error

### DIFF
--- a/bindings/wasm/build/web.js
+++ b/bindings/wasm/build/web.js
@@ -3,11 +3,13 @@ const fs = require('fs')
 
 const entryFilePath = path.join(__dirname, '../web/identity_wasm.js')
 const entryFile = fs.readFileSync(entryFilePath).toString()
-// comment out this code so it works for Webpack
-let changedFile = entryFile.replace(
-    "input = import.meta.url.replace(",
-    "// input = import.meta.url.replace("
-)
+let changedFile = entryFile
+    // Comment out generated code as a workaround for Webpack (does not recognise import.meta)
+    // Regex to avoid hard-coding 'identity_wasm_bg.wasm'
+    .replace(
+        /input = new URL\('(.*)', import\.meta\.url\);/i,
+        "// input = new URL('$1', import.meta.url);"
+    )
     // Rename original init function, because we want to use the name for our own function
     .replace(
         "async function init(input) {",

--- a/bindings/wasm/build/web.js
+++ b/bindings/wasm/build/web.js
@@ -4,11 +4,11 @@ const fs = require('fs')
 const entryFilePath = path.join(__dirname, '../web/identity_wasm.js')
 const entryFile = fs.readFileSync(entryFilePath).toString()
 let changedFile = entryFile
-    // Comment out generated code as a workaround for Webpack (does not recognise import.meta)
+    // Comment out generated code as a workaround for webpack (does not recognise import.meta)
     // Regex to avoid hard-coding 'identity_wasm_bg.wasm'
     .replace(
-        /input = new URL\('(.*)', import\.meta\.url\);/i,
-        "// input = new URL('$1', import.meta.url);"
+        /input = new URL\((.*), import\.meta\.url\);/i,
+        "// input = new URL($1, import.meta.url);"
     )
     // Rename original init function, because we want to use the name for our own function
     .replace(


### PR DESCRIPTION
# Description of change
Updates the workaround for `webpack` not supporting `import.meta` properties, which causes an error when trying to use the identity Wasm web bindings with some frameworks, e.g. React.

We had a workaround for this exact issue, it just looks like the code generated by `wasm-bindgen` was changed recently so the workaround stopped working.

The fix is to use a build script to comment out the problematic line, which is never reached since we always pass in a valid path:

```
async function initWasm(input) {
    if (typeof input === 'undefined') {
        // input = new URL('identity_wasm_bg.wasm', import.meta.url);  <--- HERE
    }
```

**This will require a new release of the `npm` package for `@iota/identity/wasm@dev`.**

## Links to any relevant issues
Fixes issue #338 

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Generated the web package locally with `npm run build:web` and checked that the line with `import.meta.url` is commented out.

Used the generated files with a new React template project to ensure it can be imported without errors:

```
npx create-react-app my-app
cd my-app
npm install @iota/identity-wasm@dev
```

Then replace the contents of the `my-app/node_modules/@iota/identity-wasm/web` folder with the `web` folder generated by `npm run build:web`.

Add `import { init } from @iota/identity-wasm` to `App.js`
Run `npm start` and the webpage should load successfully without errors.


## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
