### PR TITLE
Update Rust nightly version in CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,19 +26,25 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-09-07
+          toolchain: nightly-2021-12-05
           override: true
           components: llvm-tools-preview
-      - uses: actions-rs/install@v0.1
+
+      - name: Install cargo-binutils
+        uses: actions-rs/install@v0.1
         with:
           crate: cargo-binutils
-          version: 0.3.3
-      - uses: actions-rs/install@v0.1
+          version: 0.3.4
+
+      - name: Install rustfilt
+        uses: actions-rs/install@v0.1
         with:
           crate: rustfilt
           version: 0.2.1
+
       - name: Run test coverage
         run: bash .github/workflows/scripts/coverage.sh
+
       - uses: coverallsapp/github-action@v1.1.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-09-07
+          toolchain: nightly-2021-12-05
           override: true
           components: rustfmt
 

--- a/.github/workflows/scripts/coverage.sh
+++ b/.github/workflows/scripts/coverage.sh
@@ -5,7 +5,7 @@ set -e
 rm -rf coverage
 mkdir coverage
 
-NIGHTLY="+nightly-2021-09-07"
+NIGHTLY="+nightly-2021-12-05"
 
 # Run tests with profiling instrumentation
 echo "Running instrumented unit tests..."


### PR DESCRIPTION
# Description of change
Updates the Rust nightly version used in GitHub Actions from 2021-09-07 to 2021-12-05 as an attempt to fix the failing coverage action due to a compilation error:

```
  error[E0658]: use of unstable library feature 'proc_macro_is_available'
    --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.33/src/detection.rs:28:21
     |
  28 |     let available = proc_macro::is_available();
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: see issue #71436 <https://github.com/rust-lang/rust/issues/71436> for more information
     = help: add `#![feature(proc_macro_is_available)]` to the crate attributes to enable
  
  For more information about this error, try `rustc --explain E0658`.
  error: could not compile `proc-macro2` due to previous error
  warning: build failed, waiting for other jobs to finish...
  error: failed to compile `cargo-binutils v0.3.3`, intermediate artifacts can be found at `/tmp/cargo-installVZ6nka`
```

We still pin the nightly version to prevent sudden breakages in the CI due to new bugs in a nightly build.

## Type of change
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Coverage action on this PR.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
