### PR TITLE
Fix credential validation failing for documents with diff updates

### DIFF
--- a/identity-iota/src/credential/validator.rs
+++ b/identity-iota/src/credential/validator.rs
@@ -1,13 +1,15 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
 use identity_core::common::Object;
 use identity_core::convert::FromJson;
 use identity_credential::credential::Credential;
 use identity_credential::presentation::Presentation;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-use std::collections::BTreeMap;
 
 use crate::did::IotaDID;
 use crate::did::IotaDocument;
@@ -156,16 +158,17 @@ impl<'a, R: TangleResolve> CredentialValidator<'a, R> {
     })
   }
 
+  /// Resolves the document from the Tangle, which performs checks on all signatures etc.
   async fn validate_document(&self, did: impl AsRef<str>) -> Result<DocumentValidation> {
     let did: IotaDID = did.as_ref().parse()?;
     let document: IotaDocument = self.client.resolve(&did).await?;
-    let verified: bool = document.verify_self_signed().is_ok();
+    // TODO: check if document is deactivated, does that matter?
 
     Ok(DocumentValidation {
       did,
       document,
       metadata: Object::new(),
-      verified,
+      verified: true,
     })
   }
 }


### PR DESCRIPTION
# Description of change
Small patch which removes an invalid signature check on issuer and subject documents from `CredentialValidator` which was causing otherwise valid credentials to fail verification.

Since the `CredentialValidator` is due for a refactor in #312 only this particular bug was addressed.

## Links to any relevant issues
Fixes issue #489 

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
The bug reproduction example in #489 succeeds with this PR and all local tests pass. Unfortunately this is difficult to test since it involves resolving documents from the Tangle.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
