### PR TITLE
Replace `testnet` with `devnet`

### DIFF
--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -55,18 +55,18 @@ const key = new identity.KeyPair(identity.KeyType.Ed25519)
 
 // Create a new DID Document with the KeyPair as the default authentication method
 const doc = identity.Document.fromKeyPair(key)
-// const doc = identity.Document.fromKeyPair(key, "test") // if using the testnet
+// const doc = identity.Document.fromKeyPair(key, "dev") // if using the devnet
 
 // Sign the DID Document with the private key
 doc.sign(key)
 
 // Create a default client instance for the mainnet
 const config = identity.Config.fromNetwork(identity.Network.mainnet())
-// const config = identity.Config.fromNetwork(identity.Network.testnet()); // if using the testnet
+// const config = identity.Config.fromNetwork(identity.Network.devnet()); // if using the devnet
 const client = identity.Client.fromConfig(config)
 
 // Publish the DID Document to the IOTA Tangle
-// The message can be viewed at https://explorer.iota.org/<mainnet|testnet>/transaction/<messageId>
+// The message can be viewed at https://explorer.iota.org/<mainnet|devnet>/transaction/<messageId>
 client.publishDocument(doc.toJSON())
     .then((receipt) => {
         console.log("Tangle Message Receipt: ", receipt)
@@ -138,8 +138,8 @@ import * as identity from "@iota/identity-wasm/web";
 identity.init().then(() => {
   const key = new identity.KeyPair(identity.KeyType.Ed25519)
   const doc = identity.Document.fromKeyPair(key)
-  // Or, if using the testnet:
-  // const doc = identity.Document.fromKeyPair(key, "test")  
+  // Or, if using the devnet:
+  // const doc = identity.Document.fromKeyPair(key, "dev")  
   console.log("Key Pair", key)
   console.log("DID Document: ", doc)
 });
@@ -150,8 +150,8 @@ identity.init().then(() => {
   await identity.init()
   const key = new identity.KeyPair(identity.KeyType.Ed25519)
   const doc = identity.Document.fromKeyPair(key)
-  // Or, if using the testnet:
-  // const doc = identity.Document.fromKeyPair(key, "test")
+  // Or, if using the devnet:
+  // const doc = identity.Document.fromKeyPair(key, "dev")
   console.log("Key Pair", key)
   console.log("DID Document: ", doc)
 })()

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -1603,7 +1603,7 @@ Deserializes a `KeyPair` object from a JSON object.
     * _static_
         * [.try_from_name(name)](#Network.try_from_name) ⇒ [<code>Network</code>](#Network)
         * [.mainnet()](#Network.mainnet) ⇒ [<code>Network</code>](#Network)
-        * [.testnet()](#Network.testnet) ⇒ [<code>Network</code>](#Network)
+        * [.devnet()](#Network.devnet) ⇒ [<code>Network</code>](#Network)
 
 <a name="Network+defaultNodeURL"></a>
 
@@ -1647,9 +1647,9 @@ Parses the provided string to a [`WasmNetwork`].
 
 ### Network.mainnet() ⇒ [<code>Network</code>](#Network)
 **Kind**: static method of [<code>Network</code>](#Network)  
-<a name="Network.testnet"></a>
+<a name="Network.devnet"></a>
 
-### Network.testnet() ⇒ [<code>Network</code>](#Network)
+### Network.devnet() ⇒ [<code>Network</code>](#Network)
 **Kind**: static method of [<code>Network</code>](#Network)  
 <a name="NewDocument"></a>
 

--- a/bindings/wasm/src/tangle/network.rs
+++ b/bindings/wasm/src/tangle/network.rs
@@ -24,8 +24,8 @@ impl WasmNetwork {
   }
 
   #[wasm_bindgen]
-  pub fn testnet() -> WasmNetwork {
-    Self(IotaNetwork::Testnet)
+  pub fn devnet() -> WasmNetwork {
+    Self(IotaNetwork::Devnet)
   }
 
   /// Returns the node URL of the Tangle network.

--- a/bindings/wasm/tests/wasm.rs
+++ b/bindings/wasm/tests/wasm.rs
@@ -81,10 +81,10 @@ fn test_did() {
   assert_eq!(did.to_string(), parsed.to_string());
 
   let public = key.public();
-  let base58 = WasmDID::from_base58(&public, Some("test".to_string())).unwrap();
+  let base58 = WasmDID::from_base58(&public, Some("dev".to_string())).unwrap();
 
   assert_eq!(base58.tag(), did.tag());
-  assert_eq!(base58.network_name(), "test");
+  assert_eq!(base58.network_name(), "dev");
 }
 
 #[test]
@@ -101,8 +101,8 @@ fn test_document() {
 
 #[test]
 fn test_document_network() {
-  let output = WasmDocument::new(KeyType::Ed25519, Some("test".into()), None).unwrap();
+  let output = WasmDocument::new(KeyType::Ed25519, Some("dev".into()), None).unwrap();
   let document = output.doc();
 
-  assert_eq!(document.id().network_name(), "test");
+  assert_eq!(document.id().network_name(), "dev");
 }

--- a/documentation/docs/specs/iota_did_method_spec.md
+++ b/documentation/docs/specs/iota_did_method_spec.md
@@ -62,7 +62,7 @@ The iota-network is an identifer of the network where the DID is stored. This ne
 
 The following values are reserved and cannot reference other networks:
 1. `main` references the main network which refers to the Tangle known to host the IOTA cryptocurrency
-2. `test` references the test network known as "devnet" or "testnet" maintained by the IOTA Foundation.
+2. `dev` references the development network known as "devnet" maintained by the IOTA Foundation.
 
 When no IOTA network is specified, it is assumed that the DID is located on the `main` network. This means that the following DIDs will resolve to the same DID Document:
 ```

--- a/identity-account/src/tests/commands.rs
+++ b/identity-account/src/tests/commands.rs
@@ -99,7 +99,7 @@ async fn test_create_identity_network() -> Result<()> {
   let account: Account = new_account().await?;
 
   // Create an identity with a valid network string
-  let create_identity: IdentityCreate = IdentityCreate::new().network("test").key_type(KeyType::Ed25519);
+  let create_identity: IdentityCreate = IdentityCreate::new().network("dev").key_type(KeyType::Ed25519);
   let snapshot: IdentitySnapshot = account.create_identity(create_identity).await?;
 
   // Ensure the identity creation was successful

--- a/identity-account/src/tests/lazy.rs
+++ b/identity-account/src/tests/lazy.rs
@@ -23,7 +23,7 @@ async fn test_lazy_updates() -> Result<()> {
       let account: Account = Account::builder().autopublish(false).build().await?;
 
       let network = if test_run % 2 == 0 {
-        Network::Testnet
+        Network::Devnet
       } else {
         Network::Mainnet
       };

--- a/identity-iota/src/did/doc/iota_document.rs
+++ b/identity-iota/src/did/doc/iota_document.rs
@@ -648,8 +648,8 @@ mod tests {
 
   const DID_ID: &str = "did:iota:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1M";
   const DID_AUTH: &str = "did:iota:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1M#authentication";
-  const DID_TESTNET_ID: &str = "did:iota:test:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1M";
-  const DID_TESTNET_AUTH: &str = "did:iota:test:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1M#authentication";
+  const DID_DEVNET_ID: &str = "did:iota:dev:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1M";
+  const DID_DEVNET_AUTH: &str = "did:iota:dev:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1M#authentication";
 
   fn valid_did() -> DID {
     DID_ID.parse().unwrap()
@@ -736,8 +736,8 @@ mod tests {
   }
 
   fn compare_document_testnet(document: &IotaDocument) {
-    assert_eq!(document.id().to_string(), DID_TESTNET_ID);
-    assert_eq!(document.authentication_id(), DID_TESTNET_AUTH);
+    assert_eq!(document.id().to_string(), DID_DEVNET_ID);
+    assert_eq!(document.authentication_id(), DID_DEVNET_AUTH);
     assert_eq!(
       document.authentication().key_type(),
       MethodType::Ed25519VerificationKey2018
@@ -927,7 +927,7 @@ mod tests {
   fn test_from_keypair_with_network() {
     //from keypair
     let keypair: KeyPair = generate_testkey();
-    let document: IotaDocument = IotaDocument::from_keypair_with_network(&keypair, "test").unwrap();
+    let document: IotaDocument = IotaDocument::from_keypair_with_network(&keypair, "dev").unwrap();
     compare_document_testnet(&document);
   }
 

--- a/identity-iota/src/did/url/iota_did.rs
+++ b/identity-iota/src/did/url/iota_did.rs
@@ -180,7 +180,7 @@ impl IotaDID {
     }
   }
 
-  /// Checks if the given `DID` has a valid [`IotaDID`] network name, e.g. "main", "test".
+  /// Checks if the given `DID` has a valid [`IotaDID`] network name, e.g. "main", "dev".
   ///
   /// # Errors
   ///
@@ -370,10 +370,10 @@ mod tests {
     assert!(IotaDID::parse(format!("did:iota:main:{}?somequery=somevalue", TAG)).is_ok());
     assert!(IotaDID::parse(format!("did:iota:main:{}?somequery=somevalue#fragment", TAG)).is_ok());
 
-    assert!(IotaDID::parse(format!("did:iota:test:{}", TAG)).is_ok());
-    assert!(IotaDID::parse(format!("did:iota:test:{}#fragment", TAG)).is_ok());
-    assert!(IotaDID::parse(format!("did:iota:test:{}?somequery=somevalue", TAG)).is_ok());
-    assert!(IotaDID::parse(format!("did:iota:test:{}?somequery=somevalue#fragment", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:dev:{}", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:dev:{}#fragment", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:dev:{}?somequery=somevalue", TAG)).is_ok());
+    assert!(IotaDID::parse(format!("did:iota:dev:{}?somequery=somevalue#fragment", TAG)).is_ok());
 
     assert!(IotaDID::parse(format!("did:iota:custom:{}", TAG)).is_ok());
     assert!(IotaDID::parse(format!("did:iota:custom:{}#fragment", TAG)).is_ok());
@@ -422,11 +422,14 @@ mod tests {
   fn test_network() {
     let key: String = IotaDID::encode_key(b"123");
 
-    let did: IotaDID = format!("did:iota:test:{}", key).parse().unwrap();
-    assert_eq!(did.network_str(), "test");
-
     let did: IotaDID = format!("did:iota:{}", key).parse().unwrap();
     assert_eq!(did.network_str(), "main");
+
+    let did: IotaDID = format!("did:iota:dev:{}", key).parse().unwrap();
+    assert_eq!(did.network_str(), "dev");
+
+    let did: IotaDID = format!("did:iota:test:{}", key).parse().unwrap();
+    assert_eq!(did.network_str(), "test");
 
     let did: IotaDID = format!("did:iota:custom:{}", key).parse().unwrap();
     assert_eq!(did.network_str(), "custom");

--- a/identity-iota/src/tangle/network.rs
+++ b/identity-iota/src/tangle/network.rs
@@ -12,22 +12,22 @@ use crate::did::IotaDID;
 use crate::error::{Error, Result};
 
 const NETWORK_NAME_MAIN: &str = "main";
-const NETWORK_NAME_TEST: &str = "test";
+const NETWORK_NAME_DEV: &str = "dev";
 
 lazy_static! {
   static ref EXPLORER_MAIN: Url = Url::parse("https://explorer.iota.org/mainnet").unwrap();
-  static ref EXPLORER_TEST: Url = Url::parse("https://explorer.iota.org/testnet").unwrap();
+  static ref EXPLORER_DEV: Url = Url::parse("https://explorer.iota.org/devnet").unwrap();
   static ref NODE_MAIN: Url = Url::parse("https://chrysalis-nodes.iota.org").unwrap();
-  static ref NODE_TEST: Url = Url::parse("https://api.lb-0.testnet.chrysalis2.com").unwrap();
+  static ref NODE_DEV: Url = Url::parse("https://api.lb-0.h.chrysalis-devnet.iota.cafe").unwrap();
 }
 
-/// The Tangle network to use ([`Mainnet`][Network::Mainnet] or [`Testnet`][Network::Testnet]).
+/// The Tangle network to use ([`Mainnet`][Network::Mainnet] or [`Devnet`][Network::Devnet]).
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub enum Network {
   #[serde(rename = "main")]
   Mainnet,
-  #[serde(rename = "test")]
-  Testnet,
+  #[serde(rename = "dev")]
+  Devnet,
   Other {
     name: NetworkName,
     explorer_url: Option<Url>,
@@ -37,10 +37,12 @@ pub enum Network {
 impl Network {
   /// Parses the provided string to a [`Network`].
   ///
-  /// The names `"test"` and `"main"` will be mapped to the well-known [`Testnet`][Network::Testnet]
-  /// and [`Mainnet`][Network::Mainnet] networks respectively. Other inputs will return an instance
-  /// of [`Other`][Network::Other] if the name is valid. It must match a part or all of the `networkId` returned in the
-  /// nodeinfo from a node. For example, if the networkId is `"private-tangle"`, `"tangle"` can be used.
+  /// The names `"main"` and `"dev"` are mapped to the well-known [`Mainnet`][Network::Mainnet]
+  /// and [`Devnet`][Network::Devnet] networks respectively.
+  ///
+  /// Other inputs will return an instance of [`Other`][Network::Other] if the name is valid.
+  /// It must match a part or all of the `networkId` returned in the nodeinfo from a node.
+  /// For example, if the networkId is `"private-tangle"`, `"tangle"` can be used.
   ///
   /// Network names must comply with the IOTA DID Method spec, that is: be non-empty, at most
   /// 6 characters long, and only include alphanumeric characters `0-9` and `a-z`.
@@ -52,8 +54,8 @@ impl Network {
     S: AsRef<str> + Into<Cow<'static, str>>,
   {
     match name.as_ref() {
-      NETWORK_NAME_TEST => Ok(Self::Testnet),
       NETWORK_NAME_MAIN => Ok(Self::Mainnet),
+      NETWORK_NAME_DEV => Ok(Self::Devnet),
       _ => {
         // Accept any other valid string - validation is performed by NetworkName
         let network_name: NetworkName = NetworkName::try_from(name)?;
@@ -95,7 +97,7 @@ impl Network {
   pub fn default_node_url(&self) -> Option<&'static Url> {
     match self {
       Self::Mainnet => Some(&*NODE_MAIN),
-      Self::Testnet => Some(&*NODE_TEST),
+      Self::Devnet => Some(&*NODE_DEV),
       _ => None,
     }
   }
@@ -104,7 +106,7 @@ impl Network {
   pub fn explorer_url(&self) -> Option<&Url> {
     match self {
       Self::Mainnet => Some(&EXPLORER_MAIN),
-      Self::Testnet => Some(&EXPLORER_TEST),
+      Self::Devnet => Some(&EXPLORER_DEV),
       Self::Other { explorer_url, .. } => explorer_url.as_ref(),
     }
   }
@@ -124,7 +126,7 @@ impl Network {
   pub fn name(&self) -> NetworkName {
     match self {
       Self::Mainnet => NetworkName(Cow::from(NETWORK_NAME_MAIN)),
-      Self::Testnet => NetworkName(Cow::from(NETWORK_NAME_TEST)),
+      Self::Devnet => NetworkName(Cow::from(NETWORK_NAME_DEV)),
       Self::Other { name, .. } => name.clone(),
     }
   }
@@ -133,7 +135,7 @@ impl Network {
   pub fn name_str(&self) -> &str {
     match self {
       Self::Mainnet => NETWORK_NAME_MAIN,
-      Self::Testnet => NETWORK_NAME_TEST,
+      Self::Devnet => NETWORK_NAME_DEV,
       Self::Other { name, .. } => name.as_ref(),
     }
   }
@@ -219,8 +221,8 @@ mod tests {
 
   #[test]
   fn test_from_name_standard_networks() {
-    assert_eq!(Network::try_from_name(NETWORK_NAME_TEST).unwrap(), Network::Testnet);
     assert_eq!(Network::try_from_name(NETWORK_NAME_MAIN).unwrap(), Network::Mainnet);
+    assert_eq!(Network::try_from_name(NETWORK_NAME_DEV).unwrap(), Network::Devnet);
   }
 
   #[test]
@@ -273,10 +275,14 @@ mod tests {
   fn test_matches_did() {
     let did: IotaDID = IotaDID::new(b"").unwrap();
     assert!(Network::matches_did(Network::Mainnet, &did));
-    assert!(!Network::matches_did(Network::Testnet, &did));
+    assert!(!Network::matches_did(Network::Devnet, &did));
 
-    let did: IotaDID = IotaDID::new_with_network(b"", "test").unwrap();
-    assert!(Network::matches_did(Network::Testnet, &did));
+    let did: IotaDID = IotaDID::new_with_network(b"", "main").unwrap();
+    assert!(Network::matches_did(Network::Mainnet, &did));
+    assert!(!Network::matches_did(Network::Devnet, &did));
+
+    let did: IotaDID = IotaDID::new_with_network(b"", "dev").unwrap();
+    assert!(Network::matches_did(Network::Devnet, &did));
     assert!(!Network::matches_did(Network::Mainnet, &did));
   }
 
@@ -286,9 +292,9 @@ mod tests {
     assert!(mainnet.explorer_url().is_some());
     assert_eq!(mainnet.explorer_url().unwrap().as_str(), EXPLORER_MAIN.as_str());
 
-    let testnet = Network::Testnet;
-    assert!(testnet.explorer_url().is_some());
-    assert_eq!(testnet.explorer_url().unwrap().as_str(), EXPLORER_TEST.as_str());
+    let devnet = Network::Devnet;
+    assert!(devnet.explorer_url().is_some());
+    assert_eq!(devnet.explorer_url().unwrap().as_str(), EXPLORER_DEV.as_str());
 
     let mut other = Network::try_from_name("atoi").unwrap();
     assert!(other.explorer_url().is_none());
@@ -301,7 +307,7 @@ mod tests {
       Error::InvalidExplorerURL
     ));
 
-    let url = Url::parse("https://explorer.iota.org/testnet").unwrap();
+    let url = Url::parse("https://explorer.iota.org/devnet").unwrap();
     assert!(other.set_explorer_url(url.clone()).is_ok());
     assert_eq!(other.explorer_url().unwrap().clone(), url);
   }


### PR DESCRIPTION
# Description of change
Replaces all references to the `testnet` with `devnet`. This includes the network name, default node URL, explorer URL, method specification, examples, and documentation.

This is due to the discontinuation of the Chrysalis P2 `testnet` in favour of the Chrysalis P2 `devnet`.

## Breaking changes:

- `Network::Testnet` -> `Network::Devnet`
- "test" is no longer a reserved network name
- "dev" is now a reserved network name
- `iota:did:test` -> `iota:did:dev`

## Links to any relevant issues
Fixes issue #358 

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Created a valid DID using the `Network::Devnet`, viewable at: https://explorer.iota.org/devnet/identity-resolver/did:iota:dev:GimqiaYtv1aNnxQS3c6sfTst6gakiZg3UwWhxoazQv59

All tests and examples pass locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
