### PR TITLE
Rename document1 to did1 in README example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,21 +101,21 @@ use identity::iota::IotaDocument;
 async fn main() -> Result<()> {
   pretty_env_logger::init();
 
-  // The Stronghold settings for the storage
+  // The Stronghold settings for the storage.
   let snapshot: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
 
-  // Create a new Account with Stronghold as the storage adapter
+  // Create a new Account with Stronghold as the storage adapter.
   let account: Account = Account::builder()
     .storage(AccountStorage::Stronghold(snapshot, Some(password)))
     .build()
     .await?;
 
-  // Create a new Identity with default settings
+  // Create a new Identity with default settings.
   let snapshot1: IdentitySnapshot = account.create_identity(IdentityCreate::default()).await?;
 
   // Retrieve the DID from the newly created Identity state.
-  let document1: &IotaDID = snapshot1.identity().try_did()?;
+  let did1: &IotaDID = snapshot1.identity().try_did()?;
 
   println!("[Example] Local Snapshot = {:#?}", snapshot1);
   println!("[Example] Local Document = {:#?}", snapshot1.identity().to_document()?);
@@ -124,7 +124,7 @@ async fn main() -> Result<()> {
   // Fetch the DID Document from the Tangle
   //
   // This is an optional step to ensure DID Document consistency.
-  let resolved: IotaDocument = account.resolve_identity(document1).await?;
+  let resolved: IotaDocument = account.resolve_identity(did1).await?;
 
   println!("[Example] Tangle Document = {:#?}", resolved);
 

--- a/README.md
+++ b/README.md
@@ -112,19 +112,19 @@ async fn main() -> Result<()> {
     .await?;
 
   // Create a new Identity with default settings.
-  let snapshot1: IdentitySnapshot = account.create_identity(IdentityCreate::default()).await?;
+  let snapshot: IdentitySnapshot = account.create_identity(IdentityCreate::default()).await?;
 
   // Retrieve the DID from the newly created Identity state.
-  let did1: &IotaDID = snapshot1.identity().try_did()?;
+  let did: &IotaDID = snapshot.identity().try_did()?;
 
-  println!("[Example] Local Snapshot = {:#?}", snapshot1);
-  println!("[Example] Local Document = {:#?}", snapshot1.identity().to_document()?);
+  println!("[Example] Local Snapshot = {:#?}", snapshot);
+  println!("[Example] Local Document = {:#?}", snapshot.identity().to_document()?);
   println!("[Example] Local Document List = {:#?}", account.list_identities().await);
 
   // Fetch the DID Document from the Tangle
   //
   // This is an optional step to ensure DID Document consistency.
-  let resolved: IotaDocument = account.resolve_identity(did1).await?;
+  let resolved: IotaDocument = account.resolve_identity(did).await?;
 
   println!("[Example] Tangle Document = {:#?}", resolved);
 


### PR DESCRIPTION
# Description of change

Previously, the example used `document1` to refer to the DID, whereas the "document" isn't resolved until `account.resolve_identity()` is called. This change fixes a mismatch between variable name and what it actually represents.

**NOTE:** The repl.it example at https://wiki.iota.org/identity.rs/getting-started/decentralized_identifiers/create should also be updated as well, but I'm not sure where that lives.

Also, consistent periods at end of comments 🙃 

## Links to any relevant issues

N/A

## Type of change

- [x] Documentation Fix

## How the change has been tested

N/A - Documentation change in README.md.

## Change checklist

- [x] I have followed the contribution guidelines for this project

