### PR TITLE
Rename Wasm `VerifiableCredential`, `VerifiablePresentation` 

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -5,6 +5,8 @@
 <dd></dd>
 <dt><a href="#Config">Config</a></dt>
 <dd></dd>
+<dt><a href="#Credential">Credential</a></dt>
+<dd></dd>
 <dt><a href="#DID">DID</a></dt>
 <dd></dd>
 <dt><a href="#DIDUrl">DIDUrl</a></dt>
@@ -32,6 +34,8 @@
 <dd></dd>
 <dt><a href="#Network">Network</a></dt>
 <dd></dd>
+<dt><a href="#Presentation">Presentation</a></dt>
+<dd></dd>
 <dt><a href="#Receipt">Receipt</a></dt>
 <dd></dd>
 <dt><a href="#ResolvedDocument">ResolvedDocument</a></dt>
@@ -41,10 +45,6 @@ merged with one or more <code>DiffMessages</code>.</p>
 <dt><a href="#Service">Service</a></dt>
 <dd></dd>
 <dt><a href="#Timestamp">Timestamp</a></dt>
-<dd></dd>
-<dt><a href="#VerifiableCredential">VerifiableCredential</a></dt>
-<dd></dd>
-<dt><a href="#VerifiablePresentation">VerifiablePresentation</a></dt>
 <dd></dd>
 <dt><a href="#VerificationMethod">VerificationMethod</a></dt>
 <dd></dd>
@@ -409,6 +409,57 @@ Creates a new `Client` with default settings for the given `Network`.
 | Param | Type |
 | --- | --- |
 | network | [<code>Network</code>](#Network) | 
+
+<a name="Credential"></a>
+
+## Credential
+**Kind**: global class  
+
+* [Credential](#Credential)
+    * _instance_
+        * [.toJSON()](#Credential+toJSON) ⇒ <code>any</code>
+    * _static_
+        * [.extend(value)](#Credential.extend) ⇒ [<code>Credential</code>](#Credential)
+        * [.issue(issuer_doc, subject_data, credential_type, credential_id)](#Credential.issue) ⇒ [<code>Credential</code>](#Credential)
+        * [.fromJSON(json)](#Credential.fromJSON) ⇒ [<code>Credential</code>](#Credential)
+
+<a name="Credential+toJSON"></a>
+
+### credential.toJSON() ⇒ <code>any</code>
+Serializes a `Credential` object as a JSON object.
+
+**Kind**: instance method of [<code>Credential</code>](#Credential)  
+<a name="Credential.extend"></a>
+
+### Credential.extend(value) ⇒ [<code>Credential</code>](#Credential)
+**Kind**: static method of [<code>Credential</code>](#Credential)  
+
+| Param | Type |
+| --- | --- |
+| value | <code>any</code> | 
+
+<a name="Credential.issue"></a>
+
+### Credential.issue(issuer_doc, subject_data, credential_type, credential_id) ⇒ [<code>Credential</code>](#Credential)
+**Kind**: static method of [<code>Credential</code>](#Credential)  
+
+| Param | Type |
+| --- | --- |
+| issuer_doc | [<code>Document</code>](#Document) | 
+| subject_data | <code>any</code> | 
+| credential_type | <code>string</code> \| <code>undefined</code> | 
+| credential_id | <code>string</code> \| <code>undefined</code> | 
+
+<a name="Credential.fromJSON"></a>
+
+### Credential.fromJSON(json) ⇒ [<code>Credential</code>](#Credential)
+Deserializes a `Credential` object from a JSON object.
+
+**Kind**: static method of [<code>Credential</code>](#Credential)  
+
+| Param | Type |
+| --- | --- |
+| json | <code>any</code> | 
 
 <a name="DID"></a>
 
@@ -795,8 +846,8 @@ with the given Document.
         * [.revokeMerkleKey(query, index)](#Document+revokeMerkleKey) ⇒ <code>boolean</code>
         * [.signSelf(key_pair, method_query)](#Document+signSelf)
         * [.verifySelfSigned()](#Document+verifySelfSigned) ⇒ <code>boolean</code>
-        * [.signCredential(data, args)](#Document+signCredential) ⇒ [<code>VerifiableCredential</code>](#VerifiableCredential)
-        * [.signPresentation(data, args)](#Document+signPresentation) ⇒ [<code>VerifiablePresentation</code>](#VerifiablePresentation)
+        * [.signCredential(data, args)](#Document+signCredential) ⇒ [<code>Credential</code>](#Credential)
+        * [.signPresentation(data, args)](#Document+signPresentation) ⇒ [<code>Presentation</code>](#Presentation)
         * [.signData(data, args)](#Document+signData) ⇒ <code>any</code>
         * [.verifyData(data)](#Document+verifyData) ⇒ <code>boolean</code>
         * [.verifyDataWithScope(data, scope)](#Document+verifyDataWithScope) ⇒ <code>boolean</code>
@@ -1012,7 +1063,7 @@ Verifies a self-signed signature on this DID document.
 **Kind**: instance method of [<code>Document</code>](#Document)  
 <a name="Document+signCredential"></a>
 
-### document.signCredential(data, args) ⇒ [<code>VerifiableCredential</code>](#VerifiableCredential)
+### document.signCredential(data, args) ⇒ [<code>Credential</code>](#Credential)
 **Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
@@ -1022,7 +1073,7 @@ Verifies a self-signed signature on this DID document.
 
 <a name="Document+signPresentation"></a>
 
-### document.signPresentation(data, args) ⇒ [<code>VerifiablePresentation</code>](#VerifiablePresentation)
+### document.signPresentation(data, args) ⇒ [<code>Presentation</code>](#Presentation)
 **Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
@@ -1623,6 +1674,46 @@ Parses the provided string to a `Network`.
 
 ### Network.devnet() ⇒ [<code>Network</code>](#Network)
 **Kind**: static method of [<code>Network</code>](#Network)  
+<a name="Presentation"></a>
+
+## Presentation
+**Kind**: global class  
+
+* [Presentation](#Presentation)
+    * [new Presentation(holder_doc, credential_data, presentation_type, presentation_id)](#new_Presentation_new)
+    * _instance_
+        * [.toJSON()](#Presentation+toJSON) ⇒ <code>any</code>
+    * _static_
+        * [.fromJSON(json)](#Presentation.fromJSON) ⇒ [<code>Presentation</code>](#Presentation)
+
+<a name="new_Presentation_new"></a>
+
+### new Presentation(holder_doc, credential_data, presentation_type, presentation_id)
+
+| Param | Type |
+| --- | --- |
+| holder_doc | [<code>Document</code>](#Document) | 
+| credential_data | <code>any</code> | 
+| presentation_type | <code>string</code> \| <code>undefined</code> | 
+| presentation_id | <code>string</code> \| <code>undefined</code> | 
+
+<a name="Presentation+toJSON"></a>
+
+### presentation.toJSON() ⇒ <code>any</code>
+Serializes a `Presentation` object as a JSON object.
+
+**Kind**: instance method of [<code>Presentation</code>](#Presentation)  
+<a name="Presentation.fromJSON"></a>
+
+### Presentation.fromJSON(json) ⇒ [<code>Presentation</code>](#Presentation)
+Deserializes a `Presentation` object from a JSON object.
+
+**Kind**: static method of [<code>Presentation</code>](#Presentation)  
+
+| Param | Type |
+| --- | --- |
+| json | <code>any</code> | 
+
 <a name="Receipt"></a>
 
 ## Receipt
@@ -1851,97 +1942,6 @@ Parses a `Timestamp` from the provided input string.
 Creates a new `Timestamp` with the current date and time.
 
 **Kind**: static method of [<code>Timestamp</code>](#Timestamp)  
-<a name="VerifiableCredential"></a>
-
-## VerifiableCredential
-**Kind**: global class  
-
-* [VerifiableCredential](#VerifiableCredential)
-    * _instance_
-        * [.toJSON()](#VerifiableCredential+toJSON) ⇒ <code>any</code>
-    * _static_
-        * [.extend(value)](#VerifiableCredential.extend) ⇒ [<code>VerifiableCredential</code>](#VerifiableCredential)
-        * [.issue(issuer_doc, subject_data, credential_type, credential_id)](#VerifiableCredential.issue) ⇒ [<code>VerifiableCredential</code>](#VerifiableCredential)
-        * [.fromJSON(json)](#VerifiableCredential.fromJSON) ⇒ [<code>VerifiableCredential</code>](#VerifiableCredential)
-
-<a name="VerifiableCredential+toJSON"></a>
-
-### verifiableCredential.toJSON() ⇒ <code>any</code>
-Serializes a `VerifiableCredential` object as a JSON object.
-
-**Kind**: instance method of [<code>VerifiableCredential</code>](#VerifiableCredential)  
-<a name="VerifiableCredential.extend"></a>
-
-### VerifiableCredential.extend(value) ⇒ [<code>VerifiableCredential</code>](#VerifiableCredential)
-**Kind**: static method of [<code>VerifiableCredential</code>](#VerifiableCredential)  
-
-| Param | Type |
-| --- | --- |
-| value | <code>any</code> | 
-
-<a name="VerifiableCredential.issue"></a>
-
-### VerifiableCredential.issue(issuer_doc, subject_data, credential_type, credential_id) ⇒ [<code>VerifiableCredential</code>](#VerifiableCredential)
-**Kind**: static method of [<code>VerifiableCredential</code>](#VerifiableCredential)  
-
-| Param | Type |
-| --- | --- |
-| issuer_doc | [<code>Document</code>](#Document) | 
-| subject_data | <code>any</code> | 
-| credential_type | <code>string</code> \| <code>undefined</code> | 
-| credential_id | <code>string</code> \| <code>undefined</code> | 
-
-<a name="VerifiableCredential.fromJSON"></a>
-
-### VerifiableCredential.fromJSON(json) ⇒ [<code>VerifiableCredential</code>](#VerifiableCredential)
-Deserializes a `VerifiableCredential` object from a JSON object.
-
-**Kind**: static method of [<code>VerifiableCredential</code>](#VerifiableCredential)  
-
-| Param | Type |
-| --- | --- |
-| json | <code>any</code> | 
-
-<a name="VerifiablePresentation"></a>
-
-## VerifiablePresentation
-**Kind**: global class  
-
-* [VerifiablePresentation](#VerifiablePresentation)
-    * [new VerifiablePresentation(holder_doc, credential_data, presentation_type, presentation_id)](#new_VerifiablePresentation_new)
-    * _instance_
-        * [.toJSON()](#VerifiablePresentation+toJSON) ⇒ <code>any</code>
-    * _static_
-        * [.fromJSON(json)](#VerifiablePresentation.fromJSON) ⇒ [<code>VerifiablePresentation</code>](#VerifiablePresentation)
-
-<a name="new_VerifiablePresentation_new"></a>
-
-### new VerifiablePresentation(holder_doc, credential_data, presentation_type, presentation_id)
-
-| Param | Type |
-| --- | --- |
-| holder_doc | [<code>Document</code>](#Document) | 
-| credential_data | <code>any</code> | 
-| presentation_type | <code>string</code> \| <code>undefined</code> | 
-| presentation_id | <code>string</code> \| <code>undefined</code> | 
-
-<a name="VerifiablePresentation+toJSON"></a>
-
-### verifiablePresentation.toJSON() ⇒ <code>any</code>
-Serializes a `VerifiablePresentation` object as a JSON object.
-
-**Kind**: instance method of [<code>VerifiablePresentation</code>](#VerifiablePresentation)  
-<a name="VerifiablePresentation.fromJSON"></a>
-
-### VerifiablePresentation.fromJSON(json) ⇒ [<code>VerifiablePresentation</code>](#VerifiablePresentation)
-Deserializes a `VerifiablePresentation` object from a JSON object.
-
-**Kind**: static method of [<code>VerifiablePresentation</code>](#VerifiablePresentation)  
-
-| Param | Type |
-| --- | --- |
-| json | <code>any</code> | 
-
 <a name="VerificationMethod"></a>
 
 ## VerificationMethod

--- a/bindings/wasm/examples/src/create_vc.js
+++ b/bindings/wasm/examples/src/create_vc.js
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import {Client, Config, VerifiableCredential} from '@iota/identity-wasm';
+import {Client, Config, Credential} from '@iota/identity-wasm';
 import {createIdentity} from './create_did';
 import {manipulateIdentity} from './manipulate_did';
 
@@ -34,7 +34,7 @@ async function createVC(clientConfig) {
     };
 
     // Create an unsigned `UniversityDegree` credential for Alice
-    const unsignedVc = VerifiableCredential.extend({
+    const unsignedVc = Credential.extend({
         id: "https://example.edu/credentials/3732",
         type: "UniversityDegreeCredential",
         issuer: issuer.doc.id.toString(),

--- a/bindings/wasm/examples/src/create_vp.js
+++ b/bindings/wasm/examples/src/create_vp.js
@@ -1,16 +1,16 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { Client, Config, VerifiablePresentation } from '@iota/identity-wasm';
-import { createVC } from './create_vc';
+import {Client, Config, Presentation} from '@iota/identity-wasm';
+import {createVC} from './create_vc';
 
 /**
-    This example shows how to create a Verifiable Presentation and validate it.
-    A Verifiable Presentation is the format in which a (collection of) Verifiable Credential(s) gets shared.
-    It is signed by the subject, to prove control over the Verifiable Credential with a nonce or timestamp.
+ This example shows how to create a Verifiable Presentation and validate it.
+ A Verifiable Presentation is the format in which a (collection of) Verifiable Credential(s) gets shared.
+ It is signed by the subject, to prove control over the Verifiable Credential with a nonce or timestamp.
 
-    @param {{network: Network, explorer: ExplorerUrl}} clientConfig
-**/
+ @param {{network: Network, explorer: ExplorerUrl}} clientConfig
+ **/
 async function createVP(clientConfig) {
     // Create a default client configuration from the parent config network.
     const config = Config.fromNetwork(clientConfig.network);
@@ -23,7 +23,7 @@ async function createVP(clientConfig) {
 
     // Create a Verifiable Presentation from the Credential - signed by Alice's key
     // TODO: Sign with a challenge
-    const unsignedVp = new VerifiablePresentation(alice.doc, signedVc.toJSON())
+    const unsignedVp = new Presentation(alice.doc, signedVc.toJSON())
 
     const signedVp = alice.doc.signPresentation(unsignedVp, {
         method: "#sign-0",

--- a/bindings/wasm/examples/src/merkle_key.js
+++ b/bindings/wasm/examples/src/merkle_key.js
@@ -4,12 +4,12 @@
 import {
     Client,
     Config,
+    Credential,
     Digest,
+    KeyCollection,
     KeyType,
     Timestamp,
-    VerifiableCredential,
-    VerificationMethod,
-    KeyCollection
+    VerificationMethod
 } from '@iota/identity-wasm';
 import {createIdentity} from './create_did';
 import {logExplorerUrl} from './utils';
@@ -59,7 +59,7 @@ async function merkleKey(clientConfig) {
     };
 
     // Create an unsigned `UniversityDegree` credential for Alice
-    const unsignedVc = VerifiableCredential.extend({
+    const unsignedVc = Credential.extend({
         id: "https://example.edu/credentials/3732",
         type: "UniversityDegreeCredential",
         issuer: issuer.doc.id.toString(),

--- a/bindings/wasm/src/credential/credential.rs
+++ b/bindings/wasm/src/credential/credential.rs
@@ -83,13 +83,13 @@ impl WasmCredential {
     builder.build().map(Self).wasm_result()
   }
 
-  /// Serializes a `VerifiableCredential` object as a JSON object.
+  /// Serializes a `Credential` object as a JSON object.
   #[wasm_bindgen(js_name = toJSON)]
   pub fn to_json(&self) -> Result<JsValue> {
     JsValue::from_serde(&self.0).wasm_result()
   }
 
-  /// Deserializes a `VerifiableCredential` object from a JSON object.
+  /// Deserializes a `Credential` object from a JSON object.
   #[wasm_bindgen(js_name = fromJSON)]
   pub fn from_json(json: &JsValue) -> Result<WasmCredential> {
     json.into_serde().map(Self).wasm_result()
@@ -100,7 +100,6 @@ impl WasmCredential {
 ///
 /// An escape-hatch for converting between types that represent the same JSON
 /// structure.
-// TODO: can we replace this with into_serde()?
 fn serde_into<T, U>(obj: T) -> identity::core::Result<U>
 where
   T: ToJson,

--- a/bindings/wasm/src/credential/credential.rs
+++ b/bindings/wasm/src/credential/credential.rs
@@ -14,17 +14,18 @@ use identity::did::DID;
 use wasm_bindgen::prelude::*;
 
 use crate::did::WasmDocument;
-use crate::error::wasm_error;
+use crate::error::Result;
+use crate::error::WasmResult;
 
-#[wasm_bindgen(inspectable)]
+#[wasm_bindgen(js_name = Credential, inspectable)]
 #[derive(Clone, Debug, PartialEq)]
-pub struct VerifiableCredential(pub(crate) Credential);
+pub struct WasmCredential(pub(crate) Credential);
 
-#[wasm_bindgen]
-impl VerifiableCredential {
+#[wasm_bindgen(js_class = Credential)]
+impl WasmCredential {
   #[wasm_bindgen]
-  pub fn extend(value: &JsValue) -> Result<VerifiableCredential, JsValue> {
-    let mut base: Object = value.into_serde().map_err(wasm_error)?;
+  pub fn extend(value: &JsValue) -> Result<WasmCredential> {
+    let mut base: Object = value.into_serde().wasm_result()?;
 
     if !base.contains_key("credentialSubject") {
       return Err("Missing property: `credentialSubject`".into());
@@ -37,23 +38,23 @@ impl VerifiableCredential {
     if !base.contains_key("@context") {
       base.insert(
         "@context".into(),
-        serde_into(Credential::<()>::base_context()).map_err(wasm_error)?,
+        serde_into(Credential::<()>::base_context()).wasm_result()?,
       );
     }
 
     let mut types: Vec<String> = match base.remove("type") {
-      Some(value) => serde_into(value).map(OneOrMany::into_vec).map_err(wasm_error)?,
+      Some(value) => serde_into(value).map(OneOrMany::into_vec).wasm_result()?,
       None => Vec::new(),
     };
 
     types.insert(0, Credential::<()>::base_type().into());
-    base.insert("type".into(), serde_into(types).map_err(wasm_error)?);
+    base.insert("type".into(), serde_into(types).wasm_result()?);
 
     if !base.contains_key("issuanceDate") {
       base.insert("issuanceDate".into(), Timestamp::now_utc().to_string().into());
     }
 
-    serde_into(base).map_err(wasm_error).map(Self)
+    serde_into(base).map(Self).wasm_result()
   }
 
   #[wasm_bindgen]
@@ -62,9 +63,9 @@ impl VerifiableCredential {
     subject_data: &JsValue,
     credential_type: Option<String>,
     credential_id: Option<String>,
-  ) -> Result<VerifiableCredential, JsValue> {
-    let subjects: OneOrMany<Subject> = subject_data.into_serde().map_err(wasm_error)?;
-    let issuer_url: Url = Url::parse(issuer_doc.0.id().as_str()).map_err(wasm_error)?;
+  ) -> Result<WasmCredential> {
+    let subjects: OneOrMany<Subject> = subject_data.into_serde().wasm_result()?;
+    let issuer_url: Url = Url::parse(issuer_doc.0.id().as_str()).wasm_result()?;
     let mut builder: CredentialBuilder = CredentialBuilder::default().issuer(issuer_url);
 
     for subject in subjects.into_vec() {
@@ -76,22 +77,22 @@ impl VerifiableCredential {
     }
 
     if let Some(credential_id) = credential_id {
-      builder = builder.id(Url::parse(credential_id).map_err(wasm_error)?);
+      builder = builder.id(Url::parse(credential_id).wasm_result()?);
     }
 
-    builder.build().map(Self).map_err(wasm_error)
+    builder.build().map(Self).wasm_result()
   }
 
   /// Serializes a `VerifiableCredential` object as a JSON object.
   #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue, JsValue> {
-    JsValue::from_serde(&self.0).map_err(wasm_error)
+  pub fn to_json(&self) -> Result<JsValue> {
+    JsValue::from_serde(&self.0).wasm_result()
   }
 
   /// Deserializes a `VerifiableCredential` object from a JSON object.
   #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<VerifiableCredential, JsValue> {
-    json.into_serde().map_err(wasm_error).map(Self)
+  pub fn from_json(json: &JsValue) -> Result<WasmCredential> {
+    json.into_serde().map(Self).wasm_result()
   }
 }
 
@@ -99,6 +100,7 @@ impl VerifiableCredential {
 ///
 /// An escape-hatch for converting between types that represent the same JSON
 /// structure.
+// TODO: can we replace this with into_serde()?
 fn serde_into<T, U>(obj: T) -> identity::core::Result<U>
 where
   T: ToJson,

--- a/bindings/wasm/src/credential/mod.rs
+++ b/bindings/wasm/src/credential/mod.rs
@@ -6,5 +6,5 @@
 mod credential;
 mod presentation;
 
-pub use self::credential::VerifiableCredential;
+pub use self::credential::WasmCredential;
 pub use self::presentation::VerifiablePresentation;

--- a/bindings/wasm/src/credential/mod.rs
+++ b/bindings/wasm/src/credential/mod.rs
@@ -7,4 +7,4 @@ mod credential;
 mod presentation;
 
 pub use self::credential::WasmCredential;
-pub use self::presentation::VerifiablePresentation;
+pub use self::presentation::WasmPresentation;

--- a/bindings/wasm/src/credential/presentation.rs
+++ b/bindings/wasm/src/credential/presentation.rs
@@ -10,23 +10,24 @@ use identity::did::DID;
 use wasm_bindgen::prelude::*;
 
 use crate::did::WasmDocument;
-use crate::error::wasm_error;
+use crate::error::Result;
+use crate::error::WasmResult;
 
-#[wasm_bindgen(inspectable)]
+#[wasm_bindgen(js_name = Presentation, inspectable)]
 #[derive(Clone, Debug, PartialEq)]
-pub struct VerifiablePresentation(pub(crate) Presentation);
+pub struct WasmPresentation(pub(crate) Presentation);
 
-#[wasm_bindgen]
-impl VerifiablePresentation {
+#[wasm_bindgen(js_class = Presentation)]
+impl WasmPresentation {
   #[wasm_bindgen(constructor)]
   pub fn new(
     holder_doc: &WasmDocument,
     credential_data: JsValue,
     presentation_type: Option<String>,
     presentation_id: Option<String>,
-  ) -> Result<VerifiablePresentation, JsValue> {
-    let credentials: OneOrMany<Credential> = credential_data.into_serde().map_err(wasm_error)?;
-    let holder_url: Url = Url::parse(holder_doc.0.id().as_str()).map_err(wasm_error)?;
+  ) -> Result<WasmPresentation> {
+    let credentials: OneOrMany<Credential> = credential_data.into_serde().wasm_result()?;
+    let holder_url: Url = Url::parse(holder_doc.0.id().as_str()).wasm_result()?;
 
     let mut builder: PresentationBuilder = PresentationBuilder::default().holder(holder_url);
 
@@ -39,21 +40,21 @@ impl VerifiablePresentation {
     }
 
     if let Some(presentation_id) = presentation_id {
-      builder = builder.id(Url::parse(presentation_id).map_err(wasm_error)?);
+      builder = builder.id(Url::parse(presentation_id).wasm_result()?);
     }
 
-    builder.build().map_err(wasm_error).map(Self)
+    builder.build().map(Self).wasm_result()
   }
 
-  /// Serializes a `VerifiablePresentation` object as a JSON object.
+  /// Serializes a `Presentation` object as a JSON object.
   #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue, JsValue> {
-    JsValue::from_serde(&self.0).map_err(wasm_error)
+  pub fn to_json(&self) -> Result<JsValue> {
+    JsValue::from_serde(&self.0).wasm_result()
   }
 
-  /// Deserializes a `VerifiablePresentation` object from a JSON object.
+  /// Deserializes a `Presentation` object from a JSON object.
   #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<VerifiablePresentation, JsValue> {
-    json.into_serde().map_err(wasm_error).map(Self)
+  pub fn from_json(json: &JsValue) -> Result<WasmPresentation> {
+    json.into_serde().map(Self).wasm_result()
   }
 }

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -20,8 +20,8 @@ use identity::iota::NetworkName;
 use wasm_bindgen::prelude::*;
 
 use crate::common::WasmTimestamp;
-use crate::credential::VerifiableCredential;
 use crate::credential::VerifiablePresentation;
+use crate::credential::WasmCredential;
 use crate::crypto::KeyPair;
 use crate::did::wasm_did_url::WasmDIDUrl;
 use crate::did::WasmDID;
@@ -186,9 +186,9 @@ impl WasmDocument {
   }
 
   #[wasm_bindgen(js_name = signCredential)]
-  pub fn sign_credential(&self, data: &JsValue, args: &JsValue) -> Result<VerifiableCredential> {
+  pub fn sign_credential(&self, data: &JsValue, args: &JsValue) -> Result<WasmCredential> {
     let json: JsValue = self.sign_data(data, args)?;
-    let data: VerifiableCredential = VerifiableCredential::from_json(&json)?;
+    let data: WasmCredential = WasmCredential::from_json(&json)?;
 
     Ok(data)
   }

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -20,8 +20,8 @@ use identity::iota::NetworkName;
 use wasm_bindgen::prelude::*;
 
 use crate::common::WasmTimestamp;
-use crate::credential::VerifiablePresentation;
 use crate::credential::WasmCredential;
+use crate::credential::WasmPresentation;
 use crate::crypto::KeyPair;
 use crate::did::wasm_did_url::WasmDIDUrl;
 use crate::did::WasmDID;
@@ -194,9 +194,9 @@ impl WasmDocument {
   }
 
   #[wasm_bindgen(js_name = signPresentation)]
-  pub fn sign_presentation(&self, data: &JsValue, args: &JsValue) -> Result<VerifiablePresentation> {
+  pub fn sign_presentation(&self, data: &JsValue, args: &JsValue) -> Result<WasmPresentation> {
     let json: JsValue = self.sign_data(data, args)?;
-    let data: VerifiablePresentation = VerifiablePresentation::from_json(&json)?;
+    let data: WasmPresentation = WasmPresentation::from_json(&json)?;
 
     Ok(data)
   }


### PR DESCRIPTION
# Description of change
This renames `VerifiableCredential` to `Credential` and `VerifiablePresentation` to `Presentation` in the Wasm bindings for parity with the core Rust library.

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Wasm tests and examples pass locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
