### PR TITLE
Fix `ResolvedDocument.integrationMessageId`

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -871,7 +871,7 @@ with the given Document.
         * [.verifyData(data, options)](#Document+verifyData) ⇒ <code>boolean</code>
         * [.diff(other, message_id, key, method)](#Document+diff) ⇒ [<code>DiffMessage</code>](#DiffMessage)
         * [.verifyDiff(diff)](#Document+verifyDiff)
-        * [.merge_diff(diff)](#Document+merge_diff)
+        * [.mergeDiff(diff)](#Document+mergeDiff)
         * [.integrationIndex()](#Document+integrationIndex) ⇒ <code>string</code>
         * [.toJSON()](#Document+toJSON) ⇒ <code>any</code>
     * _static_
@@ -1156,9 +1156,9 @@ Fails if an unsupported verification method is used or the verification operatio
 | --- | --- |
 | diff | [<code>DiffMessage</code>](#DiffMessage) | 
 
-<a name="Document+merge_diff"></a>
+<a name="Document+mergeDiff"></a>
 
-### document.merge\_diff(diff)
+### document.mergeDiff(diff)
 Verifies a `DiffMessage` signature and attempts to merge the changes into `self`.
 
 **Kind**: instance method of [<code>Document</code>](#Document)  

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -1963,7 +1963,7 @@ merged with one or more `DiffMessages`.
         * [.document](#ResolvedDocument+document) ⇒ [<code>Document</code>](#Document)
         * [.diffMessageId](#ResolvedDocument+diffMessageId) ⇒ <code>string</code>
         * [.diffMessageId](#ResolvedDocument+diffMessageId)
-        * [.metadataPreviousMessageId](#ResolvedDocument+metadataPreviousMessageId) ⇒ <code>string</code>
+        * [.integrationMessageId](#ResolvedDocument+integrationMessageId) ⇒ <code>string</code>
         * [.integrationMessageId](#ResolvedDocument+integrationMessageId)
         * [.mergeDiffMessage(diff_message)](#ResolvedDocument+mergeDiffMessage)
         * [.intoDocument()](#ResolvedDocument+intoDocument) ⇒ [<code>Document</code>](#Document)
@@ -1996,9 +1996,9 @@ Sets the diff chain message id.
 | --- | --- |
 | value | <code>string</code> | 
 
-<a name="ResolvedDocument+metadataPreviousMessageId"></a>
+<a name="ResolvedDocument+integrationMessageId"></a>
 
-### resolvedDocument.metadataPreviousMessageId ⇒ <code>string</code>
+### resolvedDocument.integrationMessageId ⇒ <code>string</code>
 Returns the integration chain message id.
 
 **Kind**: instance property of [<code>ResolvedDocument</code>](#ResolvedDocument)  

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -340,7 +340,7 @@ impl WasmDocument {
   }
 
   /// Verifies a `DiffMessage` signature and attempts to merge the changes into `self`.
-  #[wasm_bindgen]
+  #[wasm_bindgen(js_name = mergeDiff)]
   pub fn merge_diff(&mut self, diff: &WasmDiffMessage) -> Result<()> {
     self.0.merge_diff(&diff.0).wasm_result()
   }

--- a/bindings/wasm/src/did/wasm_resolved_document.rs
+++ b/bindings/wasm/src/did/wasm_resolved_document.rs
@@ -78,7 +78,7 @@ impl WasmResolvedDocument {
   }
 
   /// Returns the integration chain message id.
-  #[wasm_bindgen(getter = metadataPreviousMessageId)]
+  #[wasm_bindgen(getter = integrationMessageId)]
   pub fn integration_message_id(&self) -> String {
     self.0.integration_message_id.to_string()
   }

--- a/bindings/wasm/src/did/wasm_resolved_document.rs
+++ b/bindings/wasm/src/did/wasm_resolved_document.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use identity::iota::MessageId;


### PR DESCRIPTION
# Description of change
Fixes the names of two functions in the Wasm bindings:

- `ResolvedDocument.integrationMessageId` was incorrectly exported as `metadataPreviousMessageId`.
- `Document.mergeDiff` was exported as `merge_diff`.

## Type of change

Technically a breaking change but really just fixes it to be as intended.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Unit tests and examples pass locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
