### PR TITLE
Change build workflow step to avoid recompilation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -133,17 +133,15 @@ jobs:
       - name: Build
         uses: actions-rs/cargo@v1
         with:
-          command: build
-          args: --all --release
+          # Build the library, tests, and examples without running them to avoid recompilation in the run tests step
+          command: test
+          args: --all --release --no-run
 
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all --release
-
-      - name: Print sccache stats
-        run: sccache --show-stats
 
       - name: Stop sccache server
         run: sccache --stop-server || true
@@ -243,9 +241,6 @@ jobs:
         with:
           command: test
           args: --manifest-path ./libjose/Cargo.toml --release
-
-      - name: Print sccache stats
-        run: sccache --show-stats
 
       - name: Stop sccache server
         run: sccache --stop-server || true
@@ -366,9 +361,6 @@ jobs:
       - name: Run wasm-bindgen tests # tests annotated with #[wasm_bindgen_test]
         run: wasm-pack test --node
         working-directory: bindings/wasm
-
-      - name: Print sccache stats
-        run: sccache --show-stats
 
       - name: Stop sccache server
         run: sccache --stop-server || true


### PR DESCRIPTION
# Description of change
Change the Rust build step in the build-and-test GitHub Actions workflow to avoid recompilation and improve CI speed.

The command changes from:
`cargo build --all --release`
to: 
`cargo test --all --release --no-run`

This is done because the compilation performed in the "Run Tests" step typically takes a significant amount of time (roughly 13 minutes) while the tests themselves complete in a few seconds to one minute. The change avoids some recompilation by compiling the tests and examples at the same time as the rest of the library, rather than separately. 

The disadvantages are that the build step is slightly different than it would be for a regular release as a library, and the tests/examples may fail compilation while a regular build may have passed. This would make debugging why a CI build failed slightly more difficult, as one would not be able to see that the build step passed but the test build step failed, but that can be resolved easily by reading the logs. I would also argue that we always want the tests and examples to compile anyway.

See the following discussion for more insight: https://github.com/iotaledger/identity.rs/pull/367#issuecomment-913808030

This PR also removes the redundant "Print sccache stats" step, as `sccache` prints statistics when it is stopped anyway.

## Type of change

- [x] Bug fix/chore (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tested the command locally, pending workflow run against this PR.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
