### PR TITLE
Migrate to latest actix-based Stronghold

### DIFF
--- a/identity-account/Cargo.toml
+++ b/identity-account/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["iota", "tangle", "identity"]
 homepage = "https://www.iota.org"
 
 [dependencies]
+actix = { version = "0.12.0", optional = true }
 async-trait = { version = "0.1", default-features = false }
 futures = { version = "0.3" }
 hashbrown = { version = "0.11", features = ["serde"] }
@@ -22,10 +23,9 @@ itoa = { version = "0.4" }
 log = { version = "0.4", default-features = false }
 once_cell = { version = "1.7", default-features = false, features = ["std"] }
 paste = { version = "1.0" }
-riker = { version = "0.4", optional = true }
 serde = { version = "1.0", default-features = false, features = [
     "alloc",
-    "derive"
+    "derive",
 ] }
 slog = { version = "2.7" }
 strum = { version = "0.21", features = ["derive"] }
@@ -34,17 +34,17 @@ tokio = { version = "1.5", features = ["sync"] }
 zeroize = { version = "1.4" }
 
 [dependencies.iota-crypto]
-version = "0.5"
+version = "0.7"
 features = ["blake2b", "ed25519", "hmac", "pbkdf", "sha", "slip10", "std"]
 
 [dependencies.iota_stronghold]
 git = "https://github.com/iotaledger/stronghold.rs"
-rev = "6dd92dc9743eba2f3b4126425e7572470d92c80b"
+rev = "ad57181e7c5baa4b6ccb66fb464667c97967db08"
 optional = true
 
 [dependencies.stronghold_engine]
 git = "https://github.com/iotaledger/stronghold.rs"
-rev = "6dd92dc9743eba2f3b4126425e7572470d92c80b"
+rev = "ad57181e7c5baa4b6ccb66fb464667c97967db08"
 optional = true
 
 [dev-dependencies]
@@ -54,7 +54,7 @@ tokio = { version = "1.5", features = [
     "macros",
     "rt",
     "rt-multi-thread",
-    "sync"
+    "sync",
 ] }
 
 [features]
@@ -62,7 +62,7 @@ mem-client = []
 stronghold = [
     "iota_stronghold",
     "stronghold_engine",
-    "riker",
+    "actix",
     "tokio/rt-multi-thread",
 ]
 wasm = ["identity-iota/wasm"]

--- a/identity-account/src/error.rs
+++ b/identity-account/src/error.rs
@@ -27,10 +27,6 @@ pub enum Error {
   /// Caused by attempting to perform an invalid IO operation.
   #[error(transparent)]
   IoError(#[from] std::io::Error),
-  /// Caused by an internal failure of the riker actor system.
-  #[cfg(feature = "stronghold")]
-  #[error(transparent)]
-  ActorSystemError(#[from] riker::system::SystemError),
   /// Caused by errors from the [iota_stronghold] crate.
   #[cfg(feature = "stronghold")]
   #[error(transparent)]

--- a/identity-account/src/storage/stronghold.rs
+++ b/identity-account/src/storage/stronghold.rs
@@ -80,7 +80,7 @@ impl Stronghold {
 #[async_trait::async_trait]
 impl Storage for Stronghold {
   async fn set_password(&self, password: EncryptionKey) -> Result<()> {
-    self.snapshot.set_password(password)
+    self.snapshot.set_password(password).await
   }
 
   async fn flush_changes(&self) -> Result<()> {

--- a/identity-account/src/stronghold/snapshot.rs
+++ b/identity-account/src/stronghold/snapshot.rs
@@ -20,15 +20,15 @@ pub struct Snapshot {
 }
 
 impl Snapshot {
-  pub fn set_password_clear(interval: Duration) -> Result<()> {
-    Context::set_password_clear(interval)
+  pub async fn set_password_clear(interval: Duration) -> Result<()> {
+    Context::set_password_clear(interval).await
   }
 
-  pub fn on_change<T>(listener: T) -> Result<()>
+  pub async fn on_change<T>(listener: T) -> Result<()>
   where
     T: FnMut(&Path, &SnapshotStatus) + Send + 'static,
   {
-    Context::on_change(listener)
+    Context::on_change(listener).await
   }
 
   pub fn new<P>(path: &P) -> Self
@@ -65,12 +65,12 @@ impl Snapshot {
     Records::new(&self.path, name, flags)
   }
 
-  pub fn status(&self) -> Result<SnapshotStatus> {
-    Context::snapshot_status(&self.path)
+  pub async fn status(&self) -> Result<SnapshotStatus> {
+    Context::snapshot_status(&self.path).await
   }
 
-  pub fn set_password(&self, password: Password) -> Result<()> {
-    Context::set_password(&self.path, password)
+  pub async fn set_password(&self, password: Password) -> Result<()> {
+    Context::set_password(&self.path, password).await
   }
 
   pub async fn load(&self, password: Password) -> Result<()> {

--- a/identity-account/src/stronghold/tests.rs
+++ b/identity-account/src/stronghold/tests.rs
@@ -61,7 +61,7 @@ rusty_fork_test! {
     block_on(async {
       let interval: Duration = Duration::from_millis(100);
 
-      Snapshot::set_password_clear(interval).unwrap();
+      Snapshot::set_password_clear(interval).await.unwrap();
 
       let filename: PathBuf = generate_filename();
       let snapshot: Snapshot = Snapshot::new(&filename);
@@ -81,7 +81,7 @@ rusty_fork_test! {
       );
 
       assert!(
-        matches!(snapshot.status().unwrap(), SnapshotStatus::Locked),
+        matches!(snapshot.status().await.unwrap(), SnapshotStatus::Locked),
         "unexpected snapshot status",
       );
     })
@@ -92,7 +92,7 @@ rusty_fork_test! {
     block_on(async {
       let interval: Duration = Duration::from_millis(300);
 
-      Snapshot::set_password_clear(interval).unwrap();
+      Snapshot::set_password_clear(interval).await.unwrap();
 
       let filename: PathBuf = generate_filename();
       let snapshot: Snapshot = Snapshot::new(&filename);
@@ -105,7 +105,7 @@ rusty_fork_test! {
         let location: Location = location(&format!("persists{}", index));
 
         let set_result = store.set(location, format!("STRONGHOLD{}", index), None).await;
-        let status: SnapshotStatus = snapshot.status().unwrap();
+        let status: SnapshotStatus = snapshot.status().await.unwrap();
 
         if let Some(timeout) = interval.checked_sub(instant.elapsed()) {
           // Prior to the expiration time, the password should not be cleared yet
@@ -122,7 +122,7 @@ rusty_fork_test! {
         } else {
           // If elapsed > interval, set the password again.
           // This might happen if the test is stopped by another thread.
-          snapshot.set_password(Default::default()).unwrap();
+          snapshot.set_password(Default::default()).await.unwrap();
           instant = Instant::now();
         }
       }
@@ -131,7 +131,7 @@ rusty_fork_test! {
 
       // Test may have taken too long / been interrupted and cleared the password already, retry
       if matches!(result, Err(Error::StrongholdPasswordNotSet)) && interval.checked_sub(instant.elapsed()).is_none() {
-        snapshot.set_password(Default::default()).unwrap();
+        snapshot.set_password(Default::default()).await.unwrap();
         result = store.get(location("persists1")).await;
       }
       assert_eq!(result.unwrap(), b"STRONGHOLD1");
@@ -146,7 +146,7 @@ rusty_fork_test! {
         error
       );
       assert!(
-        matches!(snapshot.status().unwrap(), SnapshotStatus::Locked),
+        matches!(snapshot.status().await.unwrap(), SnapshotStatus::Locked),
         "unexpected snapshot status",
       );
     })

--- a/identity-core/Cargo.toml
+++ b/identity-core/Cargo.toml
@@ -29,7 +29,7 @@ url = { version = "2.2", default-features = false, features = ["serde"] }
 zeroize = { version = "1.4", default-features = false }
 
 [dependencies.iota-crypto]
-version = "0.5"
+version = "0.7"
 default-features = false
 features = ["blake2b", "ed25519", "random", "sha"]
 

--- a/identity-core/src/crypto/signature/ed25519.rs
+++ b/identity-core/src/crypto/signature/ed25519.rs
@@ -4,7 +4,7 @@
 use core::convert::TryInto;
 use core::marker::PhantomData;
 use crypto::signatures::ed25519;
-use crypto::signatures::ed25519::COMPRESSED_PUBLIC_KEY_LENGTH as PUBLIC_KEY_LENGTH;
+use crypto::signatures::ed25519::PUBLIC_KEY_LENGTH;
 use crypto::signatures::ed25519::SECRET_KEY_LENGTH;
 use crypto::signatures::ed25519::SIGNATURE_LENGTH;
 
@@ -53,7 +53,7 @@ fn parse_public(slice: &[u8]) -> Result<ed25519::PublicKey> {
     .and_then(|bytes| bytes.try_into().ok())
     .ok_or_else(|| Error::InvalidKeyLength(slice.len(), PUBLIC_KEY_LENGTH))?;
 
-  ed25519::PublicKey::from_compressed_bytes(bytes).map_err(Into::into)
+  ed25519::PublicKey::try_from_bytes(bytes).map_err(Into::into)
 }
 
 fn parse_secret(slice: &[u8]) -> Result<ed25519::SecretKey> {
@@ -62,7 +62,7 @@ fn parse_secret(slice: &[u8]) -> Result<ed25519::SecretKey> {
     .and_then(|bytes| bytes.try_into().ok())
     .ok_or_else(|| Error::InvalidKeyLength(slice.len(), SECRET_KEY_LENGTH))?;
 
-  ed25519::SecretKey::from_le_bytes(bytes).map_err(Into::into)
+  Ok(ed25519::SecretKey::from_bytes(bytes))
 }
 
 fn parse_signature(slice: &[u8]) -> Result<ed25519::Signature> {

--- a/identity-core/src/utils/ed25519.rs
+++ b/identity-core/src/utils/ed25519.rs
@@ -12,8 +12,8 @@ pub fn generate_ed25519_keypair() -> Result<(PublicKey, SecretKey)> {
   let secret: ed25519::SecretKey = ed25519::SecretKey::generate()?;
   let public: ed25519::PublicKey = secret.public_key();
 
-  let secret: SecretKey = secret.to_le_bytes().to_vec().into();
-  let public: PublicKey = public.to_compressed_bytes().to_vec().into();
+  let secret: SecretKey = secret.to_bytes().to_vec().into();
+  let public: PublicKey = public.to_bytes().to_vec().into();
 
   Ok((public, secret))
 }

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -30,7 +30,7 @@ rev = "e8c050a749a2e7c13633e97b3372b38388f48c37"
 default-features = false
 
 [dependencies.iota-crypto]
-version = "0.5"
+version = "0.7"
 default-features = false
 features = ["blake2b"]
 


### PR DESCRIPTION
# Description of change

This migrates the riker-based stronghold to the new actix-based version. The system was previously set up in a static context, and I've kept that pattern. The `actix::System` required to run stronghold is essentially a single-threaded tokio runtime (the so-called `LocalSet`). Since we are already running in a `tokio` runtime (per the examples), we cannot start an `actix::System` in the same thread. Doing so results in a: `Cannot start a runtime from within a runtime. This happens because a function (like block_on) attempted to block the current thread while the thread is being used to drive asynchronous tasks.`
Moreover, some thread needs to actively drive the `actix::System`'s event loop, i.e. `system.run()`, so this blocking operation essentially requires the extra thread.

## Considered alternatives

It would be nice if we could attach the `actix::System` to the already running `tokio::Runtime`, but the `actix::System::with_tokio_rt`, is the closest to that functionality that exists, and it takes a closure that needs to return a new `Runtime`. An existing runtime can only be attained using `Runtime::handle`, which returns a `Handle`. Thus, afaik, this is not possible :-1:.

One other solution is to change our examples to use `#[actix::main]` rather than `#[tokio::main]`. If I'm understanding actix right, then it is running on a tokio `LocalSet`, i.e. the single-threaded runtime variant. Given that, changing to `#[actix::main]` would force our entire application to run on a single-threaded tokio runtime, which would be too big of a limitation.

## Links to any relevant issues

Required to complete #352, because the newer stronghold version contains a bugfix.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

The stronghold tests in the account pass locally.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
