### PR TITLE
Update TimeCop to avoid Into<SystemTime>

### DIFF
--- a/libjose/src/jwt/profile/core.rs
+++ b/libjose/src/jwt/profile/core.rs
@@ -238,8 +238,8 @@ impl TimeCop {
     }
   }
 
-  pub fn set_current(&mut self, value: impl Into<SystemTime>) {
-    self.current = Some(value.into());
+  pub fn set_current(&mut self, value: SystemTime) {
+    self.current = Some(value);
   }
 
   pub fn set_max_iat(&mut self, value: impl Into<Duration>) {


### PR DESCRIPTION
# Description of change
Avoids an automatic `SystemTime` conversion out of an abundance of caution due to issue #302. We don't currently have a vulnerability since `set_current` is unused and we don't use any `SystemTime` conversions affected by a known vulnerability, so this is just to prevent any potential issues with it in the future.

## Links to any relevant issues
Issue #302 

## Type of change

- [x] Chore/bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tests pass.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
