### PR TITLE
Improve client error messages

### DIFF
--- a/identity-iota/src/chain/integration_chain.rs
+++ b/identity-iota/src/chain/integration_chain.rs
@@ -58,20 +58,20 @@ impl IntegrationChain {
     let root_document: IotaDocument = {
       let valid_root_documents: Vec<IotaDocument> = index
         .remove(&MessageId::null())
-        .ok_or(Error::DIDNotFound("DID not found or pruned"))?
+        .ok_or_else(|| Error::DIDNotFound("DID not found or pruned".to_owned()))?
         .into_iter()
         .filter(|doc| IotaDocument::verify_root_document(doc).is_ok())
         .collect();
 
       if valid_root_documents.is_empty() {
-        return Err(Error::DIDNotFound("no valid root document found"));
+        return Err(Error::DIDNotFound("no valid root document found".to_owned()));
       }
 
       let sorted_root_documents: Vec<IotaDocument> = sort_by_milestone(valid_root_documents, client).await?;
       sorted_root_documents
         .into_iter()
         .next()
-        .ok_or(Error::DIDNotFound("no root document confirmed by a milestone found"))?
+        .ok_or_else(|| Error::DIDNotFound("no root document confirmed by a milestone found".to_owned()))?
     };
 
     // Construct the rest of the integration chain.

--- a/identity-iota/src/error.rs
+++ b/identity-iota/src/error.rs
@@ -40,7 +40,7 @@ pub enum Error {
   MissingSigningKey,
   #[error("Cannot Revoke Verification Method")]
   CannotRevokeMethod,
-  #[error("No Client Nodes Provided")]
+  #[error("no client nodes provided for network")]
   NoClientNodesProvided,
   #[error("No Explorer URL Set")]
   NoExplorerURLSet,

--- a/identity-iota/src/error.rs
+++ b/identity-iota/src/error.rs
@@ -19,8 +19,9 @@ pub enum Error {
   ClientError(#[from] iota_client::error::Error),
   #[error("Invalid Message: {0}")]
   InvalidMessage(#[from] iota_client::bee_message::Error),
+
   #[error("{0}")]
-  DIDNotFound(&'static str),
+  DIDNotFound(String),
   #[error("Invalid Document - Missing Message Id")]
   InvalidDocumentMessageId,
   #[error("Invalid Document - Signing Verification Method Type Not Supported")]

--- a/identity-iota/src/error.rs
+++ b/identity-iota/src/error.rs
@@ -32,16 +32,6 @@ pub enum Error {
   InvalidRootDocument,
   #[error("Invalid Network Name")]
   InvalidNetworkName,
-  #[error("Invalid Tryte Conversion")]
-  InvalidTryteConversion,
-  #[error("Invalid Transaction Bundle")]
-  InvalidTransactionBundle,
-  #[error("Invalid Transaction Hashes")]
-  InvalidTransactionHashes,
-  #[error("Invalid Transaction Trytes")]
-  InvalidTransactionTrytes,
-  #[error("Invalid Bundle Tail")]
-  InvalidBundleTail,
   #[error("Invalid Presentation Holder")]
   InvalidPresentationHolder,
   #[error("Chain Error: {error}")]

--- a/identity-iota/src/tangle/client.rs
+++ b/identity-iota/src/tangle/client.rs
@@ -18,6 +18,7 @@ use crate::did::IotaDID;
 use crate::document::DiffMessage;
 use crate::document::IotaDocument;
 use crate::error::Error;
+use crate::error::Error::DIDNotFound;
 use crate::error::Result;
 use crate::tangle::ClientBuilder;
 use crate::tangle::DIDMessageEncoding;
@@ -155,9 +156,16 @@ impl Client {
   /// Fetches a [`DocumentChain`] given an [`IotaDID`].
   pub async fn read_document_chain(&self, did: &IotaDID) -> Result<DocumentChain> {
     log::trace!("Read Document Chain: {}", did);
-    log::trace!("Integration Chain Address: {}", did.tag());
+    if self.network != did.network()? {
+      return Err(DIDNotFound(format!(
+        "DID network '{}' does not match client network '{}'",
+        did.network_str(),
+        self.network.name_str()
+      )));
+    }
 
     // Fetch all messages for the integration chain.
+    log::trace!("Integration Chain Address: {}", did.tag());
     let messages: Vec<Message> = self.read_messages(did.tag()).await?;
     let integration_chain: IntegrationChain = IntegrationChain::try_from_messages(did, &messages, self).await?;
 
@@ -251,7 +259,7 @@ impl Client {
   }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait(? Send)]
 impl TangleResolve for Client {
   async fn resolve(&self, did: &IotaDID) -> Result<IotaDocument> {
     self.read_document(did).await

--- a/identity-iota/src/tangle/client.rs
+++ b/identity-iota/src/tangle/client.rs
@@ -259,7 +259,7 @@ impl Client {
   }
 }
 
-#[async_trait::async_trait(? Send)]
+#[async_trait::async_trait(?Send)]
 impl TangleResolve for Client {
   async fn resolve(&self, did: &IotaDID) -> Result<IotaDocument> {
     self.read_document(did).await


### PR DESCRIPTION
# Description of change
Throw a more informative `DIDNotFound` error message when the network of the DID does not match that of the `Client` when resolving it. 

Removes several defunct and unused error variants from `identity-iota`.

## Links to any relevant issues
Fixes #505 

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix/chore (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tests and examples pass locally.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
