### PR TITLE
Fix dependent diff updates being rejected

### DIFF
--- a/bindings/wasm/examples/src/diff_chain.js
+++ b/bindings/wasm/examples/src/diff_chain.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 import {Client, Config, Document, Service, Timestamp} from '@iota/identity-wasm';
@@ -31,7 +31,7 @@ async function createDiff(clientConfig) {
     let serviceJSON = {
         id: doc.id + "#linked-domain-1",
         type: "LinkedDomains",
-        serviceEndpoint: "https://identity.iota.org",
+        serviceEndpoint: "https://example.com/",
     };
     updatedDoc.insertService(Service.fromJSON(serviceJSON));
     updatedDoc.metadataUpdated = Timestamp.nowUTC();

--- a/examples/low-level-api/diff_chain.rs
+++ b/examples/low-level-api/diff_chain.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 //! An example that demonstrates how to publish changes to the integration chain to update a

--- a/identity-did/src/diff/diff_document.rs
+++ b/identity-did/src/diff/diff_document.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::Deserialize;

--- a/identity-did/src/diff/diff_method.rs
+++ b/identity-did/src/diff/diff_method.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use identity_core::common::Object;

--- a/identity-diff/derive/src/model.rs
+++ b/identity-diff/derive/src/model.rs
@@ -241,6 +241,7 @@ impl InputModel {
     }
   }
 
+  #[allow(clippy::wrong_self_convention)]
   pub fn from_into(&self) -> bool {
     match self {
       Self::Struct(InputStruct { from_into, .. }) => *from_into,

--- a/identity-diff/src/object.rs
+++ b/identity-diff/src/object.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use serde_json::Value;

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -40,6 +40,9 @@ version = "0.7"
 default-features = false
 features = ["blake2b"]
 
+[dev-dependencies]
+tokio = { version = "1.15", default-features = false, features = ["macros"] }
+
 [features]
 default = ["async"]
 

--- a/identity-iota/src/chain/diff_chain.rs
+++ b/identity-iota/src/chain/diff_chain.rs
@@ -1,22 +1,20 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt::Display;
 use core::fmt::Formatter;
-
 use core::slice::Iter;
 
 use serde;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::chain::IntegrationChain;
 use identity_core::convert::FmtJson;
 
 use crate::chain::milestone::sort_by_milestone;
+use crate::chain::IntegrationChain;
 use crate::did::IotaDID;
 use crate::diff::DiffMessage;
-use crate::document::IotaDocument;
 use crate::document::ResolvedIotaDocument;
 use crate::error::Error;
 use crate::error::Result;
@@ -76,23 +74,40 @@ impl DiffChain {
     }
 
     let mut this: Self = Self::new();
+    let mut current_document: ResolvedIotaDocument = integration_document.clone();
     while let Some(diffs) = index.remove(
       this
         .current_message_id()
-        .unwrap_or_else(|| integration_document.message_id()),
+        .unwrap_or_else(|| current_document.message_id()),
     ) {
-      // Extract valid diffs.
+      // Extract diffs that reference the last message (either the integration message or the
+      // diff message from the previous iteration). If more than one references the
+      // same message, they are conflicting.
       let expected_prev_message_id: &MessageId = this
         .current_message_id()
-        .unwrap_or_else(|| integration_document.message_id());
+        .unwrap_or_else(|| current_document.message_id());
+      // Filter out diffs with invalid signatures.
       let valid_diffs: Vec<DiffMessage> = diffs
         .into_iter()
-        .filter(|diff| Self::check_valid_addition(diff, integration_document, expected_prev_message_id).is_ok())
+        .filter(|diff| Self::verify_diff(diff, integration_document, expected_prev_message_id).is_ok())
         .collect();
 
-      // Sort and push the diff referenced by the oldest milestone.
-      if let Some(next) = sort_by_milestone(valid_diffs, client).await?.into_iter().next() {
-        this.push_unchecked(next); // checked by check_valid_addition above
+      // Sort and apply the diff referenced by the oldest milestone.
+      if let Some((diff, merged_document)) = sort_by_milestone(valid_diffs, client)
+        .await?
+        .into_iter()
+        .filter_map(|diff|
+          // Try merge the diff changes into the document. Important to prevent changes to the
+          // signing verification methods and reject invalid changes to non-existent sections.
+          match Self::try_merge(&diff, &current_document) {
+            Ok(merged_document) => Some((diff, merged_document)),
+            _ => None,
+          })
+        .next()
+      {
+        // Update the document for the next diff to allow updating sections added by previous diffs.
+        current_document = merged_document;
+        this.push_unchecked(diff); // checked by check_valid_addition and try_merge above
       }
       // If no diff is appended, the chain ends.
     }
@@ -130,33 +145,39 @@ impl DiffChain {
     self.inner.last().map(|diff| diff.message_id())
   }
 
-  /// Adds a new diff to the [`DiffChain`].
+  /// Adds a new diff to the [`DiffChain`] while merging it with the given integration document.
+  /// Returns the merged document if valid.
   ///
   /// # Errors
   ///
-  /// Fails if the diff signature is invalid or the Tangle message
-  /// references within the diff are invalid.
-  pub fn try_push(&mut self, diff: DiffMessage, integration_chain: &IntegrationChain) -> Result<()> {
-    let document: &ResolvedIotaDocument = integration_chain.current();
-    let expected_prev_message_id: &MessageId = self.current_message_id().unwrap_or_else(|| document.message_id());
-    Self::check_valid_addition(&diff, document, expected_prev_message_id)?;
+  /// Fails if the diff signature is invalid, the Tangle message
+  /// references within the diff are invalid, or the merge fails.
+  pub fn try_push_and_merge(
+    &mut self,
+    diff: DiffMessage,
+    integration_document: &ResolvedIotaDocument,
+  ) -> Result<ResolvedIotaDocument> {
+    let expected_prev_message_id: &MessageId = self
+      .current_message_id()
+      .unwrap_or_else(|| integration_document.message_id());
+    let updated_document: ResolvedIotaDocument =
+      Self::check_valid_addition(&diff, integration_document, expected_prev_message_id)?;
     self.push_unchecked(diff);
 
-    Ok(())
+    Ok(updated_document)
   }
 
-  /// Adds a new diff to the [`DiffChain`] without performing validation checks on the signature or Tangle references
-  /// of the [`DiffMessage`].
+  /// Adds a new diff to the [`DiffChain`] without performing any validation checks on
+  /// the [`DiffMessage`].
   fn push_unchecked(&mut self, diff: DiffMessage) {
     self.inner.push(diff);
   }
 
-  /// Checks if the [`DiffMessage`] can be added to the [`DiffChain`].
+  /// Checks whether the [`DiffMessage`] attributes and signature are valid.
   ///
-  /// # Errors
-  ///
-  /// Fails if the [`DiffMessage`] is not a valid addition.
-  pub fn check_valid_addition(
+  /// NOTE: does not verify the changes contained in the diff are valid.
+  /// See [`DiffChain::try_merge`].
+  pub fn verify_diff(
     diff: &DiffMessage,
     document: &ResolvedIotaDocument,
     expected_prev_message_id: &MessageId,
@@ -167,36 +188,63 @@ impl DiffChain {
 
     if diff.message_id().is_null() {
       return Err(Error::ChainError {
-        error: "Invalid Message Id",
+        error: "invalid message id",
       });
     }
 
     if diff.previous_message_id().is_null() {
       return Err(Error::ChainError {
-        error: "Invalid Previous Message Id",
+        error: "invalid previous message id",
       });
     }
 
     if diff.previous_message_id() != expected_prev_message_id {
       return Err(Error::ChainError {
-        error: "Invalid Previous Message Id",
+        error: "invalid previous message id",
       });
     }
 
     if document.document.verify_diff(diff).is_err() {
       return Err(Error::ChainError {
-        error: "Invalid Signature",
+        error: "invalid diff signature",
       });
     }
 
-    let updated_doc: IotaDocument = diff.merge(&document.document)?;
-    if let Some(PublishType::Integration) = PublishType::new(&document.document, &updated_doc) {
+    Ok(())
+  }
+
+  /// Attempts to merge the [`DiffMessage`] changes into the given document and returns the
+  /// resulting [`ResolvedIotaDocument`] if valid.
+  ///
+  /// NOTE: does not verify the signature and attributes.
+  /// See [`DiffChain::verify_diff`].
+  pub fn try_merge(diff: &DiffMessage, document: &ResolvedIotaDocument) -> Result<ResolvedIotaDocument> {
+    let mut updated_document: ResolvedIotaDocument = document.clone();
+    updated_document.merge_diff_message(diff)?;
+    if let Some(PublishType::Integration) = PublishType::new(&document.document, &updated_document.document) {
       return Err(Error::ChainError {
         error: "diff cannot alter update signing methods",
       });
     }
 
-    Ok(())
+    Ok(updated_document)
+  }
+
+  /// Checks if the [`DiffMessage`] can be added to the [`DiffChain`]. Returns the merged
+  /// document if valid.
+  ///
+  /// Equivalent to calling [`DiffChain::verify_diff`] then [`DiffChain::verify_merge`].
+  ///
+  /// # Errors
+  ///
+  /// Fails if the [`DiffMessage`] is not a valid addition.
+  pub fn check_valid_addition(
+    diff: &DiffMessage,
+    document: &ResolvedIotaDocument,
+    expected_prev_message_id: &MessageId,
+  ) -> Result<ResolvedIotaDocument> {
+    Self::verify_diff(diff, document, expected_prev_message_id)?;
+    Self::try_merge(diff, document)
   }
 }
 
@@ -215,5 +263,161 @@ impl Display for DiffChain {
 impl From<DiffChain> for Vec<DiffMessage> {
   fn from(diff_chain: DiffChain) -> Self {
     diff_chain.inner
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use identity_core::convert::FromJson;
+  use identity_core::crypto::KeyPair;
+  use identity_core::json;
+  use identity_did::did::DID;
+  use identity_did::service::Service;
+
+  use crate::diff::DiffMessage;
+  use crate::document::IotaDocument;
+  use crate::document::ResolvedIotaDocument;
+  use crate::tangle::ClientBuilder;
+  use crate::tangle::MessageId;
+  use crate::tangle::MessageIndex;
+  use crate::tangle::TangleRef;
+
+  use super::*;
+
+  fn create_document() -> (ResolvedIotaDocument, KeyPair) {
+    let keypair: KeyPair = KeyPair::new_ed25519().unwrap();
+    let mut document: IotaDocument = IotaDocument::new(&keypair).unwrap();
+    document
+      .sign_self(keypair.private(), &document.default_signing_method().unwrap().id())
+      .unwrap();
+    let mut resolved: ResolvedIotaDocument = ResolvedIotaDocument::from(document);
+    resolved.set_message_id(MessageId::new([1; 32]));
+    (resolved, keypair)
+  }
+
+  #[tokio::test]
+  async fn test_diff_chain_add_remove_service() {
+    let (original, keypair) = create_document();
+
+    // Add a new service in a diff update.
+    let mut updated1: IotaDocument = original.document.clone();
+    let service: Service = Service::from_json_value(json!({
+      "id": updated1.id().to_url().join("#linked-domain").unwrap(),
+      "type": "LinkedDomains",
+      "serviceEndpoint": "https://iota.org"
+    }))
+    .unwrap();
+    assert!(updated1.insert_service(service));
+    let mut diff_add: DiffMessage = original
+      .document
+      .diff(
+        &updated1,
+        original.integration_message_id,
+        keypair.private(),
+        original.document.default_signing_method().unwrap().id(),
+      )
+      .unwrap();
+    diff_add.set_message_id(MessageId::new([2; 32]));
+
+    // Remove the same service in a diff update.
+    let mut updated2: IotaDocument = updated1.clone();
+    assert!(updated2
+      .remove_service(updated1.id().to_url().join("#linked-domain").unwrap())
+      .is_ok());
+    let mut diff_delete: DiffMessage = updated1
+      .diff(
+        &updated2,
+        diff_add.message_id,
+        keypair.private(),
+        updated1.default_signing_method().unwrap().id(),
+      )
+      .unwrap();
+    diff_delete.set_message_id(MessageId::new([3; 32]));
+
+    // Ensure both diffs are resolved by the DiffChain.
+    let mut message_index: MessageIndex<DiffMessage> = MessageIndex::new();
+    message_index.insert(diff_add.clone());
+    message_index.insert(diff_delete.clone());
+    let client: Client = ClientBuilder::new().node_sync_disabled().build().await.unwrap();
+    let diff_chain: DiffChain = DiffChain::try_from_index_with_document(&original, message_index, &client)
+      .await
+      .unwrap();
+    assert_eq!(diff_chain.len(), 2);
+    assert_eq!(diff_chain.inner.get(0), Some(&diff_add));
+    assert_eq!(diff_chain.inner.get(1), Some(&diff_delete));
+
+    // Ensure the merged result does not have the service.
+    let mut merged: ResolvedIotaDocument = original.clone();
+    for diff in diff_chain.iter() {
+      merged.merge_diff_message(diff).unwrap();
+    }
+    assert!(merged.document.service().is_empty());
+  }
+
+  #[tokio::test]
+  async fn test_diff_chain_add_edit_service() {
+    let (original, keypair) = create_document();
+
+    // Add a new service in a diff update.
+    let mut updated1: IotaDocument = original.document.clone();
+    let service: Service = Service::from_json_value(json!({
+      "id": updated1.id().to_url().join("#linked-domain").unwrap(),
+      "type": "LinkedDomains",
+      "serviceEndpoint": "https://iota.org"
+    }))
+    .unwrap();
+    assert!(updated1.insert_service(service.clone()));
+    let mut diff_add: DiffMessage = original
+      .document
+      .diff(
+        &updated1,
+        original.integration_message_id,
+        keypair.private(),
+        original.document.default_signing_method().unwrap().id(),
+      )
+      .unwrap();
+    diff_add.set_message_id(MessageId::new([2; 32]));
+
+    // Edit the same service in a diff update.
+    let mut updated2: IotaDocument = updated1.clone();
+    let service_updated: Service = Service::from_json_value(json!({
+      "id": updated1.id().to_url().join("#linked-domain").unwrap(),
+      "type": "LinkedDomains",
+      "serviceEndpoint": ["https://example.com", "https://example.org"],
+    }))
+    .unwrap();
+    updated2
+      .document
+      .service_mut()
+      .replace(&service, service_updated.clone());
+    let mut diff_edit: DiffMessage = updated1
+      .diff(
+        &updated2,
+        diff_add.message_id,
+        keypair.private(),
+        updated1.default_signing_method().unwrap().id(),
+      )
+      .unwrap();
+    diff_edit.set_message_id(MessageId::new([3; 32]));
+
+    // Ensure both diffs are resolved by the DiffChain.
+    let mut message_index: MessageIndex<DiffMessage> = MessageIndex::new();
+    message_index.insert(diff_add.clone());
+    message_index.insert(diff_edit.clone());
+    let client: Client = ClientBuilder::new().node_sync_disabled().build().await.unwrap();
+    let diff_chain: DiffChain = DiffChain::try_from_index_with_document(&original, message_index, &client)
+      .await
+      .unwrap();
+    assert_eq!(diff_chain.len(), 2);
+    assert_eq!(diff_chain.inner.get(0), Some(&diff_add));
+    assert_eq!(diff_chain.inner.get(1), Some(&diff_edit));
+
+    // Ensure the merged result has the updated service.
+    let mut merged: ResolvedIotaDocument = original.clone();
+    for diff in diff_chain.iter() {
+      merged.merge_diff_message(diff).unwrap();
+    }
+    assert_ne!(merged.document.service().first().unwrap(), &service);
+    assert_eq!(merged.document.service().first().unwrap(), &service_updated);
   }
 }

--- a/identity-iota/src/chain/diff_chain.rs
+++ b/identity-iota/src/chain/diff_chain.rs
@@ -183,7 +183,7 @@ impl DiffChain {
     expected_prev_message_id: &MessageId,
   ) -> Result<()> {
     if document.document.id() != &diff.id {
-      return Err(Error::ChainError { error: "Invalid DID" });
+      return Err(Error::ChainError { error: "invalid DID" });
     }
 
     if diff.message_id().is_null() {

--- a/identity-iota/src/chain/diff_chain.rs
+++ b/identity-iota/src/chain/diff_chain.rs
@@ -107,7 +107,8 @@ impl DiffChain {
       {
         // Update the document for the next diff to allow updating sections added by previous diffs.
         current_document = merged_document;
-        this.push_unchecked(diff); // checked by check_valid_addition and try_merge above
+        // Checked by check_valid_addition and try_merge above.
+        this.push_unchecked(diff);
       }
       // If no diff is appended, the chain ends.
     }

--- a/identity-iota/src/chain/diff_chain.rs
+++ b/identity-iota/src/chain/diff_chain.rs
@@ -107,7 +107,7 @@ impl DiffChain {
       {
         // Update the document for the next diff to allow updating sections added by previous diffs.
         current_document = merged_document;
-        // Checked by check_valid_addition and try_merge above.
+        // Checked by verify_diff and try_merge above.
         this.push_unchecked(diff);
       }
       // If no diff is appended, the chain ends.

--- a/identity-iota/src/diff/diff_iota_document_metadata.rs
+++ b/identity-iota/src/diff/diff_iota_document_metadata.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use std::str::FromStr;

--- a/identity-iota/src/document/iota_document.rs
+++ b/identity-iota/src/document/iota_document.rs
@@ -311,6 +311,7 @@ impl IotaDocument {
   }
 
   /// Remove a [`Service`] identified by the given [`IotaDIDUrl`] from the document.
+  // TODO: return an error or bool if no service was removed?
   pub fn remove_service(&mut self, did_url: IotaDIDUrl) -> Result<()> {
     let core_did_url: CoreDIDUrl = CoreDIDUrl::from(did_url);
     self.document.service_mut().remove(&core_did_url);

--- a/identity-iota/src/document/iota_document.rs
+++ b/identity-iota/src/document/iota_document.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt;
@@ -738,6 +738,7 @@ mod tests {
 
   use identity_core::common::Object;
   use identity_core::common::Timestamp;
+  use identity_core::common::Value;
   use identity_core::convert::FromJson;
   use identity_core::convert::ToJson;
   use identity_core::crypto::merkle_key::Sha256;
@@ -1192,7 +1193,7 @@ mod tests {
   }
 
   #[test]
-  fn test_diff() {
+  fn test_diff_signing_methods() {
     // Ensure only capability invocation methods are allowed to sign a diff.
     for scope in [
       MethodScope::assertion_method(),
@@ -1241,6 +1242,126 @@ mod tests {
       } else {
         assert!(diff_result.is_err());
       }
+    }
+  }
+
+  #[test]
+  fn test_diff_properties() {
+    // Ensure custom fields added to properties are retained by diffs.
+    let key1: KeyPair = generate_testkey();
+    let doc1: IotaDocument = IotaDocument::new(&key1).unwrap();
+    let message_id: MessageId = MessageId::new([3_u8; 32]);
+
+    // Add a new property on the document.
+    let doc2 = {
+      let mut doc2: IotaDocument = doc1.clone();
+      doc2.properties_mut().insert("foo".into(), 123.into());
+      let diff2: DiffMessage = doc1
+        .diff(
+          &doc2,
+          message_id,
+          key1.private(),
+          doc1.default_signing_method().unwrap().id(),
+        )
+        .unwrap();
+      assert!(doc1.verify_diff(&diff2).is_ok());
+      assert_eq!(
+        diff2.merge(&doc1).unwrap().properties().get("foo").unwrap(),
+        &Value::from(123)
+      );
+      doc2
+    };
+
+    // Mutate a property on the document.
+    let doc3 = {
+      let mut doc3: IotaDocument = doc2.clone();
+      *doc3.properties_mut().get_mut("foo").unwrap() = 456.into();
+      let diff3: DiffMessage = doc2
+        .diff(
+          &doc3,
+          message_id,
+          key1.private(),
+          doc2.default_signing_method().unwrap().id(),
+        )
+        .unwrap();
+      assert!(doc2.verify_diff(&diff3).is_ok());
+      assert_eq!(
+        diff3.merge(&doc2).unwrap().properties().get("foo").unwrap(),
+        &Value::from(456)
+      );
+      doc3
+    };
+
+    // Remove a property on the document.
+    {
+      let mut doc4: IotaDocument = doc3.clone();
+      assert_eq!(doc4.properties_mut().remove("foo").unwrap(), Value::from(456));
+      let diff4: DiffMessage = doc3
+        .diff(
+          &doc4,
+          message_id,
+          key1.private(),
+          doc3.default_signing_method().unwrap().id(),
+        )
+        .unwrap();
+      assert!(doc3.verify_diff(&diff4).is_ok());
+      assert!(diff4.merge(&doc3).unwrap().properties().get("foo").is_none());
+    }
+
+    // Add a new property on the metadata.
+    let doc5 = {
+      let mut doc5: IotaDocument = doc1.clone();
+      doc5.metadata.properties.insert("bar".into(), 789.into());
+      let diff5: DiffMessage = doc1
+        .diff(
+          &doc5,
+          message_id,
+          key1.private(),
+          doc1.default_signing_method().unwrap().id(),
+        )
+        .unwrap();
+      assert!(doc1.verify_diff(&diff5).is_ok());
+      assert_eq!(
+        diff5.merge(&doc1).unwrap().metadata.properties.get("bar").unwrap(),
+        &Value::from(789)
+      );
+      doc5
+    };
+
+    // Mutate a property on the metadata.
+    let doc6 = {
+      let mut doc6: IotaDocument = doc5.clone();
+      *doc6.metadata.properties.get_mut("bar").unwrap() = "abc".into();
+      let diff6: DiffMessage = doc5
+        .diff(
+          &doc6,
+          message_id,
+          key1.private(),
+          doc5.default_signing_method().unwrap().id(),
+        )
+        .unwrap();
+      assert!(doc5.verify_diff(&diff6).is_ok());
+      assert_eq!(
+        diff6.merge(&doc5).unwrap().metadata.properties.get("bar").unwrap(),
+        &Value::from("abc")
+      );
+      doc6
+    };
+
+    // Remove a property on the metadata.
+    {
+      let mut doc7: IotaDocument = doc6.clone();
+      assert_eq!(doc7.metadata.properties.remove("bar").unwrap(), Value::from("abc"));
+      let diff7: DiffMessage = doc6
+        .diff(
+          &doc7,
+          message_id,
+          key1.private(),
+          doc6.default_signing_method().unwrap().id(),
+        )
+        .unwrap();
+      assert!(doc6.verify_diff(&diff7).is_ok());
+      assert!(diff7.merge(&doc6).unwrap().metadata.properties.get("bar").is_none());
     }
   }
 

--- a/identity-iota/src/document/iota_document_metadata.rs
+++ b/identity-iota/src/document/iota_document_metadata.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt::Debug;
@@ -30,6 +30,7 @@ pub struct IotaDocumentMetadata {
   pub previous_message_id: MessageId,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub proof: Option<Signature>,
+  #[serde(flatten)]
   pub properties: Object,
 }
 

--- a/identity-iota/src/tangle/message/compression_brotli.rs
+++ b/identity-iota/src/tangle/message/compression_brotli.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use std::io::Read;

--- a/identity-iota/src/tangle/message/message_ext.rs
+++ b/identity-iota/src/tangle/message/message_ext.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_client::bee_message::payload::transaction::Essence;


### PR DESCRIPTION
# Description of change

Fixes the `DiffChain` rejecting `DiffMessages` that update document sections added in previous diffs. From the example given in #593: adding a service in a diff update then editing or removing it in another diff update will result in the latter update being rejected/discarded by the `DiffChain` during resolution.

Thank you to @PhilippGackstatter and @abdulmth for identifying and investigating the issue!

This also flattens the properties of `DocumentMetadata` serialization (this ensures unhandled fields are captured during deserialization), which may lead to breaking changes if any existing user-defined custom fields conflict with hardcoded field names.

**WARNING:** this may result in resolutions of IOTA DID Documents that contain diff updates being different after this is merged.

## Links to any relevant issues
Fixes #593 

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Existing and new tests pass, including examples.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
