### PR TITLE
Ignore `serde_cbor` unmaintained advisory in audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,4 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2021-0127", # serde_cbor is unmaintained https://github.com/iotaledger/identity.rs/issues/518
+  "RUSTSEC-2021-0127", # serde_cbor is unmaintained https://github.com/iotaledger/identity.rs/issues/518
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,4 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2021-0127", # serde_cbor is unmaintained https://github.com/iotaledger/identity.rs/issues/518
+]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,12 +9,14 @@ on:
     paths:
       - "**/Cargo.lock"
       - "**/Cargo.toml"
+      - ".github/workflows/audit.yml"
   pull_request:
     branches:
       - main
     paths:
       - "**/Cargo.lock"
       - "**/Cargo.toml"
+      - ".github/workflows/audit.yml"
 
 jobs:
   audit:


### PR DESCRIPTION
# Description of change
Ignore [RUSTSEC-2021-0127](https://rustsec.org/advisories/RUSTSEC-2021-0127.html) advising that the `serde_cbor` crate is unmaintained to prevent audit checks failing when releasing to main (all other advisories have been resolved at this point).

Issue #518 will remain open to track this. We also do not directly use `serde_cbor`, it is only a dependency of `criterion.rs` which we use for benchmarking. Just because it is unmaintained does not mean there is a vulnerability right now so it seems fine to ignore repeat warnings and wait for `critertion.rs` to migrate away from `serde_cbor`.

## Links to any relevant issues
Related to issue #518 

## Type of change

- [x] Bug fix/Chore (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
`cargo audit` ran locally and ignored the advisory.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
