### PR TITLE
Rename JSON serialization field name to match spec.

### DIFF
--- a/identity-did/src/resolution/dereference.rs
+++ b/identity-did/src/resolution/dereference.rs
@@ -11,13 +11,13 @@ use crate::resolution::Resource;
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 pub struct Dereference {
   /// Metadata regarding the base resolution process.
-  #[serde(rename = "did-url-dereferencing-metadata")]
+  #[serde(rename = "dereferencingMetadata")]
   pub metadata: ResolutionMetadata,
   /// The output resource of a successful dereference.
-  #[serde(rename = "content-stream", skip_serializing_if = "Option::is_none")]
+  #[serde(rename = "contentStream", skip_serializing_if = "Option::is_none")]
   pub content: Option<Resource>,
   /// Content-specific metadata.
-  #[serde(rename = "content-metadata", skip_serializing_if = "Option::is_none")]
+  #[serde(rename = "contentMetadata", skip_serializing_if = "Option::is_none")]
   pub content_metadata: Option<DocumentMetadata>,
 }
 

--- a/identity-did/src/resolution/error_kind.rs
+++ b/identity-did/src/resolution/error_kind.rs
@@ -8,13 +8,13 @@
 pub enum ErrorKind {
   /// The DID supplied to the DID resolution function does not conform to
   /// valid syntax.
-  #[serde(rename = "invalid-did")]
+  #[serde(rename = "invalidDid")]
   InvalidDID,
   /// The DID resolver does not support the specified method.
-  #[serde(rename = "not-supported")]
+  #[serde(rename = "notSupported")]
   NotSupported,
   /// The DID resolver was unable to return the DID document resulting from
   /// this resolution request.
-  #[serde(rename = "not-found")]
+  #[serde(rename = "notFound")]
   NotFound,
 }

--- a/identity-did/src/resolution/resolution.rs
+++ b/identity-did/src/resolution/resolution.rs
@@ -11,13 +11,13 @@ use crate::resolution::ResolutionMetadata;
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 pub struct Resolution {
   /// Resolution-specific metadata.
-  #[serde(rename = "did-resolution-metadata")]
+  #[serde(rename = "didResolutionMetadata")]
   pub metadata: ResolutionMetadata,
   /// The DID Document of a successful resolution.
-  #[serde(rename = "did-document", skip_serializing_if = "Option::is_none")]
+  #[serde(rename = "didDocument", skip_serializing_if = "Option::is_none")]
   pub document: Option<CoreDocument>,
   /// Document-specific metadata.
-  #[serde(rename = "did-document-metadata", skip_serializing_if = "Option::is_none")]
+  #[serde(rename = "didDocumentMetadata", skip_serializing_if = "Option::is_none")]
   pub document_metadata: Option<DocumentMetadata>,
 }
 


### PR DESCRIPTION
# Description of change

Update `#[serde(rename =' pragmas to use `camelCase` to match DID specification.

* `did-url-dereferencing-metadata` -> `dereferencingMetadata`
* `content-stream` -> `contentStream`
* `content-metadata` -> `contentMetadata`
* `invalid-did` -> `invalidDid`
* `not-supported` -> `notSupported`
* `not-found` -> `notFound`
* `did-resolution-metadata` -> `didResolutionMetadata`
* `did-document` -> `didDocument`
* `did-document-metadata` -> `didDocumentMetadata`

## Links to any relevant issues

#222

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

BREAKING because JSON serialization field names are changed

## How the change has been tested

`cargo test`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
