### PR TITLE
Move drop trait to stronghold

### DIFF
--- a/examples/account/config.rs
+++ b/examples/account/config.rs
@@ -38,7 +38,6 @@ async fn main() -> Result<()> {
     .autosave(AutoSave::Every) // save immediately after every action
     .autosave(AutoSave::Batch(10)) // save after every 10 actions
     .autopublish(true) // publish to the tangle automatically on every update
-    .dropsave(true) // save the account state on drop
     .milestone(4) // save a snapshot every 4 actions
     .storage(AccountStorage::Memory) // use the default in-memory storage
     // configure a mainnet Tangle client with node and permanode

--- a/examples/account/create_did.rs
+++ b/examples/account/create_did.rs
@@ -21,7 +21,6 @@ async fn main() -> Result<()> {
   // It implements best practices for security and is the recommended way of handling private keys.
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
-  let dropsave: bool = false;
 
   // Create a new identity using Stronghold as local storage.
   //
@@ -31,7 +30,7 @@ async fn main() -> Result<()> {
     .storage(AccountStorage::Stronghold(
       stronghold_path,
       Some(password),
-      Some(dropsave),
+      None,
     ))
     .create_identity(IdentitySetup::default())
     .await?;

--- a/examples/account/create_did.rs
+++ b/examples/account/create_did.rs
@@ -27,11 +27,7 @@ async fn main() -> Result<()> {
   // The creation step generates a keypair, builds an identity
   // and publishes it to the IOTA mainnet.
   let account: Account = Account::builder()
-    .storage(AccountStorage::Stronghold(
-      stronghold_path,
-      Some(password),
-      None,
-    ))
+    .storage(AccountStorage::Stronghold(stronghold_path, Some(password), None))
     .create_identity(IdentitySetup::default())
     .await?;
 

--- a/examples/account/create_did.rs
+++ b/examples/account/create_did.rs
@@ -21,13 +21,18 @@ async fn main() -> Result<()> {
   // It implements best practices for security and is the recommended way of handling private keys.
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
+  let dropsave: bool = false;
 
   // Create a new identity using Stronghold as local storage.
   //
   // The creation step generates a keypair, builds an identity
   // and publishes it to the IOTA mainnet.
   let account: Account = Account::builder()
-    .storage(AccountStorage::Stronghold(stronghold_path, Some(password)))
+    .storage(AccountStorage::Stronghold(
+      stronghold_path,
+      Some(password),
+      Some(dropsave),
+    ))
     .create_identity(IdentitySetup::default())
     .await?;
 

--- a/examples/account/lazy.rs
+++ b/examples/account/lazy.rs
@@ -23,11 +23,7 @@ async fn main() -> Result<()> {
   // This means updates are not pushed to the tangle automatically.
   // Rather, when we publish, multiple updates are batched together.
   let mut account: Account = Account::builder()
-    .storage(AccountStorage::Stronghold(
-      stronghold_path,
-      Some(password),
-      None,
-    ))
+    .storage(AccountStorage::Stronghold(stronghold_path, Some(password), None))
     .autopublish(false)
     .create_identity(IdentitySetup::default())
     .await?;

--- a/examples/account/lazy.rs
+++ b/examples/account/lazy.rs
@@ -18,12 +18,17 @@ async fn main() -> Result<()> {
   // Stronghold settings
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
+  let dropsave: bool = false;
 
   // Create a new Account with auto publishing set to false.
   // This means updates are not pushed to the tangle automatically.
   // Rather, when we publish, multiple updates are batched together.
   let mut account: Account = Account::builder()
-    .storage(AccountStorage::Stronghold(stronghold_path, Some(password)))
+    .storage(AccountStorage::Stronghold(
+      stronghold_path,
+      Some(password),
+      Some(dropsave),
+    ))
     .autopublish(false)
     .create_identity(IdentitySetup::default())
     .await?;

--- a/examples/account/lazy.rs
+++ b/examples/account/lazy.rs
@@ -18,7 +18,6 @@ async fn main() -> Result<()> {
   // Stronghold settings
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
-  let dropsave: bool = false;
 
   // Create a new Account with auto publishing set to false.
   // This means updates are not pushed to the tangle automatically.
@@ -27,7 +26,7 @@ async fn main() -> Result<()> {
     .storage(AccountStorage::Stronghold(
       stronghold_path,
       Some(password),
-      Some(dropsave),
+      None,
     ))
     .autopublish(false)
     .create_identity(IdentitySetup::default())

--- a/examples/account/manipulate_did.rs
+++ b/examples/account/manipulate_did.rs
@@ -27,11 +27,7 @@ async fn main() -> Result<()> {
 
   // Create a new Account with the default configuration
   let mut account: Account = Account::builder()
-    .storage(AccountStorage::Stronghold(
-      stronghold_path,
-      Some(password),
-      None,
-    ))
+    .storage(AccountStorage::Stronghold(stronghold_path, Some(password), None))
     .create_identity(IdentitySetup::default())
     .await?;
 

--- a/examples/account/manipulate_did.rs
+++ b/examples/account/manipulate_did.rs
@@ -24,14 +24,13 @@ async fn main() -> Result<()> {
   // Stronghold settings
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
-  let dropsave: bool = false;
 
   // Create a new Account with the default configuration
   let mut account: Account = Account::builder()
     .storage(AccountStorage::Stronghold(
       stronghold_path,
       Some(password),
-      Some(dropsave),
+      None,
     ))
     .create_identity(IdentitySetup::default())
     .await?;

--- a/examples/account/manipulate_did.rs
+++ b/examples/account/manipulate_did.rs
@@ -24,10 +24,15 @@ async fn main() -> Result<()> {
   // Stronghold settings
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
+  let dropsave: bool = false;
 
   // Create a new Account with the default configuration
   let mut account: Account = Account::builder()
-    .storage(AccountStorage::Stronghold(stronghold_path, Some(password)))
+    .storage(AccountStorage::Stronghold(
+      stronghold_path,
+      Some(password),
+      Some(dropsave),
+    ))
     .create_identity(IdentitySetup::default())
     .await?;
 

--- a/examples/account/multiple_identities.rs
+++ b/examples/account/multiple_identities.rs
@@ -22,11 +22,15 @@ async fn main() -> Result<()> {
   // It implements best practices for security and is the recommended way of handling private keys.
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
+  let dropsave: bool = false;
 
   // Create an AccountBuilder to make it easier to create multiple identities.
   // Every account created from the builder will use the same storage - stronghold in this case.
-  let mut builder: AccountBuilder =
-    Account::builder().storage(AccountStorage::Stronghold(stronghold_path, Some(password)));
+  let mut builder: AccountBuilder = Account::builder().storage(AccountStorage::Stronghold(
+    stronghold_path,
+    Some(password),
+    Some(dropsave),
+  ));
 
   // The creation step generates a keypair, builds an identity
   // and publishes it to the IOTA mainnet.

--- a/examples/account/multiple_identities.rs
+++ b/examples/account/multiple_identities.rs
@@ -25,11 +25,8 @@ async fn main() -> Result<()> {
 
   // Create an AccountBuilder to make it easier to create multiple identities.
   // Every account created from the builder will use the same storage - stronghold in this case.
-  let mut builder: AccountBuilder = Account::builder().storage(AccountStorage::Stronghold(
-    stronghold_path,
-    Some(password),
-    None,
-  ));
+  let mut builder: AccountBuilder =
+    Account::builder().storage(AccountStorage::Stronghold(stronghold_path, Some(password), None));
 
   // The creation step generates a keypair, builds an identity
   // and publishes it to the IOTA mainnet.

--- a/examples/account/multiple_identities.rs
+++ b/examples/account/multiple_identities.rs
@@ -22,14 +22,13 @@ async fn main() -> Result<()> {
   // It implements best practices for security and is the recommended way of handling private keys.
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
-  let dropsave: bool = false;
 
   // Create an AccountBuilder to make it easier to create multiple identities.
   // Every account created from the builder will use the same storage - stronghold in this case.
   let mut builder: AccountBuilder = Account::builder().storage(AccountStorage::Stronghold(
     stronghold_path,
     Some(password),
-    Some(dropsave),
+    None,
   ));
 
   // The creation step generates a keypair, builds an identity

--- a/examples/account/signing.rs
+++ b/examples/account/signing.rs
@@ -30,10 +30,15 @@ async fn main() -> Result<()> {
   // Stronghold settings
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
+  let dropsave: bool = false;
 
   // Create a new Account with stronghold storage.
   let mut account: Account = Account::builder()
-    .storage(AccountStorage::Stronghold(stronghold_path, Some(password)))
+    .storage(AccountStorage::Stronghold(
+      stronghold_path,
+      Some(password),
+      Some(dropsave),
+    ))
     .create_identity(IdentitySetup::default())
     .await?;
 

--- a/examples/account/signing.rs
+++ b/examples/account/signing.rs
@@ -33,11 +33,7 @@ async fn main() -> Result<()> {
 
   // Create a new Account with stronghold storage.
   let mut account: Account = Account::builder()
-    .storage(AccountStorage::Stronghold(
-      stronghold_path,
-      Some(password),
-      None,
-    ))
+    .storage(AccountStorage::Stronghold(stronghold_path, Some(password), None))
     .create_identity(IdentitySetup::default())
     .await?;
 

--- a/examples/account/signing.rs
+++ b/examples/account/signing.rs
@@ -30,14 +30,13 @@ async fn main() -> Result<()> {
   // Stronghold settings
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
-  let dropsave: bool = false;
 
   // Create a new Account with stronghold storage.
   let mut account: Account = Account::builder()
     .storage(AccountStorage::Stronghold(
       stronghold_path,
       Some(password),
-      Some(dropsave),
+      None,
     ))
     .create_identity(IdentitySetup::default())
     .await?;

--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -1,8 +1,6 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use futures::executor;
-
 use identity_core::crypto::SetSignature;
 use identity_iota::did::DocumentDiff;
 use identity_iota::did::IotaDID;
@@ -125,11 +123,6 @@ impl Account {
   /// Returns the auto-save configuration value.
   pub fn autosave(&self) -> AutoSave {
     self.config.autosave
-  }
-
-  /// Returns whether save-on-drop is enabled.
-  pub fn dropsave(&self) -> bool {
-    self.config.dropsave
   }
 
   /// Returns the total number of actions executed by this instance.
@@ -418,14 +411,5 @@ impl Account {
     }
 
     Ok(())
-  }
-}
-
-impl Drop for Account {
-  fn drop(&mut self) {
-    if self.config.dropsave && self.actions() != 0 {
-      // TODO: Handle Result (?)
-      let _ = executor::block_on(self.storage().flush_changes());
-    }
   }
 }

--- a/identity-account/src/account/builder.rs
+++ b/identity-account/src/account/builder.rs
@@ -85,14 +85,6 @@ impl AccountBuilder {
     self
   }
 
-  /// Save the account state on drop.
-  ///
-  /// See the config's [`dropsave`][AccountConfig::dropsave] documentation for details.
-  pub fn dropsave(mut self, value: bool) -> Self {
-    self.config = self.config.dropsave(value);
-    self
-  }
-
   /// Save a state snapshot every N actions.
   pub fn milestone(mut self, value: u32) -> Self {
     self.config = self.config.milestone(value);

--- a/identity-account/src/account/builder.rs
+++ b/identity-account/src/account/builder.rs
@@ -33,7 +33,7 @@ use super::config::AutoSave;
 pub enum AccountStorage {
   Memory,
   #[cfg(feature = "stronghold")]
-  Stronghold(PathBuf, Option<String>),
+  Stronghold(PathBuf, Option<String>, Option<bool>),
   Custom(Arc<dyn Storage>),
 }
 
@@ -112,9 +112,9 @@ impl AccountBuilder {
         self.storage = Some(storage);
       }
       #[cfg(feature = "stronghold")]
-      Some(AccountStorage::Stronghold(snapshot, password)) => {
+      Some(AccountStorage::Stronghold(snapshot, password, dropsave)) => {
         let passref: Option<&str> = password.as_deref();
-        let adapter: Stronghold = Stronghold::new(&snapshot, passref).await?;
+        let adapter: Stronghold = Stronghold::new(&snapshot, passref, dropsave).await?;
 
         if let Some(mut password) = password {
           password.zeroize();

--- a/identity-account/src/account/config.rs
+++ b/identity-account/src/account/config.rs
@@ -67,7 +67,6 @@ impl AccountSetup {
 pub(crate) struct AccountConfig {
   pub(crate) autosave: AutoSave,
   pub(crate) autopublish: bool,
-  pub(crate) dropsave: bool,
   pub(crate) testmode: bool,
   pub(crate) milestone: u32,
 }
@@ -80,7 +79,6 @@ impl AccountConfig {
     Self {
       autosave: AutoSave::Every,
       autopublish: true,
-      dropsave: true,
       testmode: false,
       milestone: Self::MILESTONE,
     }
@@ -90,9 +88,6 @@ impl AccountConfig {
   /// - [`Every`][AutoSave::Every] => Save to storage on every update
   /// - [`Never`][AutoSave::Never] => Never save to storage when updating
   /// - [`Batch(n)`][AutoSave::Batch] => Save to storage after every `n` updates.
-  ///
-  /// Note that when [`Never`][AutoSave::Never] is selected, you will most
-  /// likely want to set [`dropsave`][Self::dropsave] to `true`.
   ///
   /// Default: [`Every`][AutoSave::Every]
   pub(crate) fn autosave(mut self, value: AutoSave) -> Self {
@@ -107,16 +102,6 @@ impl AccountConfig {
   /// Default: `true`
   pub(crate) fn autopublish(mut self, value: bool) -> Self {
     self.autopublish = value;
-    self
-  }
-
-  /// Save the account state on drop.
-  /// If set to `false`, set [`autosave`][Self::autosave] to
-  /// either [`Every`][AutoSave::Every] or [`Batch(n)`][AutoSave::Batch].
-  ///
-  /// Default: `true`
-  pub(crate) fn dropsave(mut self, value: bool) -> Self {
-    self.dropsave = value;
     self
   }
 

--- a/identity-account/src/storage/stronghold.rs
+++ b/identity-account/src/storage/stronghold.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crypto::keys::slip10::Chain;
+use futures::executor;
 
 use hashbrown::hash_map::Entry;
 use hashbrown::HashMap;
@@ -256,6 +257,12 @@ impl Storage for Stronghold {
       .await?;
 
     Ok(())
+  }
+}
+
+impl Drop for Stronghold {
+  fn drop(&mut self) {
+    let _ = executor::block_on(self.flush_changes());
   }
 }
 

--- a/identity-account/src/storage/stronghold.rs
+++ b/identity-account/src/storage/stronghold.rs
@@ -76,7 +76,8 @@ impl Stronghold {
     self.dropsave
   }
 
-  /// Save the storage changes on drop.
+  /// Set whether to save the storage changes on drop.
+  /// Default: true
   pub fn set_dropsave(&mut self, value: bool) {
     self.dropsave = value;
   }

--- a/identity-account/src/storage/stronghold.rs
+++ b/identity-account/src/storage/stronghold.rs
@@ -45,7 +45,7 @@ pub struct Stronghold {
 }
 
 impl Stronghold {
-  pub async fn new<'a, T, U>(snapshot: &T, password: U, dropsave: bool) -> Result<Self>
+  pub async fn new<'a, T, U>(snapshot: &T, password: U, dropsave: Option<bool>) -> Result<Self>
   where
     T: AsRef<Path> + ?Sized,
     U: Into<Option<&'a str>>,
@@ -59,7 +59,7 @@ impl Stronghold {
     Ok(Self {
       did_leases: Mutex::new(HashMap::new()),
       snapshot: Arc::new(snapshot),
-      dropsave,
+      dropsave: dropsave.unwrap_or(false),
     })
   }
 

--- a/identity-account/src/storage/stronghold.rs
+++ b/identity-account/src/storage/stronghold.rs
@@ -59,7 +59,7 @@ impl Stronghold {
     Ok(Self {
       did_leases: Mutex::new(HashMap::new()),
       snapshot: Arc::new(snapshot),
-      dropsave: dropsave.unwrap_or(false),
+      dropsave: dropsave.unwrap_or(true),
     })
   }
 

--- a/identity-account/src/tests/account.rs
+++ b/identity-account/src/tests/account.rs
@@ -16,9 +16,6 @@ use identity_iota::did::IotaDID;
 use identity_iota::tangle::MessageId;
 use identity_iota::tangle::MessageIdExt;
 
-use crate::storage::Stronghold;
-use std::path::PathBuf;
-
 #[tokio::test]
 async fn test_account_builder() -> Result<()> {
   let mut builder: AccountBuilder = AccountBuilder::default().testmode(true);

--- a/identity-account/src/tests/account.rs
+++ b/identity-account/src/tests/account.rs
@@ -16,6 +16,9 @@ use identity_iota::did::IotaDID;
 use identity_iota::tangle::MessageId;
 use identity_iota::tangle::MessageIdExt;
 
+use crate::storage::Stronghold;
+use std::path::PathBuf;
+
 #[tokio::test]
 async fn test_account_builder() -> Result<()> {
   let mut builder: AccountBuilder = AccountBuilder::default().testmode(true);


### PR DESCRIPTION
# Description of change
Moves the drop trait to `Stronhold`.

## Links to any relevant issues
closes #452 

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Multiple accounts with the same `AccountSetup` were created, and performed multiple actions concurrently, before being dropped. 

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
