### PR TITLE
Update GitHub Actions to use Node 16

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 15.x
+          node-version: 16.x
 
       - name: Install txm # for running README.md examples https://github.com/anko/txm
         run: npm install -g txm

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 15.x
+          node-version: 16.x
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install JS dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 15.x
+          node-version: 16.x
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install JS dependencies


### PR DESCRIPTION
# Description of change
Update the Node version in all GitHub Actions workflows from 15.x to 16.x. This was required due to the minimum Node version requirement being increased to 16.x for the Wasm bindings to work in #455.

The actions with Node 15.x currently fail when trying to run the Wasm examples. E.g. https://github.com/iotaledger/identity.rs/actions/runs/1497202484

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
GitHub Actions on this PR.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
