### PR TITLE
Enforce Ed25519 private key length

### DIFF
--- a/identity-core/src/crypto/key/pair.rs
+++ b/identity-core/src/crypto/key/pair.rs
@@ -38,6 +38,10 @@ impl KeyPair {
   }
 
   /// Reconstructs the [`Ed25519`][`KeyType::Ed25519`] [`KeyPair`] from a private key.
+  ///
+  /// The private key must be exactly 32 bytes. Other implementations have different conventions for private keys, but
+  /// we follow RFC 8032. What we and the aforementioned RFC call a private key, is called a *secret key* in the paper [High-speed high-security signatures](http://ed25519.cr.yp.to/ed25519-20110926.pdf).
+  /// The following [blog post](https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/) renames the aforementioned private key/secret key to be called a *seed*.
   pub fn try_from_ed25519_bytes(private_key_bytes: &[u8]) -> Result<Self, crypto::Error> {
     let private_key_bytes: [u8; ed25519::SECRET_KEY_LENGTH] = private_key_bytes
       .try_into()

--- a/identity-core/src/crypto/key/pair.rs
+++ b/identity-core/src/crypto/key/pair.rs
@@ -39,9 +39,8 @@ impl KeyPair {
 
   /// Reconstructs the [`Ed25519`][`KeyType::Ed25519`] [`KeyPair`] from a private key.
   ///
-  /// The private key must be exactly 32 bytes. Other implementations have different conventions for private keys, but
-  /// we follow RFC 8032. What we and the aforementioned RFC call a private key, is called a *secret key* in the paper [High-speed high-security signatures](http://ed25519.cr.yp.to/ed25519-20110926.pdf).
-  /// The following [blog post](https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/) renames the aforementioned private key/secret key to be called a *seed*.
+  ///  The private key must be a 32-byte seed in compliance with [RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032#section-3.2).
+/// Other implementations often use another format. See [this blog post](https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/) for further explanation.
   pub fn try_from_ed25519_bytes(private_key_bytes: &[u8]) -> Result<Self, crypto::Error> {
     let private_key_bytes: [u8; ed25519::SECRET_KEY_LENGTH] = private_key_bytes
       .try_into()

--- a/identity-core/src/crypto/key/pair.rs
+++ b/identity-core/src/crypto/key/pair.rs
@@ -40,7 +40,7 @@ impl KeyPair {
   /// Reconstructs the [`Ed25519`][`KeyType::Ed25519`] [`KeyPair`] from a private key.
   ///
   ///  The private key must be a 32-byte seed in compliance with [RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032#section-3.2).
-/// Other implementations often use another format. See [this blog post](https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/) for further explanation.
+  /// Other implementations often use another format. See [this blog post](https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/) for further explanation.
   pub fn try_from_ed25519_bytes(private_key_bytes: &[u8]) -> Result<Self, crypto::Error> {
     let private_key_bytes: [u8; ed25519::SECRET_KEY_LENGTH] = private_key_bytes
       .try_into()

--- a/identity-core/src/crypto/proof/jcs_ed25519.rs
+++ b/identity-core/src/crypto/proof/jcs_ed25519.rs
@@ -85,7 +85,7 @@ mod tests {
   use crate::crypto::Signer as _;
   use crate::crypto::Verifier as _;
   use crate::json;
-  use crate::utils::decode_b58;
+  use crate::utils;
 
   type Signer = JcsEd25519<Ed25519<PrivateKey>>;
 
@@ -103,8 +103,11 @@ mod tests {
   #[test]
   fn test_tvs() {
     for tv in TVS {
-      let public: PublicKey = decode_b58(tv.public).unwrap().into();
-      let private: PrivateKey = decode_b58(tv.private).unwrap().into();
+      let public: PublicKey = utils::decode_b58(tv.public).unwrap().into();
+      // The test vectors have been taken from: [here](https://github.com/decentralized-identity/JcsEd25519Signature2020/tree/master/signature-suite-impls/test-vectors),
+      // and use [GO crypto/ed25519](https://pkg.go.dev/crypto/ed25519#pkg-types)'s convention of representing an Ed25519 private key as: seed (secret key in the original paper) followed by public key (computed from the seed)
+      // We follow the convention from RFC [8032](https://datatracker.ietf.org/doc/html/rfc8032) and need the seed.
+      let private: PrivateKey = (utils::decode_b58(tv.private).unwrap()[..32]).to_vec().into();
       let badkey: PublicKey = b"IOTA".to_vec().into();
 
       let input: Object = Object::from_json(tv.input).unwrap();
@@ -133,8 +136,8 @@ mod tests {
     const SIG: &[u8] = b"4VjbV3672WRhKqUVn4Cdp6e7AaXYYv2f71dM8ZDHqWexfku4oLUeDVFuxGRXxpkVUwZ924zFHu527Z2ZNiPKZVeF";
     const MSG: &[u8] = b"hello";
 
-    let public: PublicKey = decode_b58(PUBLIC).unwrap().into();
-    let private: PrivateKey = decode_b58(SECRET).unwrap().into();
+    let public: PublicKey = utils::decode_b58(PUBLIC).unwrap().into();
+    let private: PrivateKey = utils::decode_b58(SECRET).unwrap().into();
 
     let signature: SignatureValue = Signer::sign(&MSG, &private).unwrap();
 

--- a/identity-core/src/crypto/proof/jcs_ed25519.rs
+++ b/identity-core/src/crypto/proof/jcs_ed25519.rs
@@ -103,10 +103,10 @@ mod tests {
   #[test]
   fn test_tvs() {
     for tv in TVS {
+      // The test vectors are from [JcsEd25519Signature2020](https://github.com/decentralized-identity/JcsEd25519Signature2020/tree/master/signature-suite-impls/test-vectors),
+      // and use [Go crypto/ed25519](https://pkg.go.dev/crypto/ed25519#pkg-types)'s convention of representing an Ed25519 private key as: 32-byte seed concatenated with the 32-byte public key (computed from the seed).
+      // We follow the convention from [RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032#section-3.2) and extract the 32-byte seed as the private key.
       let public: PublicKey = utils::decode_b58(tv.public).unwrap().into();
-      // The test vectors have been taken from: [here](https://github.com/decentralized-identity/JcsEd25519Signature2020/tree/master/signature-suite-impls/test-vectors),
-      // and use [GO crypto/ed25519](https://pkg.go.dev/crypto/ed25519#pkg-types)'s convention of representing an Ed25519 private key as: seed (secret key in the original paper) followed by public key (computed from the seed)
-      // We follow the convention from RFC [8032](https://datatracker.ietf.org/doc/html/rfc8032) and need the seed.
       let private: PrivateKey = (utils::decode_b58(tv.private).unwrap()[..32]).to_vec().into();
       let badkey: PublicKey = b"IOTA".to_vec().into();
 

--- a/identity-core/src/crypto/signature/ed25519.rs
+++ b/identity-core/src/crypto/signature/ed25519.rs
@@ -81,7 +81,7 @@ mod tests {
   use crate::crypto::Sign;
   use crate::crypto::Verify;
 
-  /// The following test vector is taken from [Test 3 of RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032#section-7)
+  // The following test vector is taken from [Test 3 of RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032#section-7)
   const PUBLIC_KEY_HEX: &str = "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025";
   const SECRET_KEY_HEX: &str = "c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7";
   const MESSAGE_HEX: &str = "af82";

--- a/identity-core/src/crypto/signature/ed25519.rs
+++ b/identity-core/src/crypto/signature/ed25519.rs
@@ -26,7 +26,7 @@ where
   /// Computes an EdDSA/Ed25519 signature.
   ///
   ///  The private key must be a 32-byte seed in compliance with [RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032#section-3.2).
-/// Other implementations often use another format. See [this blog post](https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/) for further explanation.
+  /// Other implementations often use another format. See [this blog post](https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/) for further explanation.
   fn sign(message: &[u8], key: &Self::Private) -> Result<Self::Output> {
     parse_secret(key.as_ref()).map(|key| key.sign(message).to_bytes())
   }

--- a/identity-core/src/crypto/signature/ed25519.rs
+++ b/identity-core/src/crypto/signature/ed25519.rs
@@ -23,7 +23,11 @@ where
 {
   type Private = T;
   type Output = [u8; SIGNATURE_LENGTH];
-
+  /// signs a message.
+  ///
+  /// The private key is expected to be exactly 32 bytes. Other implementations have different conventions for private
+  /// keys, but we follow RFC 8032. What we and the aforementioned RFC call a private key, is called a *secret key* in the paper [High-speed high-security signatures](http://ed25519.cr.yp.to/ed25519-20110926.pdf).
+  /// The following [blog post](https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/) renames the aforementioned private key/secret key to be called a *seed*.
   fn sign(message: &[u8], key: &Self::Private) -> Result<Self::Output> {
     parse_secret(key.as_ref()).map(|key| key.sign(message).to_bytes())
   }
@@ -49,27 +53,24 @@ where
 
 fn parse_public(slice: &[u8]) -> Result<ed25519::PublicKey> {
   let bytes: [u8; PUBLIC_KEY_LENGTH] = slice
-    .get(..PUBLIC_KEY_LENGTH)
-    .and_then(|bytes| bytes.try_into().ok())
-    .ok_or_else(|| Error::InvalidKeyLength(slice.len(), PUBLIC_KEY_LENGTH))?;
+    .try_into()
+    .map_err(|_| Error::InvalidKeyLength(slice.len(), PUBLIC_KEY_LENGTH))?;
 
   ed25519::PublicKey::try_from_bytes(bytes).map_err(Into::into)
 }
 
 fn parse_secret(slice: &[u8]) -> Result<ed25519::SecretKey> {
   let bytes: [u8; SECRET_KEY_LENGTH] = slice
-    .get(..SECRET_KEY_LENGTH)
-    .and_then(|bytes| bytes.try_into().ok())
-    .ok_or_else(|| Error::InvalidKeyLength(slice.len(), SECRET_KEY_LENGTH))?;
+    .try_into()
+    .map_err(|_| Error::InvalidKeyLength(slice.len(), SECRET_KEY_LENGTH))?;
 
   Ok(ed25519::SecretKey::from_bytes(bytes))
 }
 
 fn parse_signature(slice: &[u8]) -> Result<ed25519::Signature> {
   let bytes: [u8; SIGNATURE_LENGTH] = slice
-    .get(..SIGNATURE_LENGTH)
-    .and_then(|bytes| bytes.try_into().ok())
-    .ok_or_else(|| Error::InvalidSigLength(slice.len(), SIGNATURE_LENGTH))?;
+    .try_into()
+    .map_err(|_| Error::InvalidSigLength(slice.len(), SIGNATURE_LENGTH))?;
 
   Ok(ed25519::Signature::from_bytes(bytes))
 }
@@ -79,28 +80,21 @@ mod tests {
   use crate::crypto::Ed25519;
   use crate::crypto::Sign;
   use crate::crypto::Verify;
-  use crate::utils::decode_b58;
 
-  const SIGNATURE_HELLO: &[u8] = &[
-    12, 203, 235, 144, 80, 6, 163, 39, 181, 17, 44, 123, 250, 162, 165, 145, 135, 132, 32, 152, 24, 168, 55, 80, 84,
-    139, 153, 101, 102, 27, 157, 29, 70, 124, 64, 120, 250, 172, 186, 163, 108, 27, 208, 248, 134, 115, 3, 154, 222,
-    165, 31, 93, 33, 108, 212, 92, 191, 14, 21, 40, 251, 103, 241, 10, 104, 101, 108, 108, 111,
-  ];
-
-  const PUBLIC_B58: &str = "6b23ioXQSAayuw13PGFMCAKqjgqoLTpeXWCy5WRfw28c";
-  const SECRET_B58: &str = "3qsrFcQqVuPpuGrRkU4wkQRvw1tc1C5EmEDPioS1GzQ2pLoThy5TYS2BsrwuzHYDnVqcYhMSpDhTXGst6H5ttFkG";
+  /// The following test vector is taken from [Test 3 of RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032#section-7)
+  const PUBLIC_KEY_HEX: &str = "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025";
+  const SECRET_KEY_HEX: &str = "c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7";
+  const MESSAGE_HEX: &str = "af82";
+  const SIGNATURE_HEX: &str = "6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a";
 
   #[test]
   fn test_ed25519_can_sign_and_verify() {
-    let public: Vec<u8> = decode_b58(PUBLIC_B58).unwrap();
-    let private: Vec<u8> = decode_b58(SECRET_B58).unwrap();
-
-    let signature: _ = Ed25519::sign(b"hello", &private).unwrap();
-    let combined: _ = [&signature[..], b"hello"].concat();
-
-    assert_eq!(&combined, SIGNATURE_HELLO);
-
-    let verified: _ = Ed25519::verify(b"hello", &signature, &public);
+    let public_key = hex::decode(PUBLIC_KEY_HEX).unwrap();
+    let private_key = hex::decode(SECRET_KEY_HEX).unwrap();
+    let message = hex::decode(MESSAGE_HEX).unwrap();
+    let signature = Ed25519::sign(&message, &private_key).unwrap();
+    assert_eq!(&hex::encode(signature), SIGNATURE_HEX);
+    let verified: _ = Ed25519::verify(&hex::decode(MESSAGE_HEX).unwrap()[..], &signature, &public_key);
     assert!(verified.is_ok());
   }
 }

--- a/identity-core/src/crypto/signature/ed25519.rs
+++ b/identity-core/src/crypto/signature/ed25519.rs
@@ -23,11 +23,10 @@ where
 {
   type Private = T;
   type Output = [u8; SIGNATURE_LENGTH];
-  /// signs a message.
+  /// Computes an EdDSA/Ed25519 signature.
   ///
-  /// The private key is expected to be exactly 32 bytes. Other implementations have different conventions for private
-  /// keys, but we follow RFC 8032. What we and the aforementioned RFC call a private key, is called a *secret key* in the paper [High-speed high-security signatures](http://ed25519.cr.yp.to/ed25519-20110926.pdf).
-  /// The following [blog post](https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/) renames the aforementioned private key/secret key to be called a *seed*.
+  ///  The private key must be a 32-byte seed in compliance with [RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032#section-3.2).
+/// Other implementations often use another format. See [this blog post](https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/) for further explanation.
   fn sign(message: &[u8], key: &Self::Private) -> Result<Self::Output> {
     parse_secret(key.as_ref()).map(|key| key.sign(message).to_bytes())
   }

--- a/identity-core/src/utils/ed25519.rs
+++ b/identity-core/src/utils/ed25519.rs
@@ -8,6 +8,9 @@ use crate::crypto::PublicKey;
 use crate::error::Result;
 
 /// Generates a new pair of public/private ed25519 keys.
+///
+/// Note that the ed25519 private keys used in this crate comply with the definition given in [RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032#section-3.2).
+/// Other implementations often have another format for ed25519 private keys. See [this blog post](https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/) for further explanations.
 pub fn generate_ed25519_keypair() -> Result<(PublicKey, PrivateKey)> {
   let secret: ed25519::SecretKey = ed25519::SecretKey::generate()?;
   let public: ed25519::PublicKey = secret.public_key();
@@ -18,8 +21,8 @@ pub fn generate_ed25519_keypair() -> Result<(PublicKey, PrivateKey)> {
   Ok((public, private))
 }
 
-/// Reconstructs the ed25519 public key given the private key.
-pub fn keypair_from_ed25519_private_key(private_key: ed25519::SecretKey) -> (PublicKey, PrivateKey) {
+// Reconstructs a pair of public/private ed25519 keys from an ed25519::SecretKey.
+pub(crate) fn keypair_from_ed25519_private_key(private_key: ed25519::SecretKey) -> (PublicKey, PrivateKey) {
   let public: ed25519::PublicKey = private_key.public_key();
 
   let private: PrivateKey = private_key.to_bytes().to_vec().into();
@@ -29,6 +32,9 @@ pub fn keypair_from_ed25519_private_key(private_key: ed25519::SecretKey) -> (Pub
 }
 
 /// Generates a list of public/private ed25519 keys.
+///
+/// Note that the ed25519 private keys used in this crate comply with the definition given in [RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032#section-3.2).
+/// Other implementations often have another format for ed25519 private keys. See [this blog post](https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/) for further explanations.
 pub fn generate_ed25519_keypairs(count: usize) -> Result<Vec<(PublicKey, PrivateKey)>> {
   (0..count).map(|_| generate_ed25519_keypair()).collect()
 }

--- a/identity-core/src/utils/ed25519.rs
+++ b/identity-core/src/utils/ed25519.rs
@@ -43,7 +43,7 @@ mod tests {
   use super::generate_ed25519_keypair;
 
   #[test]
-  fn generate_private_key_has_expected_length() {
+  fn generate_ed25519_keypair_has_expected_length() {
     let (public_key, private_key) = generate_ed25519_keypair().unwrap();
     assert_eq!(
       private_key.as_ref().len(),

--- a/identity-core/src/utils/ed25519.rs
+++ b/identity-core/src/utils/ed25519.rs
@@ -38,3 +38,18 @@ pub(crate) fn keypair_from_ed25519_private_key(private_key: ed25519::SecretKey) 
 pub fn generate_ed25519_keypairs(count: usize) -> Result<Vec<(PublicKey, PrivateKey)>> {
   (0..count).map(|_| generate_ed25519_keypair()).collect()
 }
+
+#[cfg(test)]
+mod tests {
+  use super::generate_ed25519_keypair;
+
+  #[test]
+  fn generate_private_key_has_expected_length() {
+    let (public_key, private_key) = generate_ed25519_keypair().unwrap();
+    assert_eq!(
+      private_key.as_ref().len(),
+      crypto::signatures::ed25519::SECRET_KEY_LENGTH
+    );
+    assert_eq!(public_key.as_ref().len(), private_key.as_ref().len());
+  }
+}

--- a/identity-core/src/utils/ed25519.rs
+++ b/identity-core/src/utils/ed25519.rs
@@ -31,10 +31,9 @@ pub(crate) fn keypair_from_ed25519_private_key(private_key: ed25519::SecretKey) 
   (public, private)
 }
 
-/// Generates a list of public/private ed25519 keys.
+/// Generates a list of public/private Ed25519 keys.
 ///
-/// Note that the ed25519 private keys used in this crate comply with the definition given in [RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032#section-3.2).
-/// Other implementations often have another format for ed25519 private keys. See [this blog post](https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/) for further explanations.
+/// See [`generate_ed25519_keypair`].
 pub fn generate_ed25519_keypairs(count: usize) -> Result<Vec<(PublicKey, PrivateKey)>> {
   (0..count).map(|_| generate_ed25519_keypair()).collect()
 }

--- a/identity-core/src/utils/ed25519.rs
+++ b/identity-core/src/utils/ed25519.rs
@@ -7,10 +7,10 @@ use crate::crypto::PrivateKey;
 use crate::crypto::PublicKey;
 use crate::error::Result;
 
-/// Generates a new pair of public/private ed25519 keys.
+/// Generates a new pair of public/private Ed25519 keys.
 ///
-/// Note that the ed25519 private keys used in this crate comply with the definition given in [RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032#section-3.2).
-/// Other implementations often have another format for ed25519 private keys. See [this blog post](https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/) for further explanations.
+/// Note that the private key is a 32-byte seed in compliance with [RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032#section-3.2).
+/// Other implementations often use another format. See [this blog post](https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/) for further explanation.
 pub fn generate_ed25519_keypair() -> Result<(PublicKey, PrivateKey)> {
   let secret: ed25519::SecretKey = ed25519::SecretKey::generate()?;
   let public: ed25519::PublicKey = secret.public_key();

--- a/identity-core/src/utils/ed25519.rs
+++ b/identity-core/src/utils/ed25519.rs
@@ -21,7 +21,7 @@ pub fn generate_ed25519_keypair() -> Result<(PublicKey, PrivateKey)> {
   Ok((public, private))
 }
 
-// Reconstructs a pair of public/private ed25519 keys from an ed25519::SecretKey.
+// Reconstructs a pair of public/private Ed25519 keys from an ed25519::SecretKey.
 pub(crate) fn keypair_from_ed25519_private_key(private_key: ed25519::SecretKey) -> (PublicKey, PrivateKey) {
   let public: ed25519::PublicKey = private_key.public_key();
 


### PR DESCRIPTION
# Description of change
The ed25519 private keys generated and parsed by this library all satisfy the definition given in [RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032#section-3.2). However it is quite common for other implementations to use another format as explained in [this blog post](https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/). 

Due to the various conventions in use it is important for us to document which private key format our library assumes which is what this PR aims to do.  This is done by both including more documentation, but also by modifying some parsing checks to be more precise. 

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

## How the change has been tested
The relevant tests have been modified to reflect the new changes. All tests run locally. 

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
