### PR TITLE
Remove `chrono` dev-dependency in Wasm bindings

### DIFF
--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -33,7 +33,6 @@ features = ["wasm"]
 wasm-bindgen-test = { version = "0.3" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-chrono = { version = "0.4", features = ["wasmbind"] }
 getrandom = { version = "0.2", features = ["js"] }
 parking_lot = { version = "0.11.2", features = ["wasm-bindgen"] }
 


### PR DESCRIPTION
# Description of change
Removes a dev dependency on `chrono` in the Wasm/JS bindings.

It was previously used to enable a feature needed for the Wasm bindings but our dependencies no longer use `chrono`.

## Links to any relevant issues
Fixes issue #440 

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Passes 
`npm run build && npm run build:examples && npm run test:node && npm run test:browser` 
and `cargo test` locally. 

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
