### PR TITLE
Fix Document constructor Typescript bindings

### DIFF
--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -54,8 +54,8 @@ const identity = require('@iota/identity-wasm/node')
 const key = new identity.KeyPair(identity.KeyType.Ed25519)
 
 // Create a new DID Document with the KeyPair as the default authentication method
-const doc = identity.Document.fromKeyPair(key)
-// const doc = identity.Document.fromKeyPair(key, "dev") // if using the devnet
+const doc = new identity.Document(key)
+// const doc = new identity.Document(key, "dev") // if using the devnet
 
 // Sign the DID Document with the private key
 doc.sign(key)
@@ -137,9 +137,8 @@ import * as identity from "@iota/identity-wasm/web";
 
 identity.init().then(() => {
   const key = new identity.KeyPair(identity.KeyType.Ed25519)
-  const doc = identity.Document.fromKeyPair(key)
-  // Or, if using the devnet:
-  // const doc = identity.Document.fromKeyPair(key, "dev")  
+  const doc = new identity.Document(key)
+  // const doc = new identity.Document(key, "dev") // if using the devnet
   console.log("Key Pair", key)
   console.log("DID Document: ", doc)
 });
@@ -149,9 +148,8 @@ identity.init().then(() => {
 (async () => {
   await identity.init()
   const key = new identity.KeyPair(identity.KeyType.Ed25519)
-  const doc = identity.Document.fromKeyPair(key)
-  // Or, if using the devnet:
-  // const doc = identity.Document.fromKeyPair(key, "dev")
+  const doc = new identity.Document(key)
+  // const doc = new identity.Document(key, "dev") // if using the devnet
   console.log("Key Pair", key)
   console.log("DID Document: ", doc)
 })()

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -750,7 +750,7 @@ Deserializes a `$ident` object from a JSON object.
 **Kind**: global class  
 
 * [Document](#Document)
-    * [new Document(keypair, network)](#new_Document_new)
+    * [new Document(keypair, network, fragment)](#new_Document_new)
     * _instance_
         * [.id](#Document+id) ⇒ [<code>DID</code>](#DID)
         * [.created](#Document+created) ⇒ [<code>Timestamp</code>](#Timestamp)
@@ -786,21 +786,29 @@ Deserializes a `$ident` object from a JSON object.
 
 <a name="new_Document_new"></a>
 
-### new Document(keypair, network)
-Creates a new DID Document from the given `KeyPair` and network, defaulting to
-`Network::Mainnet` if unspecified.
+### new Document(keypair, network, fragment)
+Creates a new DID Document from the given `KeyPair`, network, and verification method
+fragment name.
 
-The DID Document will be pre-populated with a single authentication verification method
-derived from the provided `KeyPair`. This method will have the DID URL fragment
-`#authentication` and can be easily retrieved with `Document::authentication`.
+The DID Document will be pre-populated with a single verification method
+derived from the provided `KeyPair`, with an attached authentication relationship.
+This method will have the DID URL fragment `#authentication` by default and can be easily
+retrieved with `Document::authentication`.
 
 NOTE: the generated document is unsigned, see `Document::sign`.
+
+Arguments:
+
+* keypair: the initial verification method is derived from the public key with this keypair.
+* network: Tangle network to use for the DID, default `Network::mainnet`.
+* fragment: name of the initial verification method, default "authentication".
 
 
 | Param | Type |
 | --- | --- |
 | keypair | [<code>KeyPair</code>](#KeyPair) | 
 | network | <code>string</code> \| <code>undefined</code> | 
+| fragment | <code>string</code> \| <code>undefined</code> | 
 
 <a name="Document+id"></a>
 

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -53,8 +53,6 @@
 <dd></dd>
 <dt><a href="#Network">Network</a></dt>
 <dd></dd>
-<dt><a href="#NewDocument">NewDocument</a></dt>
-<dd></dd>
 <dt><a href="#PresentationRequest">PresentationRequest</a></dt>
 <dd></dd>
 <dt><a href="#PresentationResponse">PresentationResponse</a></dt>
@@ -101,7 +99,7 @@
 <a name="AuthenticationRequest"></a>
 
 ## AuthenticationRequest
-**Kind**: global class
+**Kind**: global class  
 
 * [AuthenticationRequest](#AuthenticationRequest)
     * _instance_
@@ -112,20 +110,20 @@
 <a name="AuthenticationRequest+toJSON"></a>
 
 ### authenticationRequest.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>AuthenticationRequest</code>](#AuthenticationRequest)
+**Kind**: instance method of [<code>AuthenticationRequest</code>](#AuthenticationRequest)  
 <a name="AuthenticationRequest.fromJSON"></a>
 
 ### AuthenticationRequest.fromJSON(value) ⇒ [<code>AuthenticationRequest</code>](#AuthenticationRequest)
-**Kind**: static method of [<code>AuthenticationRequest</code>](#AuthenticationRequest)
+**Kind**: static method of [<code>AuthenticationRequest</code>](#AuthenticationRequest)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="AuthenticationResponse"></a>
 
 ## AuthenticationResponse
-**Kind**: global class
+**Kind**: global class  
 
 * [AuthenticationResponse](#AuthenticationResponse)
     * _instance_
@@ -136,20 +134,20 @@
 <a name="AuthenticationResponse+toJSON"></a>
 
 ### authenticationResponse.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>AuthenticationResponse</code>](#AuthenticationResponse)
+**Kind**: instance method of [<code>AuthenticationResponse</code>](#AuthenticationResponse)  
 <a name="AuthenticationResponse.fromJSON"></a>
 
 ### AuthenticationResponse.fromJSON(value) ⇒ [<code>AuthenticationResponse</code>](#AuthenticationResponse)
-**Kind**: static method of [<code>AuthenticationResponse</code>](#AuthenticationResponse)
+**Kind**: static method of [<code>AuthenticationResponse</code>](#AuthenticationResponse)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="Client"></a>
 
 ## Client
-**Kind**: global class
+**Kind**: global class  
 
 * [Client](#Client)
     * [new Client()](#new_Client_new)
@@ -177,61 +175,61 @@ Creates a new `Client` with default settings.
 ### client.network() ⇒ [<code>Network</code>](#Network)
 Returns the `Client` Tangle network.
 
-**Kind**: instance method of [<code>Client</code>](#Client)
+**Kind**: instance method of [<code>Client</code>](#Client)  
 <a name="Client+publishDocument"></a>
 
 ### client.publishDocument(document) ⇒ <code>Promise.&lt;any&gt;</code>
 Publishes an `IotaDocument` to the Tangle.
 
-**Kind**: instance method of [<code>Client</code>](#Client)
+**Kind**: instance method of [<code>Client</code>](#Client)  
 
 | Param | Type |
 | --- | --- |
-| document | <code>any</code> |
+| document | <code>any</code> | 
 
 <a name="Client+publishDiff"></a>
 
 ### client.publishDiff(message_id, diff) ⇒ <code>Promise.&lt;any&gt;</code>
 Publishes a `DocumentDiff` to the Tangle.
 
-**Kind**: instance method of [<code>Client</code>](#Client)
+**Kind**: instance method of [<code>Client</code>](#Client)  
 
 | Param | Type |
 | --- | --- |
-| message_id | <code>string</code> |
-| diff | [<code>DocumentDiff</code>](#DocumentDiff) |
+| message_id | <code>string</code> | 
+| diff | [<code>DocumentDiff</code>](#DocumentDiff) | 
 
 <a name="Client+publishJSON"></a>
 
 ### client.publishJSON(index, data) ⇒ <code>Promise.&lt;any&gt;</code>
 Publishes arbitrary JSON data to the specified index on the Tangle.
 
-**Kind**: instance method of [<code>Client</code>](#Client)
+**Kind**: instance method of [<code>Client</code>](#Client)  
 
 | Param | Type |
 | --- | --- |
-| index | <code>string</code> |
-| data | <code>any</code> |
+| index | <code>string</code> | 
+| data | <code>any</code> | 
 
 <a name="Client+resolve"></a>
 
 ### client.resolve(did) ⇒ <code>Promise.&lt;any&gt;</code>
-**Kind**: instance method of [<code>Client</code>](#Client)
+**Kind**: instance method of [<code>Client</code>](#Client)  
 
 | Param | Type |
 | --- | --- |
-| did | <code>string</code> |
+| did | <code>string</code> | 
 
 <a name="Client+resolveHistory"></a>
 
 ### client.resolveHistory(did) ⇒ <code>Promise.&lt;any&gt;</code>
 Returns the message history of the given DID.
 
-**Kind**: instance method of [<code>Client</code>](#Client)
+**Kind**: instance method of [<code>Client</code>](#Client)  
 
 | Param | Type |
 | --- | --- |
-| did | <code>string</code> |
+| did | <code>string</code> | 
 
 <a name="Client+resolveDiffHistory"></a>
 
@@ -242,60 +240,60 @@ integration chain.
 NOTE: the document must have been published to the tangle and have a valid message id and
 authentication method.
 
-**Kind**: instance method of [<code>Client</code>](#Client)
+**Kind**: instance method of [<code>Client</code>](#Client)  
 
 | Param | Type |
 | --- | --- |
-| document | [<code>Document</code>](#Document) |
+| document | [<code>Document</code>](#Document) | 
 
 <a name="Client+checkCredential"></a>
 
 ### client.checkCredential(data) ⇒ <code>Promise.&lt;any&gt;</code>
 Validates a credential with the DID Document from the Tangle.
 
-**Kind**: instance method of [<code>Client</code>](#Client)
+**Kind**: instance method of [<code>Client</code>](#Client)  
 
 | Param | Type |
 | --- | --- |
-| data | <code>string</code> |
+| data | <code>string</code> | 
 
 <a name="Client+checkPresentation"></a>
 
 ### client.checkPresentation(data) ⇒ <code>Promise.&lt;any&gt;</code>
 Validates a presentation with the DID Document from the Tangle.
 
-**Kind**: instance method of [<code>Client</code>](#Client)
+**Kind**: instance method of [<code>Client</code>](#Client)  
 
 | Param | Type |
 | --- | --- |
-| data | <code>string</code> |
+| data | <code>string</code> | 
 
 <a name="Client.fromConfig"></a>
 
 ### Client.fromConfig(config) ⇒ [<code>Client</code>](#Client)
 Creates a new `Client` with settings from the given `Config`.
 
-**Kind**: static method of [<code>Client</code>](#Client)
+**Kind**: static method of [<code>Client</code>](#Client)  
 
 | Param | Type |
 | --- | --- |
-| config | [<code>Config</code>](#Config) |
+| config | [<code>Config</code>](#Config) | 
 
 <a name="Client.fromNetwork"></a>
 
 ### Client.fromNetwork(network) ⇒ [<code>Client</code>](#Client)
 Creates a new `Client` with default settings for the given `Network`.
 
-**Kind**: static method of [<code>Client</code>](#Client)
+**Kind**: static method of [<code>Client</code>](#Client)  
 
 | Param | Type |
 | --- | --- |
-| network | [<code>Network</code>](#Network) |
+| network | [<code>Network</code>](#Network) | 
 
 <a name="Config"></a>
 
 ## Config
-**Kind**: global class
+**Kind**: global class  
 
 * [Config](#Config)
     * _instance_
@@ -319,149 +317,149 @@ Creates a new `Client` with default settings for the given `Network`.
 <a name="Config+setNetwork"></a>
 
 ### config.setNetwork(network)
-**Kind**: instance method of [<code>Config</code>](#Config)
+**Kind**: instance method of [<code>Config</code>](#Config)  
 
 | Param | Type |
 | --- | --- |
-| network | [<code>Network</code>](#Network) |
+| network | [<code>Network</code>](#Network) | 
 
 <a name="Config+setNode"></a>
 
 ### config.setNode(url)
-**Kind**: instance method of [<code>Config</code>](#Config)
+**Kind**: instance method of [<code>Config</code>](#Config)  
 
 | Param | Type |
 | --- | --- |
-| url | <code>string</code> |
+| url | <code>string</code> | 
 
 <a name="Config+setPrimaryNode"></a>
 
 ### config.setPrimaryNode(url, jwt, username, password)
-**Kind**: instance method of [<code>Config</code>](#Config)
+**Kind**: instance method of [<code>Config</code>](#Config)  
 
 | Param | Type |
 | --- | --- |
-| url | <code>string</code> |
-| jwt | <code>string</code> \| <code>undefined</code> |
-| username | <code>string</code> \| <code>undefined</code> |
-| password | <code>string</code> \| <code>undefined</code> |
+| url | <code>string</code> | 
+| jwt | <code>string</code> \| <code>undefined</code> | 
+| username | <code>string</code> \| <code>undefined</code> | 
+| password | <code>string</code> \| <code>undefined</code> | 
 
 <a name="Config+setPrimaryPoWNode"></a>
 
 ### config.setPrimaryPoWNode(url, jwt, username, password)
-**Kind**: instance method of [<code>Config</code>](#Config)
+**Kind**: instance method of [<code>Config</code>](#Config)  
 
 | Param | Type |
 | --- | --- |
-| url | <code>string</code> |
-| jwt | <code>string</code> \| <code>undefined</code> |
-| username | <code>string</code> \| <code>undefined</code> |
-| password | <code>string</code> \| <code>undefined</code> |
+| url | <code>string</code> | 
+| jwt | <code>string</code> \| <code>undefined</code> | 
+| username | <code>string</code> \| <code>undefined</code> | 
+| password | <code>string</code> \| <code>undefined</code> | 
 
 <a name="Config+setPermanode"></a>
 
 ### config.setPermanode(url, jwt, username, password)
-**Kind**: instance method of [<code>Config</code>](#Config)
+**Kind**: instance method of [<code>Config</code>](#Config)  
 
 | Param | Type |
 | --- | --- |
-| url | <code>string</code> |
-| jwt | <code>string</code> \| <code>undefined</code> |
-| username | <code>string</code> \| <code>undefined</code> |
-| password | <code>string</code> \| <code>undefined</code> |
+| url | <code>string</code> | 
+| jwt | <code>string</code> \| <code>undefined</code> | 
+| username | <code>string</code> \| <code>undefined</code> | 
+| password | <code>string</code> \| <code>undefined</code> | 
 
 <a name="Config+setNodeAuth"></a>
 
 ### config.setNodeAuth(url, jwt, username, password)
-**Kind**: instance method of [<code>Config</code>](#Config)
+**Kind**: instance method of [<code>Config</code>](#Config)  
 
 | Param | Type |
 | --- | --- |
-| url | <code>string</code> |
-| jwt | <code>string</code> \| <code>undefined</code> |
-| username | <code>string</code> \| <code>undefined</code> |
-| password | <code>string</code> \| <code>undefined</code> |
+| url | <code>string</code> | 
+| jwt | <code>string</code> \| <code>undefined</code> | 
+| username | <code>string</code> \| <code>undefined</code> | 
+| password | <code>string</code> \| <code>undefined</code> | 
 
 <a name="Config+setNodeSyncInterval"></a>
 
 ### config.setNodeSyncInterval(value)
-**Kind**: instance method of [<code>Config</code>](#Config)
+**Kind**: instance method of [<code>Config</code>](#Config)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>number</code> |
+| value | <code>number</code> | 
 
 <a name="Config+setNodeSyncDisabled"></a>
 
 ### config.setNodeSyncDisabled()
-**Kind**: instance method of [<code>Config</code>](#Config)
+**Kind**: instance method of [<code>Config</code>](#Config)  
 <a name="Config+setQuorum"></a>
 
 ### config.setQuorum(value)
-**Kind**: instance method of [<code>Config</code>](#Config)
+**Kind**: instance method of [<code>Config</code>](#Config)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>boolean</code> |
+| value | <code>boolean</code> | 
 
 <a name="Config+setQuorumSize"></a>
 
 ### config.setQuorumSize(value)
-**Kind**: instance method of [<code>Config</code>](#Config)
+**Kind**: instance method of [<code>Config</code>](#Config)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>number</code> |
+| value | <code>number</code> | 
 
 <a name="Config+setQuorumThreshold"></a>
 
 ### config.setQuorumThreshold(value)
-**Kind**: instance method of [<code>Config</code>](#Config)
+**Kind**: instance method of [<code>Config</code>](#Config)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>number</code> |
+| value | <code>number</code> | 
 
 <a name="Config+setLocalPoW"></a>
 
 ### config.setLocalPoW(value)
-**Kind**: instance method of [<code>Config</code>](#Config)
+**Kind**: instance method of [<code>Config</code>](#Config)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>boolean</code> |
+| value | <code>boolean</code> | 
 
 <a name="Config+setTipsInterval"></a>
 
 ### config.setTipsInterval(value)
-**Kind**: instance method of [<code>Config</code>](#Config)
+**Kind**: instance method of [<code>Config</code>](#Config)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>number</code> |
+| value | <code>number</code> | 
 
 <a name="Config+setRequestTimeout"></a>
 
 ### config.setRequestTimeout(value)
-**Kind**: instance method of [<code>Config</code>](#Config)
+**Kind**: instance method of [<code>Config</code>](#Config)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>number</code> |
+| value | <code>number</code> | 
 
 <a name="Config.fromNetwork"></a>
 
 ### Config.fromNetwork(network) ⇒ [<code>Config</code>](#Config)
-**Kind**: static method of [<code>Config</code>](#Config)
+**Kind**: static method of [<code>Config</code>](#Config)  
 
 | Param | Type |
 | --- | --- |
-| network | [<code>Network</code>](#Network) |
+| network | [<code>Network</code>](#Network) | 
 
 <a name="CredentialIssuance"></a>
 
 ## CredentialIssuance
-**Kind**: global class
+**Kind**: global class  
 
 * [CredentialIssuance](#CredentialIssuance)
     * _instance_
@@ -472,20 +470,20 @@ Creates a new `Client` with default settings for the given `Network`.
 <a name="CredentialIssuance+toJSON"></a>
 
 ### credentialIssuance.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>CredentialIssuance</code>](#CredentialIssuance)
+**Kind**: instance method of [<code>CredentialIssuance</code>](#CredentialIssuance)  
 <a name="CredentialIssuance.fromJSON"></a>
 
 ### CredentialIssuance.fromJSON(value) ⇒ [<code>CredentialIssuance</code>](#CredentialIssuance)
-**Kind**: static method of [<code>CredentialIssuance</code>](#CredentialIssuance)
+**Kind**: static method of [<code>CredentialIssuance</code>](#CredentialIssuance)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="CredentialOptionRequest"></a>
 
 ## CredentialOptionRequest
-**Kind**: global class
+**Kind**: global class  
 
 * [CredentialOptionRequest](#CredentialOptionRequest)
     * _instance_
@@ -496,20 +494,20 @@ Creates a new `Client` with default settings for the given `Network`.
 <a name="CredentialOptionRequest+toJSON"></a>
 
 ### credentialOptionRequest.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>CredentialOptionRequest</code>](#CredentialOptionRequest)
+**Kind**: instance method of [<code>CredentialOptionRequest</code>](#CredentialOptionRequest)  
 <a name="CredentialOptionRequest.fromJSON"></a>
 
 ### CredentialOptionRequest.fromJSON(value) ⇒ [<code>CredentialOptionRequest</code>](#CredentialOptionRequest)
-**Kind**: static method of [<code>CredentialOptionRequest</code>](#CredentialOptionRequest)
+**Kind**: static method of [<code>CredentialOptionRequest</code>](#CredentialOptionRequest)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="CredentialOptionResponse"></a>
 
 ## CredentialOptionResponse
-**Kind**: global class
+**Kind**: global class  
 
 * [CredentialOptionResponse](#CredentialOptionResponse)
     * _instance_
@@ -520,20 +518,20 @@ Creates a new `Client` with default settings for the given `Network`.
 <a name="CredentialOptionResponse+toJSON"></a>
 
 ### credentialOptionResponse.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>CredentialOptionResponse</code>](#CredentialOptionResponse)
+**Kind**: instance method of [<code>CredentialOptionResponse</code>](#CredentialOptionResponse)  
 <a name="CredentialOptionResponse.fromJSON"></a>
 
 ### CredentialOptionResponse.fromJSON(value) ⇒ [<code>CredentialOptionResponse</code>](#CredentialOptionResponse)
-**Kind**: static method of [<code>CredentialOptionResponse</code>](#CredentialOptionResponse)
+**Kind**: static method of [<code>CredentialOptionResponse</code>](#CredentialOptionResponse)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="CredentialRevocation"></a>
 
 ## CredentialRevocation
-**Kind**: global class
+**Kind**: global class  
 
 * [CredentialRevocation](#CredentialRevocation)
     * _instance_
@@ -544,20 +542,20 @@ Creates a new `Client` with default settings for the given `Network`.
 <a name="CredentialRevocation+toJSON"></a>
 
 ### credentialRevocation.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>CredentialRevocation</code>](#CredentialRevocation)
+**Kind**: instance method of [<code>CredentialRevocation</code>](#CredentialRevocation)  
 <a name="CredentialRevocation.fromJSON"></a>
 
 ### CredentialRevocation.fromJSON(value) ⇒ [<code>CredentialRevocation</code>](#CredentialRevocation)
-**Kind**: static method of [<code>CredentialRevocation</code>](#CredentialRevocation)
+**Kind**: static method of [<code>CredentialRevocation</code>](#CredentialRevocation)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="CredentialSelection"></a>
 
 ## CredentialSelection
-**Kind**: global class
+**Kind**: global class  
 
 * [CredentialSelection](#CredentialSelection)
     * _instance_
@@ -568,20 +566,20 @@ Creates a new `Client` with default settings for the given `Network`.
 <a name="CredentialSelection+toJSON"></a>
 
 ### credentialSelection.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>CredentialSelection</code>](#CredentialSelection)
+**Kind**: instance method of [<code>CredentialSelection</code>](#CredentialSelection)  
 <a name="CredentialSelection.fromJSON"></a>
 
 ### CredentialSelection.fromJSON(value) ⇒ [<code>CredentialSelection</code>](#CredentialSelection)
-**Kind**: static method of [<code>CredentialSelection</code>](#CredentialSelection)
+**Kind**: static method of [<code>CredentialSelection</code>](#CredentialSelection)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="DID"></a>
 
 ## DID
-**Kind**: global class
+**Kind**: global class  
 
 * [DID](#DID)
     * [new DID(key, network)](#new_DID_new)
@@ -602,60 +600,60 @@ Creates a new `DID` from a `KeyPair` object.
 
 | Param | Type |
 | --- | --- |
-| key | [<code>KeyPair</code>](#KeyPair) |
-| network | <code>string</code> \| <code>undefined</code> |
+| key | [<code>KeyPair</code>](#KeyPair) | 
+| network | <code>string</code> \| <code>undefined</code> | 
 
 <a name="DID+network"></a>
 
 ### did.network ⇒ [<code>Network</code>](#Network)
 Returns the IOTA tangle network of the `DID`.
 
-**Kind**: instance property of [<code>DID</code>](#DID)
+**Kind**: instance property of [<code>DID</code>](#DID)  
 <a name="DID+networkName"></a>
 
 ### did.networkName ⇒ <code>string</code>
 Returns the IOTA tangle network of the `DID`.
 
-**Kind**: instance property of [<code>DID</code>](#DID)
+**Kind**: instance property of [<code>DID</code>](#DID)  
 <a name="DID+tag"></a>
 
 ### did.tag ⇒ <code>string</code>
 Returns the unique tag of the `DID`.
 
-**Kind**: instance property of [<code>DID</code>](#DID)
+**Kind**: instance property of [<code>DID</code>](#DID)  
 <a name="DID+toString"></a>
 
 ### did.toString() ⇒ <code>string</code>
 Returns the `DID` object as a string.
 
-**Kind**: instance method of [<code>DID</code>](#DID)
+**Kind**: instance method of [<code>DID</code>](#DID)  
 <a name="DID.fromBase58"></a>
 
 ### DID.fromBase58(key, network) ⇒ [<code>DID</code>](#DID)
 Creates a new `DID` from a base58-encoded public key.
 
-**Kind**: static method of [<code>DID</code>](#DID)
+**Kind**: static method of [<code>DID</code>](#DID)  
 
 | Param | Type |
 | --- | --- |
-| key | <code>string</code> |
-| network | <code>string</code> \| <code>undefined</code> |
+| key | <code>string</code> | 
+| network | <code>string</code> \| <code>undefined</code> | 
 
 <a name="DID.parse"></a>
 
 ### DID.parse(input) ⇒ [<code>DID</code>](#DID)
 Parses a `DID` from the input string.
 
-**Kind**: static method of [<code>DID</code>](#DID)
+**Kind**: static method of [<code>DID</code>](#DID)  
 
 | Param | Type |
 | --- | --- |
-| input | <code>string</code> |
+| input | <code>string</code> | 
 
 <a name="DidRequest"></a>
 
 ## DidRequest
-**Kind**: global class
+**Kind**: global class  
 
 * [DidRequest](#DidRequest)
     * _instance_
@@ -666,20 +664,20 @@ Parses a `DID` from the input string.
 <a name="DidRequest+toJSON"></a>
 
 ### didRequest.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>DidRequest</code>](#DidRequest)
+**Kind**: instance method of [<code>DidRequest</code>](#DidRequest)  
 <a name="DidRequest.fromJSON"></a>
 
 ### DidRequest.fromJSON(value) ⇒ [<code>DidRequest</code>](#DidRequest)
-**Kind**: static method of [<code>DidRequest</code>](#DidRequest)
+**Kind**: static method of [<code>DidRequest</code>](#DidRequest)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="DidResponse"></a>
 
 ## DidResponse
-**Kind**: global class
+**Kind**: global class  
 
 * [DidResponse](#DidResponse)
     * _instance_
@@ -690,20 +688,20 @@ Parses a `DID` from the input string.
 <a name="DidResponse+toJSON"></a>
 
 ### didResponse.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>DidResponse</code>](#DidResponse)
+**Kind**: instance method of [<code>DidResponse</code>](#DidResponse)  
 <a name="DidResponse.fromJSON"></a>
 
 ### DidResponse.fromJSON(value) ⇒ [<code>DidResponse</code>](#DidResponse)
-**Kind**: static method of [<code>DidResponse</code>](#DidResponse)
+**Kind**: static method of [<code>DidResponse</code>](#DidResponse)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="DiffChainHistory"></a>
 
 ## DiffChainHistory
-**Kind**: global class
+**Kind**: global class  
 
 * [DiffChainHistory](#DiffChainHistory)
     * _instance_
@@ -720,7 +718,7 @@ Returns a [`js_sys::Array`] of `$wasm_ty` as strings.
 
 NOTE: this clones the field.
 
-**Kind**: instance method of [<code>DiffChainHistory</code>](#DiffChainHistory)
+**Kind**: instance method of [<code>DiffChainHistory</code>](#DiffChainHistory)  
 <a name="DiffChainHistory+spam"></a>
 
 ### diffChainHistory.spam() ⇒ <code>Array.&lt;any&gt;</code>
@@ -728,31 +726,31 @@ Returns a [`js_sys::Array`] of [`MessageIds`][MessageId] as strings.
 
 NOTE: this clones the field.
 
-**Kind**: instance method of [<code>DiffChainHistory</code>](#DiffChainHistory)
+**Kind**: instance method of [<code>DiffChainHistory</code>](#DiffChainHistory)  
 <a name="DiffChainHistory+toJSON"></a>
 
 ### diffChainHistory.toJSON() ⇒ <code>any</code>
 Serializes a `$ident` object as a JSON object.
 
-**Kind**: instance method of [<code>DiffChainHistory</code>](#DiffChainHistory)
+**Kind**: instance method of [<code>DiffChainHistory</code>](#DiffChainHistory)  
 <a name="DiffChainHistory.fromJSON"></a>
 
 ### DiffChainHistory.fromJSON(json) ⇒ [<code>DiffChainHistory</code>](#DiffChainHistory)
 Deserializes a `$ident` object from a JSON object.
 
-**Kind**: static method of [<code>DiffChainHistory</code>](#DiffChainHistory)
+**Kind**: static method of [<code>DiffChainHistory</code>](#DiffChainHistory)  
 
 | Param | Type |
 | --- | --- |
-| json | <code>any</code> |
+| json | <code>any</code> | 
 
 <a name="Document"></a>
 
 ## Document
-**Kind**: global class
+**Kind**: global class  
 
 * [Document](#Document)
-    * [new Document(type_, network, tag)](#new_Document_new)
+    * [new Document(keypair, network)](#new_Document_new)
     * _instance_
         * [.id](#Document+id) ⇒ [<code>DID</code>](#DID)
         * [.created](#Document+created) ⇒ [<code>Timestamp</code>](#Timestamp)
@@ -782,178 +780,183 @@ Deserializes a `$ident` object from a JSON object.
         * [.integrationIndex()](#Document+integrationIndex) ⇒ <code>string</code>
         * [.toJSON()](#Document+toJSON) ⇒ <code>any</code>
     * _static_
-        * [.fromKeyPair(key, network)](#Document.fromKeyPair) ⇒ [<code>Document</code>](#Document)
         * [.fromAuthentication(method)](#Document.fromAuthentication) ⇒ [<code>Document</code>](#Document)
         * [.diffIndex(message_id)](#Document.diffIndex) ⇒ <code>string</code>
         * [.fromJSON(json)](#Document.fromJSON) ⇒ [<code>Document</code>](#Document)
 
 <a name="new_Document_new"></a>
 
-### new Document(type_, network, tag)
-Creates a new DID Document from the given KeyPair.
+### new Document(keypair, network)
+Creates a new DID Document from the given `KeyPair` and network, defaulting to
+`Network::Mainnet` if unspecified.
+
+The DID Document will be pre-populated with a single authentication verification method
+derived from the provided `KeyPair`. This method will have the DID URL fragment
+`#authentication` and can be easily retrieved with `Document::authentication`.
+
+NOTE: the generated document is unsigned, see `Document::sign`.
 
 
 | Param | Type |
 | --- | --- |
-| type_ | <code>number</code> |
-| network | <code>string</code> \| <code>undefined</code> |
-| tag | <code>string</code> \| <code>undefined</code> |
+| keypair | [<code>KeyPair</code>](#KeyPair) | 
+| network | <code>string</code> \| <code>undefined</code> | 
 
 <a name="Document+id"></a>
 
 ### document.id ⇒ [<code>DID</code>](#DID)
 Returns the DID Document `id`.
 
-**Kind**: instance property of [<code>Document</code>](#Document)
+**Kind**: instance property of [<code>Document</code>](#Document)  
 <a name="Document+created"></a>
 
 ### document.created ⇒ [<code>Timestamp</code>](#Timestamp)
 Returns the timestamp of when the DID document was created.
 
-**Kind**: instance property of [<code>Document</code>](#Document)
+**Kind**: instance property of [<code>Document</code>](#Document)  
 <a name="Document+created"></a>
 
 ### document.created
 Sets the timestamp of when the DID document was created.
 
-**Kind**: instance property of [<code>Document</code>](#Document)
+**Kind**: instance property of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| timestamp | [<code>Timestamp</code>](#Timestamp) |
+| timestamp | [<code>Timestamp</code>](#Timestamp) | 
 
 <a name="Document+updated"></a>
 
 ### document.updated ⇒ [<code>Timestamp</code>](#Timestamp)
 Returns the timestamp of the last DID document update.
 
-**Kind**: instance property of [<code>Document</code>](#Document)
+**Kind**: instance property of [<code>Document</code>](#Document)  
 <a name="Document+updated"></a>
 
 ### document.updated
 Sets the timestamp of the last DID document update.
 
-**Kind**: instance property of [<code>Document</code>](#Document)
+**Kind**: instance property of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| timestamp | [<code>Timestamp</code>](#Timestamp) |
+| timestamp | [<code>Timestamp</code>](#Timestamp) | 
 
 <a name="Document+proof"></a>
 
 ### document.proof ⇒ <code>any</code>
 Returns the DID Document `proof` object.
 
-**Kind**: instance property of [<code>Document</code>](#Document)
+**Kind**: instance property of [<code>Document</code>](#Document)  
 <a name="Document+messageId"></a>
 
 ### document.messageId ⇒ <code>string</code>
 Get the message_id of the DID Document.
 
-**Kind**: instance property of [<code>Document</code>](#Document)
+**Kind**: instance property of [<code>Document</code>](#Document)  
 <a name="Document+messageId"></a>
 
 ### document.messageId
 Set the message_id of the DID Document.
 
-**Kind**: instance property of [<code>Document</code>](#Document)
+**Kind**: instance property of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| message_id | <code>string</code> |
+| message_id | <code>string</code> | 
 
 <a name="Document+previousMessageId"></a>
 
 ### document.previousMessageId ⇒ <code>string</code>
-**Kind**: instance property of [<code>Document</code>](#Document)
+**Kind**: instance property of [<code>Document</code>](#Document)  
 <a name="Document+previousMessageId"></a>
 
 ### document.previousMessageId
-**Kind**: instance property of [<code>Document</code>](#Document)
+**Kind**: instance property of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>string</code> |
+| value | <code>string</code> | 
 
 <a name="Document+authentication"></a>
 
 ### document.authentication() ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
 Returns the default Verification Method of the DID Document.
 
-**Kind**: instance method of [<code>Document</code>](#Document)
+**Kind**: instance method of [<code>Document</code>](#Document)  
 <a name="Document+insertMethod"></a>
 
 ### document.insertMethod(method, scope) ⇒ <code>boolean</code>
-**Kind**: instance method of [<code>Document</code>](#Document)
+**Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| method | [<code>VerificationMethod</code>](#VerificationMethod) |
-| scope | <code>string</code> \| <code>undefined</code> |
+| method | [<code>VerificationMethod</code>](#VerificationMethod) | 
+| scope | <code>string</code> \| <code>undefined</code> | 
 
 <a name="Document+removeMethod"></a>
 
 ### document.removeMethod(did)
-**Kind**: instance method of [<code>Document</code>](#Document)
+**Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| did | [<code>DID</code>](#DID) |
+| did | [<code>DID</code>](#DID) | 
 
 <a name="Document+insertService"></a>
 
 ### document.insertService(service) ⇒ <code>boolean</code>
-**Kind**: instance method of [<code>Document</code>](#Document)
+**Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| service | [<code>Service</code>](#Service) |
+| service | [<code>Service</code>](#Service) | 
 
 <a name="Document+removeService"></a>
 
 ### document.removeService(did)
-**Kind**: instance method of [<code>Document</code>](#Document)
+**Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| did | [<code>DID</code>](#DID) |
+| did | [<code>DID</code>](#DID) | 
 
 <a name="Document+sign"></a>
 
 ### document.sign(key)
 Signs the DID Document with the default authentication method.
 
-**Kind**: instance method of [<code>Document</code>](#Document)
+**Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| key | [<code>KeyPair</code>](#KeyPair) |
+| key | [<code>KeyPair</code>](#KeyPair) | 
 
 <a name="Document+verify"></a>
 
 ### document.verify() ⇒ <code>boolean</code>
 Verify the signature with the authentication_key
 
-**Kind**: instance method of [<code>Document</code>](#Document)
+**Kind**: instance method of [<code>Document</code>](#Document)  
 <a name="Document+signCredential"></a>
 
 ### document.signCredential(data, args) ⇒ [<code>VerifiableCredential</code>](#VerifiableCredential)
-**Kind**: instance method of [<code>Document</code>](#Document)
+**Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| data | <code>any</code> |
-| args | <code>any</code> |
+| data | <code>any</code> | 
+| args | <code>any</code> | 
 
 <a name="Document+signPresentation"></a>
 
 ### document.signPresentation(data, args) ⇒ [<code>VerifiablePresentation</code>](#VerifiablePresentation)
-**Kind**: instance method of [<code>Document</code>](#Document)
+**Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| data | <code>any</code> |
-| args | <code>any</code> |
+| data | <code>any</code> | 
+| args | <code>any</code> | 
 
 <a name="Document+signData"></a>
 
@@ -964,66 +967,66 @@ Verification Method.
 An additional `proof` property is required if using a Merkle Key
 Collection verification Method.
 
-**Kind**: instance method of [<code>Document</code>](#Document)
+**Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| data | <code>any</code> |
-| args | <code>any</code> |
+| data | <code>any</code> | 
+| args | <code>any</code> | 
 
 <a name="Document+verifyData"></a>
 
 ### document.verifyData(data) ⇒ <code>boolean</code>
 Verifies the authenticity of `data` using the target verification method.
 
-**Kind**: instance method of [<code>Document</code>](#Document)
+**Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| data | <code>any</code> |
+| data | <code>any</code> | 
 
 <a name="Document+resolveKey"></a>
 
 ### document.resolveKey(query) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
-**Kind**: instance method of [<code>Document</code>](#Document)
+**Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| query | <code>string</code> |
+| query | <code>string</code> | 
 
 <a name="Document+revokeMerkleKey"></a>
 
 ### document.revokeMerkleKey(query, index) ⇒ <code>boolean</code>
-**Kind**: instance method of [<code>Document</code>](#Document)
+**Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| query | <code>string</code> |
-| index | <code>number</code> |
+| query | <code>string</code> | 
+| index | <code>number</code> | 
 
 <a name="Document+diff"></a>
 
 ### document.diff(other, message, key) ⇒ [<code>DocumentDiff</code>](#DocumentDiff)
 Generate the difference between two DID Documents and sign it
 
-**Kind**: instance method of [<code>Document</code>](#Document)
+**Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| other | [<code>Document</code>](#Document) |
-| message | <code>string</code> |
-| key | [<code>KeyPair</code>](#KeyPair) |
+| other | [<code>Document</code>](#Document) | 
+| message | <code>string</code> | 
+| key | [<code>KeyPair</code>](#KeyPair) | 
 
 <a name="Document+merge"></a>
 
 ### document.merge(diff)
 Verifies a `DocumentDiff` signature and merges the changes into `self`.
 
-**Kind**: instance method of [<code>Document</code>](#Document)
+**Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| diff | [<code>DocumentDiff</code>](#DocumentDiff) |
+| diff | [<code>DocumentDiff</code>](#DocumentDiff) | 
 
 <a name="Document+integrationIndex"></a>
 
@@ -1035,37 +1038,25 @@ E.g.
 For an [`IotaDocument`] `doc` with DID: did:iota:1234567890abcdefghijklmnopqrstuvxyzABCDEFGHI,
 `doc.integration_index()` == "1234567890abcdefghijklmnopqrstuvxyzABCDEFGHI"
 
-**Kind**: instance method of [<code>Document</code>](#Document)
+**Kind**: instance method of [<code>Document</code>](#Document)  
 <a name="Document+toJSON"></a>
 
 ### document.toJSON() ⇒ <code>any</code>
 Serializes a `Document` object as a JSON object.
 
-**Kind**: instance method of [<code>Document</code>](#Document)
-<a name="Document.fromKeyPair"></a>
-
-### Document.fromKeyPair(key, network) ⇒ [<code>Document</code>](#Document)
-Creates a new DID Document from the given KeyPair and optional network.
-
-If unspecified, network defaults to the mainnet.
-
-**Kind**: static method of [<code>Document</code>](#Document)
-
-| Param | Type |
-| --- | --- |
-| key | [<code>KeyPair</code>](#KeyPair) |
-| network | <code>string</code> \| <code>undefined</code> |
-
+**Kind**: instance method of [<code>Document</code>](#Document)  
 <a name="Document.fromAuthentication"></a>
 
 ### Document.fromAuthentication(method) ⇒ [<code>Document</code>](#Document)
-Creates a new DID Document from the given verification [`method`][`Method`].
+Creates a new DID Document from the given `VerificationMethod`.
 
-**Kind**: static method of [<code>Document</code>](#Document)
+NOTE: the generated document is unsigned, see Document::sign.
+
+**Kind**: static method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| method | [<code>VerificationMethod</code>](#VerificationMethod) |
+| method | [<code>VerificationMethod</code>](#VerificationMethod) | 
 
 <a name="Document.diffIndex"></a>
 
@@ -1075,29 +1066,29 @@ published on the integration chain.
 
 This is the Base58-btc encoded SHA-256 digest of the hex-encoded message id.
 
-**Kind**: static method of [<code>Document</code>](#Document)
+**Kind**: static method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| message_id | <code>string</code> |
+| message_id | <code>string</code> | 
 
 <a name="Document.fromJSON"></a>
 
 ### Document.fromJSON(json) ⇒ [<code>Document</code>](#Document)
 Deserializes a `Document` object from a JSON object.
 
-**Kind**: static method of [<code>Document</code>](#Document)
+**Kind**: static method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| json | <code>any</code> |
+| json | <code>any</code> | 
 
 <a name="DocumentDiff"></a>
 
 ## DocumentDiff
 Defines the difference between two DID [`Document`]s' JSON representations.
 
-**Kind**: global class
+**Kind**: global class  
 
 * [DocumentDiff](#DocumentDiff)
     * [.did](#DocumentDiff+did) ⇒ [<code>DID</code>](#DID)
@@ -1115,7 +1106,7 @@ Defines the difference between two DID [`Document`]s' JSON representations.
 ### documentDiff.did ⇒ [<code>DID</code>](#DID)
 Returns the DID of the associated DID Document.
 
-**Kind**: instance property of [<code>DocumentDiff</code>](#DocumentDiff)
+**Kind**: instance property of [<code>DocumentDiff</code>](#DocumentDiff)  
 <a name="DocumentDiff+diff"></a>
 
 ### documentDiff.diff ⇒ <code>string</code>
@@ -1123,40 +1114,40 @@ Returns the raw contents of the DID Document diff.
 
 NOTE: clones the data.
 
-**Kind**: instance property of [<code>DocumentDiff</code>](#DocumentDiff)
+**Kind**: instance property of [<code>DocumentDiff</code>](#DocumentDiff)  
 <a name="DocumentDiff+messageId"></a>
 
 ### documentDiff.messageId ⇒ <code>string</code>
 Returns the message_id of the DID Document diff.
 
-**Kind**: instance property of [<code>DocumentDiff</code>](#DocumentDiff)
+**Kind**: instance property of [<code>DocumentDiff</code>](#DocumentDiff)  
 <a name="DocumentDiff+messageId"></a>
 
 ### documentDiff.messageId
 Sets the message_id of the DID Document diff.
 
-**Kind**: instance property of [<code>DocumentDiff</code>](#DocumentDiff)
+**Kind**: instance property of [<code>DocumentDiff</code>](#DocumentDiff)  
 
 | Param | Type |
 | --- | --- |
-| message_id | <code>string</code> |
+| message_id | <code>string</code> | 
 
 <a name="DocumentDiff+previousMessageId"></a>
 
 ### documentDiff.previousMessageId ⇒ <code>string</code>
 Returns the Tangle message id of the previous DID Document diff.
 
-**Kind**: instance property of [<code>DocumentDiff</code>](#DocumentDiff)
+**Kind**: instance property of [<code>DocumentDiff</code>](#DocumentDiff)  
 <a name="DocumentDiff+previousMessageId"></a>
 
 ### documentDiff.previousMessageId
 Sets the Tangle message id of the previous DID Document diff.
 
-**Kind**: instance property of [<code>DocumentDiff</code>](#DocumentDiff)
+**Kind**: instance property of [<code>DocumentDiff</code>](#DocumentDiff)  
 
 | Param | Type |
 | --- | --- |
-| message_id | <code>string</code> |
+| message_id | <code>string</code> | 
 
 <a name="DocumentDiff+proof"></a>
 
@@ -1171,25 +1162,25 @@ Returns the DID of the associated DID Document.
 
 NOTE: clones the data.
 
-**Kind**: instance method of [<code>DocumentDiff</code>](#DocumentDiff)
+**Kind**: instance method of [<code>DocumentDiff</code>](#DocumentDiff)  
 <a name="DocumentDiff+merge"></a>
 
 ### documentDiff.merge(document) ⇒ [<code>Document</code>](#Document)
 Returns a new DID Document which is the result of merging `self`
 with the given Document.
 
-**Kind**: instance method of [<code>DocumentDiff</code>](#DocumentDiff)
+**Kind**: instance method of [<code>DocumentDiff</code>](#DocumentDiff)  
 
 | Param | Type |
 | --- | --- |
-| document | [<code>Document</code>](#Document) |
+| document | [<code>Document</code>](#Document) | 
 
 <a name="DocumentHistory"></a>
 
 ## DocumentHistory
 A DID Document's history and current state.
 
-**Kind**: global class
+**Kind**: global class  
 
 * [DocumentHistory](#DocumentHistory)
     * _instance_
@@ -1208,7 +1199,7 @@ Returns a [`js_sys::Array`] of integration chain [`WasmDocuments`](WasmDocument)
 
 NOTE: clones the data.
 
-**Kind**: instance method of [<code>DocumentHistory</code>](#DocumentHistory)
+**Kind**: instance method of [<code>DocumentHistory</code>](#DocumentHistory)  
 <a name="DocumentHistory+integrationChainSpam"></a>
 
 ### documentHistory.integrationChainSpam() ⇒ <code>Array.&lt;any&gt;</code>
@@ -1217,7 +1208,7 @@ as the integration chain.
 
 NOTE: clones the data.
 
-**Kind**: instance method of [<code>DocumentHistory</code>](#DocumentHistory)
+**Kind**: instance method of [<code>DocumentHistory</code>](#DocumentHistory)  
 <a name="DocumentHistory+diffChainData"></a>
 
 ### documentHistory.diffChainData() ⇒ <code>Array.&lt;any&gt;</code>
@@ -1225,7 +1216,7 @@ Returns a [`js_sys::Array`] of diff chain [`WasmDocumentDiffs`](WasmDocumentDiff
 
 NOTE: clones the data.
 
-**Kind**: instance method of [<code>DocumentHistory</code>](#DocumentHistory)
+**Kind**: instance method of [<code>DocumentHistory</code>](#DocumentHistory)  
 <a name="DocumentHistory+diffChainSpam"></a>
 
 ### documentHistory.diffChainSpam() ⇒ <code>Array.&lt;any&gt;</code>
@@ -1234,28 +1225,28 @@ as the diff chain.
 
 NOTE: clones the data.
 
-**Kind**: instance method of [<code>DocumentHistory</code>](#DocumentHistory)
+**Kind**: instance method of [<code>DocumentHistory</code>](#DocumentHistory)  
 <a name="DocumentHistory+toJSON"></a>
 
 ### documentHistory.toJSON() ⇒ <code>any</code>
 Serializes a [`WasmDocumentHistory`] object as a JSON object.
 
-**Kind**: instance method of [<code>DocumentHistory</code>](#DocumentHistory)
+**Kind**: instance method of [<code>DocumentHistory</code>](#DocumentHistory)  
 <a name="DocumentHistory.fromJSON"></a>
 
 ### DocumentHistory.fromJSON(json) ⇒ [<code>DocumentHistory</code>](#DocumentHistory)
 Deserializes a [`WasmDocumentHistory`] object from a JSON object.
 
-**Kind**: static method of [<code>DocumentHistory</code>](#DocumentHistory)
+**Kind**: static method of [<code>DocumentHistory</code>](#DocumentHistory)  
 
 | Param | Type |
 | --- | --- |
-| json | <code>any</code> |
+| json | <code>any</code> | 
 
 <a name="FeaturesRequest"></a>
 
 ## FeaturesRequest
-**Kind**: global class
+**Kind**: global class  
 
 * [FeaturesRequest](#FeaturesRequest)
     * _instance_
@@ -1266,20 +1257,20 @@ Deserializes a [`WasmDocumentHistory`] object from a JSON object.
 <a name="FeaturesRequest+toJSON"></a>
 
 ### featuresRequest.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>FeaturesRequest</code>](#FeaturesRequest)
+**Kind**: instance method of [<code>FeaturesRequest</code>](#FeaturesRequest)  
 <a name="FeaturesRequest.fromJSON"></a>
 
 ### FeaturesRequest.fromJSON(value) ⇒ [<code>FeaturesRequest</code>](#FeaturesRequest)
-**Kind**: static method of [<code>FeaturesRequest</code>](#FeaturesRequest)
+**Kind**: static method of [<code>FeaturesRequest</code>](#FeaturesRequest)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="FeaturesResponse"></a>
 
 ## FeaturesResponse
-**Kind**: global class
+**Kind**: global class  
 
 * [FeaturesResponse](#FeaturesResponse)
     * _instance_
@@ -1290,20 +1281,20 @@ Deserializes a [`WasmDocumentHistory`] object from a JSON object.
 <a name="FeaturesResponse+toJSON"></a>
 
 ### featuresResponse.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>FeaturesResponse</code>](#FeaturesResponse)
+**Kind**: instance method of [<code>FeaturesResponse</code>](#FeaturesResponse)  
 <a name="FeaturesResponse.fromJSON"></a>
 
 ### FeaturesResponse.fromJSON(value) ⇒ [<code>FeaturesResponse</code>](#FeaturesResponse)
-**Kind**: static method of [<code>FeaturesResponse</code>](#FeaturesResponse)
+**Kind**: static method of [<code>FeaturesResponse</code>](#FeaturesResponse)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="IntegrationChainHistory"></a>
 
 ## IntegrationChainHistory
-**Kind**: global class
+**Kind**: global class  
 
 * [IntegrationChainHistory](#IntegrationChainHistory)
     * _instance_
@@ -1320,7 +1311,7 @@ Returns a [`js_sys::Array`] of `$wasm_ty` as strings.
 
 NOTE: this clones the field.
 
-**Kind**: instance method of [<code>IntegrationChainHistory</code>](#IntegrationChainHistory)
+**Kind**: instance method of [<code>IntegrationChainHistory</code>](#IntegrationChainHistory)  
 <a name="IntegrationChainHistory+spam"></a>
 
 ### integrationChainHistory.spam() ⇒ <code>Array.&lt;any&gt;</code>
@@ -1328,28 +1319,28 @@ Returns a [`js_sys::Array`] of [`MessageIds`][MessageId] as strings.
 
 NOTE: this clones the field.
 
-**Kind**: instance method of [<code>IntegrationChainHistory</code>](#IntegrationChainHistory)
+**Kind**: instance method of [<code>IntegrationChainHistory</code>](#IntegrationChainHistory)  
 <a name="IntegrationChainHistory+toJSON"></a>
 
 ### integrationChainHistory.toJSON() ⇒ <code>any</code>
 Serializes a `$ident` object as a JSON object.
 
-**Kind**: instance method of [<code>IntegrationChainHistory</code>](#IntegrationChainHistory)
+**Kind**: instance method of [<code>IntegrationChainHistory</code>](#IntegrationChainHistory)  
 <a name="IntegrationChainHistory.fromJSON"></a>
 
 ### IntegrationChainHistory.fromJSON(json) ⇒ [<code>IntegrationChainHistory</code>](#IntegrationChainHistory)
 Deserializes a `$ident` object from a JSON object.
 
-**Kind**: static method of [<code>IntegrationChainHistory</code>](#IntegrationChainHistory)
+**Kind**: static method of [<code>IntegrationChainHistory</code>](#IntegrationChainHistory)  
 
 | Param | Type |
 | --- | --- |
-| json | <code>any</code> |
+| json | <code>any</code> | 
 
 <a name="Introduction"></a>
 
 ## Introduction
-**Kind**: global class
+**Kind**: global class  
 
 * [Introduction](#Introduction)
     * _instance_
@@ -1360,20 +1351,20 @@ Deserializes a `$ident` object from a JSON object.
 <a name="Introduction+toJSON"></a>
 
 ### introduction.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>Introduction</code>](#Introduction)
+**Kind**: instance method of [<code>Introduction</code>](#Introduction)  
 <a name="Introduction.fromJSON"></a>
 
 ### Introduction.fromJSON(value) ⇒ [<code>Introduction</code>](#Introduction)
-**Kind**: static method of [<code>Introduction</code>](#Introduction)
+**Kind**: static method of [<code>Introduction</code>](#Introduction)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="IntroductionProposal"></a>
 
 ## IntroductionProposal
-**Kind**: global class
+**Kind**: global class  
 
 * [IntroductionProposal](#IntroductionProposal)
     * _instance_
@@ -1384,20 +1375,20 @@ Deserializes a `$ident` object from a JSON object.
 <a name="IntroductionProposal+toJSON"></a>
 
 ### introductionProposal.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>IntroductionProposal</code>](#IntroductionProposal)
+**Kind**: instance method of [<code>IntroductionProposal</code>](#IntroductionProposal)  
 <a name="IntroductionProposal.fromJSON"></a>
 
 ### IntroductionProposal.fromJSON(value) ⇒ [<code>IntroductionProposal</code>](#IntroductionProposal)
-**Kind**: static method of [<code>IntroductionProposal</code>](#IntroductionProposal)
+**Kind**: static method of [<code>IntroductionProposal</code>](#IntroductionProposal)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="IntroductionResponse"></a>
 
 ## IntroductionResponse
-**Kind**: global class
+**Kind**: global class  
 
 * [IntroductionResponse](#IntroductionResponse)
     * _instance_
@@ -1408,20 +1399,20 @@ Deserializes a `$ident` object from a JSON object.
 <a name="IntroductionResponse+toJSON"></a>
 
 ### introductionResponse.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>IntroductionResponse</code>](#IntroductionResponse)
+**Kind**: instance method of [<code>IntroductionResponse</code>](#IntroductionResponse)  
 <a name="IntroductionResponse.fromJSON"></a>
 
 ### IntroductionResponse.fromJSON(value) ⇒ [<code>IntroductionResponse</code>](#IntroductionResponse)
-**Kind**: static method of [<code>IntroductionResponse</code>](#IntroductionResponse)
+**Kind**: static method of [<code>IntroductionResponse</code>](#IntroductionResponse)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="KeyCollection"></a>
 
 ## KeyCollection
-**Kind**: global class
+**Kind**: global class  
 
 * [KeyCollection](#KeyCollection)
     * [new KeyCollection(type_, count)](#new_KeyCollection_new)
@@ -1445,94 +1436,94 @@ Creates a new `KeyCollection` with the specified key type.
 
 | Param | Type |
 | --- | --- |
-| type_ | <code>number</code> |
-| count | <code>number</code> |
+| type_ | <code>number</code> | 
+| count | <code>number</code> | 
 
 <a name="KeyCollection+length"></a>
 
 ### keyCollection.length ⇒ <code>number</code>
 Returns the number of keys in the collection.
 
-**Kind**: instance property of [<code>KeyCollection</code>](#KeyCollection)
+**Kind**: instance property of [<code>KeyCollection</code>](#KeyCollection)  
 <a name="KeyCollection+isEmpty"></a>
 
 ### keyCollection.isEmpty() ⇒ <code>boolean</code>
 Returns `true` if the collection contains no keys.
 
-**Kind**: instance method of [<code>KeyCollection</code>](#KeyCollection)
+**Kind**: instance method of [<code>KeyCollection</code>](#KeyCollection)  
 <a name="KeyCollection+keypair"></a>
 
 ### keyCollection.keypair(index) ⇒ [<code>KeyPair</code>](#KeyPair) \| <code>undefined</code>
 Returns the keypair at the specified `index`.
 
-**Kind**: instance method of [<code>KeyCollection</code>](#KeyCollection)
+**Kind**: instance method of [<code>KeyCollection</code>](#KeyCollection)  
 
 | Param | Type |
 | --- | --- |
-| index | <code>number</code> |
+| index | <code>number</code> | 
 
 <a name="KeyCollection+public"></a>
 
 ### keyCollection.public(index) ⇒ <code>string</code> \| <code>undefined</code>
 Returns the public key at the specified `index` as a base58-encoded string.
 
-**Kind**: instance method of [<code>KeyCollection</code>](#KeyCollection)
+**Kind**: instance method of [<code>KeyCollection</code>](#KeyCollection)  
 
 | Param | Type |
 | --- | --- |
-| index | <code>number</code> |
+| index | <code>number</code> | 
 
 <a name="KeyCollection+private"></a>
 
 ### keyCollection.private(index) ⇒ <code>string</code> \| <code>undefined</code>
 Returns the private key at the specified `index` as a base58-encoded string.
 
-**Kind**: instance method of [<code>KeyCollection</code>](#KeyCollection)
+**Kind**: instance method of [<code>KeyCollection</code>](#KeyCollection)  
 
 | Param | Type |
 | --- | --- |
-| index | <code>number</code> |
+| index | <code>number</code> | 
 
 <a name="KeyCollection+merkleRoot"></a>
 
 ### keyCollection.merkleRoot(digest) ⇒ <code>string</code>
-**Kind**: instance method of [<code>KeyCollection</code>](#KeyCollection)
+**Kind**: instance method of [<code>KeyCollection</code>](#KeyCollection)  
 
 | Param | Type |
 | --- | --- |
-| digest | <code>number</code> |
+| digest | <code>number</code> | 
 
 <a name="KeyCollection+merkleProof"></a>
 
 ### keyCollection.merkleProof(digest, index) ⇒ <code>string</code> \| <code>undefined</code>
-**Kind**: instance method of [<code>KeyCollection</code>](#KeyCollection)
+**Kind**: instance method of [<code>KeyCollection</code>](#KeyCollection)  
 
 | Param | Type |
 | --- | --- |
-| digest | <code>number</code> |
-| index | <code>number</code> |
+| digest | <code>number</code> | 
+| index | <code>number</code> | 
 
 <a name="KeyCollection+toJSON"></a>
 
 ### keyCollection.toJSON() ⇒ <code>any</code>
 Serializes a `KeyCollection` object as a JSON object.
 
-**Kind**: instance method of [<code>KeyCollection</code>](#KeyCollection)
+**Kind**: instance method of [<code>KeyCollection</code>](#KeyCollection)  
 <a name="KeyCollection.fromJSON"></a>
 
 ### KeyCollection.fromJSON(json) ⇒ [<code>KeyCollection</code>](#KeyCollection)
 Deserializes a `KeyCollection` object from a JSON object.
 
-**Kind**: static method of [<code>KeyCollection</code>](#KeyCollection)
+**Kind**: static method of [<code>KeyCollection</code>](#KeyCollection)  
 
 | Param | Type |
 | --- | --- |
-| json | <code>any</code> |
+| json | <code>any</code> | 
 
 <a name="KeyPair"></a>
 
 ## KeyPair
-**Kind**: global class
+**Kind**: global class  
 
 * [KeyPair](#KeyPair)
     * [new KeyPair(type_)](#new_KeyPair_new)
@@ -1552,54 +1543,54 @@ Generates a new `KeyPair` object.
 
 | Param | Type |
 | --- | --- |
-| type_ | <code>number</code> |
+| type_ | <code>number</code> | 
 
 <a name="KeyPair+public"></a>
 
 ### keyPair.public ⇒ <code>string</code>
 Returns the public key as a base58-encoded string.
 
-**Kind**: instance property of [<code>KeyPair</code>](#KeyPair)
+**Kind**: instance property of [<code>KeyPair</code>](#KeyPair)  
 <a name="KeyPair+private"></a>
 
 ### keyPair.private ⇒ <code>string</code>
 Returns the private key as a base58-encoded string.
 
-**Kind**: instance property of [<code>KeyPair</code>](#KeyPair)
+**Kind**: instance property of [<code>KeyPair</code>](#KeyPair)  
 <a name="KeyPair+toJSON"></a>
 
 ### keyPair.toJSON() ⇒ <code>any</code>
 Serializes a `KeyPair` object as a JSON object.
 
-**Kind**: instance method of [<code>KeyPair</code>](#KeyPair)
+**Kind**: instance method of [<code>KeyPair</code>](#KeyPair)  
 <a name="KeyPair.fromBase58"></a>
 
 ### KeyPair.fromBase58(type_, public_key, private_key) ⇒ [<code>KeyPair</code>](#KeyPair)
 Parses a `KeyPair` object from base58-encoded public/private keys.
 
-**Kind**: static method of [<code>KeyPair</code>](#KeyPair)
+**Kind**: static method of [<code>KeyPair</code>](#KeyPair)  
 
 | Param | Type |
 | --- | --- |
-| type_ | <code>number</code> |
-| public_key | <code>string</code> |
-| private_key | <code>string</code> |
+| type_ | <code>number</code> | 
+| public_key | <code>string</code> | 
+| private_key | <code>string</code> | 
 
 <a name="KeyPair.fromJSON"></a>
 
 ### KeyPair.fromJSON(json) ⇒ [<code>KeyPair</code>](#KeyPair)
 Deserializes a `KeyPair` object from a JSON object.
 
-**Kind**: static method of [<code>KeyPair</code>](#KeyPair)
+**Kind**: static method of [<code>KeyPair</code>](#KeyPair)  
 
 | Param | Type |
 | --- | --- |
-| json | <code>any</code> |
+| json | <code>any</code> | 
 
 <a name="Network"></a>
 
 ## Network
-**Kind**: global class
+**Kind**: global class  
 
 * [Network](#Network)
     * _instance_
@@ -1617,68 +1608,51 @@ Deserializes a `KeyPair` object from a JSON object.
 ### network.defaultNodeURL ⇒ <code>string</code> \| <code>undefined</code>
 Returns the node URL of the Tangle network.
 
-**Kind**: instance property of [<code>Network</code>](#Network)
+**Kind**: instance property of [<code>Network</code>](#Network)  
 <a name="Network+explorerURL"></a>
 
 ### network.explorerURL ⇒ <code>string</code> \| <code>undefined</code>
 Returns the web explorer URL of the Tangle network.
 
-**Kind**: instance property of [<code>Network</code>](#Network)
+**Kind**: instance property of [<code>Network</code>](#Network)  
 <a name="Network+messageURL"></a>
 
 ### network.messageURL(message_id) ⇒ <code>string</code>
 Returns the web explorer URL of the given `message`.
 
-**Kind**: instance method of [<code>Network</code>](#Network)
+**Kind**: instance method of [<code>Network</code>](#Network)  
 
 | Param | Type |
 | --- | --- |
-| message_id | <code>string</code> |
+| message_id | <code>string</code> | 
 
 <a name="Network+toString"></a>
 
 ### network.toString() ⇒ <code>string</code>
-**Kind**: instance method of [<code>Network</code>](#Network)
+**Kind**: instance method of [<code>Network</code>](#Network)  
 <a name="Network.try_from_name"></a>
 
 ### Network.try\_from\_name(name) ⇒ [<code>Network</code>](#Network)
 Parses the provided string to a [`WasmNetwork`].
 
-**Kind**: static method of [<code>Network</code>](#Network)
+**Kind**: static method of [<code>Network</code>](#Network)  
 
 | Param | Type |
 | --- | --- |
-| name | <code>string</code> |
+| name | <code>string</code> | 
 
 <a name="Network.mainnet"></a>
 
 ### Network.mainnet() ⇒ [<code>Network</code>](#Network)
-**Kind**: static method of [<code>Network</code>](#Network)
+**Kind**: static method of [<code>Network</code>](#Network)  
 <a name="Network.devnet"></a>
 
 ### Network.devnet() ⇒ [<code>Network</code>](#Network)
-**Kind**: static method of [<code>Network</code>](#Network)
-<a name="NewDocument"></a>
-
-## NewDocument
-**Kind**: global class
-
-* [NewDocument](#NewDocument)
-    * [.key](#NewDocument+key) ⇒ [<code>KeyPair</code>](#KeyPair)
-    * [.doc](#NewDocument+doc) ⇒ [<code>Document</code>](#Document)
-
-<a name="NewDocument+key"></a>
-
-### newDocument.key ⇒ [<code>KeyPair</code>](#KeyPair)
-**Kind**: instance property of [<code>NewDocument</code>](#NewDocument)
-<a name="NewDocument+doc"></a>
-
-### newDocument.doc ⇒ [<code>Document</code>](#Document)
-**Kind**: instance property of [<code>NewDocument</code>](#NewDocument)
+**Kind**: static method of [<code>Network</code>](#Network)  
 <a name="PresentationRequest"></a>
 
 ## PresentationRequest
-**Kind**: global class
+**Kind**: global class  
 
 * [PresentationRequest](#PresentationRequest)
     * _instance_
@@ -1689,20 +1663,20 @@ Parses the provided string to a [`WasmNetwork`].
 <a name="PresentationRequest+toJSON"></a>
 
 ### presentationRequest.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>PresentationRequest</code>](#PresentationRequest)
+**Kind**: instance method of [<code>PresentationRequest</code>](#PresentationRequest)  
 <a name="PresentationRequest.fromJSON"></a>
 
 ### PresentationRequest.fromJSON(value) ⇒ [<code>PresentationRequest</code>](#PresentationRequest)
-**Kind**: static method of [<code>PresentationRequest</code>](#PresentationRequest)
+**Kind**: static method of [<code>PresentationRequest</code>](#PresentationRequest)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="PresentationResponse"></a>
 
 ## PresentationResponse
-**Kind**: global class
+**Kind**: global class  
 
 * [PresentationResponse](#PresentationResponse)
     * _instance_
@@ -1713,20 +1687,20 @@ Parses the provided string to a [`WasmNetwork`].
 <a name="PresentationResponse+toJSON"></a>
 
 ### presentationResponse.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>PresentationResponse</code>](#PresentationResponse)
+**Kind**: instance method of [<code>PresentationResponse</code>](#PresentationResponse)  
 <a name="PresentationResponse.fromJSON"></a>
 
 ### PresentationResponse.fromJSON(value) ⇒ [<code>PresentationResponse</code>](#PresentationResponse)
-**Kind**: static method of [<code>PresentationResponse</code>](#PresentationResponse)
+**Kind**: static method of [<code>PresentationResponse</code>](#PresentationResponse)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="ResolutionRequest"></a>
 
 ## ResolutionRequest
-**Kind**: global class
+**Kind**: global class  
 
 * [ResolutionRequest](#ResolutionRequest)
     * _instance_
@@ -1737,20 +1711,20 @@ Parses the provided string to a [`WasmNetwork`].
 <a name="ResolutionRequest+toJSON"></a>
 
 ### resolutionRequest.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>ResolutionRequest</code>](#ResolutionRequest)
+**Kind**: instance method of [<code>ResolutionRequest</code>](#ResolutionRequest)  
 <a name="ResolutionRequest.fromJSON"></a>
 
 ### ResolutionRequest.fromJSON(value) ⇒ [<code>ResolutionRequest</code>](#ResolutionRequest)
-**Kind**: static method of [<code>ResolutionRequest</code>](#ResolutionRequest)
+**Kind**: static method of [<code>ResolutionRequest</code>](#ResolutionRequest)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="ResolutionResponse"></a>
 
 ## ResolutionResponse
-**Kind**: global class
+**Kind**: global class  
 
 * [ResolutionResponse](#ResolutionResponse)
     * _instance_
@@ -1761,20 +1735,20 @@ Parses the provided string to a [`WasmNetwork`].
 <a name="ResolutionResponse+toJSON"></a>
 
 ### resolutionResponse.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>ResolutionResponse</code>](#ResolutionResponse)
+**Kind**: instance method of [<code>ResolutionResponse</code>](#ResolutionResponse)  
 <a name="ResolutionResponse.fromJSON"></a>
 
 ### ResolutionResponse.fromJSON(value) ⇒ [<code>ResolutionResponse</code>](#ResolutionResponse)
-**Kind**: static method of [<code>ResolutionResponse</code>](#ResolutionResponse)
+**Kind**: static method of [<code>ResolutionResponse</code>](#ResolutionResponse)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="Service"></a>
 
 ## Service
-**Kind**: global class
+**Kind**: global class  
 
 * [Service](#Service)
     * _instance_
@@ -1787,22 +1761,22 @@ Parses the provided string to a [`WasmNetwork`].
 ### service.toJSON() ⇒ <code>any</code>
 Serializes a `Service` object as a JSON object.
 
-**Kind**: instance method of [<code>Service</code>](#Service)
+**Kind**: instance method of [<code>Service</code>](#Service)  
 <a name="Service.fromJSON"></a>
 
 ### Service.fromJSON(value) ⇒ [<code>Service</code>](#Service)
 Deserializes a `Service` object from a JSON object.
 
-**Kind**: static method of [<code>Service</code>](#Service)
+**Kind**: static method of [<code>Service</code>](#Service)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="Timestamp"></a>
 
 ## Timestamp
-**Kind**: global class
+**Kind**: global class  
 
 * [Timestamp](#Timestamp)
     * _instance_
@@ -1816,28 +1790,28 @@ Deserializes a `Service` object from a JSON object.
 ### timestamp.toRFC3339() ⇒ <code>string</code>
 Returns the `Timestamp` as an RFC 3339 `String`.
 
-**Kind**: instance method of [<code>Timestamp</code>](#Timestamp)
+**Kind**: instance method of [<code>Timestamp</code>](#Timestamp)  
 <a name="Timestamp.parse"></a>
 
 ### Timestamp.parse(input) ⇒ [<code>Timestamp</code>](#Timestamp)
 Parses a `Timestamp` from the provided input string.
 
-**Kind**: static method of [<code>Timestamp</code>](#Timestamp)
+**Kind**: static method of [<code>Timestamp</code>](#Timestamp)  
 
 | Param | Type |
 | --- | --- |
-| input | <code>string</code> |
+| input | <code>string</code> | 
 
 <a name="Timestamp.nowUTC"></a>
 
 ### Timestamp.nowUTC() ⇒ [<code>Timestamp</code>](#Timestamp)
 Creates a new `Timestamp` with the current date and time.
 
-**Kind**: static method of [<code>Timestamp</code>](#Timestamp)
+**Kind**: static method of [<code>Timestamp</code>](#Timestamp)  
 <a name="Timing"></a>
 
 ## Timing
-**Kind**: global class
+**Kind**: global class  
 
 * [Timing](#Timing)
     * _instance_
@@ -1860,98 +1834,98 @@ Creates a new `Timestamp` with the current date and time.
 <a name="Timing+outTime"></a>
 
 ### timing.outTime ⇒ <code>string</code> \| <code>undefined</code>
-**Kind**: instance property of [<code>Timing</code>](#Timing)
+**Kind**: instance property of [<code>Timing</code>](#Timing)  
 <a name="Timing+outTime"></a>
 
 ### timing.outTime
-**Kind**: instance property of [<code>Timing</code>](#Timing)
+**Kind**: instance property of [<code>Timing</code>](#Timing)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>string</code> |
+| value | <code>string</code> | 
 
 <a name="Timing+inTime"></a>
 
 ### timing.inTime ⇒ <code>string</code> \| <code>undefined</code>
-**Kind**: instance property of [<code>Timing</code>](#Timing)
+**Kind**: instance property of [<code>Timing</code>](#Timing)  
 <a name="Timing+inTime"></a>
 
 ### timing.inTime
-**Kind**: instance property of [<code>Timing</code>](#Timing)
+**Kind**: instance property of [<code>Timing</code>](#Timing)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>string</code> |
+| value | <code>string</code> | 
 
 <a name="Timing+staleTime"></a>
 
 ### timing.staleTime ⇒ <code>string</code> \| <code>undefined</code>
-**Kind**: instance property of [<code>Timing</code>](#Timing)
+**Kind**: instance property of [<code>Timing</code>](#Timing)  
 <a name="Timing+staleTime"></a>
 
 ### timing.staleTime
-**Kind**: instance property of [<code>Timing</code>](#Timing)
+**Kind**: instance property of [<code>Timing</code>](#Timing)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>string</code> |
+| value | <code>string</code> | 
 
 <a name="Timing+expiresTime"></a>
 
 ### timing.expiresTime ⇒ <code>string</code> \| <code>undefined</code>
-**Kind**: instance property of [<code>Timing</code>](#Timing)
+**Kind**: instance property of [<code>Timing</code>](#Timing)  
 <a name="Timing+expiresTime"></a>
 
 ### timing.expiresTime
-**Kind**: instance property of [<code>Timing</code>](#Timing)
+**Kind**: instance property of [<code>Timing</code>](#Timing)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>string</code> |
+| value | <code>string</code> | 
 
 <a name="Timing+waitUntilTime"></a>
 
 ### timing.waitUntilTime ⇒ <code>string</code> \| <code>undefined</code>
-**Kind**: instance property of [<code>Timing</code>](#Timing)
+**Kind**: instance property of [<code>Timing</code>](#Timing)  
 <a name="Timing+waitUntilTime"></a>
 
 ### timing.waitUntilTime
-**Kind**: instance property of [<code>Timing</code>](#Timing)
+**Kind**: instance property of [<code>Timing</code>](#Timing)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>string</code> |
+| value | <code>string</code> | 
 
 <a name="Timing+delayMilli"></a>
 
 ### timing.delayMilli ⇒ <code>number</code> \| <code>undefined</code>
-**Kind**: instance property of [<code>Timing</code>](#Timing)
+**Kind**: instance property of [<code>Timing</code>](#Timing)  
 <a name="Timing+delayMilli"></a>
 
 ### timing.delayMilli
-**Kind**: instance property of [<code>Timing</code>](#Timing)
+**Kind**: instance property of [<code>Timing</code>](#Timing)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>number</code> |
+| value | <code>number</code> | 
 
 <a name="Timing+toJSON"></a>
 
 ### timing.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>Timing</code>](#Timing)
+**Kind**: instance method of [<code>Timing</code>](#Timing)  
 <a name="Timing.fromJSON"></a>
 
 ### Timing.fromJSON(value) ⇒ [<code>Timing</code>](#Timing)
-**Kind**: static method of [<code>Timing</code>](#Timing)
+**Kind**: static method of [<code>Timing</code>](#Timing)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="TrustPing"></a>
 
 ## TrustPing
-**Kind**: global class
+**Kind**: global class  
 
 * [TrustPing](#TrustPing)
     * _instance_
@@ -1962,20 +1936,20 @@ Creates a new `Timestamp` with the current date and time.
 <a name="TrustPing+toJSON"></a>
 
 ### trustPing.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>TrustPing</code>](#TrustPing)
+**Kind**: instance method of [<code>TrustPing</code>](#TrustPing)  
 <a name="TrustPing.fromJSON"></a>
 
 ### TrustPing.fromJSON(value) ⇒ [<code>TrustPing</code>](#TrustPing)
-**Kind**: static method of [<code>TrustPing</code>](#TrustPing)
+**Kind**: static method of [<code>TrustPing</code>](#TrustPing)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="TrustedIssuer"></a>
 
 ## TrustedIssuer
-**Kind**: global class
+**Kind**: global class  
 
 * [TrustedIssuer](#TrustedIssuer)
     * _instance_
@@ -1986,20 +1960,20 @@ Creates a new `Timestamp` with the current date and time.
 <a name="TrustedIssuer+toJSON"></a>
 
 ### trustedIssuer.toJSON() ⇒ <code>any</code>
-**Kind**: instance method of [<code>TrustedIssuer</code>](#TrustedIssuer)
+**Kind**: instance method of [<code>TrustedIssuer</code>](#TrustedIssuer)  
 <a name="TrustedIssuer.fromJSON"></a>
 
 ### TrustedIssuer.fromJSON(value) ⇒ [<code>TrustedIssuer</code>](#TrustedIssuer)
-**Kind**: static method of [<code>TrustedIssuer</code>](#TrustedIssuer)
+**Kind**: static method of [<code>TrustedIssuer</code>](#TrustedIssuer)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="VerifiableCredential"></a>
 
 ## VerifiableCredential
-**Kind**: global class
+**Kind**: global class  
 
 * [VerifiableCredential](#VerifiableCredential)
     * _instance_
@@ -2014,43 +1988,43 @@ Creates a new `Timestamp` with the current date and time.
 ### verifiableCredential.toJSON() ⇒ <code>any</code>
 Serializes a `VerifiableCredential` object as a JSON object.
 
-**Kind**: instance method of [<code>VerifiableCredential</code>](#VerifiableCredential)
+**Kind**: instance method of [<code>VerifiableCredential</code>](#VerifiableCredential)  
 <a name="VerifiableCredential.extend"></a>
 
 ### VerifiableCredential.extend(value) ⇒ [<code>VerifiableCredential</code>](#VerifiableCredential)
-**Kind**: static method of [<code>VerifiableCredential</code>](#VerifiableCredential)
+**Kind**: static method of [<code>VerifiableCredential</code>](#VerifiableCredential)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="VerifiableCredential.issue"></a>
 
 ### VerifiableCredential.issue(issuer_doc, subject_data, credential_type, credential_id) ⇒ [<code>VerifiableCredential</code>](#VerifiableCredential)
-**Kind**: static method of [<code>VerifiableCredential</code>](#VerifiableCredential)
+**Kind**: static method of [<code>VerifiableCredential</code>](#VerifiableCredential)  
 
 | Param | Type |
 | --- | --- |
-| issuer_doc | [<code>Document</code>](#Document) |
-| subject_data | <code>any</code> |
-| credential_type | <code>string</code> \| <code>undefined</code> |
-| credential_id | <code>string</code> \| <code>undefined</code> |
+| issuer_doc | [<code>Document</code>](#Document) | 
+| subject_data | <code>any</code> | 
+| credential_type | <code>string</code> \| <code>undefined</code> | 
+| credential_id | <code>string</code> \| <code>undefined</code> | 
 
 <a name="VerifiableCredential.fromJSON"></a>
 
 ### VerifiableCredential.fromJSON(json) ⇒ [<code>VerifiableCredential</code>](#VerifiableCredential)
 Deserializes a `VerifiableCredential` object from a JSON object.
 
-**Kind**: static method of [<code>VerifiableCredential</code>](#VerifiableCredential)
+**Kind**: static method of [<code>VerifiableCredential</code>](#VerifiableCredential)  
 
 | Param | Type |
 | --- | --- |
-| json | <code>any</code> |
+| json | <code>any</code> | 
 
 <a name="VerifiablePresentation"></a>
 
 ## VerifiablePresentation
-**Kind**: global class
+**Kind**: global class  
 
 * [VerifiablePresentation](#VerifiablePresentation)
     * [new VerifiablePresentation(holder_doc, credential_data, presentation_type, presentation_id)](#new_VerifiablePresentation_new)
@@ -2065,32 +2039,32 @@ Deserializes a `VerifiableCredential` object from a JSON object.
 
 | Param | Type |
 | --- | --- |
-| holder_doc | [<code>Document</code>](#Document) |
-| credential_data | <code>any</code> |
-| presentation_type | <code>string</code> \| <code>undefined</code> |
-| presentation_id | <code>string</code> \| <code>undefined</code> |
+| holder_doc | [<code>Document</code>](#Document) | 
+| credential_data | <code>any</code> | 
+| presentation_type | <code>string</code> \| <code>undefined</code> | 
+| presentation_id | <code>string</code> \| <code>undefined</code> | 
 
 <a name="VerifiablePresentation+toJSON"></a>
 
 ### verifiablePresentation.toJSON() ⇒ <code>any</code>
 Serializes a `VerifiablePresentation` object as a JSON object.
 
-**Kind**: instance method of [<code>VerifiablePresentation</code>](#VerifiablePresentation)
+**Kind**: instance method of [<code>VerifiablePresentation</code>](#VerifiablePresentation)  
 <a name="VerifiablePresentation.fromJSON"></a>
 
 ### VerifiablePresentation.fromJSON(json) ⇒ [<code>VerifiablePresentation</code>](#VerifiablePresentation)
 Deserializes a `VerifiablePresentation` object from a JSON object.
 
-**Kind**: static method of [<code>VerifiablePresentation</code>](#VerifiablePresentation)
+**Kind**: static method of [<code>VerifiablePresentation</code>](#VerifiablePresentation)  
 
 | Param | Type |
 | --- | --- |
-| json | <code>any</code> |
+| json | <code>any</code> | 
 
 <a name="VerificationMethod"></a>
 
 ## VerificationMethod
-**Kind**: global class
+**Kind**: global class  
 
 * [VerificationMethod](#VerificationMethod)
     * [new VerificationMethod(key, tag)](#new_VerificationMethod_new)
@@ -2113,88 +2087,88 @@ Creates a new `VerificationMethod` object from the given `key`.
 
 | Param | Type |
 | --- | --- |
-| key | [<code>KeyPair</code>](#KeyPair) |
-| tag | <code>string</code> \| <code>undefined</code> |
+| key | [<code>KeyPair</code>](#KeyPair) | 
+| tag | <code>string</code> \| <code>undefined</code> | 
 
 <a name="VerificationMethod+id"></a>
 
 ### verificationMethod.id ⇒ [<code>DID</code>](#DID)
 Returns the `id` DID of the `VerificationMethod` object.
 
-**Kind**: instance property of [<code>VerificationMethod</code>](#VerificationMethod)
+**Kind**: instance property of [<code>VerificationMethod</code>](#VerificationMethod)  
 <a name="VerificationMethod+controller"></a>
 
 ### verificationMethod.controller ⇒ [<code>DID</code>](#DID)
 Returns the `controller` DID of the `VerificationMethod` object.
 
-**Kind**: instance property of [<code>VerificationMethod</code>](#VerificationMethod)
+**Kind**: instance property of [<code>VerificationMethod</code>](#VerificationMethod)  
 <a name="VerificationMethod+type"></a>
 
 ### verificationMethod.type ⇒ <code>string</code>
 Returns the `VerificationMethod` type.
 
-**Kind**: instance property of [<code>VerificationMethod</code>](#VerificationMethod)
+**Kind**: instance property of [<code>VerificationMethod</code>](#VerificationMethod)  
 <a name="VerificationMethod+data"></a>
 
 ### verificationMethod.data ⇒ <code>any</code>
 Returns the `VerificationMethod` public key data.
 
-**Kind**: instance property of [<code>VerificationMethod</code>](#VerificationMethod)
+**Kind**: instance property of [<code>VerificationMethod</code>](#VerificationMethod)  
 <a name="VerificationMethod+toJSON"></a>
 
 ### verificationMethod.toJSON() ⇒ <code>any</code>
 Serializes a `VerificationMethod` object as a JSON object.
 
-**Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)
+**Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)  
 <a name="VerificationMethod.fromDID"></a>
 
 ### VerificationMethod.fromDID(did, key, tag) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
 Creates a new `VerificationMethod` object from the given `did` and `key`.
 
-**Kind**: static method of [<code>VerificationMethod</code>](#VerificationMethod)
+**Kind**: static method of [<code>VerificationMethod</code>](#VerificationMethod)  
 
 | Param | Type |
 | --- | --- |
-| did | [<code>DID</code>](#DID) |
-| key | [<code>KeyPair</code>](#KeyPair) |
-| tag | <code>string</code> \| <code>undefined</code> |
+| did | [<code>DID</code>](#DID) | 
+| key | [<code>KeyPair</code>](#KeyPair) | 
+| tag | <code>string</code> \| <code>undefined</code> | 
 
 <a name="VerificationMethod.createMerkleKey"></a>
 
 ### VerificationMethod.createMerkleKey(digest, did, keys, tag) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
 Creates a new Merkle Key Collection Method from the given key collection.
 
-**Kind**: static method of [<code>VerificationMethod</code>](#VerificationMethod)
+**Kind**: static method of [<code>VerificationMethod</code>](#VerificationMethod)  
 
 | Param | Type |
 | --- | --- |
-| digest | <code>number</code> |
-| did | [<code>DID</code>](#DID) |
-| keys | [<code>KeyCollection</code>](#KeyCollection) |
-| tag | <code>string</code> \| <code>undefined</code> |
+| digest | <code>number</code> | 
+| did | [<code>DID</code>](#DID) | 
+| keys | [<code>KeyCollection</code>](#KeyCollection) | 
+| tag | <code>string</code> \| <code>undefined</code> | 
 
 <a name="VerificationMethod.fromJSON"></a>
 
 ### VerificationMethod.fromJSON(value) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
 Deserializes a `VerificationMethod` object from a JSON object.
 
-**Kind**: static method of [<code>VerificationMethod</code>](#VerificationMethod)
+**Kind**: static method of [<code>VerificationMethod</code>](#VerificationMethod)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> |
+| value | <code>any</code> | 
 
 <a name="Digest"></a>
 
 ## Digest
-**Kind**: global variable
+**Kind**: global variable  
 <a name="KeyType"></a>
 
 ## KeyType
-**Kind**: global variable
+**Kind**: global variable  
 <a name="start"></a>
 
 ## start()
 Initializes the console error panic hook for better error messages
 
-**Kind**: global function
+**Kind**: global function  

--- a/bindings/wasm/examples/src/create_did.js
+++ b/bindings/wasm/examples/src/create_did.js
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { Client, Config, Document, KeyType } from '@iota/identity-wasm';
+import { Client, Config, Document, KeyPair, KeyType } from '@iota/identity-wasm';
 import { logExplorerUrl } from './utils';
 
 /**
@@ -13,9 +13,11 @@ import { logExplorerUrl } from './utils';
     @param {{defaultNodeURL: string, explorerURL: string, network: Network}} clientConfig
 **/
 async function createIdentity(clientConfig) {
+    // Generate a new ed25519 public/private key pair.
+    const key = new KeyPair(KeyType.Ed25519);
 
-    // Create a DID Document (an identity).
-    const { doc, key } = new Document(KeyType.Ed25519, clientConfig.network.toString());
+    // Create a DID Document (an identity) from the generated key pair.
+    const doc = new Document(key, clientConfig.network.toString());
 
     // Sign the DID Document with the generated key.
     doc.sign(key);

--- a/bindings/wasm/examples/src/create_vp.js
+++ b/bindings/wasm/examples/src/create_vp.js
@@ -26,7 +26,7 @@ async function createVP(clientConfig) {
     const unsignedVp = new VerifiablePresentation(alice.doc, signedVc.toJSON())
 
     const signedVp = alice.doc.signPresentation(unsignedVp, {
-        method: "#key",
+        method: "#authentication",
         private: alice.key.private,
     })
 

--- a/bindings/wasm/examples/src/private_tangle.js
+++ b/bindings/wasm/examples/src/private_tangle.js
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { Client, Config, Document, KeyType, Network } from '@iota/identity-wasm';
+import {Client, Config, Document, KeyPair, KeyType, Network} from '@iota/identity-wasm';
 
 /**
     This example shows how a DID document can be created on a private tangle.
@@ -15,8 +15,12 @@ async function createIdentityPrivateTangle(restURL, networkName) {
     // but we can only use 6 characters, we use just `tangle`.
     const network = Network.try_from_name(networkName || "tangle");
 
-    // Create a DID Document (an identity).
-    const { doc, key } = new Document(KeyType.Ed25519, network.toString());
+    // Generate a new ed25519 public/private key pair.
+    const key = new KeyPair(KeyType.Ed25519);
+
+    // Create a DID with the network set explicitly.
+    // This will result in a DID prefixed by `did:iota:tangle`.
+    const doc = new Document(key, network.toString());
 
     // Sign the DID Document with the generated key.
     doc.sign(key);

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -12,11 +12,11 @@ use identity::crypto::PrivateKey;
 use identity::crypto::PublicKey;
 use identity::did::verifiable;
 use identity::did::MethodScope;
-use identity::iota::Error;
 use identity::iota::IotaDocument;
 use identity::iota::IotaVerificationMethod;
 use identity::iota::MessageId;
 use identity::iota::TangleRef;
+use identity::iota::{Error, NetworkName};
 use wasm_bindgen::prelude::*;
 
 use crate::common::WasmTimestamp;
@@ -54,7 +54,8 @@ impl WasmDocument {
   /// * fragment: name of the initial verification method, default "authentication".
   #[wasm_bindgen(constructor)]
   pub fn new(keypair: &KeyPair, network: Option<String>, fragment: Option<String>) -> Result<WasmDocument> {
-    IotaDocument::new_with_options(&keypair.0, network.as_deref(), fragment.as_deref())
+    let network_name = network.map(NetworkName::try_from).transpose().wasm_result()?;
+    IotaDocument::new_with_options(&keypair.0, network_name, fragment.as_deref())
       .map(Self)
       .wasm_result()
   }

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -37,17 +37,24 @@ pub struct WasmDocument(pub(crate) IotaDocument);
 
 #[wasm_bindgen(js_class = Document)]
 impl WasmDocument {
-  /// Creates a new DID Document from the given `KeyPair` and network, defaulting to
-  /// `Network::Mainnet` if unspecified.
+  /// Creates a new DID Document from the given `KeyPair`, network, and verification method
+  /// fragment name.
   ///
-  /// The DID Document will be pre-populated with a single authentication verification method
-  /// derived from the provided `KeyPair`. This method will have the DID URL fragment
-  /// `#authentication` and can be easily retrieved with `Document::authentication`.
+  /// The DID Document will be pre-populated with a single verification method
+  /// derived from the provided `KeyPair`, with an attached authentication relationship.
+  /// This method will have the DID URL fragment `#authentication` by default and can be easily
+  /// retrieved with `Document::authentication`.
   ///
   /// NOTE: the generated document is unsigned, see `Document::sign`.
+  ///
+  /// Arguments:
+  ///
+  /// * keypair: the initial verification method is derived from the public key with this keypair.
+  /// * network: Tangle network to use for the DID, default `Network::mainnet`.
+  /// * fragment: name of the initial verification method, default "authentication".
   #[wasm_bindgen(constructor)]
-  pub fn new(keypair: &KeyPair, network: Option<String>) -> Result<WasmDocument> {
-    IotaDocument::new(&keypair.0, network.as_deref())
+  pub fn new(keypair: &KeyPair, network: Option<String>, fragment: Option<String>) -> Result<WasmDocument> {
+    IotaDocument::new_with_options(&keypair.0, network.as_deref(), fragment.as_deref())
       .map(Self)
       .wasm_result()
   }

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -13,7 +13,6 @@ use identity::crypto::PublicKey;
 use identity::did::verifiable;
 use identity::did::MethodScope;
 use identity::iota::Error;
-use identity::iota::IotaDID;
 use identity::iota::IotaDocument;
 use identity::iota::IotaVerificationMethod;
 use identity::iota::MessageId;
@@ -24,30 +23,10 @@ use crate::common::WasmTimestamp;
 use crate::credential::VerifiableCredential;
 use crate::credential::VerifiablePresentation;
 use crate::crypto::KeyPair;
-use crate::crypto::KeyType;
 use crate::did::WasmVerificationMethod;
 use crate::did::{WasmDID, WasmDocumentDiff};
 use crate::error::{Result, WasmResult};
 use crate::service::Service;
-
-#[wasm_bindgen(inspectable)]
-pub struct NewDocument {
-  key: KeyPair,
-  doc: WasmDocument,
-}
-
-#[wasm_bindgen]
-impl NewDocument {
-  #[wasm_bindgen(getter)]
-  pub fn key(&self) -> KeyPair {
-    self.key.clone()
-  }
-
-  #[wasm_bindgen(getter)]
-  pub fn doc(&self) -> WasmDocument {
-    self.doc.clone()
-  }
-}
 
 // =============================================================================
 // =============================================================================
@@ -58,42 +37,24 @@ pub struct WasmDocument(pub(crate) IotaDocument);
 
 #[wasm_bindgen(js_class = Document)]
 impl WasmDocument {
-  /// Creates a new DID Document from the given KeyPair.
-  #[wasm_bindgen(constructor)]
-  #[allow(clippy::new_ret_no_self)]
-  pub fn new(type_: KeyType, network: Option<String>, tag: Option<String>) -> Result<NewDocument> {
-    let keypair: KeyPair = KeyPair::new(type_)?;
-    let public: &PublicKey = keypair.0.public();
-
-    let did: IotaDID = if let Some(network) = network.as_deref() {
-      IotaDID::new_with_network(public.as_ref(), network).wasm_result()?
-    } else {
-      IotaDID::new(public.as_ref()).wasm_result()?
-    };
-
-    let method: IotaVerificationMethod =
-      IotaVerificationMethod::from_did(did, &keypair.0, tag.as_deref()).wasm_result()?;
-    let document: IotaDocument = IotaDocument::from_authentication(method).wasm_result()?;
-
-    Ok(NewDocument {
-      key: keypair,
-      doc: Self(document),
-    })
-  }
-
-  /// Creates a new DID Document from the given KeyPair and optional network.
+  /// Creates a new DID Document from the given `KeyPair` and network, defaulting to
+  /// `Network::Mainnet` if unspecified.
   ///
-  /// If unspecified, network defaults to the mainnet.
-  #[wasm_bindgen(js_name = fromKeyPair)]
-  pub fn from_keypair(key: &KeyPair, network: Option<String>) -> Result<WasmDocument> {
-    let doc = match network {
-      Some(net) => IotaDocument::from_keypair_with_network(&key.0, &net),
-      None => IotaDocument::from_keypair(&key.0),
-    };
-    doc.map(Self).wasm_result()
+  /// The DID Document will be pre-populated with a single authentication verification method
+  /// derived from the provided `KeyPair`. This method will have the DID URL fragment
+  /// `#authentication` and can be easily retrieved with `Document::authentication`.
+  ///
+  /// NOTE: the generated document is unsigned, see `Document::sign`.
+  #[wasm_bindgen(constructor)]
+  pub fn new(keypair: &KeyPair, network: Option<String>) -> Result<WasmDocument> {
+    IotaDocument::new(&keypair.0, network.as_deref())
+      .map(Self)
+      .wasm_result()
   }
 
-  /// Creates a new DID Document from the given verification [`method`][`Method`].
+  /// Creates a new DID Document from the given `VerificationMethod`.
+  ///
+  /// NOTE: the generated document is unsigned, see Document::sign.
   #[wasm_bindgen(js_name = fromAuthentication)]
   pub fn from_authentication(method: &WasmVerificationMethod) -> Result<WasmDocument> {
     IotaDocument::from_authentication(method.0.clone())

--- a/bindings/wasm/tests/wasm.rs
+++ b/bindings/wasm/tests/wasm.rs
@@ -81,18 +81,16 @@ fn test_did() {
   assert_eq!(did.to_string(), parsed.to_string());
 
   let public = key.public();
-  let base58 = WasmDID::from_base58(&public, Some("dev".to_string())).unwrap();
+  let base58 = WasmDID::from_base58(&public, Some("dev".to_owned())).unwrap();
 
   assert_eq!(base58.tag(), did.tag());
   assert_eq!(base58.network_name(), "dev");
 }
 
 #[test]
-fn test_document() {
-  let output = WasmDocument::new(KeyType::Ed25519, None, None).unwrap();
-
-  let mut document = output.doc();
-  let keypair = output.key();
+fn test_document_new() {
+  let keypair: KeyPair = KeyPair::new(KeyType::Ed25519).unwrap();
+  let mut document: WasmDocument = WasmDocument::new(&keypair, None).unwrap();
 
   document.sign(&keypair).unwrap();
 
@@ -101,8 +99,8 @@ fn test_document() {
 
 #[test]
 fn test_document_network() {
-  let output = WasmDocument::new(KeyType::Ed25519, Some("dev".into()), None).unwrap();
-  let document = output.doc();
+  let keypair: KeyPair = KeyPair::new(KeyType::Ed25519).unwrap();
+  let document: WasmDocument = WasmDocument::new(&keypair, Some("dev".to_owned())).unwrap();
 
   assert_eq!(document.id().network_name(), "dev");
 }

--- a/bindings/wasm/tests/wasm.rs
+++ b/bindings/wasm/tests/wasm.rs
@@ -90,7 +90,7 @@ fn test_did() {
 #[test]
 fn test_document_new() {
   let keypair: KeyPair = KeyPair::new(KeyType::Ed25519).unwrap();
-  let mut document: WasmDocument = WasmDocument::new(&keypair, None).unwrap();
+  let mut document: WasmDocument = WasmDocument::new(&keypair, None, None).unwrap();
 
   document.sign(&keypair).unwrap();
 
@@ -100,7 +100,7 @@ fn test_document_new() {
 #[test]
 fn test_document_network() {
   let keypair: KeyPair = KeyPair::new(KeyType::Ed25519).unwrap();
-  let document: WasmDocument = WasmDocument::new(&keypair, Some("dev".to_owned())).unwrap();
+  let document: WasmDocument = WasmDocument::new(&keypair, Some("dev".to_owned()), None).unwrap();
 
   assert_eq!(document.id().network_name(), "dev");
 }

--- a/examples/account/private_tangle.rs
+++ b/examples/account/private_tangle.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
     .build()
     .await?;
 
-  let id_create = IdentityCreate::new().network(network_name);
+  let id_create = IdentityCreate::new().network(network_name)?;
 
   // Create a new Identity with the network name set.
   let snapshot: IdentitySnapshot = match account.create_identity(id_create).await {

--- a/examples/low-level-api/create_did.rs
+++ b/examples/low-level-api/create_did.rs
@@ -14,11 +14,11 @@ pub async fn run() -> Result<(IotaDocument, KeyPair, Receipt)> {
   // Create a client instance to send messages to the Tangle.
   let client: ClientMap = ClientMap::new();
 
-  // Generate a new ed25519 public/private key pair.
+  // Generate a new Ed25519 public/private key pair.
   let keypair: KeyPair = KeyPair::new_ed25519()?;
 
   // Create a DID Document (an identity) from the generated key pair.
-  let mut document: IotaDocument = IotaDocument::new(&keypair, None)?;
+  let mut document: IotaDocument = IotaDocument::new(&keypair)?;
 
   // Sign the DID Document with the default authentication key.
   document.sign(keypair.private())?;

--- a/examples/low-level-api/create_did.rs
+++ b/examples/low-level-api/create_did.rs
@@ -18,7 +18,7 @@ pub async fn run() -> Result<(IotaDocument, KeyPair, Receipt)> {
   let keypair: KeyPair = KeyPair::new_ed25519()?;
 
   // Create a DID Document (an identity) from the generated key pair.
-  let mut document: IotaDocument = IotaDocument::from_keypair(&keypair)?;
+  let mut document: IotaDocument = IotaDocument::new(&keypair, None)?;
 
   // Sign the DID Document with the default authentication key.
   document.sign(keypair.private())?;

--- a/examples/low-level-api/private_tangle.rs
+++ b/examples/low-level-api/private_tangle.rs
@@ -36,7 +36,7 @@ pub async fn main() -> Result<()> {
 
   // Create a DID with the network set explicitly.
   // This will result in a DID prefixed by `did:iota:tangle`.
-  let mut document: IotaDocument = IotaDocument::from_keypair_with_network(&keypair, network_name)?;
+  let mut document: IotaDocument = IotaDocument::new(&keypair, Some(network_name))?;
 
   // Sign the DID Document with the default authentication key.
   document.sign(keypair.private())?;

--- a/examples/low-level-api/private_tangle.rs
+++ b/examples/low-level-api/private_tangle.rs
@@ -31,12 +31,12 @@ pub async fn main() -> Result<()> {
     .build()
     .await?;
 
-  // Generate a new ed25519 public/private key pair.
+  // Generate a new Ed25519 public/private key pair.
   let keypair: KeyPair = KeyPair::new_ed25519()?;
 
   // Create a DID with the network set explicitly.
   // This will result in a DID prefixed by `did:iota:tangle`.
-  let mut document: IotaDocument = IotaDocument::new(&keypair, Some(network_name))?;
+  let mut document: IotaDocument = IotaDocument::new_with_options(&keypair, Some(network_name), None)?;
 
   // Sign the DID Document with the default authentication key.
   document.sign(keypair.private())?;

--- a/examples/low-level-api/private_tangle.rs
+++ b/examples/low-level-api/private_tangle.rs
@@ -19,8 +19,7 @@ pub async fn main() -> Result<()> {
   // This name needs to match the id of the network or part of it.
   // Since the id of the one-click private tangle is `private-tangle`
   // but we can only use 6 characters, we use just `tangle`.
-  let network_name = "tangle";
-  let network = Network::try_from_name(network_name)?;
+  let network = Network::try_from_name("tangle")?;
 
   // Set the network and the URL that points to
   // the REST API of the locally running hornet node.
@@ -36,7 +35,7 @@ pub async fn main() -> Result<()> {
 
   // Create a DID with the network set explicitly.
   // This will result in a DID prefixed by `did:iota:tangle`.
-  let mut document: IotaDocument = IotaDocument::new_with_options(&keypair, Some(network_name), None)?;
+  let mut document: IotaDocument = IotaDocument::new_with_options(&keypair, Some(client.network().name()), None)?;
 
   // Sign the DID Document with the default authentication key.
   document.sign(keypair.private())?;

--- a/identity-account/src/identity/identity_create.rs
+++ b/identity-account/src/identity/identity_create.rs
@@ -1,16 +1,20 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::convert::TryInto;
+
 use identity_core::crypto::KeyType;
+use identity_iota::tangle::NetworkName;
 
 use crate::types::MethodSecret;
+use crate::Result;
 
 /// Configuration used to create a new Identity.
 #[derive(Clone, Debug)]
 pub struct IdentityCreate {
   pub(crate) key_type: KeyType,
   pub(crate) name: Option<String>,
-  pub(crate) network: Option<String>,
+  pub(crate) network: Option<NetworkName>,
   pub(crate) method_secret: Option<MethodSecret>,
 }
 
@@ -43,13 +47,14 @@ impl IdentityCreate {
   }
 
   /// Sets the IOTA Tangle network of the Identity DID.
+  #[allow(clippy::double_must_use)]
   #[must_use]
-  pub fn network<T>(mut self, value: T) -> Self
+  pub fn network<T>(mut self, value: T) -> Result<Self>
   where
-    T: Into<String>,
+    T: TryInto<NetworkName>,
   {
-    self.network = Some(value.into());
-    self
+    self.network = Some(value.try_into().map_err(|_| identity_iota::Error::InvalidNetworkName)?);
+    Ok(self)
   }
 
   /// Sets the [`MethodSecret`] for the Identity creation.

--- a/identity-account/src/tests/commands.rs
+++ b/identity-account/src/tests/commands.rs
@@ -99,7 +99,7 @@ async fn test_create_identity_network() -> Result<()> {
   let account: Account = new_account().await?;
 
   // Create an identity with a valid network string
-  let create_identity: IdentityCreate = IdentityCreate::new().network("dev").key_type(KeyType::Ed25519);
+  let create_identity: IdentityCreate = IdentityCreate::new().network("dev")?.key_type(KeyType::Ed25519);
   let snapshot: IdentitySnapshot = account.create_identity(create_identity).await?;
 
   // Ensure the identity creation was successful
@@ -111,18 +111,13 @@ async fn test_create_identity_network() -> Result<()> {
 
 #[tokio::test]
 async fn test_create_identity_invalid_network() -> Result<()> {
-  let account: Account = new_account().await?;
-
   // Attempt to create an identity with an invalid network string
-  let create_identity: IdentityCreate = IdentityCreate::new()
-    .network("Invalid=Network!")
-    .key_type(KeyType::Ed25519);
-  let result = account.create_identity(create_identity).await;
+  let result: Result<IdentityCreate> = IdentityCreate::new().network("Invalid=Network!");
 
   // Ensure an `InvalidNetworkName` error is thrown
   assert!(matches!(
     result.unwrap_err(),
-    Error::IotaError(identity_iota::Error::InvalidNetworkName(_)),
+    Error::IotaError(identity_iota::Error::InvalidNetworkName),
   ));
 
   Ok(())

--- a/identity-account/src/tests/lazy.rs
+++ b/identity-account/src/tests/lazy.rs
@@ -29,7 +29,7 @@ async fn test_lazy_updates() -> Result<()> {
       };
 
       let snapshot: IdentitySnapshot = account
-        .create_identity(IdentityCreate::new().network(network.name().as_ref()))
+        .create_identity(IdentityCreate::new().network(network.name()).unwrap())
         .await?;
 
       let did: &IotaDID = snapshot.identity().try_did()?;

--- a/identity-iota/src/chain/diff_chain.rs
+++ b/identity-iota/src/chain/diff_chain.rs
@@ -232,7 +232,7 @@ mod test {
 
     {
       let keypair: KeyPair = KeyPair::new_ed25519().unwrap();
-      let mut document: IotaDocument = IotaDocument::new(&keypair, None).unwrap();
+      let mut document: IotaDocument = IotaDocument::new(&keypair).unwrap();
       document.sign(keypair.private()).unwrap();
       document.set_message_id(MessageId::new([8; 32]));
       chain = DocumentChain::new(IntegrationChain::new(document).unwrap());

--- a/identity-iota/src/chain/diff_chain.rs
+++ b/identity-iota/src/chain/diff_chain.rs
@@ -232,7 +232,7 @@ mod test {
 
     {
       let keypair: KeyPair = KeyPair::new_ed25519().unwrap();
-      let mut document: IotaDocument = IotaDocument::from_keypair(&keypair).unwrap();
+      let mut document: IotaDocument = IotaDocument::new(&keypair, None).unwrap();
       document.sign(keypair.private()).unwrap();
       document.set_message_id(MessageId::new([8; 32]));
       chain = DocumentChain::new(IntegrationChain::new(document).unwrap());

--- a/identity-iota/src/did/doc/iota_document.rs
+++ b/identity-iota/src/did/doc/iota_document.rs
@@ -72,9 +72,10 @@ impl IotaDocument {
   /// Creates a new DID Document from the given [`KeyPair`] and network, defaulting to
   /// [`Network::Mainnet`](crate::tangle::Network::Mainnet) if unspecified.
   ///
-  /// The DID Document will be pre-populated with a single authentication verification method
-  /// derived from the provided [`KeyPair`]. This method will have the DID URL fragment
-  /// `#authentication` and can be easily retrieved with [`Document::authentication`].
+  /// The DID Document will be pre-populated with a single verification method
+  /// derived from the provided [`KeyPair`], with an attached authentication relationship.
+  /// This method will have the DID URL fragment `#authentication` and can be easily
+  /// retrieved with [`Document::authentication`].
   ///
   /// NOTE: the generated document is unsigned, see [`Document::sign`].
   pub fn new(keypair: &KeyPair, network: Option<&str>) -> Result<Self> {
@@ -516,7 +517,7 @@ impl IotaDocument {
 
   /// Returns the Tangle index of the integration chain for this DID.
   ///
-  /// This corresponds with the tag segment of the [`IotaDID`].
+  /// This is equivalent to the tag segment of the [`IotaDID`].
   ///
   /// E.g.
   /// For an [`IotaDocument`] `doc` with `"did:iota:1234567890abcdefghijklmnopqrstuvxyzABCDEFGHI"`,

--- a/identity-iota/src/did/doc/iota_document.rs
+++ b/identity-iota/src/did/doc/iota_document.rs
@@ -42,9 +42,9 @@ use crate::did::IotaVerificationMethod;
 use crate::did::Properties as BaseProperties;
 use crate::error::Error;
 use crate::error::Result;
-use crate::tangle::MessageId;
 use crate::tangle::MessageIdExt;
 use crate::tangle::TangleRef;
+use crate::tangle::{MessageId, NetworkName};
 
 type Properties = VerifiableProperties<BaseProperties>;
 type BaseDocument = CoreDocument<Properties, Object, Object>;
@@ -87,7 +87,7 @@ impl IotaDocument {
   /// #
   /// // Create a DID Document from a new Ed25519 keypair.
   /// let keypair = KeyPair::new_ed25519().unwrap();
-  /// let mut document = IotaDocument::new(&keypair).unwrap();
+  /// let document = IotaDocument::new(&keypair).unwrap();
   /// ```
   pub fn new(keypair: &KeyPair) -> Result<Self> {
     Self::new_with_options(keypair, None, None)
@@ -109,18 +109,19 @@ impl IotaDocument {
   /// ```
   /// # use identity_core::crypto::KeyPair;
   /// # use identity_iota::did::IotaDocument;
+  /// # use identity_iota::tangle::Network;
   /// #
   /// // Create a new DID Document for the devnet from a new Ed25519 keypair.
   /// let keypair = KeyPair::new_ed25519().unwrap();
-  /// let mut document = IotaDocument::new_with_options(&keypair, Some("dev"), Some("auth-key")).unwrap();
+  /// let document = IotaDocument::new_with_options(&keypair, Some(Network::Devnet.name()), Some("auth-key")).unwrap();
   /// assert_eq!(document.id().network_str(), "dev");
   /// assert_eq!(document.authentication().try_into_fragment().unwrap(), "#auth-key");
   /// ```
-  pub fn new_with_options(keypair: &KeyPair, network: Option<&str>, fragment: Option<&str>) -> Result<Self> {
+  pub fn new_with_options(keypair: &KeyPair, network: Option<NetworkName>, fragment: Option<&str>) -> Result<Self> {
     let public_key: &PublicKey = keypair.public();
 
-    let did: IotaDID = if let Some(network) = network {
-      IotaDID::new_with_network(public_key.as_ref(), network)?
+    let did: IotaDID = if let Some(network_name) = network {
+      IotaDID::new_with_network(public_key.as_ref(), network_name)?
     } else {
       IotaDID::new(public_key.as_ref())?
     };
@@ -959,8 +960,7 @@ mod tests {
   #[test]
   fn test_new_with_options_network() {
     let keypair: KeyPair = generate_testkey();
-    let document: IotaDocument =
-      IotaDocument::new_with_options(&keypair, Some(Network::Devnet.name_str()), None).unwrap();
+    let document: IotaDocument = IotaDocument::new_with_options(&keypair, Some(Network::Devnet.name()), None).unwrap();
     compare_document_devnet(&document);
   }
 

--- a/identity-iota/src/did/doc/iota_verification_method.rs
+++ b/identity-iota/src/did/doc/iota_verification_method.rs
@@ -26,6 +26,7 @@ use identity_did::verification::VerificationMethod;
 use crate::did::IotaDID;
 use crate::error::Error;
 use crate::error::Result;
+use crate::tangle::NetworkName;
 
 /// A DID Document verification method
 #[derive(Clone, PartialEq, Deserialize, Serialize)]
@@ -73,7 +74,7 @@ impl IotaVerificationMethod {
 
   /// Creates a new [`IotaVerificationMethod`] object from the given [`KeyPair`] on the specified
   /// `network`.
-  pub fn from_keypair_with_network<'a, F>(keypair: &KeyPair, fragment: F, network: &str) -> Result<Self>
+  pub fn from_keypair_with_network<'a, F>(keypair: &KeyPair, fragment: F, network: NetworkName) -> Result<Self>
   where
     F: Into<Option<&'a str>>,
   {

--- a/identity-iota/src/did/doc/iota_verification_method.rs
+++ b/identity-iota/src/did/doc/iota_verification_method.rs
@@ -91,6 +91,7 @@ impl IotaVerificationMethod {
   where
     F: Into<Option<&'a str>>,
   {
+    // TODO: validate fragment contents properly
     let tag: String = format!("#{}", fragment.into().unwrap_or(Self::DEFAULT_TAG));
     let key: IotaDID = did.join(tag)?;
 
@@ -149,7 +150,8 @@ impl IotaVerificationMethod {
     IotaDID::check_validity(method.controller())?;
 
     // Ensure the authentication method has an identifying fragment
-    if method.id().fragment().is_none() {
+    // TODO: validate fragment properly
+    if method.id().fragment().is_none() || method.id().fragment().unwrap_or_default().is_empty() {
       return Err(Error::InvalidDocumentAuthFragment);
     }
 

--- a/identity-iota/src/did/url/iota_did.rs
+++ b/identity-iota/src/did/url/iota_did.rs
@@ -7,6 +7,7 @@ use core::fmt::Display;
 use core::fmt::Formatter;
 use core::fmt::Result as FmtResult;
 use core::str::FromStr;
+use std::convert::TryInto;
 
 use crypto::hashes::blake2b::Blake2b256;
 use crypto::hashes::Digest;
@@ -102,17 +103,9 @@ impl IotaDID {
   ///
   /// Returns `Err` if the input does not form a valid [`IotaDID`] or the `network` is invalid.
   /// See [`NetworkName`] for validation requirements.
-  pub fn new_with_network(public: &[u8], network: &str) -> Result<Self> {
-    NetworkName::validate_network_name(network)?;
-    try_construct_did!(public, network)
-  }
-
-  #[doc(hidden)]
-  pub fn from_components(public: &[u8], network: Option<&str>) -> Result<Self> {
-    match network {
-      Some(network) => Self::new_with_network(public, network),
-      None => Self::new(public),
-    }
+  pub fn new_with_network(public: &[u8], network: impl TryInto<NetworkName>) -> Result<Self> {
+    let network_name = network.try_into().map_err(|_| Error::InvalidNetworkName)?;
+    try_construct_did!(public, network_name.as_ref())
   }
 
   /// Creates a new `DID` by joining `self` with the relative DID `other`.
@@ -447,22 +440,15 @@ mod tests {
   #[test]
   fn test_new() {
     let key: KeyPair = KeyPair::new_ed25519().unwrap();
-    let did: IotaDID = IotaDID::new(key.public().as_ref()).unwrap();
     let tag: String = IotaDID::encode_key(key.public().as_ref());
 
+    let did: IotaDID = IotaDID::new(key.public().as_ref()).unwrap();
     assert_eq!(did.tag(), tag);
-    assert_eq!(did.network_str(), IotaDID::DEFAULT_NETWORK);
-
-    let did = IotaDID::from_components(key.public().as_ref(), None).unwrap();
-    assert_eq!(did.tag(), tag);
-    assert_eq!(did.network_str(), IotaDID::DEFAULT_NETWORK);
-
-    let did = IotaDID::from_components(key.public().as_ref(), Some(IotaDID::DEFAULT_NETWORK)).unwrap();
     assert_eq!(did.network_str(), IotaDID::DEFAULT_NETWORK);
   }
 
   #[test]
-  fn test_with_network() {
+  fn test_new_with_network() {
     let key: KeyPair = KeyPair::new_ed25519().unwrap();
     let did: IotaDID = IotaDID::new_with_network(key.public().as_ref(), "foo").unwrap();
     let tag: String = IotaDID::encode_key(key.public().as_ref());

--- a/identity-iota/src/error.rs
+++ b/identity-iota/src/error.rs
@@ -27,8 +27,8 @@ pub enum Error {
   InvalidDocumentAuthFragment,
   #[error("Invalid Document - Authentication Type Not Supported")]
   InvalidDocumentAuthType,
-  #[error("Invalid Network Name: {0}")]
-  InvalidNetworkName(&'static str),
+  #[error("Invalid Network Name")]
+  InvalidNetworkName,
   #[error("Invalid Tryte Conversion")]
   InvalidTryteConversion,
   #[error("Invalid Transaction Bundle")]

--- a/identity/benches/benchmark.rs
+++ b/identity/benches/benchmark.rs
@@ -19,7 +19,7 @@ use self::diff_chain::update_diff_chain;
 use self::diff_chain::update_integration_chain;
 
 fn generate_signed_document(keypair: &KeyPair) {
-  let mut document: IotaDocument = IotaDocument::new(keypair, None).unwrap();
+  let mut document: IotaDocument = IotaDocument::new(keypair).unwrap();
 
   document.sign(keypair.private()).unwrap();
 }

--- a/identity/benches/benchmark.rs
+++ b/identity/benches/benchmark.rs
@@ -19,7 +19,7 @@ use self::diff_chain::update_diff_chain;
 use self::diff_chain::update_integration_chain;
 
 fn generate_signed_document(keypair: &KeyPair) {
-  let mut document: IotaDocument = IotaDocument::from_keypair(keypair).unwrap();
+  let mut document: IotaDocument = IotaDocument::new(keypair).unwrap();
 
   document.sign(keypair.private()).unwrap();
 }

--- a/identity/benches/benchmark.rs
+++ b/identity/benches/benchmark.rs
@@ -19,7 +19,7 @@ use self::diff_chain::update_diff_chain;
 use self::diff_chain::update_integration_chain;
 
 fn generate_signed_document(keypair: &KeyPair) {
-  let mut document: IotaDocument = IotaDocument::new(keypair).unwrap();
+  let mut document: IotaDocument = IotaDocument::new(keypair, None).unwrap();
 
   document.sign(keypair.private()).unwrap();
 }

--- a/identity/benches/diff_chain.rs
+++ b/identity/benches/diff_chain.rs
@@ -16,7 +16,7 @@ use identity::iota::TangleRef;
 
 pub fn setup_diff_chain_bench() -> (IotaDocument, KeyPair) {
   let keypair: KeyPair = KeyPair::new_ed25519().unwrap();
-  let mut document: IotaDocument = IotaDocument::from_keypair(&keypair).unwrap();
+  let mut document: IotaDocument = IotaDocument::new(&keypair).unwrap();
 
   document.sign(keypair.private()).unwrap();
   document.set_message_id(MessageId::new([8; 32]));

--- a/identity/benches/diff_chain.rs
+++ b/identity/benches/diff_chain.rs
@@ -16,7 +16,7 @@ use identity::iota::TangleRef;
 
 pub fn setup_diff_chain_bench() -> (IotaDocument, KeyPair) {
   let keypair: KeyPair = KeyPair::new_ed25519().unwrap();
-  let mut document: IotaDocument = IotaDocument::new(&keypair).unwrap();
+  let mut document: IotaDocument = IotaDocument::new(&keypair, None).unwrap();
 
   document.sign(keypair.private()).unwrap();
   document.set_message_id(MessageId::new([8; 32]));

--- a/identity/benches/diff_chain.rs
+++ b/identity/benches/diff_chain.rs
@@ -16,7 +16,7 @@ use identity::iota::TangleRef;
 
 pub fn setup_diff_chain_bench() -> (IotaDocument, KeyPair) {
   let keypair: KeyPair = KeyPair::new_ed25519().unwrap();
-  let mut document: IotaDocument = IotaDocument::new(&keypair, None).unwrap();
+  let mut document: IotaDocument = IotaDocument::new(&keypair).unwrap();
 
   document.sign(keypair.private()).unwrap();
   document.set_message_id(MessageId::new([8; 32]));


### PR DESCRIPTION
# Description of change
This replaces the constructor for `WasmDocument` to fix a type mismatch in the generated bindings. Several `Document` constructors are also replaced with a single `new()` function in both Rust and Wasm. This is for consistency and to clarify the canonical method of constructing a new `Document`.

~~The downside is that this removes the ability for a developer to pass in the desired fragment name for the authentication verification method on a newly generated `Document` in Wasm (e.g. instead of "#authentication" one could specify "#customkey123"). This was not possible in Rust, if that behaviour is still desired we should add it in this PR to both languages.~~ 
Edit: added the ability to set the default verification method fragment in both Rust and Wasm.

**Breaking changes**:
- replace IotaDocument `from_keypair()`, `from_keypair_with_network()` with `new()`, `new_with_options()`.
- the default authentication verification method fragment for a new `WasmDocument` is changed from `"#key"` to `"#authentication"`
  - this discrepancy seemed unintentional and now matches the Rust behaviour
- `new Document()` in the Wasm bindings now take a `KeyPair` instead of a `KeyType` and returns just a `Document` instead of a `NewDocument { Document, KeyPair }` struct.
  - BEFORE: `pub fn new(type_: KeyType, network: Option<String>, tag: Option<String>) -> Result<NewDocument>`
  - AFTER:  `pub fn new(key: KeyPair, network: Option<String>, fragment: Option<String>) -> Result<Document>`

Creating a new DID document in Wasm is also now a two-step process, which should be acceptable since this only affects the low-level API and matches the Rust experience.

BEFORE:
```ts
const { doc, key } = new Document(KeyType.Ed25519);
```

AFTER:
```ts
const key = new KeyPair(KeyType.Ed25519);
const doc = new Document(key);
```

**NOTE: this will require updating the repl.it examples in the documentation.**

# Motivation
This is currently a mismatch in the expected type returned by the `WasmDocument` constructor compared to the generated Typescript definition:

```rust
  /// Creates a new DID Document from the given KeyPair.
  #[wasm_bindgen(constructor)]
  #[allow(clippy::new_ret_no_self)]
  pub fn new(type_: KeyType, network: Option<String>, tag: Option<String>) -> Result<NewDocument> {
```

where `NewDocument` is a struct holding the new `WasmDocument` and `KeyPair`:

```rust
#[wasm_bindgen(inspectable)]
pub struct NewDocument {
  key: KeyPair,
  doc: WasmDocument,
}
```

However, the generated Typescript constructor implicitly expects it to return `WasmDocument`, not `NewDocument`:

```ts
export class Document {
  free(): void;
/**
* Creates a new DID Document from the given KeyPair.
* @param {number} type_
* @param {string | undefined} network
* @param {string | undefined} tag
*/
  constructor(type_: number, network?: string, tag?: string);
```

Unfortunately there is no easy way to catch these types of bugs without creating dedicated Typescript tests or converting our examples to Typescript. I tried using `tsc --allowJs --checkJs --noEmit` on the examples but it doesn't link up to the Typescript definitions to catch the type-mismatch.

## Minimal Reproducible Example

The following code snippet fails to compile when using Typescript:

example.ts:
```ts
import { Document, KeyType } from "@iota/identity-wasm/node";
const { doc, key } = new Document(KeyType.Ed25519);
```

Run `tsc example.ts`

Error:
```ts
example.ts:2:13 - error TS2339: Property 'doc' does not exist on type 'Document'.

7     const { doc, key } = new Document(KeyType.Ed25519);
              ~~~

example.ts:2:18 - error TS2339: Property 'key' does not exist on type 'Document'.

7     const { doc, key } = new Document(KeyType.Ed25519);
                   ~~~


Found 2 errors.
```

Note that this example runs fine in Javascript because it doesn't validate the expected type.

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tests and examples were updated and pass locally. New constructor compiles to Typescript.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
