### PR TITLE
Fix diff properties (de)serialization

### DIFF
--- a/bindings/wasm/examples/src/diff_chain.js
+++ b/bindings/wasm/examples/src/diff_chain.js
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import {Client, Config, Document, Service} from '@iota/identity-wasm';
+import {Client, Config, Document, Service, Timestamp} from '@iota/identity-wasm';
 import {createIdentity} from "./create_did";
 import {logExplorerUrl, logResolverUrl} from "./utils";
 
@@ -29,11 +29,12 @@ async function createDiff(clientConfig) {
 
     // Add a Service
     let serviceJSON = {
-        id: doc.id + "#new-linked-domain",
+        id: doc.id + "#linked-domain-1",
         type: "LinkedDomains",
         serviceEndpoint: "https://identity.iota.org",
     };
     updatedDoc.insertService(Service.fromJSON(serviceJSON));
+    updatedDoc.metadataUpdated = Timestamp.nowUTC();
     console.log(updatedDoc);
 
     // Create diff

--- a/documentation/docs/specs/did/iota_did_method_spec.md
+++ b/documentation/docs/specs/did/iota_did_method_spec.md
@@ -121,23 +121,23 @@ Example of an Integration DID Message:
 ```json
 {
   "doc": {
-    "id": "did:iota:DqmknfA6pF6LpaGeHs3qcLjCPicWNgaG9AvinvpTKCGD",
+    "id": "did:iota:X7U84ez4YeaLwpfdnhdgFyPLa53twvAuMSYdRQas54e",
     "capabilityInvocation": [
       {
-        "id": "did:iota:DqmknfA6pF6LpaGeHs3qcLjCPicWNgaG9AvinvpTKCGD#sign-0",
-        "controller": "did:iota:DqmknfA6pF6LpaGeHs3qcLjCPicWNgaG9AvinvpTKCGD",
+        "id": "did:iota:X7U84ez4YeaLwpfdnhdgFyPLa53twvAuMSYdRQas54e#sign-0",
+        "controller": "did:iota:X7U84ez4YeaLwpfdnhdgFyPLa53twvAuMSYdRQas54e",
         "type": "Ed25519VerificationKey2018",
-        "publicKeyMultibase": "z9wLQANgLeBLaKzejMuxa61gswLx6eYCsgK1tP3aW5SQA"
+        "publicKeyMultibase": "zCqNmbG7e4GMohTndkStNXUQGHFD5YusnwWpFdpyWFWH3"
       }
     ]
   },
   "meta": {
-    "created": "2022-01-17T19:13:17Z",
-    "updated": "2022-01-17T19:13:17Z",
+    "created": "2022-01-21T09:50:09Z",
+    "updated": "2022-01-21T09:50:09Z",
     "proof": {
       "type": "JcsEd25519Signature2020",
       "verificationMethod": "#sign-0",
-      "signatureValue": "4JouG4VVZircUnWZGLexW5nnV2EWHvNinySF7YJauhNRdQCC94w33jhFF4v1tgxcRQrxA2Mye78Np52HR5FZ3va5"
+      "signatureValue": "4pzMWzn19oqibHXqEdLr4EEHygs7QF2mMdvEhSMPiCVejEZGL4Vi5BGnmrJjMqKyNr6c6sSd3EXKoYxAuC2YiZNF"
     }
   }
 }
@@ -158,27 +158,26 @@ A Differentiation (Diff) DID message does not contain a valid DID Document. Inst
 Example of a Diff DID message:
 ```json
 {
-  "id": "did:iota:DqmknfA6pF6LpaGeHs3qcLjCPicWNgaG9AvinvpTKCGD",
+  "id": "did:iota:X7U84ez4YeaLwpfdnhdgFyPLa53twvAuMSYdRQas54e",
   "diff": {
     "doc": {
       "service": [
         {
-          "id": "did:iota:DqmknfA6pF6LpaGeHs3qcLjCPicWNgaG9AvinvpTKCGD#linked-domain-1",
+          "id": "did:iota:X7U84ez4YeaLwpfdnhdgFyPLa53twvAuMSYdRQas54e#linked-domain-1",
           "type_": "LinkedDomains",
-          "service_endpoint": "https://example.com/",
-          "properties": null
+          "service_endpoint": "https://example.com/"
         }
       ]
     },
     "meta": {
-      "updated": "2022-01-17T19:13:35Z"
+      "updated": "2022-01-21T09:50:28Z"
     }
   },
-  "previousMessageId": "c8a6213cf87e3917ef20936ab215ba1825b02e2f235f258d1f4eaddb799bac65",
+  "previousMessageId": "5dfff82c34c75b3436e7e03370e220e4693d39026fee315e6db7b7815305df4a",
   "proof": {
     "type": "JcsEd25519Signature2020",
     "verificationMethod": "#sign-0",
-    "signatureValue": "3jGSsgWbaDv1mtkbA8sqBA62nm9omUtTVHonTGdafv3ftbQqvYLffe6AdoRKPQHrXUnZnXTB6TDtD66a8zXMQdRp"
+    "signatureValue": "3TG8LiXbWPcH3ecg4is5mswENVuQBakhv8R5TMXopHgPg578oLoczySvZMsEdjRHYgJGihK2VHEqyCHPjQyXW61m"
   }
 }
 ```
@@ -224,15 +223,14 @@ Example `diff` of adding a new service entry to the document and changing the `u
     "doc": {
       "service": [
         {
-          "id": "did:iota:DqmknfA6pF6LpaGeHs3qcLjCPicWNgaG9AvinvpTKCGD#linked-domain-1",
+          "id": "did:iota:X7U84ez4YeaLwpfdnhdgFyPLa53twvAuMSYdRQas54e#linked-domain-1",
           "type_": "LinkedDomains",
-          "service_endpoint": "https://example.com/",
-          "properties": null
+          "service_endpoint": "https://example.com/"
         }
       ]
     },
     "meta": {
-      "updated": "2022-01-17T19:13:35Z"
+      "updated": "2022-01-21T09:50:28Z"
     }
   }
 }

--- a/examples/low-level-api/diff_chain.rs
+++ b/examples/low-level-api/diff_chain.rs
@@ -8,6 +8,8 @@
 
 use identity::core::json;
 use identity::core::FromJson;
+use identity::core::Timestamp;
+use identity::core::ToJson;
 use identity::did::Service;
 use identity::did::DID;
 use identity::iota::ClientMap;
@@ -32,11 +34,12 @@ async fn main() -> Result<()> {
 
     // Add a Service
     let service: Service = Service::from_json_value(json!({
-      "id": doc.id().to_url().join("#linked-domain")?,
+      "id": doc.id().to_url().join("#linked-domain-1")?,
       "type": "LinkedDomains",
-      "serviceEndpoint": "https://iota.org"
+      "serviceEndpoint": "https://example.com/"
     }))?;
     assert!(doc.insert_service(service));
+    doc.metadata.updated = Timestamp::now_utc();
     doc
   };
 
@@ -48,7 +51,7 @@ async fn main() -> Result<()> {
     document.default_signing_method()?.id(),
   )?;
 
-  println!("Diff > {:#?}", diff);
+  println!("Diff > {}", diff.to_json_pretty().unwrap());
 
   // Publish the diff object to the Tangle, starting a diff chain.
   let update_receipt: Receipt = client.publish_diff(receipt.message_id(), &diff).await?;

--- a/identity-did/src/diff/diff_method.rs
+++ b/identity-did/src/diff/diff_method.rs
@@ -147,11 +147,15 @@ where
 
   fn into_diff(self) -> Result<Self::Type> {
     Ok(DiffMethod {
-      id: Some(self.id().to_string().into_diff()?),
-      controller: Some(self.controller().to_string().into_diff()?),
-      key_type: Some(self.key_type().into_diff()?),
-      key_data: Some(self.key_data().clone().into_diff()?),
-      properties: Some(self.properties().clone().into_diff()?),
+      id: Some(self.id.into_diff()?),
+      controller: Some(self.controller.into_diff()?),
+      key_type: Some(self.key_type.into_diff()?),
+      key_data: Some(self.key_data.into_diff()?),
+      properties: if self.properties == Default::default() {
+        None
+      } else {
+        Some(self.properties.into_diff()?)
+      },
     })
   }
 }
@@ -161,6 +165,7 @@ mod test {
   use super::*;
   use identity_core::common::Object;
   use identity_core::common::Value;
+  use identity_core::convert::{FromJson, ToJson};
 
   fn test_method() -> VerificationMethod {
     VerificationMethod::builder(Default::default())
@@ -375,5 +380,20 @@ mod test {
     assert_eq!(merge, new);
 
     assert_eq!(new.into_diff().unwrap(), diff);
+  }
+
+  #[test]
+  fn test_from_into_diff() {
+    let method: VerificationMethod = test_method();
+
+    let diff: DiffMethod = method.clone().into_diff().unwrap();
+    let new: VerificationMethod = VerificationMethod::from_diff(diff.clone()).unwrap();
+    assert_eq!(method, new);
+
+    let ser: String = diff.to_json().unwrap();
+    let de: DiffMethod = DiffMethod::from_json(&ser).unwrap();
+    assert_eq!(de, diff);
+    let merge: VerificationMethod = Diff::merge(&method, de).unwrap();
+    assert_eq!(method, merge);
   }
 }

--- a/identity-did/src/diff/diff_method.rs
+++ b/identity-did/src/diff/diff_method.rs
@@ -165,7 +165,8 @@ mod test {
   use super::*;
   use identity_core::common::Object;
   use identity_core::common::Value;
-  use identity_core::convert::{FromJson, ToJson};
+  use identity_core::convert::FromJson;
+  use identity_core::convert::ToJson;
 
   fn test_method() -> VerificationMethod {
     VerificationMethod::builder(Default::default())
@@ -393,7 +394,7 @@ mod test {
     let ser: String = diff.to_json().unwrap();
     let de: DiffMethod = DiffMethod::from_json(&ser).unwrap();
     assert_eq!(de, diff);
-    let merge: VerificationMethod = Diff::merge(&method, de).unwrap();
-    assert_eq!(method, merge);
+    let from: VerificationMethod = VerificationMethod::from_diff(de).unwrap();
+    assert_eq!(method, from);
   }
 }

--- a/identity-did/src/diff/diff_service.rs
+++ b/identity-did/src/diff/diff_service.rs
@@ -124,8 +124,8 @@ where
 
   fn into_diff(self) -> Result<Self::Type> {
     Ok(DiffService {
-      id: Some(self.id().to_string().into_diff()?),
-      type_: Some(self.type_().to_string().into_diff()?),
+      id: Some(self.id.into_diff()?),
+      type_: Some(self.type_.into_diff()?),
       service_endpoint: Some(self.service_endpoint.into_diff()?),
       properties: if self.properties != T::default() {
         Some(self.properties.into_diff()?)
@@ -168,11 +168,12 @@ impl Diff for ServiceEndpoint {
 mod test {
   use indexmap::IndexMap;
 
+  use crate::utils::OrderedSet;
   use identity_core::common::Object;
   use identity_core::common::Url;
-  use identity_core::convert::{FromJson, ToJson};
+  use identity_core::convert::FromJson;
+  use identity_core::convert::ToJson;
   use identity_core::diff::DiffVec;
-  use crate::utils::OrderedSet;
 
   use super::*;
 
@@ -328,6 +329,8 @@ mod test {
     let ser: String = diff.to_json().unwrap();
     let de: DiffService = DiffService::from_json(&ser).unwrap();
     assert_eq!(diff, de);
+    let from: Service = Service::from_diff(de).unwrap();
+    assert_eq!(from, service);
   }
 
   #[test]

--- a/identity-diff/src/object.rs
+++ b/identity-diff/src/object.rs
@@ -42,9 +42,9 @@ impl Diff for ObjectSrc {
 
 #[cfg(test)]
 mod tests {
-  use serde_json::json;
-  use crate::hashmap::InnerValue;
   use super::*;
+  use crate::hashmap::InnerValue;
+  use serde_json::json;
 
   #[test]
   fn test_diff_empty() {

--- a/identity-diff/src/object.rs
+++ b/identity-diff/src/object.rs
@@ -39,3 +39,63 @@ impl Diff for ObjectSrc {
     self.into_iter().collect::<ObjectDst>().into_diff()
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use serde_json::json;
+  use crate::hashmap::InnerValue;
+  use super::*;
+
+  #[test]
+  fn test_diff_empty() {
+    // Ensure diff is none.
+    let a: ObjectSrc = ObjectSrc::default();
+    let b: ObjectSrc = ObjectSrc::default();
+    let diff: DiffObject = Diff::diff(&a, &b).unwrap();
+    assert!(diff.0.is_none());
+    let merge: ObjectSrc = a.merge(diff.clone()).unwrap();
+    assert_eq!(merge, a);
+
+    // Test serde round-trip.
+    let serialized: String = serde_json::to_string(&diff).unwrap();
+    let deserialized: DiffObject = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(diff, deserialized)
+  }
+
+  #[test]
+  fn test_diff() {
+    let mut a: ObjectSrc = ObjectSrc::new();
+    a.insert("foo".into(), 12.into());
+    a.insert("bar".into(), 34.into());
+    a.insert("baz".into(), 56.into());
+    a.insert("qux".into(), 78.into());
+
+    let mut b: ObjectSrc = ObjectSrc::new();
+    b.insert("foo".into(), 56.into());
+    b.insert("thud".into(), 9.into());
+    b.insert("bar".into(), 34.into());
+    b.insert("qux".into(), 78.into());
+
+    let diff: DiffObject = Diff::diff(&a, &b).unwrap();
+    let expected: DiffObject = DiffHashMap(Some(vec![
+      InnerValue::Change {
+        key: "foo".into(),
+        value: json!(56).into_diff().unwrap(),
+      },
+      InnerValue::Add {
+        key: "thud".into(),
+        value: json!(9).into_diff().unwrap(),
+      },
+      InnerValue::Remove { key: "baz".into() },
+    ]));
+    assert_eq!(expected, diff);
+
+    let merge: ObjectSrc = a.merge(diff.clone()).unwrap();
+    assert_eq!(merge, b);
+
+    // Test serde round-trip.
+    let serialized: String = serde_json::to_string(&diff).unwrap();
+    let deserialized: DiffObject = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(diff, deserialized)
+  }
+}

--- a/identity-iota/src/diff/diff_iota_document_metadata.rs
+++ b/identity-iota/src/diff/diff_iota_document_metadata.rs
@@ -125,11 +125,7 @@ impl Diff for IotaDocumentMetadata {
       .map_err(identity_core::diff::Error::merge)?
       .ok_or_else(|| Error::convert("Missing field `metadata.previous_message_id`"))?;
 
-    let properties: Object = diff
-      .properties
-      .map(Object::from_diff)
-      .transpose()?
-      .unwrap_or_default();
+    let properties: Object = diff.properties.map(Object::from_diff).transpose()?.unwrap_or_default();
 
     Ok(IotaDocumentMetadata {
       created,
@@ -159,7 +155,8 @@ mod test {
   use iota_client::bee_message::MESSAGE_ID_LENGTH;
 
   use identity_core::common::Object;
-  use identity_core::convert::{FromJson, ToJson};
+  use identity_core::convert::FromJson;
+  use identity_core::convert::ToJson;
 
   use super::*;
 
@@ -255,8 +252,8 @@ mod test {
     let ser: String = diff.to_json().unwrap();
     let de: DiffIotaDocumentMetadata = DiffIotaDocumentMetadata::from_json(&ser).unwrap();
     assert_eq!(diff, de);
-    let merge: IotaDocumentMetadata = Diff::merge(&original, de).unwrap();
-    assert_eq!(merge, original);
+    let from: IotaDocumentMetadata = IotaDocumentMetadata::from_diff(de).unwrap();
+    assert_eq!(from, original);
   }
 
   #[test]

--- a/identity-iota/src/diff/diff_iota_document_metadata.rs
+++ b/identity-iota/src/diff/diff_iota_document_metadata.rs
@@ -129,7 +129,7 @@ impl Diff for IotaDocumentMetadata {
       .properties
       .map(Object::from_diff)
       .transpose()?
-      .ok_or_else(|| Error::convert("Missing field `metadata.properties`"))?;
+      .unwrap_or_default();
 
     Ok(IotaDocumentMetadata {
       created,
@@ -145,7 +145,11 @@ impl Diff for IotaDocumentMetadata {
       created: Some(self.created.into_diff()?),
       updated: Some(self.updated.into_diff()?),
       previous_message_id: Some(self.previous_message_id.to_string().into_diff()?),
-      properties: Some(self.properties.into_diff()?),
+      properties: if self.properties == Default::default() {
+        None
+      } else {
+        Some(self.properties.into_diff()?)
+      },
     })
   }
 }

--- a/identity-iota/src/tangle/message/compression_brotli.rs
+++ b/identity-iota/src/tangle/message/compression_brotli.rs
@@ -40,12 +40,12 @@ mod test {
     let keypair: KeyPair = KeyPair::new_ed25519().unwrap();
     let mut document: IotaDocument = IotaDocument::new(&keypair).unwrap();
     document
-      .sign_self(keypair.private(), &document.default_signing_method().unwrap().id())
+      .sign_self(keypair.private(), document.default_signing_method().unwrap().id())
       .unwrap();
 
-    let data = document.to_json().unwrap();
-    let compressed = compress_brotli(data.as_str()).unwrap();
-    let decompressed = decompress_brotli(&compressed).unwrap();
+    let data: String = document.to_json().unwrap();
+    let compressed: Vec<u8> = compress_brotli(data.as_str()).unwrap();
+    let decompressed: Vec<u8> = decompress_brotli(&compressed).unwrap();
 
     assert_eq!(decompressed, data.as_bytes());
   }

--- a/identity-iota/src/tangle/message/message_ext.rs
+++ b/identity-iota/src/tangle/message/message_ext.rs
@@ -163,13 +163,15 @@ impl TryFromMessage for DiffMessage {
 #[cfg(test)]
 mod test {
   use identity_core::common::Url;
-  use identity_core::crypto::{KeyPair, KeyType};
+  use identity_core::crypto::KeyPair;
+  use identity_core::crypto::KeyType;
   use identity_did::did::CoreDIDUrl;
-  use identity_did::service::{ServiceBuilder, ServiceEndpoint};
+  use identity_did::service::ServiceBuilder;
+  use identity_did::service::ServiceEndpoint;
   use identity_did::verification::MethodScope;
 
-
-  use crate::document::{IotaDocument, IotaVerificationMethod};
+  use crate::document::IotaDocument;
+  use crate::document::IotaVerificationMethod;
   use crate::document::ResolvedIotaDocument;
   use crate::tangle::message::message_encoding::DIDMessageEncoding;
   use crate::tangle::MessageId;
@@ -209,10 +211,23 @@ mod test {
         .id(CoreDIDUrl::from(doc1.id().to_url().join("#linked-domain").unwrap()))
         .service_endpoint(ServiceEndpoint::One(Url::parse("https://example.com/").unwrap()))
         .type_("LinkedDomains")
-        .build().unwrap())
-    );
-    doc2.insert_method(IotaVerificationMethod::from_did(doc1.id().clone(), KeyType::Ed25519, keypair.public(), "key-1").unwrap(), MethodScope::authentication()).unwrap();
-    let diff: DiffMessage = doc1.diff(&doc2, MessageId::new([1; 32]), keypair.private(), doc1.default_signing_method().unwrap().id()).unwrap();
+        .build()
+        .unwrap()
+    ));
+    doc2
+      .insert_method(
+        IotaVerificationMethod::from_did(doc1.id().clone(), KeyType::Ed25519, keypair.public(), "key-1").unwrap(),
+        MethodScope::authentication(),
+      )
+      .unwrap();
+    let diff: DiffMessage = doc1
+      .diff(
+        &doc2,
+        MessageId::new([1; 32]),
+        keypair.private(),
+        doc1.default_signing_method().unwrap().id(),
+      )
+      .unwrap();
 
     for encoding in [DIDMessageEncoding::Json, DIDMessageEncoding::JsonBrotli] {
       let encoded: Vec<u8> = pack_did_message(&diff, encoding).unwrap();


### PR DESCRIPTION
# Description of change
Fixes a bug introduced in #598 where `DiffMessages` from the Tangle no longer match the expected signature due to serialization differences, causing verification in `DiffChain` to fail and any diffs that add a `Service` or `VerificationMethod` to be rejected.
Before #598, the `DiffIotaDocument` was serialised to a JSON string first for the `DiffMessage::diff` field. This meant the signature verification of `DiffMessage` was not affected, since `DiffIotaDocument` was not deserialised then serialised again during verification.

The root cause is due to how `properties` in `Service` and `VerificationMethod` are handled in their `ServiceDiff::into_diff` and `DiffMethod::into_diff` implementations: empty `properties` (of type `Object` i.e. `BTreeMap`) would be diffed to `Some(DiffHashMap([]))`. Internally `DiffHashMap([])` (which is `None`) skips serialization, but wrapping it in `Some` means it serializes to `"properties": null` instead. Deserializing `"properties": null` results in `None` instead of `Some(DiffHashMap([]))`, so the JSON serialization changes after deserialization, which means the signature verification (which internally serializes objects to canonical JSON) fails. 

This scenario only occurs for types with this bug when wrapped in a collection (like `OrderedSet`s of `Service`s and `VerificationMethod`s in `CoreDocument`) with `DiffVec`, and then only for additions (which use `Diff::into_diff` and `Diff::from_diff`) since other changes like editing or removing a collection entry do not use `Diff:into_diff`.

It would be worth investigating if it's possible to remove `Diff::into_diff` and `Diff::from_diff` by refactoring `DiffVec` (specifically `InnerVec`) to store the actual type `T` instead of converting between its `<T as Diff>::Type`. However: I'm unsure if that's possible, how long it would take, or what other bugs that would introduce.

Multiple unit tests have been introduced to prevent regressions but we do not have coverage for every possible diff of every field.

### Example

Serialising a `DiffService` with a default/empty `properties` field to JSON, then serializing its deserialisation.

#### 1. Before (current) serialisation changes.

Initial serialisation:
```json
{"id":"did:example:1234","type_":"test_service","service_endpoint":"did:service:1234","properties":null}
```
Serialisation after deserialisation:
```json
{"id":"did:example:1234","type_":"test_service","service_endpoint":"did:service:1234"}
```

#### 2. After (this PR) serialisation is consistent.

Initial serialisation:
```json
{"id":"did:example:1234","type_":"test_service","service_endpoint":"did:service:1234"}
```
Serialisation after deserialisation:
```json
{"id":"did:example:1234","type_":"test_service","service_endpoint":"did:service:1234"}
```

Aside: this also removes some unnecessary clones from `Diff::into_diff` implementations.

NOTE: the fix in #605 is still required for diffs to work as expected. This PR fixes adding structs in diffs, #605 fixes editing or removing structs added in previous diffs.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Examples were hand-checked to work as-expected (but still suffer from the bug to be fixed by #605). New unit and integration tests were added.

All tests and examples pass locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
