### PR TITLE
Add M1 Mac instructions for building WASM bindings

### DIFF
--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -19,6 +19,8 @@ npm install @iota/identity-wasm@dev
 
 ## Build
 
+**NOTE:** _If you're on an M1 Mac the `npm install` command below will fail due to missing support for the architecture in the `npm` version of `wasm-pack`. To work around this use `cargo install wasm-pack` and then go directly to the `npm run` step._
+
 Alternatively, you can build the bindings if you have Rust installed. If not, refer to [rustup.rs](https://rustup.rs) for the installation. Then install the necessary dependencies using:
 ```bash
 npm install


### PR DESCRIPTION
# Description of change

The npm version of wasm-pack does not support the new Darwin arm64 architecture. For some reason installing through cargo works though, so suggest that as a workaround.

## Links to any relevant issues

N/A

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

## How the change has been tested

N/A - README.md change only.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
