### PR TITLE
Bump to 0.3.8 for @iota/identity-wasm@dev, add set_message_id

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -715,6 +715,7 @@ Parses a `DID` from the input string.
         * [.updated](#Document+updated)
         * [.proof](#Document+proof) ⇒ <code>any</code>
         * [.messageId](#Document+messageId) ⇒ <code>string</code>
+        * [.messageId](#Document+messageId)
         * [.previousMessageId](#Document+previousMessageId) ⇒ <code>string</code>
         * [.previousMessageId](#Document+previousMessageId)
         * [.authentication()](#Document+authentication) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
@@ -801,7 +802,20 @@ Returns the DID Document `proof` object.
 <a name="Document+messageId"></a>
 
 ### document.messageId ⇒ <code>string</code>
+Get the message_id of the DID Document.
+
 **Kind**: instance property of [<code>Document</code>](#Document)  
+<a name="Document+messageId"></a>
+
+### document.messageId
+Set the message_id of the DID Document.
+
+**Kind**: instance property of [<code>Document</code>](#Document)  
+
+| Param | Type |
+| --- | --- |
+| message_id | <code>string</code> | 
+
 <a name="Document+previousMessageId"></a>
 
 ### document.previousMessageId ⇒ <code>string</code>

--- a/bindings/wasm/examples/browser/create_did.js
+++ b/bindings/wasm/examples/browser/create_did.js
@@ -37,6 +37,7 @@ export async function createIdentity(clientConfig, log = true) {
 
     // Publish the Identity to the IOTA Network, this may take a few seconds to complete Proof-of-Work.
     const receipt = await client.publishDocument(doc.toJSON());
+    doc.message_id = receipt.messageId;
 
     const explorerUrl = getExplorerUrl(doc, receipt.messageId);
 

--- a/bindings/wasm/examples/browser/create_did.js
+++ b/bindings/wasm/examples/browser/create_did.js
@@ -37,7 +37,7 @@ export async function createIdentity(clientConfig, log = true) {
 
     // Publish the Identity to the IOTA Network, this may take a few seconds to complete Proof-of-Work.
     const receipt = await client.publishDocument(doc.toJSON());
-    doc.message_id = receipt.messageId;
+    doc.messageId = receipt.messageId;
 
     const explorerUrl = getExplorerUrl(doc, receipt.messageId);
 

--- a/bindings/wasm/examples/node/create_did.js
+++ b/bindings/wasm/examples/node/create_did.js
@@ -27,6 +27,7 @@ async function createIdentity(clientConfig) {
 
     // Publish the Identity to the IOTA Network, this may take a few seconds to complete Proof-of-Work.
     const receipt = await client.publishDocument(doc.toJSON());
+    doc.message_id = receipt.messageId;
 
     // Log the results.
     logExplorerUrl("Identity Creation:", clientConfig.network.toString(), receipt.messageId);

--- a/bindings/wasm/examples/node/create_did.js
+++ b/bindings/wasm/examples/node/create_did.js
@@ -27,7 +27,7 @@ async function createIdentity(clientConfig) {
 
     // Publish the Identity to the IOTA Network, this may take a few seconds to complete Proof-of-Work.
     const receipt = await client.publishDocument(doc.toJSON());
-    doc.message_id = receipt.messageId;
+    doc.messageId = receipt.messageId;
 
     // Log the results.
     logExplorerUrl("Identity Creation:", clientConfig.network.toString(), receipt.messageId);

--- a/bindings/wasm/package-lock.json
+++ b/bindings/wasm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iota/identity-wasm",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iota/identity-wasm",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "WASM bindings for IOTA Identity - A Self Sovereign Identity Framework implementing the DID and VC standards from W3C. To be used in Javascript/Typescript",
   "repository": {
     "type": "git",

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -151,9 +151,18 @@ impl WasmDocument {
     WasmVerificationMethod(self.0.authentication().clone())
   }
 
+  /// Get the message_id of the DID Document.
   #[wasm_bindgen(getter = messageId)]
   pub fn message_id(&self) -> String {
     self.0.message_id().to_string()
+  }
+
+  /// Set the message_id of the DID Document.
+  #[wasm_bindgen(setter = messageId)]
+  pub fn set_message_id(&mut self, message_id: &str) -> Result<()> {
+    let message_id: MessageId = MessageId::from_str(message_id).wasm_result()?;
+    self.0.set_message_id(message_id);
+    Ok(())
   }
 
   #[wasm_bindgen(getter = previousMessageId)]
@@ -164,9 +173,7 @@ impl WasmDocument {
   #[wasm_bindgen(setter = previousMessageId)]
   pub fn set_previous_message_id(&mut self, value: &str) -> Result<()> {
     let message: MessageId = MessageId::from_str(value).wasm_result()?;
-
     self.0.set_previous_message_id(message);
-
     Ok(())
   }
 


### PR DESCRIPTION
# Description of change
Add `set_message_id` to `WasmDocument` to allow setting the `messageId` on DID documents in the wasm bindings. 
Bump version to 0.3.8.

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tests, examples pass locally.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
