### PR TITLE
Add `identity-diff` derive feature gate

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -46,11 +46,11 @@
 ## Members
 
 <dl>
+<dt><a href="#KeyType">KeyType</a></dt>
+<dd></dd>
 <dt><a href="#DIDMessageEncoding">DIDMessageEncoding</a></dt>
 <dd></dd>
 <dt><a href="#Digest">Digest</a></dt>
-<dd></dd>
-<dt><a href="#KeyType">KeyType</a></dt>
 <dd></dd>
 </dl>
 
@@ -1898,6 +1898,10 @@ Deserializes a `VerificationMethod` object from a JSON object.
 | --- | --- |
 | value | <code>any</code> | 
 
+<a name="KeyType"></a>
+
+## KeyType
+**Kind**: global variable  
 <a name="DIDMessageEncoding"></a>
 
 ## DIDMessageEncoding
@@ -1905,10 +1909,6 @@ Deserializes a `VerificationMethod` object from a JSON object.
 <a name="Digest"></a>
 
 ## Digest
-**Kind**: global variable  
-<a name="KeyType"></a>
-
-## KeyType
 **Kind**: global variable  
 <a name="start"></a>
 

--- a/identity-diff/Cargo.toml
+++ b/identity-diff/Cargo.toml
@@ -12,7 +12,7 @@ description = "The `Diff` trait for the identity-rs library."
 
 [dependencies]
 did_url = { version = "0.1", default-features = false, features = ["alloc"] }
-identity-derive = { version = "=0.4.0", path = "derive" }
+identity-diff-derive = { version = "=0.4.0", path = "derive", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 strum = { version = "0.21", features = ["derive"] }
@@ -20,6 +20,10 @@ thiserror = { version = "1.0" }
 
 [dev-dependencies]
 serde_json = "1.0"
+
+[features]
+default = ["derive"]
+derive = ["identity-diff-derive"]
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/identity-diff/README.md
+++ b/identity-diff/README.md
@@ -2,5 +2,5 @@ This module implements a `Diff` trait type.  The Diff trait gives data structure
 themselves to another data structure of the same type over time.  The library pairs off with `identity_derive` which
 implements a derive macro for the `Diff` Trait. Types supported include `HashMap`, `Option`, `String`,
 `serde_json::Value`, `Vec` and primitives such as `i8`/`u8` up to `usize` and `isize` as well as the unit type `()`,
-`bool`, and `char` types.  Structs and Enums are supported via `identity_derive` and can be composed of any number
+`bool`, and `char` types.  Structs and Enums are supported via `identity_diff_derive` and can be composed of any number
 of these types.

--- a/identity-diff/derive/Cargo.toml
+++ b/identity-diff/derive/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "identity-derive"
+name = "identity-diff-derive"
 version = "0.4.0"
 authors = ["IOTA Stiftung"]
-edition = "2018"
+edition = "2021"
 homepage = "https://www.iota.org"
 keywords = ["iota", "tangle", "identity"]
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ repository = "https://github.com/iotaledger/identity.rs"
 description = "Derive `Diff` support for the identity-rs library."
 
 [lib]
-name = "identity_derive"
+name = "identity_diff_derive"
 proc-macro = true
 
 [dependencies]

--- a/identity-diff/src/lib.rs
+++ b/identity-diff/src/lib.rs
@@ -17,8 +17,9 @@
   // clippy::missing_errors_doc,
 )]
 
+#[cfg(feature = "derive")]
 #[doc(hidden)]
-pub use identity_derive::*;
+pub use identity_diff_derive::Diff;
 
 mod error;
 mod hashmap;

--- a/identity-diff/tests/derive_enum_test.rs
+++ b/identity-diff/tests/derive_enum_test.rs
@@ -1,6 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#![cfg(feature = "derive")]
 #![allow(unused_variables)]
 
 use identity_diff::Diff;

--- a/identity-diff/tests/derive_struct_test.rs
+++ b/identity-diff/tests/derive_struct_test.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+// #![cfg(feature = "derive")]
+
 // use identity_diff::Diff;
 // use serde::Deserialize;
 // use serde::Serialize;


### PR DESCRIPTION
# Description of change

- Renames `identity-derive` to `identity-diff-derive` for clarity and to reserve `identity-derive` for future use.
- Feature-gates `identity-diff-derive` in `identity-diff` behind a new `derive` feature.
- Updates `identity-diff-derive` to Rust edition 2021 in line with the rest of the projects.

The `Diff` proc-macro from `identity-diff-derive` is only used within `identity-diff` tests currently, so feature-gating it is a minor optimisation for releases. With these changes, `identity-diff-derive` no longer appears in the Wasm bindings dependency tree.

## Type of change

- [x] Bug fix/chore (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Local tests and Wasm examples pass.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
