### PR TITLE
Fix `Window` undefined error

### DIFF
--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -25,7 +25,8 @@ strum = { version = "0.21", features = ["derive"] }
 thiserror = { version = "1.0", default-features = false }
 
 [dependencies.iota-client]
-version = "1.1.0"
+git = "https://github.com/iotaledger/iota.rs"
+rev = "c7d1cc4bae4ef00f16314239463ce115f8c6b35a"
 default-features = false
 features = ["pow-fallback"]
 


### PR DESCRIPTION
# Description of change
Bump `iota-client` from 1.1 to the pinned git-revision used on `dev`. This changes the `wasm-timer` dependency to use the forked version from @PhilippGackstatter (https://github.com/PhilippGackstatter/wasm-timer?rev=448c2be0c4feeb6b5df1da265489232dff2f03c1), which calls `js_sys::global` rather than `web_sys::window`.

This is to fix a bug currently encountered in 0.4.2 where the following block of generated code throws an undefined error when called under uncertain circumstances:

```js
module.exports.__wbg_instanceof_Window_c4b70662a0d2c5ec = function(arg0) {
    var ret = getObject(arg0) instanceof Window;
    return ret;
};
```

With this change, the function is no longer generated or called.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Wasm tests and examples pass locally for Node.js and the browser.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
