### PR TITLE
Change `Account::state` visibility to `pub(crate)`

### DIFF
--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::unused_unit)]
 
 #[macro_use]
 extern crate serde;

--- a/examples/account/create_did.rs
+++ b/examples/account/create_did.rs
@@ -36,11 +36,7 @@ async fn main() -> Result<()> {
   let iota_did: &IotaDID = account.did();
 
   // Print the local state of the DID Document
-  println!(
-    "[Example] Local Document from {} = {:#?}",
-    iota_did,
-    account.state().document()
-  );
+  println!("[Example] Local Document from {} = {:#?}", iota_did, account.document());
 
   // Prints the Identity Resolver Explorer URL.
   // The entire history can be observed on this page by clicking "Loading History".

--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -160,7 +160,7 @@ impl Account {
   }
 
   /// Return the latest state of the identity.
-  pub fn state(&self) -> &IdentityState {
+  pub(crate) fn state(&self) -> &IdentityState {
     &self.state
   }
 


### PR DESCRIPTION
# Description of change

Changes the visibility of `Account::state` to `pub(crate)`, because the `IdentityState` is not required to be exposed to users. Moreover, `IdentityState` is planned to be removed with #508. This PR is supposed to prevent unnecessary work on the account bindings (e.g. #574).

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

n/a

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
