### PR TITLE
Fix lint warnings

### DIFF
--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -47,7 +47,7 @@ pub struct Account {
   actions: AtomicUsize,
   chain_state: ChainState,
   state: IdentityState,
-  did_lease: DIDLease,
+  _did_lease: DIDLease,
 }
 
 impl Account {
@@ -74,7 +74,7 @@ impl Account {
       actions: AtomicUsize::new(0),
       chain_state,
       state,
-      did_lease,
+      _did_lease: did_lease,
     })
   }
 

--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -47,7 +47,8 @@ pub struct Account {
   actions: AtomicUsize,
   chain_state: ChainState,
   state: IdentityState,
-  _did_lease: DIDLease,
+  _did_lease: DIDLease, /* This field is not read, but has special behaviour on drop which is why it is needed in
+                         * the Account. */
 }
 
 impl Account {

--- a/identity-did/src/resolution/resource.rs
+++ b/identity-did/src/resolution/resource.rs
@@ -36,6 +36,7 @@ impl From<SecondaryResource> for Resource {
 ///
 /// [SPEC]: https://www.w3.org/TR/did-core/#dfn-did-url-dereferencing
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[allow(clippy::large_enum_variant)]
 #[serde(untagged)]
 pub enum PrimaryResource {
   /// A dereferenced DID Document.

--- a/identity-did/src/resolution/resource.rs
+++ b/identity-did/src/resolution/resource.rs
@@ -36,7 +36,7 @@ impl From<SecondaryResource> for Resource {
 ///
 /// [SPEC]: https://www.w3.org/TR/did-core/#dfn-did-url-dereferencing
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[allow(clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant)] //temporary fix until the resolver gets refactored
 #[serde(untagged)]
 pub enum PrimaryResource {
   /// A dereferenced DID Document.


### PR DESCRIPTION
# Description of change
Added `#[allow(clippy::large_enum_variant)]` for the `PrimaryResource` enum until the resolver gets refactored. Also renamed a private field in `Account` to make `cargo check` pass without warnings. 

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
