### PR TITLE
Replace `ClientMap` with `Client` in `Account`

### DIFF
--- a/bindings/wasm/examples/src/private_tangle.js
+++ b/bindings/wasm/examples/src/private_tangle.js
@@ -33,7 +33,7 @@ async function privateTangle(restURL, networkName) {
     config.setNetwork(network);
 
     // This URL points to the REST API of the locally running hornet node.
-    config.setNode(restURL || "http://127.0.0.1:14265/");
+    config.setPrimaryNode(restURL || "http://127.0.0.1:14265/");
 
     // Use DIDMessageEncoding.Json instead to publish plaintext messages to the Tangle for debugging.
     config.setEncoding(DIDMessageEncoding.JsonBrotli);

--- a/examples/account/config.rs
+++ b/examples/account/config.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
   // If you deployed an explorer locally this would usually be `http://127.0.0.1:8082`
   let explorer = ExplorerUrl::parse("https://explorer.iota.org/devnet")?;
 
-  // In a locally running one-click tangle, this would often be `http://127.0.0.1:14265`
+  // In a locally running one-click tangle, this would usually be `http://127.0.0.1:14265`
   let private_node_url = "https://api.lb-0.h.chrysalis-devnet.iota.cafe";
 
   // Create a new Account with explicit configuration
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
         // .permanode(<permanode_url>, None, None)?
     );
 
-  // Create an identity specifically on the specified private Tangle by passing `network_name`.
+  // Create an identity on the specified private Tangle by passing `network_name`.
   let identity_setup: IdentitySetup = IdentitySetup::new().network(network_name)?;
 
   let identity: Account = match builder.create_identity(identity_setup).await {

--- a/examples/account/config.rs
+++ b/examples/account/config.rs
@@ -9,7 +9,8 @@ use identity::account::AccountStorage;
 use identity::account::AutoSave;
 use identity::account::IdentitySetup;
 use identity::account::Result;
-use identity::iota::{ClientBuilder, ExplorerUrl};
+use identity::iota::ClientBuilder;
+use identity::iota::ExplorerUrl;
 use identity::iota::IotaDID;
 use identity::iota::Network;
 
@@ -46,8 +47,7 @@ async fn main() -> Result<()> {
       ClientBuilder::new()
         .network(network.clone())
         .primary_node(private_node_url, None, None)?
-        // Set a permanode from the same network (important for real-world deployments)
-        // .permanode(<permanode_url>, None, None)?
+        // .permanode(<permanode_url>, None, None)? // set a permanode for the same network
     );
 
   // Create an identity on the specified private Tangle by passing `network_name`.

--- a/examples/low-level-api/private_tangle.rs
+++ b/examples/low-level-api/private_tangle.rs
@@ -31,7 +31,7 @@ pub async fn main() -> Result<()> {
   // If you deployed an explorer locally this would usually be `http://127.0.0.1:8082`
   let explorer = ExplorerUrl::parse("https://explorer.iota.org/devnet")?;
 
-  // In a locally running one-click tangle, this would often be `http://127.0.0.1:14265`
+  // In a locally running one-click tangle, this would usually be `http://127.0.0.1:14265`
   let private_node_url = "https://api.lb-0.h.chrysalis-devnet.iota.cafe";
 
   // Use DIDMessageEncoding::Json instead to publish plaintext messages to the Tangle for debugging.

--- a/examples/low-level-api/private_tangle.rs
+++ b/examples/low-level-api/private_tangle.rs
@@ -40,7 +40,7 @@ pub async fn main() -> Result<()> {
   let client = ClientBuilder::new()
     .network(network.clone())
     .encoding(encoding)
-    .node(private_node_url)?
+    .primary_node(private_node_url, None, None)?
     .build()
     .await?;
 

--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -1,9 +1,9 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 use serde::Serialize;
 
@@ -15,28 +15,30 @@ use identity_iota::diff::DiffMessage;
 use identity_iota::document::IotaDocument;
 use identity_iota::document::IotaVerificationMethod;
 use identity_iota::document::ResolvedIotaDocument;
-use identity_iota::tangle::{Client, Network, NetworkName};
+use identity_iota::tangle::Client;
 use identity_iota::tangle::MessageId;
 use identity_iota::tangle::MessageIdExt;
+use identity_iota::tangle::Network;
+use identity_iota::tangle::NetworkName;
 use identity_iota::tangle::PublishType;
 
 use crate::account::AccountBuilder;
 use crate::account::PublishOptions;
-use crate::Error;
 use crate::identity::ChainState;
 use crate::identity::DIDLease;
 use crate::identity::IdentitySetup;
 use crate::identity::IdentityState;
 use crate::identity::IdentityUpdater;
-use crate::Result;
 use crate::storage::Storage;
 use crate::types::KeyLocation;
 use crate::updates::create_identity;
 use crate::updates::Update;
+use crate::Error;
+use crate::Result;
 
-use super::AccountConfig;
 use super::config::AccountSetup;
 use super::config::AutoSave;
+use super::AccountConfig;
 
 /// An account manages one identity.
 ///
@@ -235,8 +237,8 @@ impl Account {
 
   /// Signs `data` with the key specified by `fragment`.
   pub async fn sign<U>(&self, fragment: &str, data: &mut U, options: SignatureOptions) -> Result<()>
-    where
-      U: Serialize + SetSignature,
+  where
+    U: Serialize + SetSignature,
   {
     let state: &IdentityState = self.state();
 
@@ -281,7 +283,7 @@ impl Account {
     // Checks if the local document is up to date
     if document_chain.integration_message_id() == self.chain_state.last_integration_message_id()
       && (document_chain.diff().is_empty()
-      || document_chain.diff_message_id() == self.chain_state.last_diff_message_id())
+        || document_chain.diff_message_id() == self.chain_state.last_diff_message_id())
     {
       return Ok(());
     }

--- a/identity-account/src/account/builder.rs
+++ b/identity-account/src/account/builder.rs
@@ -9,7 +9,8 @@ use std::sync::Arc;
 use zeroize::Zeroize;
 
 use identity_iota::did::IotaDID;
-use identity_iota::tangle::{Client, ClientBuilder};
+use identity_iota::tangle::Client;
+use identity_iota::tangle::ClientBuilder;
 
 use crate::account::Account;
 use crate::error::Result;

--- a/identity-account/src/account/config.rs
+++ b/identity-account/src/account/config.rs
@@ -3,62 +3,33 @@
 
 use std::sync::Arc;
 
-use identity_iota::tangle::ClientMap;
+use identity_iota::tangle::Client;
 
-use crate::storage::MemStore;
 use crate::storage::Storage;
 
 /// A wrapper that holds configuration for an [`Account`] instantiation.
 ///
 /// The setup implements `Clone` so multiple [`Account`]s can be created
-/// from the same setup. [`Storage`] and [`ClientMap`] are shared among
+/// from the same setup. [`Storage`] and [`Client`] are shared among
 /// those accounts, while the [`Config`] is unique to each account.
 ///
 /// [`Account`]([crate::account::Account])
 #[derive(Clone, Debug)]
 pub(crate) struct AccountSetup {
-  pub(crate) config: AccountConfig,
   pub(crate) storage: Arc<dyn Storage>,
-  pub(crate) client_map: Arc<ClientMap>,
-}
-
-impl Default for AccountSetup {
-  fn default() -> Self {
-    Self::new(Arc::new(MemStore::new()))
-  }
+  pub(crate) client: Arc<Client>,
+  pub(crate) config: AccountConfig,
 }
 
 impl AccountSetup {
   /// Create a new setup from the given [`Storage`] implementation
-  /// and with defaults for [`Config`] and [`ClientMap`].
-  pub(crate) fn new(storage: Arc<dyn Storage>) -> Self {
+  /// and with defaults for [`Config`] and [`Client`].
+  pub(crate) fn new(storage: Arc<dyn Storage>, client: Arc<Client>, config: AccountConfig) -> Self {
     Self {
-      config: AccountConfig::new(),
       storage,
-      client_map: Arc::new(ClientMap::new()),
+      client,
+      config,
     }
-  }
-
-  /// Create a new setup from the given [`Storage`] implementation,
-  /// as well as optional [`Config`] and [`ClientMap`].
-  /// If `None` is passed, the defaults will be used.
-  pub(crate) fn new_with_options(
-    storage: Arc<dyn Storage>,
-    config: Option<AccountConfig>,
-    client_map: Option<Arc<ClientMap>>,
-  ) -> Self {
-    Self {
-      config: config.unwrap_or_default(),
-      storage,
-      client_map: client_map.unwrap_or_else(|| Arc::new(ClientMap::new())),
-    }
-  }
-
-  #[cfg(test)]
-  /// Set the [`Config`] for this setup.
-  pub(crate) fn config(mut self, value: AccountConfig) -> Self {
-    self.config = value;
-    self
   }
 }
 
@@ -111,9 +82,9 @@ impl AccountConfig {
     self
   }
 
-  #[cfg(test)]
   /// Set whether the account is in testmode or not.
   /// In testmode, the account skips publishing to the tangle.
+  #[cfg(test)]
   pub(crate) fn testmode(mut self, value: bool) -> Self {
     self.testmode = value;
     self

--- a/identity-account/src/error.rs
+++ b/identity-account/src/error.rs
@@ -3,6 +3,8 @@
 
 //! Errors that may occur when working with Identity Accounts.
 
+use identity_iota::tangle::NetworkName;
+
 /// Alias for a `Result` with the error type [`Error`].
 pub type Result<T, E = Error> = ::core::result::Result<T, E>;
 
@@ -74,6 +76,10 @@ pub enum Error {
   /// [`KeyType`][identity_core::crypto::KeyType].
   #[error("Invalid Private Key: {0}")]
   InvalidPrivateKey(String),
+  /// Caused by creating or loading an identity on an Account with a client configured for a
+  /// different network.
+  #[error("identity network {0:?} does not match client network {0:?}")]
+  InvalidIdentityNetwork(NetworkName, NetworkName),
   /// Caused by attempting to create an account for an identity that is already managed by another account.
   #[error("Identity Is In-use")]
   IdentityInUse,

--- a/identity-account/src/tests/account.rs
+++ b/identity-account/src/tests/account.rs
@@ -13,7 +13,8 @@ use identity_iota::chain::DocumentChain;
 use identity_iota::did::IotaDID;
 use identity_iota::diff::DiffMessage;
 use identity_iota::document::IotaDocument;
-use identity_iota::tangle::{Client, ClientBuilder};
+use identity_iota::tangle::Client;
+use identity_iota::tangle::ClientBuilder;
 use identity_iota::tangle::MessageId;
 use identity_iota::tangle::MessageIdExt;
 use identity_iota::tangle::Network;
@@ -25,12 +26,12 @@ use crate::account::AccountSetup;
 use crate::account::AccountStorage;
 use crate::account::AutoSave;
 use crate::account::PublishOptions;
-use crate::Error;
 use crate::identity::ChainState;
 use crate::identity::IdentitySetup;
 use crate::identity::IdentityState;
-use crate::Result;
 use crate::storage::MemStore;
+use crate::Error;
+use crate::Result;
 
 #[tokio::test]
 async fn test_account_builder() -> Result<()> {
@@ -375,7 +376,7 @@ async fn test_account_sync_no_changes() -> Result<()> {
       Ok(())
     })
   })
-    .await?;
+  .await?;
   Ok(())
 }
 
@@ -418,7 +419,7 @@ async fn test_account_sync_integration_msg_update() -> Result<()> {
       Ok(())
     })
   })
-    .await?;
+  .await?;
   Ok(())
 }
 
@@ -440,7 +441,7 @@ async fn test_account_sync_diff_msg_update() -> Result<()> {
         &new_doc,
         *account.chain_state().last_integration_message_id(),
       )
-        .unwrap();
+      .unwrap();
       account
         .sign(
           IotaDocument::DEFAULT_METHOD_FRAGMENT,
@@ -470,7 +471,7 @@ async fn test_account_sync_diff_msg_update() -> Result<()> {
       Ok(())
     })
   })
-    .await?;
+  .await?;
   Ok(())
 }
 
@@ -494,7 +495,7 @@ async fn create_account(network: Network) -> Account {
 // Other errors end the test immediately.
 async fn network_resilient_test(
   test_runs: u32,
-  f: impl Fn(u32) -> Pin<Box<dyn Future<Output=Result<()>>>>,
+  f: impl Fn(u32) -> Pin<Box<dyn Future<Output = Result<()>>>>,
 ) -> Result<()> {
   for test_run in 0..test_runs {
     let test_attempt = f(test_run).await;

--- a/identity-did/src/resolution/impls.rs
+++ b/identity-did/src/resolution/impls.rs
@@ -120,7 +120,6 @@ where
   // 3. If the original input DID URL contained a fragment, execute the
   //    algorithm for Dereferencing the Secondary Resource.
   if let Some(fragment) = did_url.fragment() {
-    //
     // Dereferencing the Secondary Resource
     //
     match primary {

--- a/identity-did/src/resolution/resource.rs
+++ b/identity-did/src/resolution/resource.rs
@@ -36,7 +36,7 @@ impl From<SecondaryResource> for Resource {
 ///
 /// [SPEC]: https://www.w3.org/TR/did-core/#dfn-did-url-dereferencing
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[allow(clippy::large_enum_variant)] //temporary fix until the resolver gets refactored
+#[allow(clippy::large_enum_variant)] // temporary fix until the resolver gets refactored
 #[serde(untagged)]
 pub enum PrimaryResource {
   /// A dereferenced DID Document.

--- a/identity-iota/src/tangle/network.rs
+++ b/identity-iota/src/tangle/network.rs
@@ -6,6 +6,7 @@ use core::fmt::Display;
 use core::fmt::Formatter;
 use core::ops::Deref;
 use std::borrow::Cow;
+use std::fmt::Debug;
 
 use serde;
 use serde::Deserialize;
@@ -112,7 +113,7 @@ impl Default for Network {
 
 /// Network name compliant with the IOTA DID method specification:
 /// https://github.com/iotaledger/identity.rs/blob/dev/documentation/docs/specs/iota_did_method_spec.md
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 #[repr(transparent)]
 pub struct NetworkName(Cow<'static, str>);
 
@@ -180,6 +181,12 @@ impl TryFrom<String> for NetworkName {
 
   fn try_from(name: String) -> Result<Self, Self::Error> {
     Self::try_from(Cow::Owned(name))
+  }
+}
+
+impl Debug for NetworkName {
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+    f.write_str(self.as_ref())
   }
 }
 


### PR DESCRIPTION
# Description of change
Refactors the `Account` to use a single `Client` rather than a `ClientMap`, since each `Account` only manages a single identity (which can only live on a single network/Tangle). This change slightly simplifies the `Account` and `AccountBuilder`.

This also means an `Account` will not be able to create both mainnet and devnet identities by default, which was a side-effect of `ClientMap` automatically creating clients for both those networks by default.

A minor downside of this refactor is that `AccountSetup` always needs a `Client` on creation, which is an async operation. Previously the `Clients` were built lazily by the `ClientMap`. However, this change only affects our internal tests as far as I can see.

Minor change: the private Tangle examples now set the `primary_node` rather than just `node` since the behaviour for `node` differs between Rust and Wasm: on Wasm the node is considered "synchronised", while in Rust the node is considered "un-synchronised" until a background task (from `iota-client`) marks it as "synchronised". This causes the Rust private Tangle examples to throw an error (when pointing to a running private Tangle or devnet or mainnet) since it considers all nodes to be "un-synchronised".

### Added

- Add `AccountBuilder::client_builder()` (in addition to `AccountBuilder::client()` to allow building a single `Client` or sharing an existing `Arc<Client>`)

### Changed

- Update `AccountBuilder::client()` to take `Arc<Client>` instead of a `ClientBuilder` closure.
- Update `Account::create_identity/load_identity` to throw an error if the DID network does not match the `Client` network, which would throw an error when publishing the document anyway.

### Removed

- Remove `Account::set_client()`

## Links to any relevant issues
Fixes issue #531 

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
All tests and examples pass locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
