### PR TITLE
improved OneOrMany

### DIFF
--- a/identity-core/src/common/one_or_many.rs
+++ b/identity-core/src/common/one_or_many.rs
@@ -74,7 +74,11 @@ impl<T> OneOrMany<T> {
         Self::Many(_) => unreachable!(),
       },
       Self::Many(ref mut inner) => {
-        inner.push(value);
+        if inner.is_empty() {
+          *self = Self::One(value);
+        } else {
+          inner.push(value);
+        }
       }
     }
   }
@@ -168,6 +172,24 @@ impl<T> From<OneOrMany<T>> for Vec<T> {
   }
 }
 
+impl<T> FromIterator<T> for OneOrMany<T> {
+  fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+    let mut iter = iter.into_iter();
+    // if the iterator contains one element or less and a correct size hint is provided we can save an allocation
+    let size_hint = iter.size_hint();
+    if size_hint.1.is_some() && (1, Some(1)) >= size_hint {
+      let mut this = iter.next().map(Self::One).unwrap_or_else(|| Self::Many(Vec::new()));
+      // if the hinted upper bound was incorrect we need to correct for it
+      for next in iter.by_ref() {
+        this.push(next);
+      }
+      this
+    } else {
+      iter.into_iter().collect::<Vec<T>>().into()
+    }
+  }
+}
+
 // =============================================================================
 // Iterator
 // =============================================================================
@@ -189,5 +211,62 @@ impl<'a, T> Iterator for OneOrManyIter<'a, T> {
   fn next(&mut self) -> Option<Self::Item> {
     self.index += 1;
     self.inner.get(self.index - 1)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn from_iterator_empty() {
+    let empty_vec = Vec::<u32>::new();
+    assert_eq!(OneOrMany::from_iter(empty_vec.clone()), OneOrMany::Many(empty_vec));
+  }
+
+  #[test]
+  fn from_iterator_single() {
+    let single_item = [1];
+    assert_eq!(OneOrMany::from_iter(single_item), OneOrMany::One(1));
+  }
+
+  #[test]
+  fn from_iterator_many() {
+    let letters = ["a", "b", "c", "d"];
+    assert_eq!(OneOrMany::from_iter(letters), OneOrMany::Many(vec!["a", "b", "c", "d"]));
+  }
+
+  #[test]
+  fn from_iterator_identity() {
+    let none = OneOrMany::Many(Vec::<u32>::new());
+    assert_eq!(OneOrMany::from_iter(none.iter()), OneOrMany::Many(Vec::<&u32>::new()));
+
+    let one = OneOrMany::One(42);
+    assert_eq!(OneOrMany::from_iter(one.iter()), OneOrMany::One(&42));
+
+    let two = OneOrMany::Many(vec![0, 1]);
+    assert_eq!(OneOrMany::from_iter(two.iter()), OneOrMany::Many(vec![&0, &1]));
+  }
+
+  #[test]
+  fn push_from_zero_elements() {
+    let mut collection = OneOrMany::Many(Vec::<u32>::new());
+    collection.push(42);
+    assert_eq!(collection, OneOrMany::One(42));
+  }
+
+  #[test]
+  fn push_one_element() {
+    let mut collection = OneOrMany::One(42);
+    collection.push(42);
+    assert_eq!(collection, OneOrMany::Many(vec![42, 42]));
+  }
+
+  #[test]
+  fn push_many_elements() {
+    let v: Vec<i32> = (0..42).collect();
+    let mut collection = OneOrMany::Many(v);
+    collection.push(42);
+    assert_eq!(collection, OneOrMany::Many((0..=42).collect()));
   }
 }


### PR DESCRIPTION
# Description of change
This PR consists of a couple of small improvements to `OneOrMany`: 

- `OneOrMany<T>` now implements `FromIterator<T>` 
- The `push` method now behaves arguably more intuitively in the edge case of `OneOrMany::Many(vec![])`. 

To elaborate further on the latter. The following test did not pass before this PR: 
```rust 
   let mut collection = OneOrMany::Many(Vec::<u32>::new());
    collection.push(42);
    assert_eq!(collection, OneOrMany::One(42));
```
This is not a bug, but most would probably expect the `One` variant to be matched when there is exactly *one element* in the collection. Our change should not affect the behaviour in any other cases. 


## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
