### PR TITLE
Fix `Timestamp` in the Wasm bindings

### DIFF
--- a/bindings/wasm/tests/wasm.rs
+++ b/bindings/wasm/tests/wasm.rs
@@ -70,7 +70,7 @@ fn test_js_error_from_wasm_error() {
   assert_eq!(js_error.message(), "Error message");
 }
 
-#[test]
+#[wasm_bindgen_test]
 fn test_did() {
   let key = KeyPair::new(KeyType::Ed25519).unwrap();
   let did = WasmDID::new(&key, None).unwrap();
@@ -88,7 +88,7 @@ fn test_did() {
   assert_eq!(base58.network_name(), "dev");
 }
 
-#[test]
+#[wasm_bindgen_test]
 fn test_did_url() {
   // Base DID Url
   let key = KeyPair::new(KeyType::Ed25519).unwrap();
@@ -114,7 +114,7 @@ fn test_did_url() {
   );
 }
 
-#[test]
+#[wasm_bindgen_test]
 fn test_document_new() {
   let keypair: KeyPair = KeyPair::new(KeyType::Ed25519).unwrap();
   let mut document: WasmDocument = WasmDocument::new(&keypair, None, None).unwrap();
@@ -126,7 +126,7 @@ fn test_document_new() {
   assert!(document.verify_self_signed());
 }
 
-#[test]
+#[wasm_bindgen_test]
 fn test_document_network() {
   let keypair: KeyPair = KeyPair::new(KeyType::Ed25519).unwrap();
   let document: WasmDocument = WasmDocument::new(&keypair, Some("dev".to_owned()), None).unwrap();

--- a/identity-core/Cargo.toml
+++ b/identity-core/Cargo.toml
@@ -15,7 +15,7 @@ base64 = { version = "0.13", default-features = false, features = ["std"] }
 bs58 = { version = "0.4", default-features = false, features = ["std"] }
 hex = { version = "0.4", default-features = false }
 identity-diff = { version = "=0.4.0", path = "../identity-diff", default-features = false }
-js-sys = { version = "0.3.55", optional = true }
+js-sys = { version = "0.3.55", default-features = false, optional = true }
 multibase = { version = "0.9", default-features = false, features = ["std"] }
 roaring = { version = "0.7", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }

--- a/identity-core/Cargo.toml
+++ b/identity-core/Cargo.toml
@@ -15,6 +15,7 @@ base64 = { version = "0.13", default-features = false, features = ["std"] }
 bs58 = { version = "0.4", default-features = false, features = ["std"] }
 hex = { version = "0.4", default-features = false }
 identity-diff = { version = "=0.4.0", path = "../identity-diff", default-features = false }
+js-sys = { version = "0.3.55", optional = true }
 multibase = { version = "0.9", default-features = false, features = ["std"] }
 roaring = { version = "0.7", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
@@ -38,6 +39,9 @@ proptest = "1.0.0"
 quickcheck = { version = "1.0" }
 quickcheck_macros = { version = "1.0" }
 rand = { version = "0.8" }
+
+[features]
+wasm = ["js-sys"]
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/identity-core/src/common/timestamp.rs
+++ b/identity-core/src/common/timestamp.rs
@@ -48,11 +48,10 @@ impl Timestamp {
   /// See the [`datetime` DID-core specification](https://www.w3.org/TR/did-core/#production).
   #[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasm"))]
   pub fn now_utc() -> Self {
-    let date = js_sys::Date::new_0();
-    let milliseconds_since_unix_epoch: u64 = date.get_time() as u64;
-    let seconds = milliseconds_since_unix_epoch / 1000;
-    // expect is okay, since we assume that the current time is less than 9999AD
-    Self::from_unix(seconds as i64).expect("Failed to accurately convert host Timestamp")
+    let milliseconds_since_unix_epoch: i64 = js_sys::Date::now() as i64;
+    let seconds: i64 = milliseconds_since_unix_epoch / 1000;
+    // expect is okay, we assume the current time is between 0AD and 9999AD
+    Self::from_unix(seconds).expect("Timestamp failed to convert system datetime")
   }
 
   /// Returns the `Timestamp` as an RFC 3339 `String`.

--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -14,7 +14,7 @@ description = "Tools for working with Self-sovereign Identity."
 [dependencies]
 identity-account = { version = "=0.4.0", path = "../identity-account", optional = true }
 identity-comm = { version = "=0.4.0", path = "../identity-comm", optional = true }
-identity-core = { version = "=0.4.0", path = "../identity-core" }
+identity-core = { version = "=0.4.0", path = "../identity-core", default-features = false }
 identity-credential = { version = "=0.4.0", path = "../identity-credential" }
 identity-did = { version = "=0.4.0", path = "../identity-did" }
 identity-iota = { version = "=0.4.0", path = "../identity-iota", default-features = false }
@@ -34,7 +34,7 @@ default = ["async"]
 async = ["identity-iota/async"]
 
 # Enables Web Assembly support
-wasm = ["identity-iota/wasm", "identity-comm/wasm"]
+wasm = ["identity-iota/wasm", "identity-comm/wasm", "identity-core/wasm"]
 
 # Enables support for secure storage of DID Documents
 account = ["identity-account"]


### PR DESCRIPTION
# Description of change
After migrating to `time` we got the following error `panicked at 'time not implemented on this platform', library/std/src/sys/wasm/../unsupported/time.rs:39:9` when running the node examples. This PR fixes that. 

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Runs successfully under 
`npm run build && npm run build:examples && npm run test:node && npm run test:browser` called from the `bindings/wasm` directory. Also passes `cargo test` called from the root directory. 

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
