### PR TITLE
Update `iota-client` version

### DIFF
--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -12,7 +12,7 @@ description = "An IOTA Tangle intergration for the identity-rs library."
 
 [dependencies]
 async-trait = { version = "0.1", default-features = false }
-bee-rest-api = { version = "0.1.6", default-features = false }
+bee-rest-api = { version = "0.1.7", default-features = false }
 brotli = { version = "3.3", default-features = false, features = ["std"] }
 dashmap = { version = "4.0" }
 form_urlencoded = { version = "1.0" }
@@ -31,7 +31,7 @@ thiserror = { version = "1.0", default-features = false }
 
 [dependencies.iota-client]
 git = "https://github.com/iotaledger/iota.rs"
-rev = "734418946243ace3b5babb8d2ec8586a4f1f2b41"
+rev = "c7d1cc4bae4ef00f16314239463ce115f8c6b35a"
 default-features = false
 
 [dependencies.iota-crypto]


### PR DESCRIPTION
# Description of change
Updates the version of `iota-client` to fix compilation by using the latest `bee-rest-api` 0.1.7 version. See https://github.com/iotaledger/bee/issues/869 .

~~Draft PR until https://github.com/iotaledger/iota.rs/pull/767  is merged.~~

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tests and Wasm examples pass locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
