### PR TITLE
Make sccache installation a bit faster on macOS

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Install sccache (macos-latest)
         if: matrix.os == 'macos-latest'
         run: |
-          brew update
+          brew update --preinstall
           brew install sccache
 
       - name: Install sccache (windows-latest)


### PR DESCRIPTION
# Description of change
Makes `sccache` installation a bit faster on macOS by adding the `--preinstall` flag to the `brew update` command, which skips some checks that are redundant when running `brew update` just before `brew install`

## Links to any relevant issues
N/A

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Chore

## How the change has been tested
CI ran successfully

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code