### PR TITLE
Fix clippy lints

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-12-05
+          toolchain: nightly-2022-01-08
           override: true
           components: llvm-tools-preview
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-12-05
+          toolchain: nightly-2022-01-08
           override: true
           components: rustfmt
 

--- a/.github/workflows/scripts/coverage.sh
+++ b/.github/workflows/scripts/coverage.sh
@@ -5,7 +5,7 @@ set -e
 rm -rf coverage
 mkdir coverage
 
-NIGHTLY="+nightly-2021-12-05"
+NIGHTLY="+nightly-2022-01-08"
 
 # Run tests with profiling instrumentation
 echo "Running instrumented unit tests..."

--- a/identity-account/src/account/builder.rs
+++ b/identity-account/src/account/builder.rs
@@ -94,7 +94,6 @@ impl AccountBuilder {
     self
   }
 
-
   /// Set whether the account is in testmode or not.
   /// In testmode, the account skips publishing to the tangle.
   #[cfg(test)]

--- a/identity-account/src/account/builder.rs
+++ b/identity-account/src/account/builder.rs
@@ -72,6 +72,7 @@ impl AccountBuilder {
   /// Sets the account auto-save behaviour.
   ///
   /// See the config's [`autosave`][AccountConfig::autosave] documentation for details.
+  #[must_use]
   pub fn autosave(mut self, value: AutoSave) -> Self {
     self.config = self.config.autosave(value);
     self
@@ -80,26 +81,31 @@ impl AccountBuilder {
   /// Sets the account auto-publish behaviour.
   ///
   /// See the config's [`autopublish`][AccountConfig::autopublish] documentation for details.
+  #[must_use]
   pub fn autopublish(mut self, value: bool) -> Self {
     self.config = self.config.autopublish(value);
     self
   }
 
   /// Save a state snapshot every N actions.
+  #[must_use]
   pub fn milestone(mut self, value: u32) -> Self {
     self.config = self.config.milestone(value);
     self
   }
 
-  #[cfg(test)]
+
   /// Set whether the account is in testmode or not.
   /// In testmode, the account skips publishing to the tangle.
+  #[cfg(test)]
+  #[must_use]
   pub(crate) fn testmode(mut self, value: bool) -> Self {
     self.config = self.config.testmode(value);
     self
   }
 
   /// Sets the account storage adapter.
+  #[must_use]
   pub fn storage(mut self, value: AccountStorage) -> Self {
     self.storage_template = Some(value);
     self
@@ -136,6 +142,7 @@ impl AccountBuilder {
   }
 
   /// Apply configuration to the IOTA Tangle client for the given [`Network`].
+  #[must_use]
   pub fn client<F>(mut self, network: Network, f: F) -> Self
   where
     F: FnOnce(ClientBuilder) -> ClientBuilder,

--- a/identity-account/src/account/publish_options.rs
+++ b/identity-account/src/account/publish_options.rs
@@ -25,6 +25,7 @@ impl PublishOptions {
   /// for identities with many updates.
   ///
   /// See the IOTA DID method specification for more details.
+  #[must_use]
   pub fn force_integration_update(mut self, force: bool) -> Self {
     self.force_integration_update = force;
     self
@@ -36,6 +37,7 @@ impl PublishOptions {
   ///
   /// If this is not set, the method used is determined by
   /// [`IotaDocument::default_signing_method`].
+  #[must_use]
   pub fn sign_with(mut self, fragment: impl Into<String>) -> Self {
     self.sign_with = Some(fragment.into());
     self

--- a/identity-account/src/updates/macros.rs
+++ b/identity-account/src/updates/macros.rs
@@ -43,6 +43,7 @@ macro_rules! impl_update_builder {
 
       impl<'account> [<$ident Builder>]<'account> {
         $(
+          #[must_use]
           pub fn $field<VALUE: Into<$ty>>(mut self, value: VALUE) -> Self {
             self.$field = Some(value.into());
             self

--- a/identity-account/src/updates/update.rs
+++ b/identity-account/src/updates/update.rs
@@ -355,6 +355,7 @@ AttachMethodRelationship {
 });
 
 impl<'account> AttachMethodRelationshipBuilder<'account> {
+  #[must_use]
   pub fn relationship(mut self, value: MethodRelationship) -> Self {
     self.relationships.get_or_insert_with(Default::default).push(value);
     self
@@ -373,6 +374,7 @@ DetachMethodRelationship {
 });
 
 impl<'account> DetachMethodRelationshipBuilder<'account> {
+  #[must_use]
   pub fn relationship(mut self, value: MethodRelationship) -> Self {
     self.relationships.get_or_insert_with(Default::default).push(value);
     self

--- a/identity-core/src/crypto/key/collection.rs
+++ b/identity-core/src/crypto/key/collection.rs
@@ -211,10 +211,12 @@ impl IntoIterator for KeyCollection {
   type IntoIter = Zip<IntoIter<PublicKey>, IntoIter<PrivateKey>>;
 
   // Vec conversion is necessary for Box<[T]>, see https://github.com/rust-lang/rust/issues/59878
-  // TODO: uncomment after Rust 1.58 stable release
-  // #[allow(clippy::unnecessary_to_owned)]
   fn into_iter(self) -> Self::IntoIter {
-    self.public.to_vec().into_iter().zip(self.private.to_vec().into_iter())
+    self
+      .public
+      .into_vec()
+      .into_iter()
+      .zip(self.private.into_vec().into_iter())
   }
 }
 

--- a/identity-core/src/crypto/key/collection.rs
+++ b/identity-core/src/crypto/key/collection.rs
@@ -211,7 +211,8 @@ impl IntoIterator for KeyCollection {
   type IntoIter = Zip<IntoIter<PublicKey>, IntoIter<PrivateKey>>;
 
   // Vec conversion is necessary for Box<[T]>, see https://github.com/rust-lang/rust/issues/59878
-  #[allow(clippy::unnecessary_to_owned)]
+  // TODO: uncomment after Rust 1.58 stable release
+  // #[allow(clippy::unnecessary_to_owned)]
   fn into_iter(self) -> Self::IntoIter {
     self.public.to_vec().into_iter().zip(self.private.to_vec().into_iter())
   }

--- a/identity-core/src/crypto/key/collection.rs
+++ b/identity-core/src/crypto/key/collection.rs
@@ -210,6 +210,8 @@ impl IntoIterator for KeyCollection {
   type Item = (PublicKey, PrivateKey);
   type IntoIter = Zip<IntoIter<PublicKey>, IntoIter<PrivateKey>>;
 
+  // Vec conversion is necessary for Box<[T]>, see https://github.com/rust-lang/rust/issues/59878
+  #[allow(clippy::unnecessary_to_owned)]
   fn into_iter(self) -> Self::IntoIter {
     self.public.to_vec().into_iter().zip(self.private.to_vec().into_iter())
   }

--- a/identity-core/src/crypto/signature/signature_options.rs
+++ b/identity-core/src/crypto/signature/signature_options.rs
@@ -41,6 +41,7 @@ impl SignatureOptions {
   }
 
   /// Sets the [`Signature::created`](crate::crypto::Signature::created) field.
+  #[must_use]
   pub fn created(mut self, created: Timestamp) -> Self {
     self.created = Some(created);
     self
@@ -48,24 +49,28 @@ impl SignatureOptions {
 
   /// Sets the [`Signature::expires`](crate::crypto::Signature::expires) field.
   /// The signature will fail validation after the specified datetime.
+  #[must_use]
   pub fn expires(mut self, expires: Timestamp) -> Self {
     self.expires = Some(expires);
     self
   }
 
   /// Sets the [`Signature::challenge`](crate::crypto::Signature::challenge) field.
+  #[must_use]
   pub fn challenge(mut self, challenge: String) -> Self {
     self.challenge = Some(challenge);
     self
   }
 
   /// Sets the [`Signature::domain`](crate::crypto::Signature::domain) field.
+  #[must_use]
   pub fn domain(mut self, domain: String) -> Self {
     self.domain = Some(domain);
     self
   }
 
   /// Sets the [`Signature::purpose`](crate::crypto::Signature::purpose) field.
+  #[must_use]
   pub fn purpose(mut self, purpose: ProofPurpose) -> Self {
     self.purpose = Some(purpose);
     self

--- a/identity-did/src/did/did_url.rs
+++ b/identity-did/src/did/did_url.rs
@@ -119,7 +119,7 @@ impl RelativeDIDUrl {
   ///
   /// E.g. `"?query1=a&query2=b" -> "query1=a&query2=b"`
   pub fn query(&self) -> Option<&str> {
-    self.query.as_deref().map(|query| query.strip_prefix('?')).flatten()
+    self.query.as_deref().and_then(|query| query.strip_prefix('?'))
   }
 
   /// Attempt to set the [query](https://www.w3.org/TR/did-core/#query) component.
@@ -172,8 +172,7 @@ impl RelativeDIDUrl {
     self
       .fragment
       .as_deref()
-      .map(|fragment| fragment.strip_prefix('#'))
-      .flatten()
+      .and_then(|fragment| fragment.strip_prefix('#'))
   }
 
   /// Attempt to set the [fragment](https://www.w3.org/TR/did-core/#fragment) component.

--- a/identity-did/src/did/did_url.rs
+++ b/identity-did/src/did/did_url.rs
@@ -169,10 +169,7 @@ impl RelativeDIDUrl {
   ///
   /// E.g. `"#fragment" -> "fragment"`
   pub fn fragment(&self) -> Option<&str> {
-    self
-      .fragment
-      .as_deref()
-      .and_then(|fragment| fragment.strip_prefix('#'))
+    self.fragment.as_deref().and_then(|fragment| fragment.strip_prefix('#'))
   }
 
   /// Attempt to set the [fragment](https://www.w3.org/TR/did-core/#fragment) component.

--- a/identity-did/src/verifiable/document_signer.rs
+++ b/identity-did/src/verifiable/document_signer.rs
@@ -60,12 +60,14 @@ impl<'base, T, U, V> DocumentSigner<'base, '_, '_, T, U, V> {
   }
 
   /// Overwrites the [`SignatureOptions`].
+  #[must_use]
   pub fn options(mut self, options: SignatureOptions) -> Self {
     self.options = options;
     self
   }
 
   /// Sets the [`Signature::created`](identity_core::crypto::Signature::created) field.
+  #[must_use]
   pub fn created(mut self, created: Timestamp) -> Self {
     self.options = self.options.created(created);
     self
@@ -73,24 +75,28 @@ impl<'base, T, U, V> DocumentSigner<'base, '_, '_, T, U, V> {
 
   /// Sets the [`Signature::expires`](identity_core::crypto::Signature::expires) field.
   /// The signature will fail validation after the specified datetime.
+  #[must_use]
   pub fn expires(mut self, expires: Timestamp) -> Self {
     self.options = self.options.expires(expires);
     self
   }
 
   /// Sets the [`Signature::challenge`](identity_core::crypto::Signature::challenge) field.
+  #[must_use]
   pub fn challenge(mut self, challenge: String) -> Self {
     self.options = self.options.challenge(challenge);
     self
   }
 
   /// Sets the [`Signature::domain`](identity_core::crypto::Signature::domain) field.
+  #[must_use]
   pub fn domain(mut self, domain: String) -> Self {
     self.options = self.options.domain(domain);
     self
   }
 
   /// Sets the [`Signature::purpose`](identity_core::crypto::Signature::purpose) field.
+  #[must_use]
   pub fn purpose(mut self, purpose: ProofPurpose) -> Self {
     self.options = self.options.purpose(purpose);
     self
@@ -98,6 +104,7 @@ impl<'base, T, U, V> DocumentSigner<'base, '_, '_, T, U, V> {
 }
 
 impl<'base, 'query, T, U, V> DocumentSigner<'base, 'query, '_, T, U, V> {
+  #[must_use]
   pub fn method<Q>(mut self, value: Q) -> Self
   where
     Q: Into<MethodQuery<'query>>,
@@ -108,6 +115,7 @@ impl<'base, 'query, T, U, V> DocumentSigner<'base, 'query, '_, T, U, V> {
 }
 
 impl<'proof, T, U, V> DocumentSigner<'_, '_, 'proof, T, U, V> {
+  #[must_use]
   pub fn merkle_key<D>(mut self, proof: (&'proof PublicKey, &'proof Proof<D>)) -> Self
   where
     D: MerkleDigest,

--- a/identity-did/src/verifiable/document_verifier.rs
+++ b/identity-did/src/verifiable/document_verifier.rs
@@ -50,6 +50,7 @@ impl<'base, T, U, V> DocumentVerifier<'base, T, U, V> {
   }
 
   /// Overwrites the [`VerifierOptions`].
+  #[must_use]
   pub fn options(mut self, options: VerifierOptions) -> Self {
     self.options = options;
     self
@@ -58,24 +59,28 @@ impl<'base, T, U, V> DocumentVerifier<'base, T, U, V> {
   /// Verify the signing verification method relationship matches this.
   ///
   /// NOTE: `purpose` overrides the `method_scope` option.
+  #[must_use]
   pub fn method_scope(mut self, method_scope: MethodScope) -> Self {
     self.options = self.options.method_scope(method_scope);
     self
   }
 
   /// Verify the signing verification method type matches one specified.
+  #[must_use]
   pub fn method_type(mut self, method_type: Vec<MethodType>) -> Self {
     self.options = self.options.method_type(method_type);
     self
   }
 
   /// Verify the [`Signature::challenge`] field matches this.
+  #[must_use]
   pub fn challenge(mut self, challenge: String) -> Self {
     self.options = self.options.challenge(challenge);
     self
   }
 
   /// Verify the [`Signature::domain`] field matches this.
+  #[must_use]
   pub fn domain(mut self, domain: String) -> Self {
     self.options = self.options.domain(domain);
     self
@@ -88,6 +93,7 @@ impl<'base, T, U, V> DocumentVerifier<'base, T, U, V> {
   /// with [`MethodRelationship::Authentication`].
   ///
   /// NOTE: `purpose` overrides the `method_scope` option.
+  #[must_use]
   pub fn purpose(mut self, purpose: ProofPurpose) -> Self {
     self.options = self.options.purpose(purpose);
     self
@@ -96,6 +102,7 @@ impl<'base, T, U, V> DocumentVerifier<'base, T, U, V> {
   /// Determines whether to error if the current time exceeds the [`Signature::expires`] field.
   ///
   /// Default: false (reject expired signatures).
+  #[must_use]
   pub fn allow_expired(mut self, allow_expired: bool) -> Self {
     self.options = self.options.allow_expired(allow_expired);
     self

--- a/identity-did/src/verifiable/verifier_options.rs
+++ b/identity-did/src/verifiable/verifier_options.rs
@@ -41,36 +41,42 @@ impl VerifierOptions {
   }
 
   /// See [`DocumentVerifier::method_scope'].
+  #[must_use]
   pub fn method_scope(mut self, method_scope: MethodScope) -> Self {
     self.method_scope = Some(method_scope);
     self
   }
 
   /// See [`DocumentVerifier::method_type'].
+  #[must_use]
   pub fn method_type(mut self, method_type: Vec<MethodType>) -> Self {
     self.method_type = Some(method_type);
     self
   }
 
   /// See [`DocumentVerifier::challenge'].
+  #[must_use]
   pub fn challenge(mut self, challenge: String) -> Self {
     self.challenge = Some(challenge);
     self
   }
 
   /// See [`DocumentVerifier::domain'].
+  #[must_use]
   pub fn domain(mut self, domain: String) -> Self {
     self.domain = Some(domain);
     self
   }
 
   /// See [`DocumentVerifier::purpose'].
+  #[must_use]
   pub fn purpose(mut self, purpose: ProofPurpose) -> Self {
     self.purpose = Some(purpose);
     self
   }
 
   /// See [`DocumentVerifier::allow_expired'].
+  #[must_use]
   pub fn allow_expired(mut self, allow_expired: bool) -> Self {
     self.allow_expired = Some(allow_expired);
     self

--- a/identity-iota/src/document/iota_document.rs
+++ b/identity-iota/src/document/iota_document.rs
@@ -275,8 +275,7 @@ impl IotaDocument {
       .core_document()
       .capability_invocation()
       .head()
-      .map(|method_ref| self.core_document().resolve_method_ref(method_ref))
-      .flatten()
+      .and_then(|method_ref| self.core_document().resolve_method_ref(method_ref))
       .map(|method: &VerificationMethod<_>|
         // SAFETY: validity of methods checked in `IotaVerificationMethod::check_validity`.
         unsafe { IotaVerificationMethod::new_unchecked_ref(method) })

--- a/identity-iota/src/tangle/client_builder.rs
+++ b/identity-iota/src/tangle/client_builder.rs
@@ -33,6 +33,7 @@ impl ClientBuilder {
   }
 
   /// Sets the IOTA Tangle network.
+  #[must_use]
   pub fn network(mut self, network: Network) -> Self {
     self.builder = self.builder.with_network(network.name_str());
     self.network = network;
@@ -40,6 +41,7 @@ impl ClientBuilder {
   }
 
   /// Sets the DID message encoding used when publishing to the Tangle.
+  #[must_use]
   pub fn encoding(mut self, encoding: DIDMessageEncoding) -> Self {
     self.encoding = encoding;
     self
@@ -86,12 +88,14 @@ impl ClientBuilder {
   }
 
   /// Sets the node sync interval.
+  #[must_use]
   pub fn node_sync_interval(mut self, value: Duration) -> Self {
     self.builder = self.builder.with_node_sync_interval(value);
     self
   }
 
   /// Disables the node sync process.
+  #[must_use]
   pub fn node_sync_disabled(mut self) -> Self {
     self.builder = self.builder.with_node_sync_disabled();
     self
@@ -105,36 +109,42 @@ impl ClientBuilder {
   }
 
   /// Enables/disables quorum.
+  #[must_use]
   pub fn quorum(mut self, value: bool) -> Self {
     self.builder = self.builder.with_quorum(value);
     self
   }
 
   /// Sets the number of nodes used for quorum.
+  #[must_use]
   pub fn quorum_size(mut self, value: usize) -> Self {
     self.builder = self.builder.with_quorum_size(value);
     self
   }
 
   /// Sets the quorum threshold.
+  #[must_use]
   pub fn quorum_threshold(mut self, value: usize) -> Self {
     self.builder = self.builder.with_quorum_threshold(value);
     self
   }
 
   /// Sets whether PoW is performed locally or remotely.
+  #[must_use]
   pub fn local_pow(mut self, value: bool) -> Self {
     self.builder = self.builder.with_local_pow(value);
     self
   }
 
   /// Sets the number of seconds that new tips will be requested during PoW.
+  #[must_use]
   pub fn tips_interval(mut self, value: u64) -> Self {
     self.builder = self.builder.with_tips_interval(value);
     self
   }
 
   /// Sets the default request timeout.
+  #[must_use]
   pub fn request_timeout(mut self, value: Duration) -> Self {
     self.builder = self.builder.with_request_timeout(value);
     self


### PR DESCRIPTION
# Description of change
Annotates builder functions with `#[must_use]` (where the result type does not already have that lint, e.g. `Result` is already `must_use`) and other minor non-functional changes to appease `clippy`.

Updates the pinned Rust nightly version in GitHub Actions from `nightly-2021-12-05` to `nightly-2022-01-08`.

## Type of change

- [x] Chore/Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tests and examples pass locally.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
