### PR TITLE
Remove `toUnix` and `fromUnix` methods in `WasmTimestamp`

### DIFF
--- a/bindings/wasm/build/lints.js
+++ b/bindings/wasm/build/lints.js
@@ -1,0 +1,13 @@
+
+// Aborts the build process if disallowed occurences are found in identity_wasm.js
+function lintBigInt(content) {
+    if (content.includes("BigInt64Array") || content.includes("BigUint64Array")) {
+        console.error("Build artifacts should not include BigInt64Array/BigUint64Array imports")
+        console.error("to ensure React Native/WebKit compatibility.")
+        console.error("Remove any u64 and i64 occurrence from the public Wasm interface.")
+        console.error("See also issue 362.")
+        process.exit(1)
+    }
+}
+
+exports.lintBigInt = lintBigInt;

--- a/bindings/wasm/build/lints.js
+++ b/bindings/wasm/build/lints.js
@@ -5,7 +5,7 @@ function lintBigInt(content) {
         console.error("Build artifacts should not include BigInt64Array/BigUint64Array imports")
         console.error("to ensure React Native/WebKit compatibility.")
         console.error("Remove any u64 and i64 occurrence from the public Wasm interface.")
-        console.error("See also issue 362.")
+        console.error("See: https://github.com/iotaledger/identity.rs/issues/362")
         process.exit(1)
     }
 }

--- a/bindings/wasm/build/node.js
+++ b/bindings/wasm/build/node.js
@@ -1,9 +1,13 @@
 const path = require('path')
 const fs = require('fs')
+const { lintBigInt } = require('./lints')
 
 // Add node fetch stuff (https://github.com/seanmonstar/reqwest/issues/910)
 const entryFilePathNode = path.join(__dirname, '../node/identity_wasm.js')
 const entryFileNode = fs.readFileSync(entryFilePathNode).toString()
+
+lintBigInt(entryFileNode);
+
 let changedFileNode = entryFileNode.replace(
     "let imports = {};",
     "const fetch = require(\'node-fetch\')\r\nglobal.Headers = fetch.Headers\r\nglobal.Request = fetch.Request\r\nglobal.Response = fetch.Response\r\nglobal.fetch = fetch\r\n\r\nlet imports = {};"

--- a/bindings/wasm/build/web.js
+++ b/bindings/wasm/build/web.js
@@ -1,8 +1,12 @@
 const path = require('path')
 const fs = require('fs')
+const { lintBigInt } = require('./lints')
 
 const entryFilePath = path.join(__dirname, '../web/identity_wasm.js')
 const entryFile = fs.readFileSync(entryFilePath).toString()
+
+lintBigInt(entryFile);
+
 let changedFile = entryFile
     // Comment out generated code as a workaround for webpack (does not recognise import.meta)
     // Regex to avoid hard-coding 'identity_wasm_bg.wasm'

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -1668,19 +1668,11 @@ Deserializes a `Service` object from a JSON object.
 
 * [Timestamp](#Timestamp)
     * _instance_
-        * [.toUnix()](#Timestamp+toUnix) ⇒ <code>BigInt</code>
         * [.toRFC3339()](#Timestamp+toRFC3339) ⇒ <code>string</code>
     * _static_
         * [.parse(input)](#Timestamp.parse) ⇒ [<code>Timestamp</code>](#Timestamp)
         * [.nowUTC()](#Timestamp.nowUTC) ⇒ [<code>Timestamp</code>](#Timestamp)
-        * [.fromUnix(seconds)](#Timestamp.fromUnix) ⇒ [<code>Timestamp</code>](#Timestamp)
 
-<a name="Timestamp+toUnix"></a>
-
-### timestamp.toUnix() ⇒ <code>BigInt</code>
-Returns the `Timestamp` as a Unix timestamp.
-
-**Kind**: instance method of [<code>Timestamp</code>](#Timestamp)  
 <a name="Timestamp+toRFC3339"></a>
 
 ### timestamp.toRFC3339() ⇒ <code>string</code>
@@ -1704,17 +1696,6 @@ Parses a `Timestamp` from the provided input string.
 Creates a new `Timestamp` with the current date and time.
 
 **Kind**: static method of [<code>Timestamp</code>](#Timestamp)  
-<a name="Timestamp.fromUnix"></a>
-
-### Timestamp.fromUnix(seconds) ⇒ [<code>Timestamp</code>](#Timestamp)
-Creates a new `Timestamp` from the given Unix timestamp.
-
-**Kind**: static method of [<code>Timestamp</code>](#Timestamp)  
-
-| Param | Type |
-| --- | --- |
-| seconds | <code>BigInt</code> | 
-
 <a name="Timing"></a>
 
 ## Timing

--- a/bindings/wasm/src/common/timestamp.rs
+++ b/bindings/wasm/src/common/timestamp.rs
@@ -24,19 +24,6 @@ impl WasmTimestamp {
     Self(Timestamp::now_utc())
   }
 
-  /// Returns the `Timestamp` as a Unix timestamp.
-  #[wasm_bindgen(js_name = toUnix)]
-  #[allow(clippy::wrong_self_convention)]
-  pub fn to_unix(&self) -> i64 {
-    self.0.to_unix()
-  }
-
-  /// Creates a new `Timestamp` from the given Unix timestamp.
-  #[wasm_bindgen(js_name = fromUnix)]
-  pub fn from_unix(seconds: i64) -> Self {
-    Self(Timestamp::from_unix(seconds))
-  }
-
   /// Returns the `Timestamp` as an RFC 3339 `String`.
   #[wasm_bindgen(js_name = toRFC3339)]
   #[allow(clippy::wrong_self_convention)]


### PR DESCRIPTION
# Description of change

These methods use `i64` in their method signatures, which causes a dependency on `BigInt64Array` on the JavaScript side. Since we already have `to_rfc3339` and `parse` methods, there are alternatives available. Thus, removing these methods is a good enough fix.

Also added a lint to the build scripts that checks the output for these imports and aborts the build process in that case.

## Links to any relevant issues

fixes #362

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Added lint scripts that run post-build.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
