### PR TITLE
Refactor `Document` and `ResolvedDocument` for interior mutability

### DIFF
--- a/bindings/wasm/src/credential/credential.rs
+++ b/bindings/wasm/src/credential/credential.rs
@@ -65,7 +65,7 @@ impl WasmCredential {
     credential_id: Option<String>,
   ) -> Result<WasmCredential> {
     let subjects: OneOrMany<Subject> = subject_data.into_serde().wasm_result()?;
-    let issuer_url: Url = Url::parse(issuer_doc.0.id().as_str()).wasm_result()?;
+    let issuer_url: Url = Url::parse(issuer_doc.0.borrow().id().as_str()).wasm_result()?;
     let mut builder: CredentialBuilder = CredentialBuilder::default().issuer(issuer_url);
 
     for subject in subjects.into_vec() {

--- a/bindings/wasm/src/credential/presentation.rs
+++ b/bindings/wasm/src/credential/presentation.rs
@@ -27,7 +27,7 @@ impl WasmPresentation {
     presentation_id: Option<String>,
   ) -> Result<WasmPresentation> {
     let credentials: OneOrMany<Credential> = credential_data.into_serde().wasm_result()?;
-    let holder_url: Url = Url::parse(holder_doc.0.id().as_str()).wasm_result()?;
+    let holder_url: Url = Url::parse(holder_doc.0.borrow().id().as_str()).wasm_result()?;
 
     let mut builder: PresentationBuilder = PresentationBuilder::default().holder(holder_url);
 

--- a/bindings/wasm/src/did/wasm_diff_message.rs
+++ b/bindings/wasm/src/did/wasm_diff_message.rs
@@ -84,7 +84,7 @@ impl WasmDiffMessage {
   /// Returns a new DID Document which is the result of merging `self`
   /// with the given Document.
   pub fn merge(&self, document: &WasmDocument) -> Result<WasmDocument> {
-    self.0.merge(&document.0).map(WasmDocument).wasm_result()
+    self.0.merge(&document.0.borrow()).map(WasmDocument::from).wasm_result()
   }
 }
 

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -455,7 +455,7 @@ impl WasmDocument {
   /// Serializes a `Document` object as a JSON object.
   #[wasm_bindgen(js_name = toJSON)]
   pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0.borrow().deref()).wasm_result()
+    JsValue::from_serde(self.0.borrow().deref()).wasm_result()
   }
 
   /// Deserializes a `Document` object from a JSON object.
@@ -468,5 +468,11 @@ impl WasmDocument {
 impl From<IotaDocument> for WasmDocument {
   fn from(document: IotaDocument) -> Self {
     Self(Rc::new(RefCell::new(document)))
+  }
+}
+
+impl From<WasmDocument> for IotaDocument {
+  fn from(wasm_document: WasmDocument) -> Self {
+    wasm_document.0.borrow().deref().clone()
   }
 }

--- a/bindings/wasm/src/tangle/client.rs
+++ b/bindings/wasm/src/tangle/client.rs
@@ -217,7 +217,7 @@ impl Client {
   #[wasm_bindgen(js_name = resolveDiffHistory)]
   pub fn resolve_diff_history(&self, document: &WasmResolvedDocument) -> Result<PromiseDiffChainHistory> {
     let client: Rc<IotaClient> = self.client.clone();
-    let resolved_document: ResolvedIotaDocument = document.0.clone();
+    let resolved_document: ResolvedIotaDocument = ResolvedIotaDocument::from(document.clone());
 
     let promise: Promise = future_to_promise(async move {
       client

--- a/bindings/wasm/src/tangle/client.rs
+++ b/bindings/wasm/src/tangle/client.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::str::FromStr;
+use std::cell::RefCell;
 use std::ops::Deref;
 use std::rc::Rc;
 
@@ -84,12 +85,12 @@ impl Client {
   /// Publishes an `IotaDocument` to the Tangle.
   #[wasm_bindgen(js_name = publishDocument)]
   pub fn publish_document(&self, document: &WasmDocument) -> Result<PromiseReceipt> {
-    let document: IotaDocument = document.0.clone();
+    let document: Rc<RefCell<IotaDocument>> = document.0.clone();
     let client: Rc<IotaClient> = self.client.clone();
 
     let promise: Promise = future_to_promise(async move {
       client
-        .publish_document(&document)
+        .publish_document(&document.deref().borrow())
         .await
         .map(WasmReceipt)
         .map(Into::into)

--- a/identity-iota/src/document/resolved_iota_document.rs
+++ b/identity-iota/src/document/resolved_iota_document.rs
@@ -57,6 +57,7 @@ impl ResolvedIotaDocument {
   ///
   /// Fails if the merge operation or signature verification on the diff fails.
   pub fn merge_diff_message(&mut self, diff_message: &DiffMessage) -> Result<()> {
+    // N.B. update WasmResolvedDocument if this function is changed.
     self.document.merge_diff(diff_message)?;
     self.diff_message_id = diff_message.message_id;
 


### PR DESCRIPTION
# Description of change
This refactors `WasmDocument` to use `Rc<RefCell>` internally to reduce clones and for interior mutability when accessed from `WasmResolvedDocument`.

The `WasmDocument` API should be unchanged in terms of usage; `WasmResolvedDocument` on the other hand has several breaking changes listed below.

TODO

## Links to any relevant issues
See discussion #603.

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

TODO TODO

## Change checklist

TODO TODO

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
