### PR TITLE
Add `FmtJson` trait

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -1261,7 +1261,7 @@ Deserializes `DocumentHistory` from a JSON object.
 ### explorerUrl.messageUrl(message_id) ⇒ <code>string</code>
 Returns the web explorer URL of the given `message_id`.
 
-E.g. https://explorer.iota.org/mainnet/message/<message_id>
+E.g. https://explorer.iota.org/mainnet/message/{message_id}
 
 **Kind**: instance method of [<code>ExplorerUrl</code>](#ExplorerUrl)  
 
@@ -1274,7 +1274,7 @@ E.g. https://explorer.iota.org/mainnet/message/<message_id>
 ### explorerUrl.resolverUrl(did) ⇒ <code>string</code>
 Returns the web identity resolver URL for the given DID.
 
-E.g. https://explorer.iota.org/mainnet/identity-resolver/&lt;did>
+E.g. https://explorer.iota.org/mainnet/identity-resolver/{did}
 
 **Kind**: instance method of [<code>ExplorerUrl</code>](#ExplorerUrl)  
 

--- a/bindings/wasm/src/tangle/explorer.rs
+++ b/bindings/wasm/src/tangle/explorer.rs
@@ -40,7 +40,7 @@ impl WasmExplorerUrl {
 
   /// Returns the web explorer URL of the given `message_id`.
   ///
-  /// E.g. https://explorer.iota.org/mainnet/message/<message_id>
+  /// E.g. https://explorer.iota.org/mainnet/message/{message_id}
   #[wasm_bindgen(js_name = messageUrl)]
   pub fn message_url(&self, message_id: &str) -> Result<String> {
     let message_id = MessageId::from_str(message_id).wasm_result()?;
@@ -49,7 +49,7 @@ impl WasmExplorerUrl {
 
   /// Returns the web identity resolver URL for the given DID.
   ///
-  /// E.g. https://explorer.iota.org/mainnet/identity-resolver/<did>
+  /// E.g. https://explorer.iota.org/mainnet/identity-resolver/{did}
   #[wasm_bindgen(js_name = resolverUrl)]
   pub fn resolver_url(&self, did: &str) -> Result<String> {
     let did: IotaDID = IotaDID::parse(did).wasm_result()?;

--- a/identity-account/src/storage/memstore.rs
+++ b/identity-account/src/storage/memstore.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::Debug;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use crypto::signatures::ed25519;
 use hashbrown::hash_map::Entry;
 use hashbrown::HashMap;
@@ -238,7 +238,7 @@ impl Storage for MemStore {
 }
 
 impl Debug for MemStore {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     if self.expand {
       f.debug_struct("MemStore")
         .field("chain_states", &self.chain_states)

--- a/identity-account/src/stronghold/records.rs
+++ b/identity-account/src/stronghold/records.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::Debug;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use crypto::hashes::blake2b::Blake2b256;
 use crypto::hashes::Digest;
 use crypto::hashes::Output;
@@ -186,7 +186,7 @@ impl RecordIndex {
 }
 
 impl Debug for RecordIndex {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.debug_set().entries(self.iter().map(encode_b58)).finish()
   }
 }

--- a/identity-account/src/types/generation.rs
+++ b/identity-account/src/types/generation.rs
@@ -4,7 +4,6 @@
 use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
 
 use crate::error::Error;
 use crate::error::Result;
@@ -53,13 +52,13 @@ impl Generation {
 }
 
 impl Debug for Generation {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.write_fmt(format_args!("Generation({})", self.to_u32()))
   }
 }
 
 impl Display for Generation {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.write_fmt(format_args!("{}", self.to_u32()))
   }
 }

--- a/identity-account/src/utils/shared.rs
+++ b/identity-account/src/utils/shared.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::Debug;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use std::sync::RwLock;
 use std::sync::RwLockReadGuard;
 use std::sync::RwLockWriteGuard;
@@ -29,7 +29,7 @@ impl<T> Shared<T> {
 }
 
 impl<T: Debug> Debug for Shared<T> {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     Debug::fmt(&self.0, f)
   }
 }

--- a/identity-core/src/common/bitset.rs
+++ b/identity-core/src/common/bitset.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use roaring::RoaringBitmap;
 use serde::de;
 use serde::de::Deserializer;
@@ -122,7 +122,7 @@ impl<'de> Deserialize<'de> for BitSet {
     impl<'de> Visitor<'de> for __Visitor {
       type Value = BitSet;
 
-      fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+      fn expecting(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.write_str("a base64-encoded string")
       }
 

--- a/identity-core/src/common/one_or_many.rs
+++ b/identity-core/src/common/one_or_many.rs
@@ -4,7 +4,7 @@
 use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use core::hash::Hash;
 use core::mem::replace;
 use core::ops::Deref;
@@ -102,7 +102,7 @@ impl<T> Debug for OneOrMany<T>
 where
   T: Debug,
 {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     match self {
       Self::One(inner) => Debug::fmt(inner, f),
       Self::Many(inner) => Debug::fmt(inner, f),
@@ -115,7 +115,7 @@ where
   T: Display,
   Vec<T>: Display,
 {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     match self {
       Self::One(inner) => Display::fmt(inner, f),
       Self::Many(inner) => Display::fmt(inner, f),

--- a/identity-core/src/common/timestamp.rs
+++ b/identity-core/src/common/timestamp.rs
@@ -5,7 +5,7 @@ use core::convert::TryFrom;
 use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use core::str::FromStr;
 
 use chrono::DateTime;
@@ -69,13 +69,13 @@ impl Default for Timestamp {
 }
 
 impl Debug for Timestamp {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     write!(f, "{:?}", self.to_rfc3339())
   }
 }
 
 impl Display for Timestamp {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     write!(f, "{}", self.to_rfc3339())
   }
 }

--- a/identity-core/src/common/url.rs
+++ b/identity-core/src/common/url.rs
@@ -4,7 +4,7 @@
 use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use core::ops::Deref;
 use core::ops::DerefMut;
 use core::str::FromStr;
@@ -39,13 +39,13 @@ impl Url {
 }
 
 impl Debug for Url {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.write_fmt(format_args!("Url({})", self.0.as_str()))
   }
 }
 
 impl Display for Url {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.write_str(self.0.as_str())
   }
 }

--- a/identity-core/src/convert/json.rs
+++ b/identity-core/src/convert/json.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use core::fmt::Formatter;
+
 use crypto::hashes::sha::Sha256;
 use crypto::hashes::Digest;
 use crypto::hashes::Output;
@@ -69,3 +71,21 @@ pub trait FromJson: for<'de> Deserialize<'de> + Sized {
 }
 
 impl<T> FromJson for T where T: for<'de> Deserialize<'de> + Sized {}
+
+// =============================================================================
+// =============================================================================
+
+/// A convenience-trait to format types as JSON strings for display.
+pub trait FmtJson: ToJson {
+  /// Format this as a JSON string or pretty-JSON string based on whether the `#` format flag
+  /// was used.
+  fn fmt_json(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+    if f.alternate() {
+      f.write_str(&self.to_json_pretty().map_err(|_| core::fmt::Error)?)
+    } else {
+      f.write_str(&self.to_json().map_err(|_| core::fmt::Error)?)
+    }
+  }
+}
+
+impl<T> FmtJson for T where T: ToJson {}

--- a/identity-core/src/convert/mod.rs
+++ b/identity-core/src/convert/mod.rs
@@ -3,9 +3,10 @@
 
 //! Traits for JSON conversions between types.
 
-mod json;
-mod serde_into;
-
+pub use self::json::FmtJson;
 pub use self::json::FromJson;
 pub use self::json::ToJson;
 pub use self::serde_into::SerdeInto;
+
+mod json;
+mod serde_into;

--- a/identity-core/src/crypto/merkle_tree/proof.rs
+++ b/identity-core/src/crypto/merkle_tree/proof.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::Debug;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use subtle::ConstantTimeEq;
 
 use crate::crypto::merkle_tree::AsLeaf;
@@ -83,7 +83,7 @@ where
 }
 
 impl<D: DigestExt> Debug for Proof<D> {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.debug_struct("Proof").field("nodes", &self.nodes).finish()
   }
 }

--- a/identity-core/src/crypto/signature/signature.rs
+++ b/identity-core/src/crypto/signature/signature.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::Debug;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use serde::__private::ser::FlatMapSerializer;
 use serde::ser::SerializeMap;
 use serde::ser::Serializer;
@@ -84,7 +84,7 @@ impl Signature {
 }
 
 impl Debug for Signature {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.debug_struct("Signature")
       .field("type_", &self.type_)
       .field("value", &self.value)

--- a/identity-credential/src/credential/credential.rs
+++ b/identity-credential/src/credential/credential.rs
@@ -3,7 +3,6 @@
 
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
 
 use serde::Serialize;
 
@@ -171,7 +170,7 @@ impl<T> Display for Credential<T>
 where
   T: Serialize,
 {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     self.fmt_json(f)
   }
 }

--- a/identity-credential/src/credential/credential.rs
+++ b/identity-credential/src/credential/credential.rs
@@ -2,22 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt::Display;
-use core::fmt::Error as FmtError;
 use core::fmt::Formatter;
 use core::fmt::Result as FmtResult;
+
+use serde::Serialize;
+
 use identity_core::common::Context;
 use identity_core::common::Object;
 use identity_core::common::OneOrMany;
 use identity_core::common::Timestamp;
 use identity_core::common::Url;
-use identity_core::convert::ToJson;
+use identity_core::convert::FmtJson;
 use identity_core::crypto::SetSignature;
 use identity_core::crypto::Signature;
 use identity_core::crypto::TrySignature;
 use identity_core::crypto::TrySignatureMut;
 use identity_did::verification::MethodUriType;
 use identity_did::verification::TryMethod;
-use serde::Serialize;
 
 use crate::credential::CredentialBuilder;
 use crate::credential::Evidence;
@@ -171,11 +172,7 @@ where
   T: Serialize,
 {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-    if f.alternate() {
-      f.write_str(&self.to_json_pretty().map_err(|_| FmtError)?)
-    } else {
-      f.write_str(&self.to_json().map_err(|_| FmtError)?)
-    }
+    self.fmt_json(f)
   }
 }
 

--- a/identity-credential/src/presentation/presentation.rs
+++ b/identity-credential/src/presentation/presentation.rs
@@ -3,7 +3,6 @@
 
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
 
 use serde::Serialize;
 
@@ -132,7 +131,7 @@ where
   T: Serialize,
   U: Serialize,
 {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     self.fmt_json(f)
   }
 }

--- a/identity-credential/src/presentation/presentation.rs
+++ b/identity-credential/src/presentation/presentation.rs
@@ -2,21 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt::Display;
-use core::fmt::Error as FmtError;
 use core::fmt::Formatter;
 use core::fmt::Result as FmtResult;
+
+use serde::Serialize;
+
 use identity_core::common::Context;
 use identity_core::common::Object;
 use identity_core::common::OneOrMany;
 use identity_core::common::Url;
-use identity_core::convert::ToJson;
+use identity_core::convert::FmtJson;
 use identity_core::crypto::SetSignature;
 use identity_core::crypto::Signature;
 use identity_core::crypto::TrySignature;
 use identity_core::crypto::TrySignatureMut;
 use identity_did::verification::MethodUriType;
 use identity_did::verification::TryMethod;
-use serde::Serialize;
 
 use crate::credential::Credential;
 use crate::credential::Policy;
@@ -132,11 +133,7 @@ where
   U: Serialize,
 {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-    if f.alternate() {
-      f.write_str(&self.to_json_pretty().map_err(|_| FmtError)?)
-    } else {
-      f.write_str(&self.to_json().map_err(|_| FmtError)?)
-    }
+    self.fmt_json(f)
   }
 }
 
@@ -164,10 +161,12 @@ impl<T> TryMethod for Presentation<T> {
 
 #[cfg(test)]
 mod tests {
-  use super::Presentation;
+  use identity_core::convert::FromJson;
+
   use crate::credential::Credential;
   use crate::credential::Subject;
-  use identity_core::convert::FromJson;
+
+  use super::Presentation;
 
   const JSON: &str = include_str!("../../tests/fixtures/presentation-1.json");
 

--- a/identity-did/src/did/did.rs
+++ b/identity-did/src/did/did.rs
@@ -5,7 +5,7 @@ use core::convert::TryFrom;
 use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use core::str::FromStr;
 use std::hash::Hash;
 
@@ -194,13 +194,13 @@ impl TryFrom<BaseDIDUrl> for CoreDID {
 }
 
 impl Debug for CoreDID {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.write_fmt(format_args!("{}", self.as_str()))
   }
 }
 
 impl Display for CoreDID {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.write_fmt(format_args!("{}", self.as_str()))
   }
 }

--- a/identity-did/src/did/did_url.rs
+++ b/identity-did/src/did/did_url.rs
@@ -5,7 +5,7 @@ use core::convert::TryFrom;
 use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use core::str::FromStr;
 use std::cmp::Ordering;
 use std::convert::TryInto;
@@ -211,7 +211,7 @@ impl RelativeDIDUrl {
 }
 
 impl Display for RelativeDIDUrl {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.write_fmt(format_args!(
       "{}{}{}",
       self.path.as_deref().unwrap_or_default(),
@@ -222,7 +222,7 @@ impl Display for RelativeDIDUrl {
 }
 
 impl Debug for RelativeDIDUrl {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.write_fmt(format_args!("{}", self))
   }
 }
@@ -540,7 +540,7 @@ impl<T> Debug for DIDUrl<T>
 where
   T: DID,
 {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.write_fmt(format_args!("{}", self))
   }
 }
@@ -549,7 +549,7 @@ impl<T> Display for DIDUrl<T>
 where
   T: DID,
 {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.write_fmt(format_args!("{}{}", self.did.as_str(), self.url))
   }
 }

--- a/identity-did/src/document/core_document.rs
+++ b/identity-did/src/document/core_document.rs
@@ -4,7 +4,6 @@
 use core::convert::TryInto as _;
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
 
 use serde::Serialize;
 
@@ -567,7 +566,7 @@ where
   U: Serialize,
   V: Serialize,
 {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     self.fmt_json(f)
   }
 }

--- a/identity-did/src/document/core_document.rs
+++ b/identity-did/src/document/core_document.rs
@@ -3,7 +3,6 @@
 
 use core::convert::TryInto as _;
 use core::fmt::Display;
-use core::fmt::Error as FmtError;
 use core::fmt::Formatter;
 use core::fmt::Result as FmtResult;
 
@@ -11,7 +10,7 @@ use serde::Serialize;
 
 use identity_core::common::Object;
 use identity_core::common::Url;
-use identity_core::convert::ToJson;
+use identity_core::convert::FmtJson;
 
 use crate::did::CoreDID;
 use crate::did::CoreDIDUrl;
@@ -569,11 +568,7 @@ where
   V: Serialize,
 {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-    if f.alternate() {
-      f.write_str(&self.to_json_pretty().map_err(|_| FmtError)?)
-    } else {
-      f.write_str(&self.to_json().map_err(|_| FmtError)?)
-    }
+    self.fmt_json(f)
   }
 }
 

--- a/identity-did/src/service/service.rs
+++ b/identity-did/src/service/service.rs
@@ -2,14 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt::Display;
-use core::fmt::Error as FmtError;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
 
 use serde::Serialize;
 
 use identity_core::common::Object;
-use identity_core::convert::ToJson;
+use identity_core::convert::FmtJson;
 
 use crate::did::CoreDIDUrl;
 use crate::error::Error;
@@ -100,12 +98,8 @@ impl<T> Display for Service<T>
 where
   T: Serialize,
 {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-    if f.alternate() {
-      f.write_str(&self.to_json_pretty().map_err(|_| FmtError)?)
-    } else {
-      f.write_str(&self.to_json().map_err(|_| FmtError)?)
-    }
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+    self.fmt_json(f)
   }
 }
 

--- a/identity-did/src/service/service_endpoint.rs
+++ b/identity-did/src/service/service_endpoint.rs
@@ -3,7 +3,6 @@
 
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
 
 use indexmap::map::IndexMap;
 use serde::Serialize;
@@ -44,7 +43,7 @@ impl From<IndexMap<String, OrderedSet<Url>>> for ServiceEndpoint {
 }
 
 impl Display for ServiceEndpoint {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     self.fmt_json(f)
   }
 }

--- a/identity-did/src/service/service_endpoint.rs
+++ b/identity-did/src/service/service_endpoint.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt::Display;
-use core::fmt::Error as FmtError;
 use core::fmt::Formatter;
 use core::fmt::Result as FmtResult;
 
@@ -10,7 +9,7 @@ use indexmap::map::IndexMap;
 use serde::Serialize;
 
 use identity_core::common::Url;
-use identity_core::convert::ToJson;
+use identity_core::convert::FmtJson;
 
 use crate::utils::OrderedSet;
 
@@ -46,11 +45,7 @@ impl From<IndexMap<String, OrderedSet<Url>>> for ServiceEndpoint {
 
 impl Display for ServiceEndpoint {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-    if f.alternate() {
-      f.write_str(&self.to_json_pretty().map_err(|_| FmtError)?)
-    } else {
-      f.write_str(&self.to_json().map_err(|_| FmtError)?)
-    }
+    self.fmt_json(f)
   }
 }
 

--- a/identity-did/src/utils/ordered_set.rs
+++ b/identity-did/src/utils/ordered_set.rs
@@ -5,7 +5,7 @@ use core::borrow::Borrow;
 use core::convert::TryFrom;
 use core::fmt::Debug;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use core::iter::FromIterator;
 use core::ops::Deref;
 use core::slice::Iter;
@@ -197,7 +197,7 @@ where
   T: Debug,
 {
   #[inline]
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.debug_set().entries(self.iter()).finish()
   }
 }

--- a/identity-did/src/verification/method_data.rs
+++ b/identity-did/src/verification/method_data.rs
@@ -3,7 +3,6 @@
 
 use core::fmt::Debug;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
 
 use identity_core::common::Object;
 use identity_core::utils::decode_b58;
@@ -55,7 +54,7 @@ impl MethodData {
 }
 
 impl Debug for MethodData {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     match self {
       Self::PublicKeyMultibase(inner) => f.write_fmt(format_args!("PublicKeyMultibase({})", inner)),
       Self::PublicKeyBase58(inner) => f.write_fmt(format_args!("PublicKeyBase58({})", inner)),

--- a/identity-did/src/verification/method_ref.rs
+++ b/identity-did/src/verification/method_ref.rs
@@ -3,7 +3,6 @@
 
 use core::fmt::Debug;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
 
 use identity_core::common::Object;
 
@@ -83,7 +82,7 @@ impl<T> Debug for MethodRef<T>
 where
   T: Debug,
 {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     match self {
       Self::Embed(inner) => Debug::fmt(inner, f),
       Self::Refer(inner) => Debug::fmt(inner, f),

--- a/identity-did/src/verification/verification_method.rs
+++ b/identity-did/src/verification/verification_method.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use core::iter::once;
 
 use serde::Serialize;
@@ -122,7 +122,7 @@ impl<T> Display for VerificationMethod<T>
 where
   T: Serialize,
 {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     self.fmt_json(f)
   }
 }

--- a/identity-did/src/verification/verification_method.rs
+++ b/identity-did/src/verification/verification_method.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt::Display;
-use core::fmt::Error as FmtError;
 use core::fmt::Formatter;
 use core::fmt::Result as FmtResult;
 use core::iter::once;
@@ -10,7 +9,7 @@ use core::iter::once;
 use serde::Serialize;
 
 use identity_core::common::Object;
-use identity_core::convert::ToJson;
+use identity_core::convert::FmtJson;
 
 use crate::did::CoreDID;
 use crate::did::CoreDIDUrl;
@@ -124,11 +123,7 @@ where
   T: Serialize,
 {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-    if f.alternate() {
-      f.write_str(&self.to_json_pretty().map_err(|_| FmtError)?)
-    } else {
-      f.write_str(&self.to_json().map_err(|_| FmtError)?)
-    }
+    self.fmt_json(f)
   }
 }
 

--- a/identity-diff/src/hashmap.rs
+++ b/identity-diff/src/hashmap.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::fmt::Formatter;
-use std::fmt::Result as FmtResult;
+
 use std::hash::Hash;
 use std::iter::empty;
 
@@ -149,7 +149,7 @@ where
   K: Debug + Diff,
   V: Debug + Diff,
 {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     write!(f, "DiffHashMap")?;
 
     let mut buf = f.debug_list();
@@ -180,7 +180,7 @@ where
   K: Debug + Diff,
   V: Debug + Diff,
 {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     match &self {
       Self::Change { key, value } => f
         .debug_struct("Change")

--- a/identity-diff/src/hashset.rs
+++ b/identity-diff/src/hashset.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::fmt::Formatter;
-use std::fmt::Result as FmtResult;
+
 use std::hash::Hash;
 use std::iter::empty;
 
@@ -101,7 +101,7 @@ impl<T> Debug for DiffHashSet<T>
 where
   T: Debug + Diff,
 {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     write!(f, "DiffHashSet")?;
     let mut buf = f.debug_list();
     if let Some(d) = &self.0 {
@@ -117,7 +117,7 @@ impl<T> Debug for InnerValue<T>
 where
   T: Debug + Diff,
 {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     match &self {
       Self::Add(val) => f.debug_tuple("Add").field(val).finish(),
       Self::Remove { remove } => f.debug_tuple("Remove").field(remove).finish(),

--- a/identity-diff/src/macros.rs
+++ b/identity-diff/src/macros.rs
@@ -5,7 +5,6 @@ use crate::traits::Diff;
 
 use std::fmt::Debug;
 use std::fmt::Formatter;
-use std::fmt::Result as FmtResult;
 
 /// A macro to implement the `Diff` traits on primitive values and the `Debug` trait on the resulting `Diff*` types.
 /// Follows this syntax, impl_diff_on_primitives { type | DiffTypeName + TraitBounds}`
@@ -48,7 +47,7 @@ macro_rules! impl_diff_on_primitives {
 
 
             impl Debug for $diff {
-                fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+                fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
                     match self.0 {
                         None => write!(f, "{} None", stringify!($diff)),
                         Some(val) => write!(f, "{} => {:#?}", stringify!($diff), val),

--- a/identity-diff/src/option.rs
+++ b/identity-diff/src/option.rs
@@ -6,7 +6,6 @@ use serde::Serialize;
 
 use std::fmt::Debug;
 use std::fmt::Formatter;
-use std::fmt::Result as FmtResult;
 
 use crate::Diff;
 
@@ -66,7 +65,7 @@ where
 
 /// Debug implementation for `DiffOption<T>`.
 impl<T: Diff> std::fmt::Debug for DiffOption<T> {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     match &self {
       Self::Some(d) => write!(f, "DiffOption::Some({:#?})", d),
       Self::None => write!(f, "DiffOption::None"),

--- a/identity-diff/src/string.rs
+++ b/identity-diff/src/string.rs
@@ -7,7 +7,6 @@ use serde::Serialize;
 use crate::Diff;
 use std::fmt::Debug;
 use std::fmt::Formatter;
-use std::fmt::Result as FmtResult;
 
 /// The Diff Type for a `String` type.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default)]
@@ -55,7 +54,7 @@ impl Diff for String {
 
 /// Debug trait implementation for DiffString.
 impl Debug for DiffString {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     match &self.0 {
       Some(val) => write!(f, "DiffString({:#?})", val),
       None => write!(f, "DiffString None"),

--- a/identity-diff/src/vec.rs
+++ b/identity-diff/src/vec.rs
@@ -6,7 +6,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::fmt::Debug;
 use std::fmt::Formatter;
-use std::fmt::Result as FmtResult;
 
 /// The Diff Type for `Vec`.
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
@@ -108,7 +107,7 @@ where
 
 /// Debug trait for `DiffVec<T>`
 impl<T: Diff> Debug for DiffVec<T> {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     write!(f, "DiffVec ")?;
     f.debug_list().entries(self.0.iter()).finish()
   }
@@ -116,7 +115,7 @@ impl<T: Diff> Debug for DiffVec<T> {
 
 /// Debug trait for `InnerVec<T>`
 impl<T: Diff> Debug for InnerVec<T> {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     match &self {
       Self::Change { index, item } => f
         .debug_struct("Change")

--- a/identity-iota/src/chain/diff_chain.rs
+++ b/identity-iota/src/chain/diff_chain.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use core::slice::Iter;
 
 use serde;
@@ -198,7 +198,7 @@ impl Default for DiffChain {
 }
 
 impl Display for DiffChain {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     self.fmt_json(f)
   }
 }

--- a/identity-iota/src/chain/diff_chain.rs
+++ b/identity-iota/src/chain/diff_chain.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt::Display;
-use core::fmt::Error as FmtError;
 use core::fmt::Formatter;
 use core::fmt::Result as FmtResult;
 use core::slice::Iter;
@@ -11,7 +10,7 @@ use serde;
 use serde::Deserialize;
 use serde::Serialize;
 
-use identity_core::convert::ToJson;
+use identity_core::convert::FmtJson;
 
 use crate::chain::milestone::sort_by_milestone;
 use crate::chain::IntegrationChain;
@@ -200,11 +199,7 @@ impl Default for DiffChain {
 
 impl Display for DiffChain {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-    if f.alternate() {
-      f.write_str(&self.to_json_pretty().map_err(|_| FmtError)?)
-    } else {
-      f.write_str(&self.to_json().map_err(|_| FmtError)?)
-    }
+    self.fmt_json(f)
   }
 }
 
@@ -287,7 +282,7 @@ mod test {
         .sign_data(
           &mut new,
           keys[0].private(),
-          chain.current().default_signing_method().unwrap().id()
+          chain.current().default_signing_method().unwrap().id(),
         )
         .is_ok());
       assert_eq!(

--- a/identity-iota/src/chain/document_chain.rs
+++ b/identity-iota/src/chain/document_chain.rs
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt::Display;
-use core::fmt::Error as FmtError;
 use core::fmt::Formatter;
 use core::fmt::Result as FmtResult;
 
 use serde::Deserialize;
 use serde::Serialize;
 
-use identity_core::convert::ToJson;
+use identity_core::convert::FmtJson;
 
 use crate::chain::DiffChain;
 use crate::chain::IntegrationChain;
@@ -164,10 +163,6 @@ impl DocumentChain {
 
 impl Display for DocumentChain {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-    if f.alternate() {
-      f.write_str(&self.to_json_pretty().map_err(|_| FmtError)?)
-    } else {
-      f.write_str(&self.to_json().map_err(|_| FmtError)?)
-    }
+    self.fmt_json(f)
   }
 }

--- a/identity-iota/src/chain/document_chain.rs
+++ b/identity-iota/src/chain/document_chain.rs
@@ -3,7 +3,6 @@
 
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -162,7 +161,7 @@ impl DocumentChain {
 }
 
 impl Display for DocumentChain {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     self.fmt_json(f)
   }
 }

--- a/identity-iota/src/chain/integration_chain.rs
+++ b/identity-iota/src/chain/integration_chain.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use core::mem;
 
 use serde;
@@ -201,7 +201,7 @@ impl IntegrationChain {
 }
 
 impl Display for IntegrationChain {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     self.fmt_json(f)
   }
 }

--- a/identity-iota/src/chain/integration_chain.rs
+++ b/identity-iota/src/chain/integration_chain.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt::Display;
-use core::fmt::Error as FmtError;
 use core::fmt::Formatter;
 use core::fmt::Result as FmtResult;
 use core::mem;
@@ -11,7 +10,7 @@ use serde;
 use serde::Deserialize;
 use serde::Serialize;
 
-use identity_core::convert::ToJson;
+use identity_core::convert::FmtJson;
 
 use crate::chain::milestone::sort_by_milestone;
 use crate::did::IotaDID;
@@ -203,11 +202,7 @@ impl IntegrationChain {
 
 impl Display for IntegrationChain {
   fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-    if f.alternate() {
-      f.write_str(&self.to_json_pretty().map_err(|_| FmtError)?)
-    } else {
-      f.write_str(&self.to_json().map_err(|_| FmtError)?)
-    }
+    self.fmt_json(f)
   }
 }
 

--- a/identity-iota/src/did/iota_did.rs
+++ b/identity-iota/src/did/iota_did.rs
@@ -5,7 +5,7 @@ use core::convert::TryFrom;
 use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use core::str::FromStr;
 use std::convert::TryInto;
 
@@ -283,13 +283,13 @@ impl DID for IotaDID {
 }
 
 impl Display for IotaDID {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     write!(f, "{}", self.0)
   }
 }
 
 impl Debug for IotaDID {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     write!(f, "{}", self.0)
   }
 }

--- a/identity-iota/src/document/iota_document.rs
+++ b/identity-iota/src/document/iota_document.rs
@@ -6,7 +6,6 @@ use core::convert::TryInto;
 use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
 
 use serde;
 use serde::Deserialize;
@@ -734,13 +733,13 @@ impl IotaDocument {
 impl<'a, 'b, 'c> IotaDocument {}
 
 impl Display for IotaDocument {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     Display::fmt(&self.document, f)
   }
 }
 
 impl Debug for IotaDocument {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     Debug::fmt(&self.document, f)
   }
 }

--- a/identity-iota/src/document/iota_verification_method.rs
+++ b/identity-iota/src/document/iota_verification_method.rs
@@ -6,7 +6,7 @@ use core::convert::TryInto;
 use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use core::ops::Deref;
 
 use serde;
@@ -208,13 +208,13 @@ impl IotaVerificationMethod {
 }
 
 impl Display for IotaVerificationMethod {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     Display::fmt(&self.0, f)
   }
 }
 
 impl Debug for IotaVerificationMethod {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     Debug::fmt(&self.0, f)
   }
 }

--- a/identity-iota/src/tangle/client_builder.rs
+++ b/identity-iota/src/tangle/client_builder.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::Debug;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use std::time::Duration;
 
 use crate::error::Result;
@@ -147,7 +147,7 @@ impl ClientBuilder {
 }
 
 impl Debug for ClientBuilder {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.debug_struct("ClientBuilder").field("network", &self.network).finish()
   }
 }

--- a/libjose/src/error.rs
+++ b/libjose/src/error.rs
@@ -5,7 +5,6 @@
 
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
 
 /// Alias for a `Result` with the error type [Error].
 pub type Result<T, E = Error> = core::result::Result<T, E>;
@@ -32,7 +31,7 @@ pub enum Error {
 }
 
 impl Display for Error {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     match self {
       Self::InvalidRsaPrime => f.write_str("Invalid Rsa Prime Value"),
       Self::InvalidJson(inner) => f.write_fmt(format_args!("Invalid JSON: {}", inner)),

--- a/libjose/src/jwe/algorithm.rs
+++ b/libjose/src/jwe/algorithm.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use crypto::ciphers::aes::Aes128Gcm;
 use crypto::ciphers::aes::Aes192Gcm;
 use crypto::ciphers::aes::Aes256Gcm;
@@ -201,7 +201,7 @@ impl JweAlgorithm {
 }
 
 impl Display for JweAlgorithm {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.write_str(self.name())
   }
 }

--- a/libjose/src/jwe/compression.rs
+++ b/libjose/src/jwe/compression.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::Display;
 use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
+
 use miniz_oxide::deflate::compress_to_vec;
 use miniz_oxide::deflate::CompressionLevel;
 use miniz_oxide::inflate::decompress_to_vec;
@@ -51,7 +51,7 @@ impl Default for JweCompression {
 }
 
 impl Display for JweCompression {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     f.write_str(self.name())
   }
 }


### PR DESCRIPTION
# Description of change
Adds a `FmtJson` trait for convenience to reduce duplicate code for structs that implement `ToJson` with `Display`.

I'm not sure if there's a better way to do this.

## Type of change

- [x] Bug fix / chore (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tests and examples pass locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
