### PR TITLE
Set `explorer_url` in private Tangle example

### DIFF
--- a/examples/account/config.rs
+++ b/examples/account/config.rs
@@ -74,7 +74,7 @@ async fn main() -> Result<()> {
 
   // Prints the Identity Resolver Explorer URL, the entire history can be observed on this page by "Loading History".
   println!(
-    "[Example] Explore the DID Document = {}/{}",
+    "[Example] Explore the DID Document = {}{}",
     network.explorer_url().expect("no explorer url was set").to_string(),
     iota_did.to_string()
   );

--- a/examples/account/create_did.rs
+++ b/examples/account/create_did.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
 
   // Prints the Identity Resolver Explorer URL, the entire history can be observed on this page by "Loading History".
   println!(
-    "[Example] Explore the DID Document = {}/{}",
+    "[Example] Explore the DID Document = {}{}",
     iota_did.network()?.explorer_url().unwrap().to_string(),
     iota_did.to_string()
   );

--- a/examples/account/lazy.rs
+++ b/examples/account/lazy.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<()> {
 
   // Prints the Identity Resolver Explorer URL, the entire history can be observed on this page by "Loading History".
   println!(
-    "[Example] Explore the DID Document = {}/{}",
+    "[Example] Explore the DID Document = {}{}",
     iota_did.network()?.explorer_url().unwrap().to_string(),
     iota_did.to_string()
   );

--- a/examples/account/manipulate_did.rs
+++ b/examples/account/manipulate_did.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<()> {
 
   // Prints the Identity Resolver Explorer URL, the entire history can be observed on this page by "Loading History".
   println!(
-    "[Example] Explore the DID Document = {}/{}",
+    "[Example] Explore the DID Document = {}{}",
     iota_did.network()?.explorer_url().unwrap().to_string(),
     iota_did.to_string()
   );

--- a/examples/account/signing.rs
+++ b/examples/account/signing.rs
@@ -88,7 +88,7 @@ async fn main() -> Result<()> {
 
   // Prints the Identity Resolver Explorer URL, the entire history can be observed on this page by "Loading History".
   println!(
-    "[Example] Explore the DID Document = {}/{}",
+    "[Example] Explore the DID Document = {}{}",
     iota_did.network()?.explorer_url().unwrap().to_string(),
     iota_did.to_string()
   );


### PR DESCRIPTION
# Description of change

The `Network` returned from `IotaDID::network` does not have the explorer url of a custom network set. In a private tangle scenario, it's better to use the custom network object directly, which has that url set. This PR changes that in the `config` example.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix


## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
