### PR TITLE
Enable lazy tangle updates in the `Account`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -27,6 +27,10 @@ name = "account_methods"
 path = "account/methods.rs"
 
 [[example]]
+name = "account_lazy"
+path = "account/lazy.rs"
+
+[[example]]
 name = "account_services"
 path = "account/services.rs"
 

--- a/examples/account/basic.rs
+++ b/examples/account/basic.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
   let snapshot: IdentitySnapshot = account.create_identity(IdentityCreate::default()).await?;
 
   // Retrieve the DID from the newly created Identity state.
-  let document: &IotaDID = snapshot.identity().try_did()?;
+  let did: &IotaDID = snapshot.identity().try_did()?;
 
   println!("[Example] Local Snapshot = {:#?}", snapshot);
   println!("[Example] Local Document = {:#?}", snapshot.identity().to_document()?);
@@ -30,12 +30,12 @@ async fn main() -> Result<()> {
   // Fetch the DID Document from the Tangle
   //
   // This is an optional step to ensure DID Document consistency.
-  let resolved: IotaDocument = account.resolve_identity(document).await?;
+  let resolved: IotaDocument = account.resolve_identity(did).await?;
 
   println!("[Example] Tangle Document = {:#?}", resolved);
 
   // Delete the identity and all associated keys
-  account.delete_identity(document).await?;
+  account.delete_identity(did).await?;
 
   Ok(())
 }

--- a/examples/account/lazy.rs
+++ b/examples/account/lazy.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
 
   // Publish the newly created DID document,
   // including the new service, to the tangle.
-  account.publish_changes(did).await?;
+  account.publish_updates(did).await?;
 
   // Add another service.
   let command: Command = Command::create_service()
@@ -51,7 +51,7 @@ async fn main() -> Result<()> {
   account.update_identity(did, command).await?;
 
   // Publish the updates as one message to the tangle.
-  account.publish_changes(did).await?;
+  account.publish_updates(did).await?;
 
   // Resolve the document to confirm its consistency.
   let doc = account.resolve_identity(did).await?;

--- a/examples/account/lazy.rs
+++ b/examples/account/lazy.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
 
   let command: Command = Command::create_service()
     .fragment("example-service")
-    .type_("Website")
+    .type_("LinkedDomains")
     .endpoint(Url::parse("https://example.org")?)
     .finish()?;
   account.update_identity(did, command).await?;
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
   // Add another service.
   let command: Command = Command::create_service()
     .fragment("another-service")
-    .type_("Website")
+    .type_("LinkedDomains")
     .endpoint(Url::parse("https://example.org")?)
     .finish()?;
   account.update_identity(did, command).await?;

--- a/examples/account/lazy.rs
+++ b/examples/account/lazy.rs
@@ -1,0 +1,62 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! cargo run --example account_methods
+
+use identity::account::Account;
+use identity::account::Command;
+use identity::account::IdentityCreate;
+use identity::account::IdentitySnapshot;
+use identity::account::Result;
+use identity::core::Url;
+use identity::iota::IotaDID;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+  pretty_env_logger::init();
+
+  // Create a new Account with auto publishing set to false.
+  // This means updates are not pushed to the tangle automatically.
+  // Rather, when we publish, multiple updates are batched together.
+  let account: Account = Account::builder().autopublish(false).build().await?;
+
+  // Create a new Identity with default settings.
+  // The identity will only be written to the local storage - not published to the tangle.
+  let snapshot: IdentitySnapshot = account.create_identity(IdentityCreate::default()).await?;
+
+  // Retrieve the DID from the newly created Identity state.
+  let did: &IotaDID = snapshot.identity().try_did()?;
+
+  let command: Command = Command::create_service()
+    .fragment("example-service")
+    .type_("Website")
+    .endpoint(Url::parse("https://example.org")?)
+    .finish()?;
+  account.update_identity(did, command).await?;
+
+  // Publish the newly created DID document,
+  // including the new service, to the tangle.
+  account.publish_changes(did).await?;
+
+  // Add another service.
+  let command: Command = Command::create_service()
+    .fragment("another-service")
+    .type_("Website")
+    .endpoint(Url::parse("https://example.org")?)
+    .finish()?;
+  account.update_identity(did, command).await?;
+
+  // Delete the previously added service.
+  let command: Command = Command::delete_service().fragment("example-service").finish()?;
+  account.update_identity(did, command).await?;
+
+  // Publish the updates as one message to the tangle.
+  account.publish_changes(did).await?;
+
+  // Resolve the document to confirm its consistency.
+  let doc = account.resolve_identity(did).await?;
+
+  println!("[Example] Document: {:#?}", doc);
+
+  Ok(())
+}

--- a/examples/account/lazy.rs
+++ b/examples/account/lazy.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! cargo run --example account_methods
+//! cargo run --example account_lazy
 
 use identity::account::Account;
 use identity::account::Command;

--- a/examples/account/methods.rs
+++ b/examples/account/methods.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
   let snapshot: IdentitySnapshot = account.create_identity(IdentityCreate::default()).await?;
 
   // Retrieve the DID from the newly created Identity state.
-  let document: &IotaDID = snapshot.identity().try_did()?;
+  let did: &IotaDID = snapshot.identity().try_did()?;
 
   // Add a new Ed25519 (defualt) verification method to the identity - the
   // verification method is included as an embedded authentication method.
@@ -32,21 +32,21 @@ async fn main() -> Result<()> {
     .finish()?;
 
   // Process the command and update the identity state.
-  account.update_identity(document, command).await?;
+  account.update_identity(did, command).await?;
 
   // Fetch and log the DID Document from the Tangle
   //
   // This is an optional step to ensure DID Document consistency.
   println!(
     "[Example] Tangle Document (1) = {:#?}",
-    account.resolve_identity(document).await?
+    account.resolve_identity(did).await?
   );
 
   // Add another Ed25519 verification method to the identity
   let command: Command = Command::create_method().fragment("my-next-key").finish()?;
 
   // Process the command and update the identity state.
-  account.update_identity(document, command).await?;
+  account.update_identity(did, command).await?;
 
   // Associate the newly created method with additional verification relationships
   let command: Command = Command::attach_method()
@@ -56,28 +56,28 @@ async fn main() -> Result<()> {
     .finish()?;
 
   // Process the command and update the identity state.
-  account.update_identity(document, command).await?;
+  account.update_identity(did, command).await?;
 
   // Fetch and log the DID Document from the Tangle
   //
   // This is an optional step to ensure DID Document consistency.
   println!(
     "[Example] Tangle Document (2) = {:#?}",
-    account.resolve_identity(document).await?
+    account.resolve_identity(did).await?
   );
 
   // Remove the original Ed25519 verification method
   let command: Command = Command::delete_method().fragment("my-auth-key").finish()?;
 
   // Process the command and update the identity state.
-  account.update_identity(document, command).await?;
+  account.update_identity(did, command).await?;
 
   // Fetch and log the DID Document from the Tangle
   //
   // This is an optional step to ensure DID Document consistency.
   println!(
     "[Example] Tangle Document (3) = {:#?}",
-    account.resolve_identity(document).await?
+    account.resolve_identity(did).await?
   );
 
   Ok(())

--- a/examples/account/private_tangle.rs
+++ b/examples/account/private_tangle.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<()> {
   };
 
   // Retrieve the DID from the newly created Identity state.
-  let document: &IotaDID = snapshot.identity().try_did()?;
+  let did: &IotaDID = snapshot.identity().try_did()?;
 
   println!("[Example] Local Snapshot = {:#?}", snapshot);
   println!("[Example] Local Document = {:#?}", snapshot.identity().to_document()?);
@@ -63,12 +63,12 @@ async fn main() -> Result<()> {
   // Fetch the DID Document from the Tangle
   //
   // This is an optional step to ensure DID Document consistency.
-  let resolved: IotaDocument = account.resolve_identity(document).await?;
+  let resolved: IotaDocument = account.resolve_identity(did).await?;
 
   println!("[Example] Tangle Document = {:#?}", resolved);
 
   // Delete the identity and all associated keys
-  account.delete_identity(document).await?;
+  account.delete_identity(did).await?;
 
   Ok(())
 }

--- a/examples/account/services.rs
+++ b/examples/account/services.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
   let snapshot: IdentitySnapshot = account.create_identity(IdentityCreate::default()).await?;
 
   // Retrieve the DID from the newly created Identity state.
-  let document: &IotaDID = snapshot.identity().try_did()?;
+  let did: &IotaDID = snapshot.identity().try_did()?;
 
   let command: Command = Command::create_service()
     .fragment("my-service-1")
@@ -31,14 +31,14 @@ async fn main() -> Result<()> {
     .finish()?;
 
   // Process the command and update the identity state.
-  account.update_identity(document, command).await?;
+  account.update_identity(did, command).await?;
 
   // Fetch and log the DID Document from the Tangle
   //
   // This is an optional step to ensure DID Document consistency.
   println!(
     "[Example] Tangle Document (1) = {:#?}",
-    account.resolve_identity(document).await?
+    account.resolve_identity(did).await?
   );
 
   Ok(())

--- a/examples/account/signing.rs
+++ b/examples/account/signing.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
   let snapshot: IdentitySnapshot = account.create_identity(IdentityCreate::default()).await?;
 
   // Retrieve the DID from the newly created Identity state.
-  let document: &IotaDID = snapshot.identity().try_did()?;
+  let did: &IotaDID = snapshot.identity().try_did()?;
 
   println!("[Example] Local Snapshot = {:#?}", snapshot);
   println!("[Example] Local Document = {:#?}", snapshot.identity().to_document()?);
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
   let command: Command = Command::create_method().fragment("key-1").finish()?;
 
   // Process the command and update the identity state.
-  account.update_identity(document, command).await?;
+  account.update_identity(did, command).await?;
 
   // Create a subject DID for the recipient of a `UniversityDegree` credential.
   let subject_key: KeyPair = KeyPair::new_ed25519()?;
@@ -54,20 +54,20 @@ async fn main() -> Result<()> {
 
   // Issue an unsigned Credential...
   let mut credential: Credential = Credential::builder(Default::default())
-    .issuer(Url::parse(document.as_str())?)
+    .issuer(Url::parse(did.as_str())?)
     .type_("UniversityDegreeCredential")
     .subject(subject)
     .build()?;
 
   // ...and sign the Credential with the previously created Verification Method
-  account.sign(document, "key-1", &mut credential).await?;
+  account.sign(did, "key-1", &mut credential).await?;
 
   println!("[Example] Local Credential = {:#}", credential);
 
   // Fetch the DID Document from the Tangle
   //
   // This is an optional step to ensure DID Document consistency.
-  let resolved: IotaDocument = account.resolve_identity(document).await?;
+  let resolved: IotaDocument = account.resolve_identity(did).await?;
 
   println!("[Example] Tangle Document = {:#?}", resolved);
 

--- a/examples/account/stronghold.rs
+++ b/examples/account/stronghold.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
   let snapshot1: IdentitySnapshot = account.create_identity(IdentityCreate::default()).await?;
 
   // Retrieve the DID from the newly created Identity state.
-  let document1: &IotaDID = snapshot1.identity().try_did()?;
+  let did1: &IotaDID = snapshot1.identity().try_did()?;
 
   println!("[Example] Local Snapshot = {:#?}", snapshot1);
   println!("[Example] Local Document = {:#?}", snapshot1.identity().to_document()?);
@@ -39,16 +39,16 @@ async fn main() -> Result<()> {
   // Fetch the DID Document from the Tangle
   //
   // This is an optional step to ensure DID Document consistency.
-  let resolved: IotaDocument = account.resolve_identity(document1).await?;
+  let resolved: IotaDocument = account.resolve_identity(did1).await?;
 
   println!("[Example] Tangle Document = {:#?}", resolved);
 
   // Create another new Identity
   let snapshot2: IdentitySnapshot = account.create_identity(IdentityCreate::default()).await?;
-  let document2: &IotaDID = snapshot2.identity().try_did()?;
+  let did2: &IotaDID = snapshot2.identity().try_did()?;
 
   // Anndddd delete it
-  account.delete_identity(document2).await?;
+  account.delete_identity(did2).await?;
 
   Ok(())
 }

--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -437,12 +437,12 @@ impl Account {
       .store
       .published_generation(identity)
       .await?
-      .unwrap_or(Generation::new());
+      .unwrap_or_default();
 
     // Get the commits that need to be published.
     let commits = self.store.collect(identity, last_published).await?;
 
-    if commits.len() == 0 {
+    if commits.is_empty() {
       return Ok(());
     }
 
@@ -465,7 +465,7 @@ impl Account {
         Publish::None => {}
       }
 
-      if commits.len() > 0 {
+      if !commits.is_empty() {
         let last_commit_generation = commits.last().unwrap().sequence();
         // Publishing adds an AuthMessage or DiffMessage event, that contains the message id
         // which is required to be set for subsequent updates.

--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -34,6 +34,7 @@ use crate::identity::IdentityCreate;
 use crate::identity::IdentityId;
 use crate::identity::IdentityIndex;
 use crate::identity::IdentityKey;
+use crate::identity::IdentityLock;
 use crate::identity::IdentitySnapshot;
 use crate::identity::IdentityState;
 use crate::identity::IdentityTag;
@@ -224,7 +225,7 @@ impl Account {
     self.resolve_id(key).await.ok_or(Error::IdentityNotFound)
   }
 
-  async fn try_resolve_id_lock<K: IdentityKey>(&self, key: K) -> Result<Arc<RwLock<IdentityId>>> {
+  async fn try_resolve_id_lock<K: IdentityKey>(&self, key: K) -> Result<IdentityLock> {
     self.index.write().await.get_lock(key).ok_or(Error::IdentityNotFound)
   }
 
@@ -436,7 +437,7 @@ impl Account {
 
   /// Push all unpublished changes for the given identity to the tangle in a single message.
   pub async fn publish_changes<K: IdentityKey>(&self, key: K) -> Result<()> {
-    let identity_lock: Arc<RwLock<IdentityId>> = self.try_resolve_id_lock(key).await?;
+    let identity_lock: IdentityLock = self.try_resolve_id_lock(key).await?;
     let identity: RwLockWriteGuard<'_, IdentityId> = identity_lock.write().await;
 
     // Get the last commit generation that was published to the tangle.

--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -456,8 +456,8 @@ impl Account {
       let id = snapshot.id();
 
       match Publish::new(&commits) {
-        Publish::Auth => self.process_auth_change(snapshot).await.unwrap(),
-        Publish::Diff => self.process_diff_change(snapshot).await.unwrap(),
+        Publish::Auth => self.process_auth_change(snapshot).await?,
+        Publish::Diff => self.process_diff_change(snapshot).await?,
         Publish::None => {}
       }
 

--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -433,11 +433,7 @@ impl Account {
     let identity: IdentityId = self.try_resolve_id(key).await?;
 
     // Get the last commit generation that was published to the tangle.
-    let last_published = self
-      .store
-      .published_generation(identity)
-      .await?
-      .unwrap_or_default();
+    let last_published = self.store.published_generation(identity).await?.unwrap_or_default();
 
     // Get the commits that need to be published.
     let commits = self.store.collect(identity, last_published).await?;

--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -225,7 +225,7 @@ impl Account {
   }
 
   async fn try_resolve_id_lock<K: IdentityKey>(&self, key: K) -> Result<Arc<RwLock<IdentityId>>> {
-    self.index.read().await.get_lock(key).ok_or(Error::IdentityNotFound)
+    self.index.write().await.get_lock(key).ok_or(Error::IdentityNotFound)
   }
 
   // ===========================================================================

--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -436,7 +436,7 @@ impl Account {
   }
 
   /// Push all unpublished changes for the given identity to the tangle in a single message.
-  pub async fn publish_changes<K: IdentityKey>(&self, key: K) -> Result<()> {
+  pub async fn publish_updates<K: IdentityKey>(&self, key: K) -> Result<()> {
     let identity_lock: IdentityLock = self.try_resolve_id_lock(key).await?;
     let identity: RwLockWriteGuard<'_, IdentityId> = identity_lock.write().await;
 

--- a/identity-account/src/account/builder.rs
+++ b/identity-account/src/account/builder.rs
@@ -54,6 +54,12 @@ impl AccountBuilder {
     self
   }
 
+  /// Sets the account auto-save behaviour.
+  pub fn autopublish(mut self, value: bool) -> Self {
+    self.config = self.config.autopublish(value);
+    self
+  }
+
   /// Save the account state on drop.
   pub fn dropsave(mut self, value: bool) -> Self {
     self.config = self.config.dropsave(value);

--- a/identity-account/src/account/builder.rs
+++ b/identity-account/src/account/builder.rs
@@ -50,21 +50,21 @@ impl AccountBuilder {
   }
 
   /// Sets the account auto-save behaviour.
-  /// See the config's [autosave][Config::autosave] documentation for details.
+  /// See the config's [`autosave`][Config::autosave] documentation for details.
   pub fn autosave(mut self, value: AutoSave) -> Self {
     self.config = self.config.autosave(value);
     self
   }
 
   /// Sets the account auto-publish behaviour.
-  /// See the config's [autopublish][Config::autopublish] documentation for details.
+  /// See the config's [`autopublish`][Config::autopublish] documentation for details.
   pub fn autopublish(mut self, value: bool) -> Self {
     self.config = self.config.autopublish(value);
     self
   }
 
   /// Save the account state on drop.
-  /// See the config's [dropsave][Config::dropsave] documentation for details.
+  /// See the config's [`dropsave`][Config::dropsave] documentation for details.
   pub fn dropsave(mut self, value: bool) -> Self {
     self.config = self.config.dropsave(value);
     self

--- a/identity-account/src/account/builder.rs
+++ b/identity-account/src/account/builder.rs
@@ -50,18 +50,21 @@ impl AccountBuilder {
   }
 
   /// Sets the account auto-save behaviour.
+  /// See the config's [autosave][Config::autosave] documentation for details.
   pub fn autosave(mut self, value: AutoSave) -> Self {
     self.config = self.config.autosave(value);
     self
   }
 
-  /// Sets the account auto-save behaviour.
+  /// Sets the account auto-publish behaviour.
+  /// See the config's [autopublish][Config::autopublish] documentation for details.
   pub fn autopublish(mut self, value: bool) -> Self {
     self.config = self.config.autopublish(value);
     self
   }
 
   /// Save the account state on drop.
+  /// See the config's [dropsave][Config::dropsave] documentation for details.
   pub fn dropsave(mut self, value: bool) -> Self {
     self.config = self.config.dropsave(value);
     self

--- a/identity-account/src/account/builder.rs
+++ b/identity-account/src/account/builder.rs
@@ -50,6 +50,7 @@ impl AccountBuilder {
   }
 
   /// Sets the account auto-save behaviour.
+  ///
   /// See the config's [`autosave`][Config::autosave] documentation for details.
   pub fn autosave(mut self, value: AutoSave) -> Self {
     self.config = self.config.autosave(value);
@@ -57,6 +58,7 @@ impl AccountBuilder {
   }
 
   /// Sets the account auto-publish behaviour.
+  ///
   /// See the config's [`autopublish`][Config::autopublish] documentation for details.
   pub fn autopublish(mut self, value: bool) -> Self {
     self.config = self.config.autopublish(value);
@@ -64,6 +66,7 @@ impl AccountBuilder {
   }
 
   /// Save the account state on drop.
+  ///
   /// See the config's [`dropsave`][Config::dropsave] documentation for details.
   pub fn dropsave(mut self, value: bool) -> Self {
     self.config = self.config.dropsave(value);

--- a/identity-account/src/identity/identity_index.rs
+++ b/identity-account/src/identity/identity_index.rs
@@ -93,13 +93,12 @@ impl IdentityIndex {
 
   fn insert(&mut self, id: IdentityId, tag: IdentityTag) -> Result<()> {
     match self.data.entry(tag) {
-      Entry::Occupied(_) => return Err(Error::IdentityAlreadyExists),
+      Entry::Occupied(_) => Err(Error::IdentityAlreadyExists),
       Entry::Vacant(entry) => {
         entry.insert(id);
+        Ok(())
       }
     }
-
-    Ok(())
   }
 }
 

--- a/identity-account/src/identity/identity_index.rs
+++ b/identity-account/src/identity/identity_index.rs
@@ -52,12 +52,14 @@ impl IdentityIndex {
   }
 
   /// Returns the id of the identity matching the given `key` wrapped in a lock.
+  ///
+  /// Should be used to synchronize write access to the given `key`.
   pub fn get_lock<K: IdentityKey>(&mut self, key: K) -> Option<Arc<RwLock<IdentityId>>> {
     if let Some(identity_id) = key.scan(self.data.iter()) {
       match self.locks.entry(identity_id) {
         Entry::Occupied(lock) => Some(Arc::clone(lock.get())),
-        Entry::Vacant(thing) => {
-          let lock = thing.insert(Arc::new(RwLock::new(identity_id)));
+        Entry::Vacant(entry) => {
+          let lock = entry.insert(Arc::new(RwLock::new(identity_id)));
           Some(Arc::clone(lock))
         }
       }

--- a/identity-account/src/identity/identity_index.rs
+++ b/identity-account/src/identity/identity_index.rs
@@ -78,11 +78,15 @@ impl IdentityIndex {
 
   /// Removes the identity specified by `key` from the index.
   pub fn del<K: IdentityKey>(&mut self, key: K) -> Result<(IdentityTag, IdentityId)> {
-    self
+    let removed_id = self
       .data
       .drain_filter(|tag, id| key.equals(tag, *id))
       .next()
-      .ok_or(Error::IdentityNotFound)
+      .ok_or(Error::IdentityNotFound)?;
+
+    self.locks.remove(&removed_id.1);
+
+    Ok(removed_id)
   }
 
   fn insert(&mut self, id: IdentityId, tag: IdentityTag) -> Result<()> {

--- a/identity-account/src/identity/identity_index.rs
+++ b/identity-account/src/identity/identity_index.rs
@@ -14,13 +14,15 @@ use crate::identity::IdentityId;
 use crate::identity::IdentityKey;
 use crate::identity::IdentityTag;
 
+pub(crate) type IdentityLock = Arc<RwLock<IdentityId>>;
+
 /// An mapping between [IdentityTag]s and [IdentityId]s.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct IdentityIndex {
   data: HashMap<IdentityTag, IdentityId>,
   #[serde(skip)]
-  locks: HashMap<IdentityId, Arc<RwLock<IdentityId>>>,
+  locks: HashMap<IdentityId, IdentityLock>,
 }
 
 impl IdentityIndex {
@@ -54,7 +56,7 @@ impl IdentityIndex {
   /// Returns the id of the identity matching the given `key` wrapped in a lock.
   ///
   /// Should be used to synchronize write access to the given `key`.
-  pub fn get_lock<K: IdentityKey>(&mut self, key: K) -> Option<Arc<RwLock<IdentityId>>> {
+  pub fn get_lock<K: IdentityKey>(&mut self, key: K) -> Option<IdentityLock> {
     if let Some(identity_id) = key.scan(self.data.iter()) {
       match self.locks.entry(identity_id) {
         Entry::Occupied(lock) => Some(Arc::clone(lock.get())),

--- a/identity-account/src/identity/identity_index.rs
+++ b/identity-account/src/identity/identity_index.rs
@@ -15,7 +15,7 @@ use crate::identity::IdentityKey;
 use crate::identity::IdentityTag;
 
 /// An mapping between [IdentityTag]s and [IdentityId]s.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct IdentityIndex {
   data: HashMap<IdentityTag, IdentityId>,
@@ -104,20 +104,6 @@ impl IdentityIndex {
 impl Default for IdentityIndex {
   fn default() -> Self {
     Self::new()
-  }
-}
-
-impl Clone for IdentityIndex {
-  fn clone(&self) -> Self {
-    let mut locks = HashMap::new();
-    self.data.values().for_each(|id| {
-      locks.insert(*id, Arc::new(RwLock::new(*id)));
-    });
-
-    Self {
-      data: self.data.clone(),
-      locks,
-    }
   }
 }
 

--- a/identity-account/src/identity/identity_index.rs
+++ b/identity-account/src/identity/identity_index.rs
@@ -1,9 +1,12 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use hashbrown::hash_map::Entry;
 use hashbrown::HashMap;
 use identity_iota::did::IotaDID;
+use tokio::sync::RwLock;
 
 use crate::error::Error;
 use crate::error::Result;
@@ -12,16 +15,21 @@ use crate::identity::IdentityKey;
 use crate::identity::IdentityTag;
 
 /// An mapping between [IdentityTag]s and [IdentityId]s.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(transparent)]
 pub struct IdentityIndex {
   data: HashMap<IdentityTag, IdentityId>,
+  #[serde(skip)]
+  locks: HashMap<IdentityId, Arc<RwLock<IdentityId>>>,
 }
 
 impl IdentityIndex {
   /// Creates a new `IdentityIndex`.
   pub fn new() -> Self {
-    Self { data: HashMap::new() }
+    Self {
+      data: HashMap::new(),
+      locks: HashMap::new(),
+    }
   }
 
   /// Returns the next IdentityId in the sequence.
@@ -41,6 +49,16 @@ impl IdentityIndex {
   /// Returns the id of the identity matching the given `key`.
   pub fn get<K: IdentityKey>(&self, key: K) -> Option<IdentityId> {
     key.scan(self.data.iter())
+  }
+
+  /// Returns the id of the identity matching the given `key` wrapped in a lock.
+  pub fn get_lock<K: IdentityKey>(&self, key: K) -> Option<Arc<RwLock<IdentityId>>> {
+    if let Some(identity_id) = key.scan(self.data.iter()) {
+      let lock = self.locks.get(&identity_id).unwrap();
+      Some(Arc::clone(lock))
+    } else {
+      None
+    }
   }
 
   /// Adds a new unnamed identity to the index.
@@ -64,18 +82,61 @@ impl IdentityIndex {
 
   fn insert(&mut self, id: IdentityId, tag: IdentityTag) -> Result<()> {
     match self.data.entry(tag) {
-      Entry::Occupied(_) => Err(Error::IdentityAlreadyExists),
+      Entry::Occupied(_) => return Err(Error::IdentityAlreadyExists),
       Entry::Vacant(entry) => {
         entry.insert(id);
-        Ok(())
       }
     }
+
+    self.locks.insert(id, Arc::new(RwLock::new(id)));
+
+    Ok(())
   }
 }
 
 impl Default for IdentityIndex {
   fn default() -> Self {
     Self::new()
+  }
+}
+
+impl Clone for IdentityIndex {
+  fn clone(&self) -> Self {
+    let mut locks = HashMap::new();
+    self.data.values().for_each(|id| {
+      locks.insert(*id, Arc::new(RwLock::new(*id)));
+    });
+
+    Self {
+      data: self.data.clone(),
+      locks,
+    }
+  }
+}
+
+impl PartialEq for IdentityIndex {
+  fn eq(&self, other: &Self) -> bool {
+    self.data == other.data
+  }
+}
+
+impl<'de> serde::Deserialize<'de> for IdentityIndex {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: serde::Deserializer<'de>,
+  {
+    Result::map(
+      serde::Deserialize::deserialize(deserializer),
+      |data: HashMap<IdentityTag, IdentityId>| {
+        let mut locks = HashMap::new();
+
+        for value in data.values() {
+          locks.insert(*value, Arc::new(RwLock::new(*value)));
+        }
+
+        IdentityIndex { data, locks }
+      },
+    )
   }
 }
 

--- a/identity-account/src/storage/memstore.rs
+++ b/identity-account/src/storage/memstore.rs
@@ -53,7 +53,7 @@ pub struct MemStore {
 impl MemStore {
   pub fn new() -> Self {
     Self {
-      expand: true,
+      expand: false,
       index: Shared::new(IdentityIndex::new()),
       published_generations: Shared::new(HashMap::new()),
       events: Shared::new(HashMap::new()),

--- a/identity-account/src/storage/memstore.rs
+++ b/identity-account/src/storage/memstore.rs
@@ -207,13 +207,8 @@ impl Storage for MemStore {
     Ok(())
   }
 
-  async fn published_generation(&self, id: IdentityId) -> Result<Generation> {
-    self
-      .published_generations
-      .read()?
-      .get(&id)
-      .cloned()
-      .ok_or(Error::IdentityNotFound)
+  async fn published_generation(&self, id: IdentityId) -> Result<Option<Generation>> {
+    Ok(self.published_generations.read()?.get(&id).copied())
   }
 
   async fn set_published_generation(&self, id: IdentityId, index: Generation) -> Result<()> {

--- a/identity-account/src/storage/stronghold.rs
+++ b/identity-account/src/storage/stronghold.rs
@@ -317,7 +317,7 @@ impl Storage for Stronghold {
     Ok(())
   }
 
-  async fn published_generation(&self, id: IdentityId) -> Result<Generation> {
+  async fn published_generation(&self, id: IdentityId) -> Result<Option<Generation>> {
     todo!()
   }
 

--- a/identity-account/src/storage/stronghold.rs
+++ b/identity-account/src/storage/stronghold.rs
@@ -316,6 +316,14 @@ impl Storage for Stronghold {
 
     Ok(())
   }
+
+  async fn published_generation(&self, id: IdentityId) -> Result<Generation> {
+    todo!()
+  }
+
+  async fn set_published_generation(&self, id: IdentityId, index: Generation) -> Result<()> {
+    todo!()
+  }
 }
 
 async fn generate_ed25519(vault: &Vault<'_>, location: &KeyLocation) -> Result<PublicKey> {

--- a/identity-account/src/storage/traits.rs
+++ b/identity-account/src/storage/traits.rs
@@ -45,6 +45,12 @@ pub trait Storage: Debug + Send + Sync + 'static {
   /// Returns the account identity index.
   async fn index(&self) -> Result<IdentityIndex>;
 
+  /// Returns the last generation that has been published to the tangle for the given `id`.
+  async fn published_generation(&self, id: IdentityId) -> Result<Generation>;
+
+  /// Sets the last generation that has been published to the tangle for the given `id`.
+  async fn set_published_generation(&self, id: IdentityId, index: Generation) -> Result<()>;
+
   /// Sets a new account identity index.
   async fn set_index(&self, index: &IdentityIndex) -> Result<()>;
 
@@ -129,5 +135,13 @@ impl Storage for Box<dyn Storage> {
 
   async fn purge(&self, id: IdentityId) -> Result<()> {
     (**self).purge(id).await
+  }
+
+  async fn published_generation(&self, id: IdentityId) -> Result<Generation> {
+    (**self).published_generation(id).await
+  }
+
+  async fn set_published_generation(&self, id: IdentityId, index: Generation) -> Result<()> {
+    (**self).set_published_generation(id, index).await
   }
 }

--- a/identity-account/src/storage/traits.rs
+++ b/identity-account/src/storage/traits.rs
@@ -46,7 +46,7 @@ pub trait Storage: Debug + Send + Sync + 'static {
   async fn index(&self) -> Result<IdentityIndex>;
 
   /// Returns the last generation that has been published to the tangle for the given `id`.
-  async fn published_generation(&self, id: IdentityId) -> Result<Generation>;
+  async fn published_generation(&self, id: IdentityId) -> Result<Option<Generation>>;
 
   /// Sets the last generation that has been published to the tangle for the given `id`.
   async fn set_published_generation(&self, id: IdentityId, index: Generation) -> Result<()>;
@@ -137,7 +137,7 @@ impl Storage for Box<dyn Storage> {
     (**self).purge(id).await
   }
 
-  async fn published_generation(&self, id: IdentityId) -> Result<Generation> {
+  async fn published_generation(&self, id: IdentityId) -> Result<Option<Generation>> {
     (**self).published_generation(id).await
   }
 

--- a/identity-account/tests/lazy.rs
+++ b/identity-account/tests/lazy.rs
@@ -1,0 +1,102 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use identity_account::account::Account;
+use identity_account::events::Command;
+use identity_account::identity::{IdentityCreate, IdentitySnapshot};
+use identity_account::Result;
+use identity_core::common::Url;
+use identity_iota::chain::DocumentHistory;
+use identity_iota::did::{IotaDID, IotaVerificationMethod};
+use identity_iota::tangle::{Client, Network};
+
+#[tokio::test]
+async fn test_lazy_updates() -> Result<()> {
+  // ===========================================================================
+  // Create, update and publish an identity
+  // ===========================================================================
+  let account: Account = Account::builder().autopublish(false).build().await?;
+
+  let snapshot: IdentitySnapshot = account.create_identity(IdentityCreate::new().network("test")).await?;
+
+  let did: &IotaDID = snapshot.identity().try_did()?;
+
+  let command: Command = Command::create_service()
+    .fragment("my-service")
+    .type_("url")
+    .endpoint(Url::parse("https://example.org").unwrap())
+    .finish()?;
+  account.update_identity(did, command).await.unwrap();
+
+  let command: Command = Command::create_service()
+    .fragment("my-other-service")
+    .type_("url")
+    .endpoint(Url::parse("https://example.org").unwrap())
+    .finish()?;
+  account.update_identity(did, command).await.unwrap();
+
+  account.publish_changes(did).await.unwrap();
+
+  // ===========================================================================
+  // First round of assertions
+  // ===========================================================================
+
+  let doc = account.resolve_identity(snapshot.identity().did().unwrap()).await?;
+
+  let services = doc.service();
+
+  assert_eq!(doc.methods().count(), 1);
+  assert_eq!(services.len(), 2);
+
+  for service in services.iter() {
+    let service_fragment = service.as_ref().id().fragment().unwrap();
+    assert!(["my-service", "my-other-service"]
+      .iter()
+      .any(|fragment| *fragment == service_fragment));
+  }
+
+  // ===========================================================================
+  // More updates to the identity
+  // ===========================================================================
+
+  let command: Command = Command::delete_service().fragment("my-service").finish()?;
+  account.update_identity(did, command).await.unwrap();
+
+  let command: Command = Command::delete_service().fragment("my-other-service").finish()?;
+  account.update_identity(did, command).await.unwrap();
+
+  let command: Command = Command::create_method().fragment("new-method").finish()?;
+  account.update_identity(did, command).await.unwrap();
+
+  account.publish_changes(did).await.unwrap();
+
+  // ===========================================================================
+  // Second round of assertions
+  // ===========================================================================
+
+  let doc = account.resolve_identity(snapshot.identity().did().unwrap()).await?;
+  let methods = doc.methods().collect::<Vec<&IotaVerificationMethod>>();
+
+  assert_eq!(doc.service().len(), 0);
+  assert_eq!(methods.len(), 2);
+
+  for method in methods {
+    let method_fragment = method.id().fragment().unwrap();
+    assert!(["_sign-0", "new-method"]
+      .iter()
+      .any(|fragment| *fragment == method_fragment));
+  }
+
+  // ===========================================================================
+  // History assertions
+  // ===========================================================================
+
+  let client: Client = Client::from_network(Network::Testnet).await?;
+
+  let history: DocumentHistory = client.resolve_history(did).await?;
+
+  assert_eq!(history.integration_chain_data.len(), 1);
+  assert_eq!(history.diff_chain_data.len(), 1);
+
+  Ok(())
+}

--- a/identity-account/tests/lazy.rs
+++ b/identity-account/tests/lazy.rs
@@ -1,102 +1,151 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::pin::Pin;
+
+use futures::Future;
 use identity_account::account::Account;
 use identity_account::events::Command;
 use identity_account::identity::{IdentityCreate, IdentitySnapshot};
-use identity_account::Result;
+use identity_account::{Error as AccountError, Result};
 use identity_core::common::Url;
 use identity_iota::chain::DocumentHistory;
 use identity_iota::did::{IotaDID, IotaVerificationMethod};
 use identity_iota::tangle::{Client, Network};
+use identity_iota::Error as IotaError;
 
 #[tokio::test]
 async fn test_lazy_updates() -> Result<()> {
-  // ===========================================================================
-  // Create, update and publish an identity
-  // ===========================================================================
-  let account: Account = Account::builder().autopublish(false).build().await?;
+  network_resilient_test(2, |test_run| {
+    Box::pin(async move {
+      // ===========================================================================
+      // Create, update and publish an identity
+      // ===========================================================================
+      let account: Account = Account::builder().autopublish(false).build().await?;
 
-  let snapshot: IdentitySnapshot = account.create_identity(IdentityCreate::new().network("test")).await?;
+      let network = if test_run % 2 == 0 {
+        Network::Testnet
+      } else {
+        Network::Mainnet
+      };
 
-  let did: &IotaDID = snapshot.identity().try_did()?;
+      let snapshot: IdentitySnapshot = account
+        .create_identity(IdentityCreate::new().network(network.name().as_ref()))
+        .await?;
 
-  let command: Command = Command::create_service()
-    .fragment("my-service")
-    .type_("url")
-    .endpoint(Url::parse("https://example.org").unwrap())
-    .finish()?;
-  account.update_identity(did, command).await.unwrap();
+      let did: &IotaDID = snapshot.identity().try_did()?;
 
-  let command: Command = Command::create_service()
-    .fragment("my-other-service")
-    .type_("url")
-    .endpoint(Url::parse("https://example.org").unwrap())
-    .finish()?;
-  account.update_identity(did, command).await.unwrap();
+      let command: Command = Command::create_service()
+        .fragment("my-service")
+        .type_("url")
+        .endpoint(Url::parse("https://example.org").unwrap())
+        .finish()?;
+      account.update_identity(did, command).await?;
 
-  account.publish_changes(did).await.unwrap();
+      let command: Command = Command::create_service()
+        .fragment("my-other-service")
+        .type_("url")
+        .endpoint(Url::parse("https://example.org").unwrap())
+        .finish()?;
+      account.update_identity(did, command).await?;
 
-  // ===========================================================================
-  // First round of assertions
-  // ===========================================================================
+      account.publish_changes(did).await?;
 
-  let doc = account.resolve_identity(snapshot.identity().did().unwrap()).await?;
+      // ===========================================================================
+      // First round of assertions
+      // ===========================================================================
 
-  let services = doc.service();
+      let doc = account.resolve_identity(snapshot.identity().did().unwrap()).await?;
 
-  assert_eq!(doc.methods().count(), 1);
-  assert_eq!(services.len(), 2);
+      let services = doc.service();
 
-  for service in services.iter() {
-    let service_fragment = service.as_ref().id().fragment().unwrap();
-    assert!(["my-service", "my-other-service"]
-      .iter()
-      .any(|fragment| *fragment == service_fragment));
+      assert_eq!(doc.methods().count(), 1);
+      assert_eq!(services.len(), 2);
+
+      for service in services.iter() {
+        let service_fragment = service.as_ref().id().fragment().unwrap();
+        assert!(["my-service", "my-other-service"]
+          .iter()
+          .any(|fragment| *fragment == service_fragment));
+      }
+
+      // ===========================================================================
+      // More updates to the identity
+      // ===========================================================================
+
+      let command: Command = Command::delete_service().fragment("my-service").finish()?;
+      account.update_identity(did, command).await?;
+
+      let command: Command = Command::delete_service().fragment("my-other-service").finish()?;
+      account.update_identity(did, command).await?;
+
+      let command: Command = Command::create_method().fragment("new-method").finish()?;
+      account.update_identity(did, command).await?;
+
+      account.publish_changes(did).await?;
+
+      // ===========================================================================
+      // Second round of assertions
+      // ===========================================================================
+
+      let doc = account.resolve_identity(snapshot.identity().did().unwrap()).await?;
+      let methods = doc.methods().collect::<Vec<&IotaVerificationMethod>>();
+
+      assert_eq!(doc.service().len(), 0);
+      assert_eq!(methods.len(), 2);
+
+      for method in methods {
+        let method_fragment = method.id().fragment().unwrap();
+        assert!(["_sign-0", "new-method"]
+          .iter()
+          .any(|fragment| *fragment == method_fragment));
+      }
+
+      // ===========================================================================
+      // History assertions
+      // ===========================================================================
+
+      let client: Client = Client::from_network(network).await?;
+
+      let history: DocumentHistory = client.resolve_history(did).await?;
+
+      assert_eq!(history.integration_chain_data.len(), 1);
+      assert_eq!(history.diff_chain_data.len(), 1);
+
+      Ok(())
+    })
+  })
+  .await?;
+
+  Ok(())
+}
+
+// Repeats the test in the closure `test_runs` number of times.
+// Network problems, i.e. a ClientError triggers a re-run.
+// Other errors end the test immediately.
+async fn network_resilient_test(
+  test_runs: u32,
+  f: impl Fn(u32) -> Pin<Box<dyn Future<Output = Result<()>>>>,
+) -> Result<()> {
+  for test_run in 0..test_runs {
+    let test_attempt = f(test_run).await;
+
+    match test_attempt {
+      ok @ Ok(_) => {
+        return ok;
+      }
+      Err(AccountError::IotaError(IotaError::ClientError(client_err))) => {
+        eprintln!("test run {} errored with {:?}", test_run, client_err);
+
+        if test_run == test_runs - 1 {
+          return Err(AccountError::IotaError(IotaError::ClientError(client_err)));
+        }
+      }
+      error @ Err(_) => {
+        return error;
+      }
+    }
   }
-
-  // ===========================================================================
-  // More updates to the identity
-  // ===========================================================================
-
-  let command: Command = Command::delete_service().fragment("my-service").finish()?;
-  account.update_identity(did, command).await.unwrap();
-
-  let command: Command = Command::delete_service().fragment("my-other-service").finish()?;
-  account.update_identity(did, command).await.unwrap();
-
-  let command: Command = Command::create_method().fragment("new-method").finish()?;
-  account.update_identity(did, command).await.unwrap();
-
-  account.publish_changes(did).await.unwrap();
-
-  // ===========================================================================
-  // Second round of assertions
-  // ===========================================================================
-
-  let doc = account.resolve_identity(snapshot.identity().did().unwrap()).await?;
-  let methods = doc.methods().collect::<Vec<&IotaVerificationMethod>>();
-
-  assert_eq!(doc.service().len(), 0);
-  assert_eq!(methods.len(), 2);
-
-  for method in methods {
-    let method_fragment = method.id().fragment().unwrap();
-    assert!(["_sign-0", "new-method"]
-      .iter()
-      .any(|fragment| *fragment == method_fragment));
-  }
-
-  // ===========================================================================
-  // History assertions
-  // ===========================================================================
-
-  let client: Client = Client::from_network(Network::Testnet).await?;
-
-  let history: DocumentHistory = client.resolve_history(did).await?;
-
-  assert_eq!(history.integration_chain_data.len(), 1);
-  assert_eq!(history.diff_chain_data.len(), 1);
 
   Ok(())
 }

--- a/identity-account/tests/lazy.rs
+++ b/identity-account/tests/lazy.rs
@@ -49,7 +49,7 @@ async fn test_lazy_updates() -> Result<()> {
         .finish()?;
       account.update_identity(did, command).await?;
 
-      account.publish_changes(did).await?;
+      account.publish_updates(did).await?;
 
       // ===========================================================================
       // First round of assertions
@@ -82,7 +82,7 @@ async fn test_lazy_updates() -> Result<()> {
       let command: Command = Command::create_method().fragment("new-method").finish()?;
       account.update_identity(did, command).await?;
 
-      account.publish_changes(did).await?;
+      account.publish_updates(did).await?;
 
       // ===========================================================================
       // Second round of assertions

--- a/identity-account/tests/lazy.rs
+++ b/identity-account/tests/lazy.rs
@@ -121,7 +121,7 @@ async fn test_lazy_updates() -> Result<()> {
 }
 
 // Repeats the test in the closure `test_runs` number of times.
-// Network problems, i.e. a ClientError triggers a re-run.
+// Network problems, i.e. a ClientError trigger a re-run.
 // Other errors end the test immediately.
 async fn network_resilient_test(
   test_runs: u32,

--- a/identity-account/tests/lazy.rs
+++ b/identity-account/tests/lazy.rs
@@ -131,19 +131,14 @@ async fn network_resilient_test(
     let test_attempt = f(test_run).await;
 
     match test_attempt {
-      ok @ Ok(_) => {
-        return ok;
-      }
-      Err(AccountError::IotaError(IotaError::ClientError(client_err))) => {
-        eprintln!("test run {} errored with {:?}", test_run, client_err);
+      error @ Err(AccountError::IotaError(IotaError::ClientError(_))) => {
+        eprintln!("test run {} errored with {:?}", test_run, error);
 
         if test_run == test_runs - 1 {
-          return Err(AccountError::IotaError(IotaError::ClientError(client_err)));
+          return error;
         }
       }
-      error @ Err(_) => {
-        return error;
-      }
+      other => return other,
     }
   }
 


### PR DESCRIPTION
# Description of change

Give users of the `Account` more control over when to publish to the tangle. For example, if an identity is created and a service and a method are added subsequently, this would currently result in three messages being published to the tangle. With this PR, all changes can be applied to a locally stored document, and then published in a single message. That increases the overall speed, since there are fewer network interactions and less Proof-of-Work, and reduces the used storage space on nodes.

## Implementation

The `Account` already organizes the updates to a document in `Commit`s. Each `Commit` is identified by a `Generation` (an incrementing `u32`). The basic idea is to store which generation was last published to the tangle, and when updating, publishing all commits that have been added since.

One potential use-case might require setting the `autopublish` configuration not just when building the `Account`, but also on the instance itself. Users could then switch between the modes very flexibly. I would probably not add this for now, though, and see if the requirement actually comes up in practice. This is mainly to be in line with the current immutability of the account config, but would be open to discuss this. It would be fairly simple to add this through an `AtomicBool` in the `Config`.

## Testing

Testing this really only makes sense if there is a tangle. As far as I'm aware, no tangle interaction is currently tested, except "passively" in the examples (they do run in CI now, but only once per day, not per PR). So we could do a couple of things:

1. We could skip testing the network aspects of this feature, too, which is basically everything in that case.
2. Another idea is to use a private tangle in CI and test it that way. That means we're not reliant on the mainnet or testnet, and tests should be faster. This would probably run per PR, and would also test the private tangle support as a side bonus. Would add a barrier to local testing though, as we need to run a private tangle locally, or skip these tests - neither is ideal.
3. We could actually start using the main- or testnet, increasing testing time, but requiring no special private tangle configuration and being always available, from both CI and locally.
4. We could add an example that includes assertions. This is quite common in Rust in general, but we don't have any assertions in our examples right now, so it would break our style a bit.

I've chosen the third option and added an example that tests directly on the testnet. The test runs in 5 seconds; not adding significantly to the CI execution time.

## Links to any relevant issues

part of #325 

The other tasks of the issue will be completed in separate PRs.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

The stronghold implementation was tested by modifying the stronghold example. The added test uses the `MemStore`.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
