### PR TITLE
Refactor `NetworkName`

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -1492,11 +1492,11 @@ Deserializes a `KeyPair` object from a JSON object.
 * [Network](#Network)
     * _instance_
         * [.defaultNodeURL](#Network+defaultNodeURL) ⇒ <code>string</code> \| <code>undefined</code>
-        * [.explorerURL](#Network+explorerURL) ⇒ <code>string</code>
+        * [.explorerURL](#Network+explorerURL) ⇒ <code>string</code> \| <code>undefined</code>
         * [.messageURL(message_id)](#Network+messageURL) ⇒ <code>string</code>
         * [.toString()](#Network+toString) ⇒ <code>string</code>
     * _static_
-        * [.from_name(string)](#Network.from_name) ⇒ [<code>Network</code>](#Network)
+        * [.from_name(name)](#Network.from_name) ⇒ [<code>Network</code>](#Network)
         * [.mainnet()](#Network.mainnet) ⇒ [<code>Network</code>](#Network)
         * [.testnet()](#Network.testnet) ⇒ [<code>Network</code>](#Network)
 
@@ -1508,7 +1508,7 @@ Returns the node URL of the Tangle network.
 **Kind**: instance property of [<code>Network</code>](#Network)  
 <a name="Network+explorerURL"></a>
 
-### network.explorerURL ⇒ <code>string</code>
+### network.explorerURL ⇒ <code>string</code> \| <code>undefined</code>
 Returns the web explorer URL of the Tangle network.
 
 **Kind**: instance property of [<code>Network</code>](#Network)  
@@ -1529,12 +1529,14 @@ Returns the web explorer URL of the given `message`.
 **Kind**: instance method of [<code>Network</code>](#Network)  
 <a name="Network.from_name"></a>
 
-### Network.from\_name(string) ⇒ [<code>Network</code>](#Network)
+### Network.from\_name(name) ⇒ [<code>Network</code>](#Network)
+Parses the provided string to a [`WasmNetwork`].
+
 **Kind**: static method of [<code>Network</code>](#Network)  
 
 | Param | Type |
 | --- | --- |
-| string | <code>string</code> | 
+| name | <code>string</code> | 
 
 <a name="Network.mainnet"></a>
 

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -1496,7 +1496,7 @@ Deserializes a `KeyPair` object from a JSON object.
         * [.messageURL(message_id)](#Network+messageURL) ⇒ <code>string</code>
         * [.toString()](#Network+toString) ⇒ <code>string</code>
     * _static_
-        * [.from_name(name)](#Network.from_name) ⇒ [<code>Network</code>](#Network)
+        * [.try_from_name(name)](#Network.try_from_name) ⇒ [<code>Network</code>](#Network)
         * [.mainnet()](#Network.mainnet) ⇒ [<code>Network</code>](#Network)
         * [.testnet()](#Network.testnet) ⇒ [<code>Network</code>](#Network)
 
@@ -1527,9 +1527,9 @@ Returns the web explorer URL of the given `message`.
 
 ### network.toString() ⇒ <code>string</code>
 **Kind**: instance method of [<code>Network</code>](#Network)  
-<a name="Network.from_name"></a>
+<a name="Network.try_from_name"></a>
 
-### Network.from\_name(name) ⇒ [<code>Network</code>](#Network)
+### Network.try\_from\_name(name) ⇒ [<code>Network</code>](#Network)
 Parses the provided string to a [`WasmNetwork`].
 
 **Kind**: static method of [<code>Network</code>](#Network)  

--- a/bindings/wasm/examples/browser/private_tangle.js
+++ b/bindings/wasm/examples/browser/private_tangle.js
@@ -30,7 +30,7 @@ export async function createIdentityPrivateTangle(inBrowser = true, log = true) 
     }
 
     // This is an arbitrarily defined network name
-    const network = Network.from_name(networkName);
+    const network = Network.try_from_name(networkName);
 
     // Create a DID Document (an identity).
     const { doc, key } = new Document(KeyType.Ed25519, network.toString());

--- a/bindings/wasm/examples/node/private_tangle.js
+++ b/bindings/wasm/examples/node/private_tangle.js
@@ -11,7 +11,7 @@ const { Client, Config, Document, KeyType, Network } = require('../../node/ident
 **/
 async function createIdentityPrivateTangle() {
     // This is an arbitrarily defined network name
-    const network = Network.from_name("custom");
+    const network = Network.try_from_name("custom");
 
     // Create a DID Document (an identity).
     const { doc, key } = new Document(KeyType.Ed25519, network.toString());

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -67,7 +67,7 @@ impl WasmDocument {
     let public: &PublicKey = keypair.0.public();
 
     let did: IotaDID = if let Some(network) = network.as_deref() {
-      IotaDID::with_network(public.as_ref(), network).wasm_result()?
+      IotaDID::new_with_network(public.as_ref(), network).wasm_result()?
     } else {
       IotaDID::new(public.as_ref()).wasm_result()?
     };

--- a/bindings/wasm/src/tangle/network.rs
+++ b/bindings/wasm/src/tangle/network.rs
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use identity::iota::Network as IotaNetwork;
-
 use wasm_bindgen::prelude::*;
 
-use crate::error::wasm_error;
+use crate::error::{Result, WasmResult};
 
 #[wasm_bindgen(js_name = Network)]
 #[derive(Clone, Debug)]
@@ -13,10 +12,10 @@ pub struct WasmNetwork(IotaNetwork);
 
 #[wasm_bindgen(js_class = Network)]
 impl WasmNetwork {
+  /// Parses the provided string to a [`WasmNetwork`].
   #[wasm_bindgen]
-  pub fn from_name(string: &str) -> Result<WasmNetwork, JsValue> {
-    let network = IotaNetwork::from_name(string).map_err(wasm_error)?;
-    Ok(Self(network))
+  pub fn from_name(name: String) -> Result<WasmNetwork> {
+    IotaNetwork::from_name(name).map(Self).wasm_result()
   }
 
   #[wasm_bindgen]
@@ -37,24 +36,20 @@ impl WasmNetwork {
 
   /// Returns the web explorer URL of the Tangle network.
   #[wasm_bindgen(getter = explorerURL)]
-  pub fn explorer_url(&self) -> Result<String, JsValue> {
-    self.0.explorer_url().map(|url| url.to_string()).map_err(wasm_error)
+  pub fn explorer_url(&self) -> Option<String> {
+    self.0.explorer_url().map(ToString::to_string)
   }
 
   /// Returns the web explorer URL of the given `message`.
   #[wasm_bindgen(js_name = messageURL)]
-  pub fn message_url(&self, message_id: &str) -> Result<String, JsValue> {
-    self
-      .0
-      .message_url(message_id)
-      .map(|url| url.to_string())
-      .map_err(wasm_error)
+  pub fn message_url(&self, message_id: &str) -> Result<String> {
+    self.0.message_url(message_id).map(|url| url.to_string()).wasm_result()
   }
 
   #[allow(clippy::inherent_to_string, clippy::wrong_self_convention)]
   #[wasm_bindgen(js_name = toString)]
   pub fn to_string(&self) -> String {
-    self.0.name().into()
+    self.0.name_str().to_owned()
   }
 }
 

--- a/bindings/wasm/src/tangle/network.rs
+++ b/bindings/wasm/src/tangle/network.rs
@@ -14,8 +14,8 @@ pub struct WasmNetwork(IotaNetwork);
 impl WasmNetwork {
   /// Parses the provided string to a [`WasmNetwork`].
   #[wasm_bindgen]
-  pub fn from_name(name: String) -> Result<WasmNetwork> {
-    IotaNetwork::from_name(name).map(Self).wasm_result()
+  pub fn try_from_name(name: String) -> Result<WasmNetwork> {
+    IotaNetwork::try_from_name(name).map(Self).wasm_result()
   }
 
   #[wasm_bindgen]

--- a/examples/account/private_tangle.rs
+++ b/examples/account/private_tangle.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
 
   // This is an arbitrarily defined network name
   let network_name = "custom";
-  let network = Network::from_name(network_name)?;
+  let network = Network::try_from_name(network_name)?;
 
   // Create a new Account with the default configuration
   let private_node_url = "http://127.0.0.1:14265/";

--- a/examples/low-level-api/private_tangle.rs
+++ b/examples/low-level-api/private_tangle.rs
@@ -19,7 +19,7 @@ use identity::prelude::*;
 pub async fn main() -> Result<()> {
   // This is an arbitrarily defined network name
   let network_name = "custom";
-  let network = Network::from_name(network_name)?;
+  let network = Network::try_from_name(network_name)?;
 
   // Set the network and the URL that points to
   // the REST API of the locally running hornet node.

--- a/identity-account/src/account/builder.rs
+++ b/identity-account/src/account/builder.rs
@@ -4,6 +4,7 @@
 use hashbrown::HashMap;
 use identity_iota::tangle::ClientBuilder;
 use identity_iota::tangle::Network;
+use identity_iota::tangle::NetworkName;
 #[cfg(feature = "stronghold")]
 use std::path::PathBuf;
 #[cfg(feature = "stronghold")]
@@ -35,7 +36,7 @@ pub enum AccountStorage {
 pub struct AccountBuilder {
   config: Config,
   storage: AccountStorage,
-  clients: Option<HashMap<Network, ClientBuilder>>,
+  clients: Option<HashMap<NetworkName, ClientBuilder>>,
 }
 
 impl AccountBuilder {
@@ -80,7 +81,7 @@ impl AccountBuilder {
     self
       .clients
       .get_or_insert_with(HashMap::new)
-      .insert(network.clone(), f(ClientBuilder::new().network(network)));
+      .insert(network.name(), f(ClientBuilder::new().network(network)));
     self
   }
 

--- a/identity-account/tests/commands.rs
+++ b/identity-account/tests/commands.rs
@@ -184,7 +184,7 @@ async fn test_create_identity_from_secret_key() -> Result<()> {
 async fn test_create_identity_from_invalid_secret_key() -> Result<()> {
   let account: Account = new_account().await?;
 
-  let secret_bytes: Box<[u8]> = Box::new(*[0; 33]);
+  let secret_bytes: Box<[u8]> = Box::new([0; 33]);
   let secret_key: SecretKey = SecretKey::from(secret_bytes);
 
   let id_create = IdentityCreate::new()
@@ -358,7 +358,7 @@ async fn test_create_method_from_invalid_secret_key() -> Result<()> {
 
   account.process(identity, command, false).await?;
 
-  let secret_bytes: Box<[u8]> = Box::new(*[0; 33]);
+  let secret_bytes: Box<[u8]> = Box::new([0; 33]);
   let secret_key = SecretKey::from(secret_bytes);
 
   let command: Command = Command::create_method()
@@ -387,7 +387,7 @@ async fn test_create_method_with_type_secret_mismatch() -> Result<()> {
 
   account.process(identity, command, false).await?;
 
-  let secret_bytes: Box<[u8]> = Box::new(*[0; 32]);
+  let secret_bytes: Box<[u8]> = Box::new([0; 32]);
   let secret_key = SecretKey::from(secret_bytes);
 
   let command: Command = Command::create_method()

--- a/identity-iota/src/did/doc/iota_verification_method.rs
+++ b/identity-iota/src/did/doc/iota_verification_method.rs
@@ -78,7 +78,7 @@ impl IotaVerificationMethod {
     F: Into<Option<&'a str>>,
   {
     let key: &[u8] = keypair.public().as_ref();
-    let did: IotaDID = IotaDID::with_network(key, network)?;
+    let did: IotaDID = IotaDID::new_with_network(key, network)?;
 
     Self::from_did(did, keypair, fragment)
   }

--- a/identity-iota/src/did/macros.rs
+++ b/identity-iota/src/did/macros.rs
@@ -3,41 +3,27 @@
 
 /// Creates a new IOTA DID from a `public` key and optional `network`.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if the DID format is not valid.
+/// Errors if the [`IotaDID`][crate::did::IotaDID] is invalid.
 ///
 /// # Example
 ///
 /// ```
-/// # use identity_iota::did;
+/// # use identity_iota::try_did;
 /// #
-/// let did = did!(b"public-key");
+/// let did = try_did!(b"public-key").unwrap();
 /// assert_eq!(did.as_str(), "did:iota:2xQiiGHDq5gCi1H7utY1ni7cf65fTay3G11S4xKp1vkS");
 ///
-/// let did = did!(b"public-key", "com");
+/// let did = try_did!(b"public-key", "com").unwrap();
 /// assert_eq!(
 ///   did.as_str(),
 ///   "did:iota:com:2xQiiGHDq5gCi1H7utY1ni7cf65fTay3G11S4xKp1vkS"
 /// );
 /// ```
 #[macro_export]
-macro_rules! did {
-  // Defining explicit branches rather than `$($tt:tt)+` gives much better docs.
-  ($public:expr, $network:expr) => {
-    $crate::try_did!($public, $network).unwrap()
-  };
-  ($public:expr, $network:expr) => {
-    $crate::try_did!($public, $network).unwrap()
-  };
-  ($public:expr) => {
-    $crate::try_did!($public).unwrap()
-  };
-}
-
-/// A fallible version of the [did] macro.
-#[macro_export]
 macro_rules! try_did {
+  // Defining explicit branches rather than `$($tt:tt)+` gives much better docs.
   ($public:expr, $network:expr) => {
     $crate::did::IotaDID::parse(format!(
       "{}:{}:{}:{}",

--- a/identity-iota/src/did/macros.rs
+++ b/identity-iota/src/did/macros.rs
@@ -10,19 +10,19 @@
 /// # Example
 ///
 /// ```
-/// # use identity_iota::try_did;
+/// # use identity_iota::try_construct_did;
 /// #
-/// let did = try_did!(b"public-key").unwrap();
+/// let did = try_construct_did!(b"public-key").unwrap();
 /// assert_eq!(did.as_str(), "did:iota:2xQiiGHDq5gCi1H7utY1ni7cf65fTay3G11S4xKp1vkS");
 ///
-/// let did = try_did!(b"public-key", "com").unwrap();
+/// let did = try_construct_did!(b"public-key", "com").unwrap();
 /// assert_eq!(
 ///   did.as_str(),
 ///   "did:iota:com:2xQiiGHDq5gCi1H7utY1ni7cf65fTay3G11S4xKp1vkS"
 /// );
 /// ```
 #[macro_export]
-macro_rules! try_did {
+macro_rules! try_construct_did {
   // Defining explicit branches rather than `$($tt:tt)+` gives much better docs.
   ($public:expr, $network:expr) => {
     $crate::did::IotaDID::parse(format!(

--- a/identity-iota/src/did/url/iota_did.rs
+++ b/identity-iota/src/did/url/iota_did.rs
@@ -248,7 +248,7 @@ impl IotaDID {
 
   /// Returns the Tangle `network` of the `DID`, if it is valid.
   pub fn network(&self) -> Result<Network> {
-    Network::from_name(self.network_str())
+    Network::from_name(self.network_str().to_owned())
   }
 
   /// Returns the Tangle `network` name of the `DID`.

--- a/identity-iota/src/did/url/iota_did.rs
+++ b/identity-iota/src/did/url/iota_did.rs
@@ -93,7 +93,7 @@ impl IotaDID {
   ///
   /// Returns `Err` if the input does not form a valid [`IotaDID`].
   pub fn new(public: &[u8]) -> Result<Self> {
-    try_did!(public)
+    try_construct_did!(public)
   }
 
   /// Creates a new [`IotaDID`] from the given `public` key and `network`.
@@ -104,7 +104,7 @@ impl IotaDID {
   /// See [`NetworkName`] for validation requirements.
   pub fn new_with_network(public: &[u8], network: &str) -> Result<Self> {
     NetworkName::validate_network_name(network)?;
-    try_did!(public, network)
+    try_construct_did!(public, network)
   }
 
   #[doc(hidden)]
@@ -265,7 +265,7 @@ impl IotaDID {
 
   /// Returns the Tangle `network` of the `DID`, if it is valid.
   pub fn network(&self) -> Result<Network> {
-    Network::from_name(self.network_str().to_owned())
+    Network::try_from_name(self.network_str().to_owned())
   }
 
   /// Returns the Tangle `network` name of the `DID`.

--- a/identity-iota/src/did/url/iota_did.rs
+++ b/identity-iota/src/did/url/iota_did.rs
@@ -110,8 +110,8 @@ impl IotaDID {
   #[doc(hidden)]
   pub fn from_components(public: &[u8], network: Option<&str>) -> Result<Self> {
     match network {
-      Some(network) => try_did!(public, network),
-      None => try_did!(public),
+      Some(network) => Self::new_with_network(public, network),
+      None => Self::new(public),
     }
   }
 

--- a/identity-iota/src/tangle/client_builder.rs
+++ b/identity-iota/src/tangle/client_builder.rs
@@ -31,7 +31,7 @@ impl ClientBuilder {
 
   /// Sets the IOTA Tangle network.
   pub fn network(mut self, network: Network) -> Self {
-    self.builder = self.builder.with_network(&network.name());
+    self.builder = self.builder.with_network(network.name_str());
     self.network = network;
     self
   }

--- a/identity-iota/src/tangle/mod.rs
+++ b/identity-iota/src/tangle/mod.rs
@@ -16,7 +16,7 @@ pub use self::message_ext::MessageExt;
 pub use self::message_ext::MessageIdExt;
 pub use self::message_ext::TryFromMessage;
 pub use self::message_index::MessageIndex;
-pub use self::network::Network;
+pub use self::network::{Network, NetworkName};
 pub use self::receipt::Receipt;
 pub use self::traits::TangleRef;
 pub use self::traits::TangleResolve;

--- a/identity-iota/src/tangle/network.rs
+++ b/identity-iota/src/tangle/network.rs
@@ -87,7 +87,7 @@ impl Network {
 
   /// Returns true if this network is the same network as specified in the DID.
   pub fn matches_did(self, did: &IotaDID) -> bool {
-    did.network_str() == self.name().deref()
+    did.network_str() == self.name_str()
   }
 
   /// Returns the default node [`Url`] of the Tangle network.
@@ -125,6 +125,15 @@ impl Network {
       Self::Mainnet => NetworkName(Cow::from(NETWORK_NAME_MAIN)),
       Self::Testnet => NetworkName(Cow::from(NETWORK_NAME_TEST)),
       Self::Other { name, .. } => name.clone(),
+    }
+  }
+
+  /// Returns the name of the network.
+  pub fn name_str(&self) -> &str {
+    match self {
+      Self::Mainnet => NETWORK_NAME_MAIN,
+      Self::Testnet => NETWORK_NAME_TEST,
+      Self::Other { name, .. } => name.as_ref(),
     }
   }
 }

--- a/identity-iota/src/tangle/network.rs
+++ b/identity-iota/src/tangle/network.rs
@@ -265,7 +265,7 @@ mod tests {
     assert!(Network::matches_did(Network::Mainnet, &did));
     assert!(!Network::matches_did(Network::Testnet, &did));
 
-    let did: IotaDID = IotaDID::with_network(b"", "test").unwrap();
+    let did: IotaDID = IotaDID::new_with_network(b"", "test").unwrap();
     assert!(Network::matches_did(Network::Testnet, &did));
     assert!(!Network::matches_did(Network::Mainnet, &did));
   }

--- a/identity/src/lib.rs
+++ b/identity/src/lib.rs
@@ -77,9 +77,6 @@ pub mod iota {
   pub use identity_iota::tangle::*;
 
   #[doc(inline)]
-  pub use identity_iota::did;
-
-  #[doc(inline)]
   pub use identity_iota::try_did;
 }
 

--- a/identity/src/lib.rs
+++ b/identity/src/lib.rs
@@ -77,7 +77,7 @@ pub mod iota {
   pub use identity_iota::tangle::*;
 
   #[doc(inline)]
-  pub use identity_iota::try_did;
+  pub use identity_iota::try_construct_did;
 }
 
 #[cfg(feature = "account")]


### PR DESCRIPTION
# Description of change
Add a newtype wrapper `NetworkName` to replace occurrences of unchecked string representations of IOTA DID network names.

This helps ensure network names comply with the [IOTA DID method spec](https://github.com/iotaledger/identity.rs/blob/dev/documentation/docs/specs/iota_did_method_spec.md):
- at most 6 characters
- only alphanumeric characters in `{0-9, a-b}`

There are several breaking changes:
- remove unused `did!` macro (which just unwrapped errors from `try_did!` as panics)
- rename `IotaDID::with_network` to `IotaDID::new_with_network`
- rename `Network::from_name` to `Network::try_from_name`
- rename `try_did!` to `try_construct_did!`
- change `IotaDID` validation to error on invalid network strings
- change `Network::explorer_url` return type from `Result` to `Option`
- change `Network::name` return type from `Cow<str>` to `NetworkName`

This also fixes the `ClientMap` possibly duplicating clients for `Network::Other` when different explorer URLs are set.

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
New and existing tests and examples pass. Some `IotaDID` tests needed to be changed as they used invalid network names.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
