### PR TITLE
Fix `txm` version in GitHub Actions

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -101,7 +101,7 @@ jobs:
           node-version: 16.x
 
       - name: Install txm # for running README.md examples https://github.com/anko/txm
-        run: npm install -g txm
+        run: npm install -g txm@7 # pin to version 7.x.x (currently 7.4.7 works)
 
       - name: Install wasm-pack
         run: npm install -g wasm-pack


### PR DESCRIPTION
# Description of change
Pins `txm` to install version 7 (currently 7.4.7) in the GitHub Actions examples workflow.

This is due to a recent breaking change to `txm` in version 8.0.0 (https://github.com/anko/txm/releases/tag/v8.0.0) which causes the examples workflow to fail with the following error:

```
Run npm run test:readme

> @iota/identity-wasm@0.4.0 test:readme
> txm README.md

file:///opt/hostedtoolcache/node/16.13.0/x64/lib/node_modules/txm/src/cli.js:16
const programName = Object.entries(packageMetadata.bin)
                           ^

TypeError: Cannot convert undefined or null to object
    at Function.entries (<anonymous>)
    at file:///opt/hostedtoolcache/node/16.13.0/x64/lib/node_modules/txm/src/cli.js:16:28
    at ModuleJob.run (node:internal/modules/esm/module_job:185:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:281:24)
    at async loadESM (node:internal/process/esm_loader:88:5)
    at async handleMainPromise (node:internal/modules/run_main:65:12)
```

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tested version `txm` version 7.4.7 works locally with `txm README.md` in the `bindings/wasm` directory.

Fixes examples workflow: https://github.com/iotaledger/identity.rs/actions/runs/1517031662

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
