### PR TITLE
fix node-fetch conflict when multiple versions are included

### DIFF
--- a/bindings/wasm/build/node.js
+++ b/bindings/wasm/build/node.js
@@ -10,7 +10,7 @@ lintBigInt(entryFileNode);
 
 let changedFileNode = entryFileNode.replace(
     "let imports = {};",
-    "const fetch = require(\'node-fetch\')\r\nglobal.Headers = fetch.Headers\r\nglobal.Request = fetch.Request\r\nglobal.Response = fetch.Response\r\nglobal.fetch = fetch\r\n\r\nlet imports = {};"
+    "if (!global.is_fetch_polyfilled) {\r\nconst fetch = require(\'node-fetch\')\r\nglobal.Headers = fetch.Headers\r\nglobal.Request = fetch.Request\r\nglobal.Response = fetch.Response\r\nglobal.fetch = fetch\r\nglobal.is_fetch_polyfilled=true\r\n}\r\nlet imports = {};"
 )
 fs.writeFileSync(
     entryFilePathNode,


### PR DESCRIPTION
# Description of change
fix issue with multiple node-fetch versions conflicting in the global namespace

## Links to any relevant issues
fixes issue #482

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tested integration in IOTA Explorer.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
