### PR TITLE
Update iota-client dependency

### DIFF
--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -18,10 +18,8 @@ crate-type = ["cdylib", "rlib"]
 console_error_panic_hook = { version = "0.1" }
 futures = { version = "0.3" }
 js-sys = { version = "0.3" }
-reqwest = { version = "=0.11.4" } # pin version to 0.11.4: https://github.com/iotaledger/identity.rs/issues/438
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
-tokio = { version = "*", default-features = false, features = ["rt"] } # enable "rt" feature to fix build: https://github.com/iotaledger/identity.rs/issues/403
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 
@@ -37,6 +35,7 @@ wasm-bindgen-test = { version = "0.3" }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 chrono = { version = "0.4", features = ["wasmbind"] }
 getrandom = { version = "0.2", features = ["js"] }
+parking_lot = { version = "0.11.2", features = ["wasm-bindgen"] }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = true

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -28,8 +28,7 @@ strum = { version = "0.21", features = ["derive"] }
 thiserror = { version = "1.0", default-features = false }
 
 [dependencies.iota-client]
-git = "https://github.com/iotaledger/iota.rs"
-rev = "e8c050a749a2e7c13633e97b3372b38388f48c37"
+version = "1.1.0"
 default-features = false
 
 [dependencies.iota-crypto]


### PR DESCRIPTION
# Description of change
Updates the `iota-client` dependency to use the published 1.1.0 crate instead of referencing a git commit, which was causing a build error in our dependency chain (#502).

Also removes workarounds for `reqwest` and `tokio` features in the wasm bindings which are no longer necessary.

## Links to any relevant issues
fixes issue #502 

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Local tests and examples pass locally, including Wasm examples.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
