### PR TITLE
Update `iota-client` dependency

### DIFF
--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -12,7 +12,7 @@ description = "An IOTA Tangle intergration for the identity-rs library."
 
 [dependencies]
 async-trait = { version = "0.1", default-features = false }
-bee-rest-api = { version = "=0.1.3", default-features = false } # pin version due to breaking change in 0.1.6, update when iota-client is fixed
+bee-rest-api = { version = "0.1.6", default-features = false }
 brotli = { version = "3.3", default-features = false, features = ["std"] }
 dashmap = { version = "4.0" }
 form_urlencoded = { version = "1.0" }
@@ -31,7 +31,7 @@ thiserror = { version = "1.0", default-features = false }
 
 [dependencies.iota-client]
 git = "https://github.com/iotaledger/iota.rs"
-rev = "c48db779d2162b9a3037ee63c4d1e267d04633eb"
+rev = "734418946243ace3b5babb8d2ec8586a4f1f2b41"
 default-features = false
 
 [dependencies.iota-crypto]

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -12,7 +12,7 @@ description = "An IOTA Tangle intergration for the identity-rs library."
 
 [dependencies]
 async-trait = { version = "0.1", default-features = false }
-bee-rest-api = { version = "0.1.3", default-features = false }
+bee-rest-api = { version = "=0.1.3", default-features = false } # pin version due to breaking change in 0.1.6, update when iota-client is fixed
 brotli = { version = "3.3", default-features = false, features = ["std"] }
 dashmap = { version = "4.0" }
 form_urlencoded = { version = "1.0" }


### PR DESCRIPTION
# Description of change

Updates the `iota-client` dependency to a later git revision to fix a bug causing compilation to fail due to breaking changes in `bee-rest-api` 0.1.6.

~~Pins the `bee-rest-api` dependency to version 0.1.3. This is to fix breaking changes introduced in `bee-rest-api` 0.1.6 which cause compilation of `iota-client` to fail.~~

~~Should be temporary until https://github.com/iotaledger/iota.rs/pull/766 is merged.~~

Compilation error:

```
   Compiling iota-client v1.1.0 (https://github.com/iotaledger/iota.rs?rev=c48db779d2162b9a3037ee63c4d1e267d04633eb#c48db779)
error[E0609]: no field `0` on type `ReceiptsResponse`
Error:     --> /Users/runner/.cargo/git/checkouts/iota.rs-1792f679be51837c/c48db77/iota-client/src/client.rs:1063:31
     |
1063 |         Ok(resp.data.receipts.0)
     |                               ^ unknown field
     |
     = note: available fields are: `receipts`

error[E0609]: no field `0` on type `ReceiptsResponse`
Error:     --> /Users/runner/.cargo/git/checkouts/iota.rs-1792f679be51837c/c48db77/iota-client/src/client.rs:1080:31
     |
1080 |         Ok(resp.data.receipts.0)
     |                               ^ unknown field
     |
     = note: available fields are: `receipts`

For more information about this error, try `rustc --explain E0609`.
error: could not compile `iota-client` due to 2 previous errors
```

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Local tests and examples pass.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
