### PR TITLE
Bump `iota-client` version to 1.1

### DIFF
--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -24,7 +24,7 @@ wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 
 [dependencies.identity]
-version = "=0.4.0"
+version = "=0.4.1"
 path = "../../identity"
 default-features = false
 features = ["comm", "wasm"]

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -18,10 +18,8 @@ crate-type = ["cdylib", "rlib"]
 console_error_panic_hook = { version = "0.1" }
 futures = { version = "0.3" }
 js-sys = { version = "0.3" }
-reqwest = { version = "=0.11.4" } # pin version to 0.11.4: https://github.com/iotaledger/identity.rs/issues/438
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
-tokio = { version = "*", default-features = false, features = ["rt"] } # enable "rt" feature to fix build: https://github.com/iotaledger/identity.rs/issues/403
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 
@@ -37,6 +35,7 @@ wasm-bindgen-test = { version = "0.3" }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 chrono = { version = "0.4", features = ["wasmbind"] }
 getrandom = { version = "0.2", features = ["js"] }
+parking_lot = { version = "0.11.2", features = ["wasm-bindgen"] }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = true

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -42,9 +42,9 @@
 ## Members
 
 <dl>
-<dt><a href="#Digest">Digest</a></dt>
-<dd></dd>
 <dt><a href="#KeyType">KeyType</a></dt>
+<dd></dd>
+<dt><a href="#Digest">Digest</a></dt>
 <dd></dd>
 </dl>
 
@@ -1687,13 +1687,13 @@ Deserializes a `VerificationMethod` object from a JSON object.
 | --- | --- |
 | value | <code>any</code> | 
 
-<a name="Digest"></a>
-
-## Digest
-**Kind**: global variable  
 <a name="KeyType"></a>
 
 ## KeyType
+**Kind**: global variable  
+<a name="Digest"></a>
+
+## Digest
 **Kind**: global variable  
 <a name="start"></a>
 

--- a/identity-account/Cargo.toml
+++ b/identity-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity-account"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["IOTA Stiftung"]
 edition = "2018"
 homepage = "https://www.iota.org"
@@ -15,10 +15,10 @@ actix = { version = "0.12.0", optional = true }
 async-trait = { version = "0.1", default-features = false }
 futures = { version = "0.3" }
 hashbrown = { version = "0.11", features = ["serde"] }
-identity-core = { version = "=0.4.0", path = "../identity-core" }
-identity-credential = { version = "=0.4.0", path = "../identity-credential" }
-identity-did = { version = "=0.4.0", path = "../identity-did" }
-identity-iota = { version = "=0.4.0", path = "../identity-iota", default-features = false }
+identity-core = { version = "=0.4.1", path = "../identity-core" }
+identity-credential = { version = "=0.4.1", path = "../identity-credential" }
+identity-did = { version = "=0.4.1", path = "../identity-did" }
+identity-iota = { version = "=0.4.1", path = "../identity-iota", default-features = false }
 itoa = { version = "0.4" }
 log = { version = "0.4", default-features = false }
 once_cell = { version = "1.7", default-features = false, features = ["std"] }

--- a/identity-comm/Cargo.toml
+++ b/identity-comm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity-comm"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["IOTA Stiftung"]
 edition = "2018"
 homepage = "https://www.iota.org"
@@ -11,10 +11,10 @@ repository = "https://github.com/iotaledger/identity.rs"
 description = "An implementation of the DIDComm Messaging Specification."
 
 [dependencies]
-identity-core = { path = "../identity-core", version = "=0.4.0" }
-identity-credential = { path = "../identity-credential", version = "=0.4.0" }
-identity-did = { path = "../identity-did", version = "=0.4.0" }
-identity-iota = { path = "../identity-iota", version = "=0.4.0", default-features = false }
+identity-core = { path = "../identity-core", version = "=0.4.1" }
+identity-credential = { path = "../identity-credential", version = "=0.4.1" }
+identity-did = { path = "../identity-did", version = "=0.4.1" }
+identity-iota = { path = "../identity-iota", version = "=0.4.1", default-features = false }
 libjose = { path = "../libjose", version = "=0.1.0" }
 paste = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/identity-core/Cargo.toml
+++ b/identity-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity-core"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["IOTA Stiftung"]
 edition = "2018"
 homepage = "https://www.iota.org"
@@ -15,7 +15,7 @@ base64 = { version = "0.13", default-features = false, features = ["std"] }
 bs58 = { version = "0.4", default-features = false, features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 hex = { version = "0.4", default-features = false }
-identity-diff = { version = "=0.4.0", path = "../identity-diff", default-features = false }
+identity-diff = { version = "=0.4.1", path = "../identity-diff", default-features = false }
 multibase = { version = "0.9", default-features = false, features = ["std"] }
 roaring = { version = "0.7", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }

--- a/identity-credential/Cargo.toml
+++ b/identity-credential/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity-credential"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["IOTA Stiftung"]
 edition = "2018"
 homepage = "https://www.iota.org"
@@ -11,8 +11,8 @@ repository = "https://github.com/iotaledger/identity.rs"
 description = "An implementation of the Verfiable Credentials standard."
 
 [dependencies]
-identity-core = { version = "=0.4.0", path = "../identity-core" }
-identity-did = { version = "=0.4.0", path = "../identity-did" }
+identity-core = { version = "=0.4.1", path = "../identity-core" }
+identity-did = { version = "=0.4.1", path = "../identity-did" }
 lazy_static = { version = "1.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
 strum = { version = "0.21", features = ["derive"] }

--- a/identity-did/Cargo.toml
+++ b/identity-did/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity-did"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["IOTA Stiftung"]
 edition = "2018"
 homepage = "https://www.iota.org"
@@ -14,7 +14,7 @@ description = "An implementation of the Decentralized Identifiers standard."
 async-trait = { version = "0.1", default-features = false }
 did_url = { version = "0.1", default-features = false, features = ["std", "serde"] }
 form_urlencoded = { version = "1.0.1", default-features = false }
-identity-core = { version = "=0.4.0", path = "../identity-core" }
+identity-core = { version = "=0.4.1", path = "../identity-core" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 strum = { version = "0.21", features = ["derive"] }
 thiserror = { version = "1.0", default-features = false }

--- a/identity-did/src/resolution/resource.rs
+++ b/identity-did/src/resolution/resource.rs
@@ -36,6 +36,7 @@ impl From<SecondaryResource> for Resource {
 /// A primary resource returned from a [DID URL dereferencing][SPEC] process.
 ///
 /// [SPEC]: https://www.w3.org/TR/did-core/#dfn-did-url-dereferencing
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PrimaryResource {

--- a/identity-diff/Cargo.toml
+++ b/identity-diff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity-diff"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["IOTA Stiftung"]
 edition = "2018"
 homepage = "https://www.iota.org"
@@ -12,7 +12,7 @@ description = "The `Diff` trait for the identity-rs library."
 
 [dependencies]
 did_url = { version = "0.1", default-features = false, features = ["alloc"] }
-identity-derive = { version = "=0.4.0", path = "derive" }
+identity-derive = { version = "=0.4.1", path = "derive" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 strum = { version = "0.21", features = ["derive"] }

--- a/identity-diff/derive/Cargo.toml
+++ b/identity-diff/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity-derive"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["IOTA Stiftung"]
 edition = "2018"
 homepage = "https://www.iota.org"

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity-iota"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["IOTA Stiftung"]
 edition = "2018"
 homepage = "https://www.iota.org"
@@ -15,9 +15,9 @@ async-trait = { version = "0.1", default-features = false }
 dashmap = { version = "4.0" }
 form_urlencoded = { version = "1.0" }
 futures = { version = "0.3" }
-identity-core = { version = "=0.4.0", path = "../identity-core" }
-identity-credential = { version = "=0.4.0", path = "../identity-credential" }
-identity-did = { version = "=0.4.0", path = "../identity-did" }
+identity-core = { version = "=0.4.1", path = "../identity-core" }
+identity-credential = { version = "=0.4.1", path = "../identity-credential" }
+identity-did = { version = "=0.4.1", path = "../identity-did" }
 lazy_static = { version = "1.4", default-features = false }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -25,8 +25,7 @@ strum = { version = "0.21", features = ["derive"] }
 thiserror = { version = "1.0", default-features = false }
 
 [dependencies.iota-client]
-git = "https://github.com/iotaledger/iota.rs"
-rev = "e8c050a749a2e7c13633e97b3372b38388f48c37"
+version = "1.1.0"
 default-features = false
 
 [dependencies.iota-crypto]

--- a/identity-iota/src/did/doc/iota_document.rs
+++ b/identity-iota/src/did/doc/iota_document.rs
@@ -208,7 +208,7 @@ impl IotaDocument {
     // Validate that the document controller (if any) conforms to the IotaDID specification.
     // This check is required to ensure the correctness of the `IotaDocument::controller()` method which
     // creates an `IotaDID::new_unchecked_ref()` from the underlying controller.
-    document.controller().map_or(Ok(()), |c| IotaDID::check_validity(c))?;
+    document.controller().map_or(Ok(()), IotaDID::check_validity)?;
 
     // Validate that the verification methods conform to the IotaDID specification.
     // This check is required to ensure the correctness of the `IotaDocument::methods()`,

--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["IOTA Stiftung"]
 documentation = "https://wiki.iota.org/identity.rs/introduction"
 edition = "2018"
@@ -12,12 +12,12 @@ repository = "https://github.com/iotaledger/identity.rs"
 description = "Tools for working with Self-sovereign Identity."
 
 [dependencies]
-identity-account = { version = "=0.4.0", path = "../identity-account", optional = true }
-identity-comm = { version = "=0.4.0", path = "../identity-comm", optional = true }
-identity-core = { version = "=0.4.0", path = "../identity-core" }
-identity-credential = { version = "=0.4.0", path = "../identity-credential" }
-identity-did = { version = "=0.4.0", path = "../identity-did" }
-identity-iota = { version = "=0.4.0", path = "../identity-iota", default-features = false }
+identity-account = { version = "=0.4.1", path = "../identity-account", optional = true }
+identity-comm = { version = "=0.4.1", path = "../identity-comm", optional = true }
+identity-core = { version = "=0.4.1", path = "../identity-core" }
+identity-credential = { version = "=0.4.1", path = "../identity-credential" }
+identity-did = { version = "=0.4.1", path = "../identity-did" }
+identity-iota = { version = "=0.4.1", path = "../identity-iota", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.3" }


### PR DESCRIPTION
# Description of change
Hot fix for a compilation error on the **main** branch reported in #524 due to the `iota-client` git dependency being updated.
Bumps the `iota-client` version to 1.1 from crates.io.

This is the same fix performed for the dev branch in #503. There should be no functional changes from applying this patch.

Edit: bumps identity to 0.4.1

## Links to any relevant issues
Fixes issue #524

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tests and examples pass locally.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
