### PR TITLE
Bump to 0.3.9 for @iota/identity-wasm@dev, fix messageId 

### DIFF
--- a/bindings/wasm/package-lock.json
+++ b/bindings/wasm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iota/identity-wasm",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iota/identity-wasm",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "WASM bindings for IOTA Identity - A Self Sovereign Identity Framework implementing the DID and VC standards from W3C. To be used in Javascript/Typescript",
   "repository": {
     "type": "git",

--- a/bindings/wasm/src/did/wasm_document_diff.rs
+++ b/bindings/wasm/src/did/wasm_document_diff.rs
@@ -42,7 +42,7 @@ impl WasmDocumentDiff {
   /// Returns the message_id of the DID Document diff.
   #[wasm_bindgen(getter = messageId)]
   pub fn message_id(&self) -> String {
-    self.0.previous_message_id().to_string()
+    self.0.message_id().to_string()
   }
 
   /// Sets the message_id of the DID Document diff.


### PR DESCRIPTION
# Description of change
Fix `message_id` returning the `previous_message_id` on `WasmDiffDocument` in the wasm bindings.
Bump version to 0.3.9.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tests and examples pass locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
