### PR TITLE
Bump to 0.3.11 for @iota/identity-wasm@dev, add proof getter

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -1106,6 +1106,7 @@ Defines the difference between two DID [`Document`]s' JSON representations.
     * [.messageId](#DocumentDiff+messageId)
     * [.previousMessageId](#DocumentDiff+previousMessageId) ⇒ <code>string</code>
     * [.previousMessageId](#DocumentDiff+previousMessageId)
+    * [.proof](#DocumentDiff+proof) ⇒ <code>any</code>
     * [.id()](#DocumentDiff+id) ⇒ [<code>DID</code>](#DID)
     * [.merge(document)](#DocumentDiff+merge) ⇒ [<code>Document</code>](#Document)
 
@@ -1157,6 +1158,12 @@ Sets the Tangle message id of the previous DID Document diff.
 | --- | --- |
 | message_id | <code>string</code> | 
 
+<a name="DocumentDiff+proof"></a>
+
+### documentDiff.proof ⇒ <code>any</code>
+Returns the `proof` object.
+
+**Kind**: instance property of [<code>DocumentDiff</code>](#DocumentDiff)  
 <a name="DocumentDiff+id"></a>
 
 ### documentDiff.id() ⇒ [<code>DID</code>](#DID)

--- a/bindings/wasm/package-lock.json
+++ b/bindings/wasm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iota/identity-wasm",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iota/identity-wasm",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "WASM bindings for IOTA Identity - A Self Sovereign Identity Framework implementing the DID and VC standards from W3C. To be used in Javascript/Typescript",
   "repository": {
     "type": "git",

--- a/bindings/wasm/src/did/wasm_document_diff.rs
+++ b/bindings/wasm/src/did/wasm_document_diff.rs
@@ -67,6 +67,15 @@ impl WasmDocumentDiff {
     Ok(())
   }
 
+  /// Returns the `proof` object.
+  #[wasm_bindgen(getter)]
+  pub fn proof(&self) -> Result<JsValue> {
+    match self.0.proof() {
+      Some(proof) => JsValue::from_serde(proof).wasm_result(),
+      None => Ok(JsValue::NULL),
+    }
+  }
+
   /// Returns a new DID Document which is the result of merging `self`
   /// with the given Document.
   pub fn merge(&self, document: &WasmDocument) -> Result<WasmDocument> {


### PR DESCRIPTION
# Description of change
Bump the `@iota/identity-wasm@dev` version to 0.3.11 for the change to `devnet`: #405.

Add `proof` field getter for WasmDocumentDiff.

## Type of change

- [x] Chore/bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Wasm examples pass locally

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
