### PR TITLE
Enable local proof-of-work fallback

### DIFF
--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = { version = "1.0", default-features = false }
 git = "https://github.com/iotaledger/iota.rs"
 rev = "c7d1cc4bae4ef00f16314239463ce115f8c6b35a"
 default-features = false
+features = ["pow-fallback"]
 
 [dependencies.iota-crypto]
 version = "0.7"

--- a/identity-iota/src/tangle/client_builder.rs
+++ b/identity-iota/src/tangle/client_builder.rs
@@ -129,7 +129,9 @@ impl ClientBuilder {
     self
   }
 
-  /// Sets whether PoW is performed locally or remotely.
+  /// Sets whether proof-of-work (PoW) is performed locally or remotely.
+  ///
+  /// NOTE: the client will always fallback to local PoW if no nodes support remote PoW.
   #[must_use]
   pub fn local_pow(mut self, value: bool) -> Self {
     self.builder = self.builder.with_local_pow(value);


### PR DESCRIPTION
# Description of change
This enables the `pow-fallback` feature for `iota-client`, which means publishing messages falls back to performing proof-of-work locally (on the client) when no nodes support remote proof-of-work.

NOTE: this changes the behaviour of the `local_pow` setting on the `ClientBuilder`, making it a preference whether or not to try remote PoW first before using local PoW rather than a hard setting. Since the `pow-fallback` is a compile-time feature we cannot change whether or not to fallback at runtime. This change may be temporary.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tested with a local one-click-Tangle with remote PoW enabled and disabled on the Hornet node.

1) When **remote PoW on the node is disabled** and **local PoW on the client is false** **_without local fallback from this PR_**, we get the following error from the `Client` when trying to publish a new identity:

    `Err > Error [ClientError]: Node error: Response error with status code 400: {"error":{"code":"400","message":"invalid parameter, error: proof of work is not enabled on this node: code=400, message=invalid parameter"}}`

2) When **remote PoW on the node is disabled** **_with the local fallback enabled by this PR_**, the client performs PoW locally and successfully publishes the new identity (regardless of the `local_pow` variable).

3) When **remote PoW on the node is enabled** the client respects the `local_pow` variable as per the current behaviour.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
