### PR TITLE
Check for existence & duplication of methods in `CoreDocument`

### DIFF
--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -163,10 +163,10 @@ impl WasmDocument {
 
   /// Adds a new Verification Method to the DID Document.
   #[wasm_bindgen(js_name = insertMethod)]
-  pub fn insert_method(&mut self, method: &WasmVerificationMethod, scope: Option<String>) -> Result<bool> {
+  pub fn insert_method(&mut self, method: &WasmVerificationMethod, scope: Option<String>) -> Result<()> {
     let scope: MethodScope = scope.unwrap_or_default().parse().wasm_result()?;
-
-    Ok(self.0.insert_method(method.0.clone(), scope))
+    self.0.insert_method(method.0.clone(), scope).wasm_result()?;
+    Ok(())
   }
 
   /// Removes all references to the specified Verification Method.

--- a/examples/account/manipulate_did.rs
+++ b/examples/account/manipulate_did.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<()> {
   // Associate the newly created method with additional verification relationships
   account
     .update_identity()
-    .attach_method()
+    .attach_method_relationship()
     .fragment("my-next-key")
     .relationship(MethodRelationship::CapabilityDelegation)
     .relationship(MethodRelationship::CapabilityInvocation)

--- a/examples/low-level-api/common.rs
+++ b/examples/low-level-api/common.rs
@@ -78,7 +78,9 @@ pub async fn add_new_key(
   let new_key: KeyPair = KeyPair::new_ed25519()?;
   let method: IotaVerificationMethod =
     IotaVerificationMethod::from_did(updated_doc.did().clone(), new_key.type_(), new_key.public(), "newKey")?;
-  assert!(updated_doc.insert_method(method, MethodScope::VerificationMethod));
+  assert!(updated_doc
+    .insert_method(method, MethodScope::VerificationMethod)
+    .is_ok());
 
   // Prepare the update
   updated_doc.set_previous_message_id(*receipt.message_id());

--- a/examples/low-level-api/manipulate_did.rs
+++ b/examples/low-level-api/manipulate_did.rs
@@ -31,7 +31,7 @@ pub async fn run() -> Result<(IotaDocument, KeyPair, KeyPair, Receipt, Receipt)>
   let new_key: KeyPair = KeyPair::new_ed25519()?;
   let method: IotaVerificationMethod =
     IotaVerificationMethod::from_did(document.did().clone(), new_key.type_(), new_key.public(), "newKey")?;
-  assert!(document.insert_method(method, MethodScope::VerificationMethod));
+  assert!(document.insert_method(method, MethodScope::VerificationMethod).is_ok());
 
   // Add a new Service
   let service: Service = Service::from_json_value(json!({

--- a/examples/low-level-api/merkle_key.rs
+++ b/examples/low-level-api/merkle_key.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
   let method = IotaVerificationMethod::create_merkle_key::<Sha256>(method_did, &keys, "merkle-key")?;
 
   // Add to the DID Document as a general-purpose verification method
-  issuer_doc.insert_method(method, MethodScope::VerificationMethod);
+  issuer_doc.insert_method(method, MethodScope::VerificationMethod)?;
   issuer_doc.set_previous_message_id(*issuer_receipt.message_id());
   issuer_doc.sign_self(issuer_key.private(), &issuer_doc.default_signing_method()?.id())?;
 

--- a/examples/low-level-api/resolve_history.rs
+++ b/examples/low-level-api/resolve_history.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<()> {
     // Add a new VerificationMethod with a new KeyPair, with the tag "keys-1"
     let keys_1: KeyPair = KeyPair::new_ed25519()?;
     let method_1: IotaVerificationMethod = IotaVerificationMethod::from_did(int_doc_1.id().clone(), keys_1.type_(), keys_1.public(), "keys-1")?;
-    assert!(int_doc_1.insert_method(method_1, MethodScope::VerificationMethod));
+    assert!(int_doc_1.insert_method(method_1, MethodScope::VerificationMethod).is_ok());
 
     // Add the `message_id` of the previous message in the chain.
     // This is REQUIRED in order for the messages to form a chain.
@@ -177,7 +177,7 @@ async fn main() -> Result<()> {
     // Add a VerificationMethod with a new KeyPair, called "keys-2"
     let keys_2: KeyPair = KeyPair::new_ed25519()?;
     let method_2: IotaVerificationMethod = IotaVerificationMethod::from_did(int_doc_2.id().clone(), keys_2.type_(), keys_2.public(), "keys-2")?;
-    assert!(int_doc_2.insert_method(method_2, MethodScope::VerificationMethod));
+    assert!(int_doc_2.insert_method(method_2, MethodScope::VerificationMethod).is_ok());
 
     // Note: the `previous_message_id` points to the `message_id` of the last integration chain
     //       update, NOT the last diff chain message.

--- a/examples/low-level-api/revoke_vc.rs
+++ b/examples/low-level-api/revoke_vc.rs
@@ -106,7 +106,9 @@ pub async fn add_new_key(
   let new_key: KeyPair = KeyPair::new_ed25519()?;
   let method: IotaVerificationMethod =
     IotaVerificationMethod::from_did(updated_doc.did().clone(), new_key.type_(), new_key.public(), "newKey")?;
-  assert!(updated_doc.insert_method(method, MethodScope::VerificationMethod));
+  assert!(updated_doc
+    .insert_method(method, MethodScope::VerificationMethod)
+    .is_ok());
 
   // Prepare the update
   updated_doc.set_previous_message_id(*receipt.message_id());

--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -205,13 +205,10 @@ impl Account {
   {
     let state: &IdentityState = self.state();
 
-    let method: &IotaVerificationMethod =
-      state
-        .document()
-        .resolve_method(fragment)
-        .ok_or(Error::IotaError(identity_iota::Error::InvalidDoc(
-          identity_did::Error::MethodNotFound,
-        )))?;
+    let method: &IotaVerificationMethod = state
+      .document()
+      .resolve_method(fragment)
+      .ok_or(Error::DIDError(identity_did::Error::MethodNotFound))?;
 
     let location: KeyLocation = state.method_location(method.key_type(), fragment.to_owned())?;
 

--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -205,7 +205,13 @@ impl Account {
   {
     let state: &IdentityState = self.state();
 
-    let method: &IotaVerificationMethod = state.document().resolve_method(fragment).ok_or(Error::MethodNotFound)?;
+    let method: &IotaVerificationMethod =
+      state
+        .document()
+        .resolve_method(fragment)
+        .ok_or(Error::IotaError(identity_iota::Error::InvalidDoc(
+          identity_did::Error::MethodNotFound,
+        )))?;
 
     let location: KeyLocation = state.method_location(method.key_type(), fragment.to_owned())?;
 

--- a/identity-account/src/error.rs
+++ b/identity-account/src/error.rs
@@ -67,9 +67,6 @@ pub enum Error {
   /// Caused by attempting to find an identity that does not exist.
   #[error("Identity not found")]
   IdentityNotFound,
-  /// Caused by attempting to find a verification method that does not exist.
-  #[error("Verification Method not found")]
-  MethodNotFound,
   /// Caused by attempting to perform an upate in an invalid context.
   #[error("Update Error: {0}")]
   UpdateError(#[from] crate::updates::UpdateError),

--- a/identity-account/src/tests/updates.rs
+++ b/identity-account/src/tests/updates.rs
@@ -382,7 +382,7 @@ async fn test_attach_method_relationship() -> Result<()> {
     .to_owned();
 
   // Attempt attaching a relationship to an embedded method.
-  let update: Update = Update::AttachMethod {
+  let update: Update = Update::AttachMethodRelationship {
     relationships: vec![MethodRelationship::AssertionMethod, MethodRelationship::KeyAgreement],
     fragment: default_method_fragment,
   };
@@ -402,7 +402,7 @@ async fn test_attach_method_relationship() -> Result<()> {
   assert_eq!(account.document().as_document().assertion_method().iter().count(), 0);
   assert_eq!(account.document().as_document().key_agreement().iter().count(), 0);
 
-  let update: Update = Update::AttachMethod {
+  let update: Update = Update::AttachMethodRelationship {
     relationships: vec![MethodRelationship::AssertionMethod, MethodRelationship::KeyAgreement],
     fragment: fragment.clone(),
   };
@@ -460,7 +460,7 @@ async fn test_detach_method_relationship() -> Result<()> {
   account.process_update(update).await?;
 
   // Attempt detaching a relationship from an embedded method.
-  let update: Update = Update::DetachMethod {
+  let update: Update = Update::DetachMethodRelationship {
     relationships: vec![MethodRelationship::Authentication],
     fragment: embedded_fragment,
   };
@@ -486,7 +486,7 @@ async fn test_detach_method_relationship() -> Result<()> {
 
   account.process_update(update).await?;
 
-  let update: Update = Update::AttachMethod {
+  let update: Update = Update::AttachMethodRelationship {
     relationships: vec![MethodRelationship::AssertionMethod, MethodRelationship::KeyAgreement],
     fragment: generic_fragment.clone(),
   };
@@ -496,7 +496,7 @@ async fn test_detach_method_relationship() -> Result<()> {
   assert_eq!(account.document().as_document().assertion_method().len(), 1);
   assert_eq!(account.document().as_document().key_agreement().len(), 1);
 
-  let update: Update = Update::DetachMethod {
+  let update: Update = Update::DetachMethodRelationship {
     relationships: vec![MethodRelationship::AssertionMethod, MethodRelationship::KeyAgreement],
     fragment: generic_fragment.clone(),
   };

--- a/identity-account/src/tests/updates.rs
+++ b/identity-account/src/tests/updates.rs
@@ -594,9 +594,7 @@ async fn test_delete_method() -> Result<()> {
 
   assert!(matches!(
     output.unwrap_err(),
-    Error::IotaError(identity_iota::Error::InvalidDoc(
-      identity_did::Error::QueryMethodNotFound
-    ))
+    Error::IotaError(identity_iota::Error::InvalidDoc(identity_did::Error::MethodNotFound))
   ));
 
   Ok(())

--- a/identity-account/src/tests/updates.rs
+++ b/identity-account/src/tests/updates.rs
@@ -261,7 +261,9 @@ async fn test_create_method_duplicate_fragment() -> Result<()> {
   let mut account_setup = account_setup();
   account_setup.config = account_setup.config.testmode(true).autopublish(false);
 
-  let mut account = Account::create_identity(account_setup, IdentitySetup::default()).await?;
+  let mut account = Account::create_identity(account_setup, IdentitySetup::default())
+    .await
+    .unwrap();
 
   let update: Update = Update::CreateMethod {
     scope: MethodScope::default(),
@@ -270,7 +272,7 @@ async fn test_create_method_duplicate_fragment() -> Result<()> {
     fragment: "key-1".to_owned(),
   };
 
-  account.process_update(update.clone()).await?;
+  account.process_update(update.clone()).await.unwrap();
 
   let output = account.process_update(update.clone()).await;
 
@@ -288,7 +290,7 @@ async fn test_create_method_duplicate_fragment() -> Result<()> {
   // Now the location is different due to the incremented generation, but the fragment is the same.
   assert!(matches!(
     output.unwrap_err(),
-    Error::UpdateError(UpdateError::DuplicateKeyFragment(_)),
+    Error::DIDError(identity_did::Error::InvalidMethodDuplicate)
   ));
 
   Ok(())

--- a/identity-account/src/tests/updates.rs
+++ b/identity-account/src/tests/updates.rs
@@ -290,7 +290,7 @@ async fn test_create_method_duplicate_fragment() -> Result<()> {
   // Now the location is different due to the incremented generation, but the fragment is the same.
   assert!(matches!(
     output.unwrap_err(),
-    Error::DIDError(identity_did::Error::InvalidMethodDuplicate)
+    Error::DIDError(identity_did::Error::MethodAlreadyExists)
   ));
 
   Ok(())

--- a/identity-account/src/tests/updates.rs
+++ b/identity-account/src/tests/updates.rs
@@ -563,7 +563,7 @@ async fn test_delete_method() -> Result<()> {
     fragment: "key-1".to_owned(),
   };
 
-  account.process_update(update).await?;
+  account.process_update(update.clone()).await?;
 
   let state: &IdentityState = account.state();
 
@@ -584,6 +584,16 @@ async fn test_delete_method() -> Result<()> {
   assert_eq!(initial_state.document().created(), state.document().created());
   // Ensure `updated` was recently set.
   assert!(state.document().updated() > Timestamp::from_unix(Timestamp::now_utc().to_unix() - 15));
+
+  // Deleting a non-existing methods fails.
+  let output = account.process_update(update).await;
+
+  assert!(matches!(
+    output.unwrap_err(),
+    Error::IotaError(identity_iota::Error::InvalidDoc(
+      identity_did::Error::QueryMethodNotFound
+    ))
+  ));
 
   Ok(())
 }

--- a/identity-account/src/tests/updates.rs
+++ b/identity-account/src/tests/updates.rs
@@ -391,7 +391,9 @@ async fn test_attach_method_relationship() -> Result<()> {
 
   assert!(matches!(
     err,
-    Error::UpdateError(UpdateError::InvalidTargetEmbeddedMethod)
+    Error::IotaError(identity_iota::Error::InvalidDoc(
+      identity_did::Error::InvalidMethodEmbedded
+    ))
   ));
 
   // No relationships were created.
@@ -467,7 +469,9 @@ async fn test_detach_method_relationship() -> Result<()> {
 
   assert!(matches!(
     err,
-    Error::UpdateError(UpdateError::InvalidTargetEmbeddedMethod)
+    Error::IotaError(identity_iota::Error::InvalidDoc(
+      identity_did::Error::InvalidMethodEmbedded
+    ))
   ));
 
   // No relationships were removed.

--- a/identity-account/src/updates/error.rs
+++ b/identity-account/src/updates/error.rs
@@ -20,9 +20,6 @@ pub enum UpdateError {
   InvalidMethodFragment(&'static str),
   #[error("invalid method secret: {0}")]
   InvalidMethodSecret(String),
-  /// Caused by attempting to attach or detach a relationship on an embedded method.
-  #[error("invalid target method - method is embedded")]
-  InvalidTargetEmbeddedMethod,
   #[error("missing required field - {0}")]
   MissingRequiredField(&'static str),
   #[error("duplicate key location - {0}")]

--- a/identity-account/src/updates/error.rs
+++ b/identity-account/src/updates/error.rs
@@ -1,7 +1,6 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use identity_core::common::Fragment;
 use identity_did::verification::MethodType;
 
 use crate::types::KeyLocation;
@@ -28,8 +27,6 @@ pub enum UpdateError {
   MissingRequiredField(&'static str),
   #[error("duplicate key location - {0}")]
   DuplicateKeyLocation(KeyLocation),
-  #[error("duplicate key fragment - {0}")]
-  DuplicateKeyFragment(Fragment),
   #[error("duplicate service fragment - {0}")]
   DuplicateServiceFragment(String),
 }

--- a/identity-account/src/updates/error.rs
+++ b/identity-account/src/updates/error.rs
@@ -10,8 +10,6 @@ use crate::types::KeyLocation;
 pub enum UpdateError {
   #[error("document already exists")]
   DocumentAlreadyExists,
-  #[error("verification method not found")]
-  MethodNotFound,
   #[error("service not found")]
   ServiceNotFound,
   #[error("invalid method type - {}", .0.as_str())]

--- a/identity-account/src/updates/update.rs
+++ b/identity-account/src/updates/update.rs
@@ -112,11 +112,11 @@ pub(crate) enum Update {
   DeleteMethod {
     fragment: String,
   },
-  AttachMethod {
+  AttachMethodRelationship {
     fragment: String,
     relationships: Vec<MethodRelationship>,
   },
-  DetachMethod {
+  DetachMethodRelationship {
     fragment: String,
     relationships: Vec<MethodRelationship>,
   },
@@ -191,7 +191,7 @@ impl Update {
 
         state.document_mut().remove_method(method_url)?;
       }
-      Self::AttachMethod {
+      Self::AttachMethodRelationship {
         fragment,
         relationships,
       } => {
@@ -206,7 +206,7 @@ impl Update {
             .attach_method_relationship(method_url.clone(), relationship)?;
         }
       }
-      Self::DetachMethod {
+      Self::DetachMethodRelationship {
         fragment,
         relationships,
       } => {
@@ -350,12 +350,12 @@ impl_update_builder!(
 /// # Parameters
 /// - `relationships`: the relationships to add, defaults to an empty [`Vec`].
 /// - `fragment`: the identifier of the method in the document, required.
-AttachMethod {
+AttachMethodRelationship {
   @required fragment String,
   @default relationships Vec<MethodRelationship>,
 });
 
-impl<'account> AttachMethodBuilder<'account> {
+impl<'account> AttachMethodRelationshipBuilder<'account> {
   pub fn relationship(mut self, value: MethodRelationship) -> Self {
     self.relationships.get_or_insert_with(Default::default).push(value);
     self
@@ -368,12 +368,12 @@ impl_update_builder!(
 /// # Parameters
 /// - `relationships`: the relationships to remove, defaults to an empty [`Vec`].
 /// - `fragment`: the identifier of the method in the document, required.
-DetachMethod {
+DetachMethodRelationship {
   @required fragment String,
   @default relationships Vec<MethodRelationship>,
 });
 
-impl<'account> DetachMethodBuilder<'account> {
+impl<'account> DetachMethodRelationshipBuilder<'account> {
   pub fn relationship(mut self, value: MethodRelationship) -> Self {
     self.relationships.get_or_insert_with(Default::default).push(value);
     self

--- a/identity-account/src/updates/update.rs
+++ b/identity-account/src/updates/update.rs
@@ -200,7 +200,8 @@ impl Update {
         let method_url: IotaDIDUrl = did.to_url().join(fragment.identifier())?;
 
         for relationship in relationships {
-          state
+          // Ignore result: attaching is idempotent.
+          let _ = state
             .document_mut()
             .attach_method_relationship(method_url.clone(), relationship)?;
         }
@@ -226,7 +227,8 @@ impl Update {
         );
 
         for relationship in relationships {
-          state
+          // Ignore result: detaching is idempotent.
+          let _ = state
             .document_mut()
             .detach_method_relationship(method_url.clone(), relationship)?;
         }

--- a/identity-account/src/updates/update.rs
+++ b/identity-account/src/updates/update.rs
@@ -144,7 +144,7 @@ impl Update {
         fragment,
         method_secret,
       } => {
-        let location: KeyLocation = state.key_location(type_, fragment.clone())?;
+        let location: KeyLocation = state.key_location(type_, fragment)?;
 
         // The key location must be available.
         // TODO: config: strict
@@ -153,8 +153,7 @@ impl Update {
           UpdateError::DuplicateKeyLocation(location)
         );
 
-        let fragment: Fragment = Fragment::new(fragment);
-        let method_url: CoreDIDUrl = did.as_ref().to_url().join(fragment.identifier())?;
+        let method_url: CoreDIDUrl = did.as_ref().to_url().join(location.fragment().identifier())?;
 
         if state.document().resolve_method(method_url).is_some() {
           return Err(crate::Error::DIDError(identity_did::Error::MethodAlreadyExists));

--- a/identity-account/src/updates/update.rs
+++ b/identity-account/src/updates/update.rs
@@ -177,12 +177,6 @@ impl Update {
       Self::DeleteMethod { fragment } => {
         let fragment: Fragment = Fragment::new(fragment);
 
-        // The verification method must exist
-        ensure!(
-          state.document().resolve_method(fragment.identifier()).is_some(),
-          UpdateError::MethodNotFound
-        );
-
         let method_url: IotaDIDUrl = did.to_url().join(fragment.identifier())?;
         let core_method_url: CoreDIDUrl = CoreDIDUrl::from(method_url.clone());
 

--- a/identity-account/src/updates/update.rs
+++ b/identity-account/src/updates/update.rs
@@ -157,7 +157,7 @@ impl Update {
         let method_url: CoreDIDUrl = did.as_ref().to_url().join(fragment.identifier())?;
 
         if state.document().resolve_method(method_url).is_some() {
-          return Err(crate::Error::DIDError(identity_did::Error::InvalidMethodDuplicate));
+          return Err(crate::Error::DIDError(identity_did::Error::MethodAlreadyExists));
         }
 
         let public: PublicKey = if let Some(method_private_key) = method_secret {

--- a/identity-account/src/updates/update.rs
+++ b/identity-account/src/updates/update.rs
@@ -208,17 +208,17 @@ impl Update {
         );
 
         // The verification method must not be embedded.
-        ensure!(
-          !state
-            .document()
-            .as_document()
-            .verification_relationships()
-            .any(|method_ref| match method_ref {
-              MethodRef::Embed(method) => method.id().fragment() == method_url.fragment(),
-              MethodRef::Refer(_) => false,
-            }),
-          UpdateError::InvalidTargetEmbeddedMethod
-        );
+        // ensure!(
+        //   !state
+        //     .document()
+        //     .as_document()
+        //     .verification_relationships()
+        //     .any(|method_ref| match method_ref {
+        //       MethodRef::Embed(method) => method.id().fragment() == method_url.fragment(),
+        //       MethodRef::Refer(_) => false,
+        //     }),
+        //   UpdateError::InvalidTargetEmbeddedMethod
+        // );
 
         for relationship in relationships {
           // We ignore the boolean result: if the relationship already existed, that's fine.
@@ -255,17 +255,17 @@ impl Update {
         );
 
         // The verification method must not be embedded.
-        ensure!(
-          !state
-            .document()
-            .as_document()
-            .verification_relationships()
-            .any(|method_ref| match method_ref {
-              MethodRef::Embed(method) => method.id().fragment() == method_url.fragment(),
-              MethodRef::Refer(_) => false,
-            }),
-          UpdateError::InvalidTargetEmbeddedMethod
-        );
+        // ensure!(
+        //   !state
+        //     .document()
+        //     .as_document()
+        //     .verification_relationships()
+        //     .any(|method_ref| match method_ref {
+        //       MethodRef::Embed(method) => method.id().fragment() == method_url.fragment(),
+        //       MethodRef::Refer(_) => false,
+        //     }),
+        //   UpdateError::InvalidTargetEmbeddedMethod
+        // );
 
         for relationship in relationships {
           state

--- a/identity-did/src/document/core_document.rs
+++ b/identity-did/src/document/core_document.rs
@@ -278,7 +278,7 @@ impl<T, U, V> CoreDocument<T, U, V> {
     if was_removed {
       Ok(())
     } else {
-      Err(Error::QueryMethodNotFound)
+      Err(Error::MethodNotFound)
     }
   }
 
@@ -299,7 +299,7 @@ impl<T, U, V> CoreDocument<T, U, V> {
     match self.resolve_method_with_scope(method_query.clone(), MethodScope::VerificationMethod) {
       None => match self.resolve_method(method_query) {
         Some(_) => Err(Error::InvalidMethodEmbedded),
-        None => Err(Error::QueryMethodNotFound),
+        None => Err(Error::MethodNotFound),
       },
       Some(method) => {
         let method_ref = MethodRef::Refer(method.id().clone());
@@ -330,7 +330,7 @@ impl<T, U, V> CoreDocument<T, U, V> {
     match self.resolve_method_with_scope(method_query.clone(), MethodScope::VerificationMethod) {
       None => match self.resolve_method(method_query) {
         Some(_) => Err(Error::InvalidMethodEmbedded),
-        None => Err(Error::QueryMethodNotFound),
+        None => Err(Error::MethodNotFound),
       },
       Some(method) => {
         let did_url: CoreDIDUrl = method.id().clone();
@@ -399,9 +399,7 @@ impl<T, U, V> CoreDocument<T, U, V> {
   where
     Q: Into<MethodQuery<'query>>,
   {
-    self
-      .resolve_method_inner(query.into())
-      .ok_or(Error::QueryMethodNotFound)
+    self.resolve_method_inner(query.into()).ok_or(Error::MethodNotFound)
   }
 
   /// Returns the first [`VerificationMethod`] with an `id` property matching the provided `query`
@@ -454,7 +452,7 @@ impl<T, U, V> CoreDocument<T, U, V> {
   {
     self
       .resolve_method_with_scope(query, scope)
-      .ok_or(Error::QueryMethodNotFound)
+      .ok_or(Error::MethodNotFound)
   }
 
   /// Returns a mutable reference to the first [`VerificationMethod`] with an `id` property
@@ -476,9 +474,7 @@ impl<T, U, V> CoreDocument<T, U, V> {
   where
     Q: Into<MethodQuery<'query>>,
   {
-    self
-      .resolve_method_mut_inner(query.into())
-      .ok_or(Error::QueryMethodNotFound)
+    self.resolve_method_mut_inner(query.into()).ok_or(Error::MethodNotFound)
   }
 
   #[doc(hidden)]

--- a/identity-did/src/document/core_document.rs
+++ b/identity-did/src/document/core_document.rs
@@ -235,7 +235,11 @@ impl<T, U, V> CoreDocument<T, U, V> {
     })
   }
 
-  /// Adds a new [`VerificationMethod`] to the Document.
+  /// Adds a new [`VerificationMethod`] to the document in the given [`MethodScope`].
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if a method with the same fragment already exists.
   pub fn insert_method(&mut self, method: VerificationMethod<U>, scope: MethodScope) -> Result<()> {
     if self.resolve_method(method.id()).is_some() {
       return Err(Error::MethodAlreadyExists);
@@ -264,6 +268,10 @@ impl<T, U, V> CoreDocument<T, U, V> {
   }
 
   /// Removes all references to the specified [`VerificationMethod`].
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the method does not exist.
   pub fn remove_method(&mut self, did: &CoreDIDUrl) -> Result<()> {
     let mut was_removed = false;
     was_removed = was_removed || self.authentication.remove(did);
@@ -280,10 +288,13 @@ impl<T, U, V> CoreDocument<T, U, V> {
     }
   }
 
-  /// Attaches the relationship to the given method, if the method exists.
+  /// Attaches the relationship to the method resolved by `method_query`.
   ///
-  /// Note: The method needs to be in the set of verification methods,
-  /// so it cannot be an embedded one.
+  /// # Errors
+  ///
+  /// Returns an error if the method does not exist or if it is embedded.
+  /// To convert an embedded method into a generic verification method, remove it first
+  /// and insert it with [`MethodScope::VerificationMethod`].
   pub fn attach_method_relationship<'query, Q>(
     &mut self,
     method_query: Q,
@@ -315,7 +326,12 @@ impl<T, U, V> CoreDocument<T, U, V> {
     }
   }
 
-  /// Detaches the given relationship from the given method, if the method exists.
+  /// Detaches the relationship from the method resolved by `method_query`.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the method does not exist or is embedded.
+  /// To remove an embedded method, use [`Self::remove_method`].
   pub fn detach_method_relationship<'query, Q>(
     &mut self,
     method_query: Q,

--- a/identity-did/src/document/core_document.rs
+++ b/identity-did/src/document/core_document.rs
@@ -242,23 +242,21 @@ impl<T, U, V> CoreDocument<T, U, V> {
     }
 
     match scope {
-      MethodScope::VerificationMethod => {
-        self.verification_method.append(method);
-      }
+      MethodScope::VerificationMethod => self.verification_method.append(method),
       MethodScope::VerificationRelationship(MethodRelationship::Authentication) => {
-        self.authentication.append(MethodRef::Embed(method));
+        self.authentication.append(MethodRef::Embed(method))
       }
       MethodScope::VerificationRelationship(MethodRelationship::AssertionMethod) => {
-        self.assertion_method.append(MethodRef::Embed(method));
+        self.assertion_method.append(MethodRef::Embed(method))
       }
       MethodScope::VerificationRelationship(MethodRelationship::KeyAgreement) => {
-        self.key_agreement.append(MethodRef::Embed(method));
+        self.key_agreement.append(MethodRef::Embed(method))
       }
       MethodScope::VerificationRelationship(MethodRelationship::CapabilityDelegation) => {
-        self.capability_delegation.append(MethodRef::Embed(method));
+        self.capability_delegation.append(MethodRef::Embed(method))
       }
       MethodScope::VerificationRelationship(MethodRelationship::CapabilityInvocation) => {
-        self.capability_invocation.append(MethodRef::Embed(method));
+        self.capability_invocation.append(MethodRef::Embed(method))
       }
     };
 

--- a/identity-did/src/document/core_document.rs
+++ b/identity-did/src/document/core_document.rs
@@ -238,7 +238,7 @@ impl<T, U, V> CoreDocument<T, U, V> {
   /// Adds a new [`VerificationMethod`] to the Document.
   pub fn insert_method(&mut self, method: VerificationMethod<U>, scope: MethodScope) -> Result<()> {
     if self.resolve_method(method.id()).is_some() {
-      return Err(Error::InvalidMethodDuplicate);
+      return Err(Error::MethodAlreadyExists);
     }
 
     match scope {

--- a/identity-did/src/error.rs
+++ b/identity-did/src/error.rs
@@ -44,8 +44,9 @@ pub enum Error {
   InvalidMethodFragment,
   #[error("Invalid Verification Method Type")]
   InvalidMethodType,
-  #[error("Invalid Verification Method - Duplicate")]
-  InvalidMethodDuplicate,
+  /// Caused by attempting to add a verification method to a document, where a method with the same fragment already exists.
+  #[error("verification method already exists")]
+  MethodAlreadyExists,
   /// Caused by attempting to attach or detach a relationship on an embedded method.
   #[error("unable to modify relationships on embedded methods, use insert or remove instead")]
   InvalidMethodEmbedded,

--- a/identity-did/src/error.rs
+++ b/identity-did/src/error.rs
@@ -46,6 +46,9 @@ pub enum Error {
   InvalidMethodType,
   #[error("Invalid Verification Method - Duplicate")]
   InvalidMethodDuplicate,
+  /// Caused by attempting to attach or detach a relationship on an embedded method.
+  #[error("unable to modify relationships on embedded methods, use insert or remove instead")]
+  InvalidMethodEmbedded,
 
   #[error("Unknown Method Scope")]
   UnknownMethodScope,

--- a/identity-did/src/error.rs
+++ b/identity-did/src/error.rs
@@ -19,7 +19,7 @@ pub enum Error {
   #[error("Duplicate Item in Ordered Set")]
   OrderedSetDuplicate,
   #[error("Verification Method Not Found")]
-  QueryMethodNotFound,
+  MethodNotFound,
 
   #[error("Invalid Document Property: `id`")]
   BuilderInvalidDocumentId,

--- a/identity-did/src/error.rs
+++ b/identity-did/src/error.rs
@@ -44,7 +44,8 @@ pub enum Error {
   InvalidMethodFragment,
   #[error("Invalid Verification Method Type")]
   InvalidMethodType,
-  /// Caused by attempting to add a verification method to a document, where a method with the same fragment already exists.
+  /// Caused by attempting to add a verification method to a document, where a method with the same fragment already
+  /// exists.
   #[error("verification method already exists")]
   MethodAlreadyExists,
   /// Caused by attempting to attach or detach a relationship on an embedded method.

--- a/identity-did/src/verifiable/document.rs
+++ b/identity-did/src/verifiable/document.rs
@@ -163,7 +163,7 @@ impl<T, U, V> DocumentSigner<'_, '_, '_, T, U, V> {
   where
     X: Serialize + SetSignature + TryMethod,
   {
-    let query: MethodQuery<'_> = self.method.clone().ok_or(Error::QueryMethodNotFound)?;
+    let query: MethodQuery<'_> = self.method.clone().ok_or(Error::MethodNotFound)?;
     let method: &VerificationMethod<U> = self.document.try_resolve_method(query)?;
     let method_uri: String = X::try_method(method)?;
 

--- a/identity-iota/src/did/doc/iota_document.rs
+++ b/identity-iota/src/did/doc/iota_document.rs
@@ -396,13 +396,13 @@ impl IotaDocument {
   ///
   /// Note: The method needs to be in the set of verification methods,
   /// so it cannot be an embedded one.
-  pub fn attach_method_relationship(&mut self, did_url: IotaDIDUrl, relationship: MethodRelationship) -> Result<bool> {
+  pub fn attach_method_relationship(&mut self, did_url: IotaDIDUrl, relationship: MethodRelationship) -> Result<()> {
     let core_did_url: CoreDIDUrl = CoreDIDUrl::from(did_url);
     Ok(self.document.attach_method_relationship(core_did_url, relationship)?)
   }
 
   /// Detaches the given relationship from the given method, if the method exists.
-  pub fn detach_method_relationship(&mut self, did_url: IotaDIDUrl, relationship: MethodRelationship) -> Result<bool> {
+  pub fn detach_method_relationship(&mut self, did_url: IotaDIDUrl, relationship: MethodRelationship) -> Result<()> {
     let core_did_url: CoreDIDUrl = CoreDIDUrl::from(did_url);
     Ok(self.document.detach_method_relationship(core_did_url, relationship)?)
   }

--- a/identity-iota/src/did/doc/iota_document.rs
+++ b/identity-iota/src/did/doc/iota_document.rs
@@ -380,13 +380,20 @@ impl IotaDocument {
         unsafe { IotaVerificationMethod::new_unchecked_ref(m) })
   }
 
-  /// Adds a new [`IotaVerificationMethod`] to the DID Document.
+  /// Adds a new [`IotaVerificationMethod`] to the document in the given [`MethodScope`].
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if a method with the same fragment already exists.
   pub fn insert_method(&mut self, method: IotaVerificationMethod, scope: MethodScope) -> Result<()> {
     Ok(self.document.insert_method(method.into(), scope)?)
   }
 
-  /// Removes all occurrences of and references to the specified [`VerificationMethod`]
-  /// from this document.
+  /// Removes all references to the specified [`VerificationMethod`].
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the method does not exist.
   pub fn remove_method(&mut self, did_url: IotaDIDUrl) -> Result<()> {
     let core_did_url: CoreDIDUrl = CoreDIDUrl::from(did_url);
     Ok(self.document.remove_method(&core_did_url)?)

--- a/identity-iota/src/did/doc/iota_document.rs
+++ b/identity-iota/src/did/doc/iota_document.rs
@@ -403,13 +403,13 @@ impl IotaDocument {
   ///
   /// Note: The method needs to be in the set of verification methods,
   /// so it cannot be an embedded one.
-  pub fn attach_method_relationship(&mut self, did_url: IotaDIDUrl, relationship: MethodRelationship) -> Result<()> {
+  pub fn attach_method_relationship(&mut self, did_url: IotaDIDUrl, relationship: MethodRelationship) -> Result<bool> {
     let core_did_url: CoreDIDUrl = CoreDIDUrl::from(did_url);
     Ok(self.document.attach_method_relationship(core_did_url, relationship)?)
   }
 
   /// Detaches the given relationship from the given method, if the method exists.
-  pub fn detach_method_relationship(&mut self, did_url: IotaDIDUrl, relationship: MethodRelationship) -> Result<()> {
+  pub fn detach_method_relationship(&mut self, did_url: IotaDIDUrl, relationship: MethodRelationship) -> Result<bool> {
     let core_did_url: CoreDIDUrl = CoreDIDUrl::from(did_url);
     Ok(self.document.detach_method_relationship(core_did_url, relationship)?)
   }

--- a/identity-iota/src/tangle/publish.rs
+++ b/identity-iota/src/tangle/publish.rs
@@ -86,7 +86,7 @@ mod test {
 
     let method3_url = method2.id();
 
-    old_doc.insert_method(method2, MethodScope::VerificationMethod);
+    old_doc.insert_method(method2, MethodScope::VerificationMethod).unwrap();
     old_doc
       .attach_method_relationship(
         method3_url,
@@ -109,7 +109,9 @@ mod test {
     let method2: IotaVerificationMethod =
       IotaVerificationMethod::from_did(old_doc.did().to_owned(), keypair.type_(), keypair.public(), "test-2")?;
 
-    new_doc.insert_method(method2, MethodScope::capability_invocation());
+    new_doc
+      .insert_method(method2, MethodScope::capability_invocation())
+      .unwrap();
 
     assert!(matches!(
       PublishType::new(&old_doc, &new_doc),
@@ -132,7 +134,9 @@ mod test {
     new_doc
       .remove_method(new_doc.did().to_url().join("#embedded").unwrap())
       .unwrap();
-    new_doc.insert_method(verif_method2, MethodScope::capability_invocation());
+    new_doc
+      .insert_method(verif_method2, MethodScope::capability_invocation())
+      .unwrap();
 
     assert!(matches!(
       PublishType::new(&old_doc, &new_doc),
@@ -177,7 +181,9 @@ mod test {
     let verif_method2: IotaVerificationMethod =
       IotaVerificationMethod::from_did(new_doc.did().to_owned(), keypair.type_(), keypair.public(), "test-2")?;
 
-    new_doc.insert_method(verif_method2, MethodScope::authentication());
+    new_doc
+      .insert_method(verif_method2, MethodScope::authentication())
+      .unwrap();
 
     assert!(matches!(PublishType::new(&old_doc, &new_doc), Some(PublishType::Diff)));
 
@@ -214,7 +220,7 @@ mod test {
     let method: IotaVerificationMethod =
       IotaVerificationMethod::create_merkle_key::<Sha256>(new_doc.did().to_owned(), &collection, "merkle")?;
 
-    new_doc.insert_method(method, MethodScope::authentication());
+    new_doc.insert_method(method, MethodScope::authentication()).unwrap();
 
     assert!(matches!(PublishType::new(&old_doc, &new_doc), Some(PublishType::Diff)));
 
@@ -229,7 +235,9 @@ mod test {
     let method: IotaVerificationMethod =
       IotaVerificationMethod::create_merkle_key::<Sha256>(old_doc.did().to_owned(), &collection, "merkle")?;
 
-    old_doc.insert_method(method, MethodScope::capability_invocation());
+    old_doc
+      .insert_method(method, MethodScope::capability_invocation())
+      .unwrap();
 
     let mut new_doc = old_doc.clone();
 


### PR DESCRIPTION
# Description of change

To prevent users from creating invalid documents, some checks were moved from the account to the lower-level crates.

- Move existence and duplication checks to `CoreDocument`.
- Move embedded check to `CoreDocument` methods that modify relationships. This check ensures that relationships cannot be attached or detached from embedded methods.
- Remove unused error types that were duplicated across crates (e.g. `MethodNotFound`) and use the variant from the `identity-did` crate.
- Improve documentation of modified methods.
- Rename `AttachMethod` to `AttachMethodRelationship`
- Rename `DetachMethod` to `DetachMethodRelationship`

## Links to any relevant issues

fixes #495 

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Insertion and removal as well as attach and detach tests were modified appropriately to test the new behavior.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
