### PR TITLE
Add union type parameters

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -180,7 +180,7 @@ Fetch the DID document specified by the given `DID`.
 
 | Param | Type |
 | --- | --- |
-| did | <code>UDID</code> | 
+| did | [<code>DID</code>](#DID) \| <code>string</code> | 
 
 <a name="Client+resolveHistory"></a>
 
@@ -191,7 +191,7 @@ Returns the message history of the given DID.
 
 | Param | Type |
 | --- | --- |
-| did | <code>UDID</code> | 
+| did | [<code>DID</code>](#DID) \| <code>string</code> | 
 
 <a name="Client+resolveDiffHistory"></a>
 
@@ -1059,7 +1059,7 @@ Throws an error if the method is not found.
 
 | Param | Type |
 | --- | --- |
-| query | <code>UMethodQuery</code> | 
+| query | [<code>DIDUrl</code>](#DIDUrl) \| <code>string</code> | 
 
 <a name="Document+revokeMerkleKey"></a>
 
@@ -1068,7 +1068,7 @@ Throws an error if the method is not found.
 
 | Param | Type |
 | --- | --- |
-| query | <code>UMethodQuery</code> | 
+| query | [<code>DIDUrl</code>](#DIDUrl) \| <code>string</code> | 
 | index | <code>number</code> | 
 
 <a name="Document+signSelf"></a>
@@ -1086,7 +1086,7 @@ verification method. See `Document::verifySelfSigned`.
 | Param | Type |
 | --- | --- |
 | key_pair | [<code>KeyPair</code>](#KeyPair) | 
-| method_query | <code>UMethodQuery</code> | 
+| method_query | [<code>DIDUrl</code>](#DIDUrl) \| <code>string</code> | 
 
 <a name="Document+signCredential"></a>
 
@@ -1152,7 +1152,7 @@ Generate a `DiffMessage` between two DID Documents and sign it using the specifi
 | other | [<code>Document</code>](#Document) | 
 | message_id | <code>string</code> | 
 | key | [<code>KeyPair</code>](#KeyPair) | 
-| method_query | <code>UMethodQuery</code> | 
+| method_query | [<code>DIDUrl</code>](#DIDUrl) \| <code>string</code> | 
 
 <a name="Document+verifyDiff"></a>
 

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -883,7 +883,7 @@ with the given Document.
         * [.signPresentation(data, args, options)](#Document+signPresentation) ⇒ [<code>Presentation</code>](#Presentation)
         * [.signData(data, args, options)](#Document+signData) ⇒ <code>any</code>
         * [.verifyData(data, options)](#Document+verifyData) ⇒ <code>boolean</code>
-        * [.diff(other, message_id, key, method)](#Document+diff) ⇒ [<code>DiffMessage</code>](#DiffMessage)
+        * [.diff(other, message_id, key, method_query)](#Document+diff) ⇒ [<code>DiffMessage</code>](#DiffMessage)
         * [.verifyDiff(diff)](#Document+verifyDiff)
         * [.mergeDiff(diff)](#Document+mergeDiff)
         * [.integrationIndex()](#Document+integrationIndex) ⇒ <code>string</code>
@@ -1041,7 +1041,7 @@ Removes all references to the specified Verification Method.
 <a name="Document+defaultSigningMethod"></a>
 
 ### document.defaultSigningMethod() ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
-Returns the first `VerificationMethod` with a capability invocation relationship
+Returns a copy of the first `VerificationMethod` with a capability invocation relationship
 capable of signing this DID document.
 
 Throws an error if no signing method is present.
@@ -1050,7 +1050,7 @@ Throws an error if no signing method is present.
 <a name="Document+resolveMethod"></a>
 
 ### document.resolveMethod(query) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
-Returns the first `VerificationMethod` with an `id` property
+Returns a copy of the first `VerificationMethod` with an `id` property
 matching the provided `query`.
 
 Throws an error if the method is not found.
@@ -1059,7 +1059,7 @@ Throws an error if the method is not found.
 
 | Param | Type |
 | --- | --- |
-| query | <code>string</code> | 
+| query | <code>UMethodQuery</code> | 
 
 <a name="Document+revokeMerkleKey"></a>
 
@@ -1068,7 +1068,7 @@ Throws an error if the method is not found.
 
 | Param | Type |
 | --- | --- |
-| query | <code>string</code> | 
+| query | <code>UMethodQuery</code> | 
 | index | <code>number</code> | 
 
 <a name="Document+signSelf"></a>
@@ -1086,7 +1086,7 @@ verification method. See `Document::verifySelfSigned`.
 | Param | Type |
 | --- | --- |
 | key_pair | [<code>KeyPair</code>](#KeyPair) | 
-| method_query | <code>string</code> | 
+| method_query | <code>UMethodQuery</code> | 
 
 <a name="Document+signCredential"></a>
 
@@ -1141,7 +1141,7 @@ Verifies the authenticity of `data` using the target verification method.
 
 <a name="Document+diff"></a>
 
-### document.diff(other, message_id, key, method) ⇒ [<code>DiffMessage</code>](#DiffMessage)
+### document.diff(other, message_id, key, method_query) ⇒ [<code>DiffMessage</code>](#DiffMessage)
 Generate a `DiffMessage` between two DID Documents and sign it using the specified
 `key` and `method`.
 
@@ -1152,7 +1152,7 @@ Generate a `DiffMessage` between two DID Documents and sign it using the specifi
 | other | [<code>Document</code>](#Document) | 
 | message_id | <code>string</code> | 
 | key | [<code>KeyPair</code>](#KeyPair) | 
-| method | <code>string</code> | 
+| method_query | <code>UMethodQuery</code> | 
 
 <a name="Document+verifyDiff"></a>
 

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -562,7 +562,7 @@ Returns the `DID` as a string.
 <a name="DID+toJSON"></a>
 
 ### did.toJSON() ⇒ <code>any</code>
-Serializes a `DID` object as a JSON object.
+Serializes a `DID` as a JSON object.
 
 **Kind**: instance method of [<code>DID</code>](#DID)  
 <a name="DID.fromBase58"></a>
@@ -702,7 +702,7 @@ Returns the `DIDUrl` as a string.
 <a name="DIDUrl+toJSON"></a>
 
 ### didUrl.toJSON() ⇒ <code>any</code>
-Serializes a `DIDUrl` object as a JSON object.
+Serializes a `DIDUrl` as a JSON object.
 
 **Kind**: instance method of [<code>DIDUrl</code>](#DIDUrl)  
 <a name="DIDUrl.parse"></a>

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -180,7 +180,7 @@ Fetch the DID document specified by the given `DID`.
 
 | Param | Type |
 | --- | --- |
-| did | <code>string</code> | 
+| did | <code>UDID</code> | 
 
 <a name="Client+resolveHistory"></a>
 
@@ -191,7 +191,7 @@ Returns the message history of the given DID.
 
 | Param | Type |
 | --- | --- |
-| did | <code>string</code> | 
+| did | <code>UDID</code> | 
 
 <a name="Client+resolveDiffHistory"></a>
 
@@ -489,13 +489,14 @@ Deserializes a `Credential` object from a JSON object.
 * [DID](#DID)
     * [new DID(key, network)](#new_DID_new)
     * _instance_
-        * [.network](#DID+network) ⇒ [<code>Network</code>](#Network)
         * [.networkName](#DID+networkName) ⇒ <code>string</code>
         * [.tag](#DID+tag) ⇒ <code>string</code>
+        * [.network()](#DID+network) ⇒ [<code>Network</code>](#Network)
         * [.join(segment)](#DID+join) ⇒ [<code>DIDUrl</code>](#DIDUrl)
         * [.toUrl()](#DID+toUrl) ⇒ [<code>DIDUrl</code>](#DIDUrl)
         * [.intoUrl()](#DID+intoUrl) ⇒ [<code>DIDUrl</code>](#DIDUrl)
         * [.toString()](#DID+toString) ⇒ <code>string</code>
+        * [.toJSON()](#DID+toJSON) ⇒ <code>any</code>
     * _static_
         * [.fromBase58(key, network)](#DID.fromBase58) ⇒ [<code>DID</code>](#DID)
         * [.parse(input)](#DID.parse) ⇒ [<code>DID</code>](#DID)
@@ -511,12 +512,6 @@ Creates a new `DID` from a `KeyPair` object.
 | key | [<code>KeyPair</code>](#KeyPair) | 
 | network | <code>string</code> \| <code>undefined</code> | 
 
-<a name="DID+network"></a>
-
-### did.network ⇒ [<code>Network</code>](#Network)
-Returns the IOTA tangle network of the `DID`.
-
-**Kind**: instance property of [<code>DID</code>](#DID)  
 <a name="DID+networkName"></a>
 
 ### did.networkName ⇒ <code>string</code>
@@ -529,6 +524,12 @@ Returns the IOTA tangle network of the `DID`.
 Returns the unique tag of the `DID`.
 
 **Kind**: instance property of [<code>DID</code>](#DID)  
+<a name="DID+network"></a>
+
+### did.network() ⇒ [<code>Network</code>](#Network)
+Returns the IOTA tangle network of the `DID`.
+
+**Kind**: instance method of [<code>DID</code>](#DID)  
 <a name="DID+join"></a>
 
 ### did.join(segment) ⇒ [<code>DIDUrl</code>](#DIDUrl)
@@ -556,6 +557,12 @@ Converts the `DID` into a `DIDUrl`.
 
 ### did.toString() ⇒ <code>string</code>
 Returns the `DID` as a string.
+
+**Kind**: instance method of [<code>DID</code>](#DID)  
+<a name="DID+toJSON"></a>
+
+### did.toJSON() ⇒ <code>any</code>
+Serializes a `DID` object as a JSON object.
 
 **Kind**: instance method of [<code>DID</code>](#DID)  
 <a name="DID.fromBase58"></a>
@@ -598,6 +605,7 @@ Parses a `DID` from the input string.
         * [.query](#DIDUrl+query)
         * [.join(segment)](#DIDUrl+join) ⇒ [<code>DIDUrl</code>](#DIDUrl)
         * [.toString()](#DIDUrl+toString) ⇒ <code>string</code>
+        * [.toJSON()](#DIDUrl+toJSON) ⇒ <code>any</code>
     * _static_
         * [.parse(input)](#DIDUrl.parse) ⇒ [<code>DIDUrl</code>](#DIDUrl)
 
@@ -689,6 +697,12 @@ I.e.
 
 ### didUrl.toString() ⇒ <code>string</code>
 Returns the `DIDUrl` as a string.
+
+**Kind**: instance method of [<code>DIDUrl</code>](#DIDUrl)  
+<a name="DIDUrl+toJSON"></a>
+
+### didUrl.toJSON() ⇒ <code>any</code>
+Serializes a `DIDUrl` object as a JSON object.
 
 **Kind**: instance method of [<code>DIDUrl</code>](#DIDUrl)  
 <a name="DIDUrl.parse"></a>
@@ -1770,6 +1784,7 @@ Deserializes a `MethodType` object from a JSON object.
 
 * [Network](#Network)
     * _instance_
+        * [.name](#Network+name) ⇒ <code>string</code>
         * [.defaultNodeURL](#Network+defaultNodeURL) ⇒ <code>string</code> \| <code>undefined</code>
         * [.toString()](#Network+toString) ⇒ <code>string</code>
     * _static_
@@ -1777,6 +1792,10 @@ Deserializes a `MethodType` object from a JSON object.
         * [.mainnet()](#Network.mainnet) ⇒ [<code>Network</code>](#Network)
         * [.devnet()](#Network.devnet) ⇒ [<code>Network</code>](#Network)
 
+<a name="Network+name"></a>
+
+### network.name ⇒ <code>string</code>
+**Kind**: instance property of [<code>Network</code>](#Network)  
 <a name="Network+defaultNodeURL"></a>
 
 ### network.defaultNodeURL ⇒ <code>string</code> \| <code>undefined</code>

--- a/bindings/wasm/examples/src/create_did.js
+++ b/bindings/wasm/examples/src/create_did.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 import {Client, Config, Document, KeyPair, KeyType} from '@iota/identity-wasm';
@@ -17,7 +17,7 @@ async function createIdentity(clientConfig) {
     const key = new KeyPair(KeyType.Ed25519);
 
     // Create a DID Document (an identity) from the generated key pair.
-    const doc = new Document(key, clientConfig.network.toString());
+    const doc = new Document(key, clientConfig.network.name);
 
     // Sign the DID Document with the generated key.
     doc.signSelf(key, doc.defaultSigningMethod().id.toString());

--- a/bindings/wasm/examples/src/create_did.js
+++ b/bindings/wasm/examples/src/create_did.js
@@ -20,7 +20,7 @@ async function createIdentity(clientConfig) {
     const doc = new Document(key, clientConfig.network.name);
 
     // Sign the DID Document with the generated key.
-    doc.signSelf(key, doc.defaultSigningMethod().id.toString());
+    doc.signSelf(key, doc.defaultSigningMethod().id);
 
     // Create a default client configuration from the parent config network.
     const config = Config.fromNetwork(clientConfig.network);

--- a/bindings/wasm/examples/src/diff_chain.js
+++ b/bindings/wasm/examples/src/diff_chain.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 import {Client, Config, Document, Service, Timestamp} from '@iota/identity-wasm';
@@ -38,7 +38,7 @@ async function createDiff(clientConfig) {
     console.log(updatedDoc);
 
     // Create diff
-    const diff = doc.diff(updatedDoc, receipt.messageId, key, doc.defaultSigningMethod().id.toString());
+    const diff = doc.diff(updatedDoc, receipt.messageId, key, doc.defaultSigningMethod().id);
     console.log(diff);
 
     // Publish diff to the Tangle

--- a/bindings/wasm/examples/src/manipulate_did.js
+++ b/bindings/wasm/examples/src/manipulate_did.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 import {
@@ -57,7 +57,7 @@ async function manipulateIdentity(clientConfig) {
     doc.metadataUpdated = Timestamp.nowUTC();
 
     // Sign the DID Document with the appropriate key.
-    doc.signSelf(key, doc.defaultSigningMethod().id.toString());
+    doc.signSelf(key, doc.defaultSigningMethod().id);
 
     // Publish the Identity to the IOTA Network, this may take a few seconds to complete Proof-of-Work.
     const updateReceipt = await client.publishDocument(doc);

--- a/bindings/wasm/examples/src/merkle_key.js
+++ b/bindings/wasm/examples/src/merkle_key.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 import {
@@ -45,7 +45,7 @@ async function merkleKey(clientConfig) {
     issuer.doc.insertMethod(method, MethodScope.VerificationMethod());
     issuer.doc.metadataPreviousMessageId = issuer.receipt.messageId;
     issuer.doc.metadataUpdated = Timestamp.nowUTC();
-    issuer.doc.signSelf(issuer.key, issuer.doc.defaultSigningMethod().id.toString());
+    issuer.doc.signSelf(issuer.key, issuer.doc.defaultSigningMethod().id);
 
     // Publish the Identity to the IOTA Network and log the results.
     // This may take a few seconds to complete proof-of-work.
@@ -86,7 +86,7 @@ async function merkleKey(clientConfig) {
     issuer.doc.revokeMerkleKey(method.id.toString(), 0);
     issuer.doc.metadataPreviousMessageId = receipt.messageId;
     issuer.doc.metadataUpdated = Timestamp.nowUTC();
-    issuer.doc.signSelf(issuer.key, issuer.doc.defaultSigningMethod().id.toString());
+    issuer.doc.signSelf(issuer.key, issuer.doc.defaultSigningMethod().id);
     const nextReceipt = await client.publishDocument(issuer.doc);
     logExplorerUrl("Identity Update:", clientConfig.explorer, nextReceipt.messageId);
 

--- a/bindings/wasm/examples/src/private_tangle.js
+++ b/bindings/wasm/examples/src/private_tangle.js
@@ -46,7 +46,7 @@ async function privateTangle(restURL, networkName) {
 
     // Create a DID with the network set explicitly.
     // This will result in a DID prefixed by `did:iota:tangle`.
-    const doc = new Document(key, network.toString());
+    const doc = new Document(key, network.name);
 
     // Sign the DID Document with the generated key.
     doc.signSelf(key, doc.defaultSigningMethod().id.toString());

--- a/bindings/wasm/examples/src/private_tangle.js
+++ b/bindings/wasm/examples/src/private_tangle.js
@@ -55,7 +55,7 @@ async function privateTangle(restURL, networkName) {
     const receipt = await client.publishDocument(doc);
 
     // Make sure the DID can be resolved on the private tangle
-    const resolved = await client.resolve(doc.id.toString());
+    const resolved = await client.resolve(doc.id);
 
     console.log(`Published the DID document to the private tangle:`);
     console.log(resolved);

--- a/bindings/wasm/examples/src/private_tangle.js
+++ b/bindings/wasm/examples/src/private_tangle.js
@@ -49,7 +49,7 @@ async function privateTangle(restURL, networkName) {
     const doc = new Document(key, network.name);
 
     // Sign the DID Document with the generated key.
-    doc.signSelf(key, doc.defaultSigningMethod().id.toString());
+    doc.signSelf(key, doc.defaultSigningMethod().id);
 
     // Publish the Identity to the IOTA Network, this may take a few seconds to complete Proof-of-Work.
     const receipt = await client.publishDocument(doc);

--- a/bindings/wasm/examples/src/resolve_history.js
+++ b/bindings/wasm/examples/src/resolve_history.js
@@ -68,7 +68,7 @@ async function resolveHistory(clientConfig) {
     intDoc1.metadataUpdated = Timestamp.nowUTC();
 
     // Sign the DID Document with the original private key.
-    intDoc1.signSelf(key, intDoc1.defaultSigningMethod().id.toString());
+    intDoc1.signSelf(key, intDoc1.defaultSigningMethod().id);
 
     // Publish the updated DID Document to the Tangle, updating the integration chain.
     // This may take a few seconds to complete proof-of-work.
@@ -97,7 +97,7 @@ async function resolveHistory(clientConfig) {
     //
     // This is the first diff so the `previousMessageId` property is
     // set to the last DID document published on the integration chain.
-    const diff1 = intDoc1.diff(diffDoc1, intReceipt1.messageId, key, intDoc1.defaultSigningMethod().id.toString());
+    const diff1 = intDoc1.diff(diffDoc1, intReceipt1.messageId, key, intDoc1.defaultSigningMethod().id);
 
     // Publish the diff to the Tangle, starting a diff chain.
     const diffReceipt1 = await client.publishDiff(intReceipt1.messageId, diff1);
@@ -123,7 +123,7 @@ async function resolveHistory(clientConfig) {
 
     // This is the second diff therefore its `previousMessageId` property is
     // set to the first published diff to extend the diff chain.
-    const diff2 = diffDoc1.diff(diffDoc2, diffReceipt1.messageId, key, diffDoc1.defaultSigningMethod().id.toString());
+    const diff2 = diffDoc1.diff(diffDoc2, diffReceipt1.messageId, key, diffDoc1.defaultSigningMethod().id);
 
     // Publish the diff to the Tangle.
     // Note that we still use the `messageId` from the last integration chain message here to link
@@ -175,7 +175,7 @@ async function resolveHistory(clientConfig) {
     //       update, NOT the last diff chain message.
     intDoc2.metadataPreviousMessageId = intReceipt1.messageId;
     intDoc2.metadataUpdated = Timestamp.nowUTC();
-    intDoc2.signSelf(key, intDoc2.defaultSigningMethod().id.toString());
+    intDoc2.signSelf(key, intDoc2.defaultSigningMethod().id);
     const intReceipt2 = await client.publishDocument(intDoc2);
 
     // Log the results.

--- a/bindings/wasm/examples/src/resolve_history.js
+++ b/bindings/wasm/examples/src/resolve_history.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 import {
@@ -148,7 +148,7 @@ async function resolveHistory(clientConfig) {
     // ===========================================================================
 
     // Retrieve the message history of the DID.
-    const history1 = await client.resolveHistory(doc.id.toString());
+    const history1 = await client.resolveHistory(doc.id);
 
     // The history shows two documents in the integration chain, and two diffs in the diff chain.
     prettyPrintJSON(history1, "History (1):");
@@ -186,7 +186,7 @@ async function resolveHistory(clientConfig) {
     // ===========================================================================
 
     // Retrieve the updated message history of the DID.
-    const history2 = await client.resolveHistory(doc.id.toString());
+    const history2 = await client.resolveHistory(doc.id);
 
     // The history now shows three documents in the integration chain, and no diffs in the diff chain.
     // This is because each integration chain document has its own diff chain but only the last one

--- a/bindings/wasm/examples/src/revoke_vc.js
+++ b/bindings/wasm/examples/src/revoke_vc.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 import {Client, Config, Timestamp, VerifierOptions} from '@iota/identity-wasm';
@@ -35,7 +35,7 @@ async function revokeVC(clientConfig) {
     issuer.doc.removeMethod(issuer.doc.id.toUrl().join("#newKey"));
     issuer.doc.metadataPreviousMessageId = issuer.updatedMessageId;
     issuer.doc.metadataUpdated = Timestamp.nowUTC();
-    issuer.doc.signSelf(issuer.key, issuer.doc.defaultSigningMethod().id.toString());
+    issuer.doc.signSelf(issuer.key, issuer.doc.defaultSigningMethod().id);
     // This is an integration chain update, so we publish the full document.
     const {messageId} = await client.publishDocument(issuer.doc);
 

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -26,6 +26,7 @@
     "test:node": "mocha ./examples/dist/test.js --exit",
     "test:browser": "cypress run --headless",
     "test:readme": "txm README.md",
+    "test:unit": "wasm-pack test --node",
     "cypress": "cypress open"
   },
   "contributors": [

--- a/bindings/wasm/src/did/mod.rs
+++ b/bindings/wasm/src/did/mod.rs
@@ -1,6 +1,7 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+pub use self::wasm_did::UWasmDID;
 pub use self::wasm_did::WasmDID;
 pub use self::wasm_did_url::WasmDIDUrl;
 pub use self::wasm_diff_message::WasmDiffMessage;

--- a/bindings/wasm/src/did/wasm_did.rs
+++ b/bindings/wasm/src/did/wasm_did.rs
@@ -109,11 +109,6 @@ impl From<IotaDID> for WasmDID {
 /// Duck-typed union to pass either a string or WasmDID as a parameter.
 #[wasm_bindgen]
 extern "C" {
-  #[wasm_bindgen(typescript_type = "UDID")]
+  #[wasm_bindgen(typescript_type = "DID | string")]
   pub type UWasmDID;
 }
-
-#[wasm_bindgen(typescript_custom_section)]
-const U_DID: &'static str = r#"
-export type UDID = DID | string;
-"#;

--- a/bindings/wasm/src/did/wasm_did.rs
+++ b/bindings/wasm/src/did/wasm_did.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use identity::core::decode_b58;
@@ -50,7 +50,7 @@ impl WasmDID {
   }
 
   /// Returns the IOTA tangle network of the `DID`.
-  #[wasm_bindgen(getter)]
+  #[wasm_bindgen]
   pub fn network(&self) -> Result<WasmNetwork> {
     self.0.network().map(Into::into).wasm_result()
   }
@@ -91,6 +91,13 @@ impl WasmDID {
   pub fn to_string(&self) -> String {
     self.0.to_string()
   }
+
+  /// Serializes a `DID` as a JSON object.
+  #[wasm_bindgen(js_name = toJSON)]
+  pub fn to_json(&self) -> JsValue {
+    // This must match the serialization of IotaDID for UWasmDID to work.
+    JsValue::from_str(self.0.as_str())
+  }
 }
 
 impl From<IotaDID> for WasmDID {
@@ -98,3 +105,15 @@ impl From<IotaDID> for WasmDID {
     Self(did)
   }
 }
+
+/// Duck-typed union to pass either a string or WasmDID as a parameter.
+#[wasm_bindgen]
+extern "C" {
+  #[wasm_bindgen(typescript_type = "UDID")]
+  pub type UWasmDID;
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const U_DID: &'static str = r#"
+export type UDID = DID | string;
+"#;

--- a/bindings/wasm/src/did/wasm_did_url.rs
+++ b/bindings/wasm/src/did/wasm_did_url.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use identity::iota::IotaDIDUrl;
@@ -90,6 +90,12 @@ impl WasmDIDUrl {
   #[wasm_bindgen(js_name = toString)]
   pub fn to_string(&self) -> String {
     self.0.to_string()
+  }
+
+  /// Serializes a `DIDUrl` as a JSON object.
+  #[wasm_bindgen(js_name = toJSON)]
+  pub fn to_json(&self) -> Result<JsValue> {
+    JsValue::from_serde(&self.0).wasm_result()
   }
 }
 

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -119,7 +119,7 @@ impl WasmDocument {
     self.0.remove_method(did.0).wasm_result()
   }
 
-  /// Returns the first `VerificationMethod` with a capability invocation relationship
+  /// Returns a copy of the first `VerificationMethod` with a capability invocation relationship
   /// capable of signing this DID document.
   ///
   /// Throws an error if no signing method is present.
@@ -133,22 +133,24 @@ impl WasmDocument {
       .wasm_result()
   }
 
-  /// Returns the first `VerificationMethod` with an `id` property
+  /// Returns a copy of the first `VerificationMethod` with an `id` property
   /// matching the provided `query`.
   ///
   /// Throws an error if the method is not found.
   #[wasm_bindgen(js_name = resolveMethod)]
-  pub fn resolve_method(&mut self, query: &str) -> Result<WasmVerificationMethod> {
+  pub fn resolve_method(&self, query: &UWasmMethodQuery) -> Result<WasmVerificationMethod> {
+    let method_query: String = query.into_serde().wasm_result()?;
     Ok(WasmVerificationMethod(
-      self.0.try_resolve_method(query).wasm_result()?.clone(),
+      self.0.try_resolve_method(&method_query).wasm_result()?.clone(),
     ))
   }
 
   #[wasm_bindgen(js_name = revokeMerkleKey)]
-  pub fn revoke_merkle_key(&mut self, query: &str, index: usize) -> Result<bool> {
+  pub fn revoke_merkle_key(&mut self, query: &UWasmMethodQuery, index: usize) -> Result<bool> {
+    let method_query: String = query.into_serde().wasm_result()?;
     let method: &mut IotaVerificationMethod = self
       .0
-      .try_resolve_method_mut(query)
+      .try_resolve_method_mut(&method_query)
       .and_then(IotaVerificationMethod::try_from_mut)
       .wasm_result()?;
 
@@ -166,7 +168,8 @@ impl WasmDocument {
   /// NOTE: does not validate whether the private key of the given `key_pair` corresponds to the
   /// verification method. See `Document::verifySelfSigned`.
   #[wasm_bindgen(js_name = signSelf)]
-  pub fn sign_self(&mut self, key_pair: &KeyPair, method_query: String) -> Result<()> {
+  pub fn sign_self(&mut self, key_pair: &KeyPair, method_query: &UWasmMethodQuery) -> Result<()> {
+    let method_query: String = method_query.into_serde().wasm_result()?;
     self.0.sign_self(key_pair.0.private(), &method_query).wasm_result()
   }
 
@@ -315,14 +318,21 @@ impl WasmDocument {
   /// Generate a `DiffMessage` between two DID Documents and sign it using the specified
   /// `key` and `method`.
   #[wasm_bindgen]
-  pub fn diff(&self, other: &WasmDocument, message_id: &str, key: &KeyPair, method: &str) -> Result<WasmDiffMessage> {
+  pub fn diff(
+    &self,
+    other: &WasmDocument,
+    message_id: &str,
+    key: &KeyPair,
+    method_query: &UWasmMethodQuery,
+  ) -> Result<WasmDiffMessage> {
+    let method_query: String = method_query.into_serde().wasm_result()?;
     self
       .0
       .diff(
         &other.0,
         MessageId::from_str(message_id).wasm_result()?,
         key.0.private(),
-        method,
+        &method_query,
       )
       .map(WasmDiffMessage::from)
       .wasm_result()
@@ -453,3 +463,15 @@ impl From<IotaDocument> for WasmDocument {
     Self(document)
   }
 }
+
+/// Duck-typed union to pass either a string or WasmDIDUrl as a parameter.
+#[wasm_bindgen]
+extern "C" {
+  #[wasm_bindgen(typescript_type = "UMethodQuery")]
+  pub type UWasmMethodQuery;
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const U_METHOD_QUERY: &'static str = r#"
+export type UMethodQuery = DIDUrl | string;
+"#;

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -467,11 +467,6 @@ impl From<IotaDocument> for WasmDocument {
 /// Duck-typed union to pass either a string or WasmDIDUrl as a parameter.
 #[wasm_bindgen]
 extern "C" {
-  #[wasm_bindgen(typescript_type = "UMethodQuery")]
+  #[wasm_bindgen(typescript_type = "DIDUrl | string")]
   pub type UWasmMethodQuery;
 }
-
-#[wasm_bindgen(typescript_custom_section)]
-const U_METHOD_QUERY: &'static str = r#"
-export type UMethodQuery = DIDUrl | string;
-"#;

--- a/bindings/wasm/src/did/wasm_verification_method.rs
+++ b/bindings/wasm/src/did/wasm_verification_method.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use identity::crypto::merkle_key::Blake2b256;
@@ -22,8 +22,8 @@ pub struct WasmVerificationMethod(pub(crate) IotaVerificationMethod);
 impl WasmVerificationMethod {
   /// Creates a new `VerificationMethod` object from the given `key`.
   #[wasm_bindgen(constructor)]
-  pub fn new(key: &KeyPair, fragment: String) -> Result<WasmVerificationMethod, JsValue> {
-    IotaVerificationMethod::from_keypair(&key.0, &fragment)
+  pub fn new(key: &KeyPair, fragment: &str) -> Result<WasmVerificationMethod, JsValue> {
+    IotaVerificationMethod::from_keypair(&key.0, fragment)
       .map_err(wasm_error)
       .map(Self)
   }

--- a/bindings/wasm/src/error.rs
+++ b/bindings/wasm/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use std::borrow::Cow;
@@ -21,7 +21,7 @@ where
 }
 
 /// Convenience trait to simplify `result.map_err(wasm_error)` to `result.wasm_result()`
-pub(crate) trait WasmResult<T> {
+pub trait WasmResult<T> {
   fn wasm_result(self) -> Result<T>;
 }
 

--- a/bindings/wasm/src/tangle/client.rs
+++ b/bindings/wasm/src/tangle/client.rs
@@ -173,7 +173,7 @@ impl Client {
 
   /// Fetch the DID document specified by the given `DID`.
   #[wasm_bindgen]
-  pub fn resolve(&self, did: UWasmDID) -> Result<PromiseResolvedDocument> {
+  pub fn resolve(&self, did: &UWasmDID) -> Result<PromiseResolvedDocument> {
     let client: Rc<IotaClient> = self.client.clone();
     let did: IotaDID = did.into_serde().wasm_result()?;
 
@@ -192,7 +192,7 @@ impl Client {
 
   /// Returns the message history of the given DID.
   #[wasm_bindgen(js_name = resolveHistory)]
-  pub fn resolve_history(&self, did: UWasmDID) -> Result<PromiseDocumentHistory> {
+  pub fn resolve_history(&self, did: &UWasmDID) -> Result<PromiseDocumentHistory> {
     let did: IotaDID = did.into_serde().wasm_result()?;
     let client: Rc<IotaClient> = self.client.clone();
 

--- a/bindings/wasm/src/tangle/client.rs
+++ b/bindings/wasm/src/tangle/client.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use core::str::FromStr;
@@ -26,6 +26,7 @@ use crate::chain::PromiseDiffChainHistory;
 use crate::chain::PromiseDocumentHistory;
 use crate::chain::WasmDocumentHistory;
 use crate::did::PromiseResolvedDocument;
+use crate::did::UWasmDID;
 use crate::did::WasmDiffMessage;
 use crate::did::WasmDocument;
 use crate::did::WasmResolvedDocument;
@@ -172,9 +173,9 @@ impl Client {
 
   /// Fetch the DID document specified by the given `DID`.
   #[wasm_bindgen]
-  pub fn resolve(&self, did: &str) -> Result<PromiseResolvedDocument> {
+  pub fn resolve(&self, did: UWasmDID) -> Result<PromiseResolvedDocument> {
     let client: Rc<IotaClient> = self.client.clone();
-    let did: IotaDID = did.parse().wasm_result()?;
+    let did: IotaDID = did.into_serde().wasm_result()?;
 
     let promise: Promise = future_to_promise(async move {
       client
@@ -191,8 +192,8 @@ impl Client {
 
   /// Returns the message history of the given DID.
   #[wasm_bindgen(js_name = resolveHistory)]
-  pub fn resolve_history(&self, did: &str) -> Result<PromiseDocumentHistory> {
-    let did: IotaDID = did.parse().wasm_result()?;
+  pub fn resolve_history(&self, did: UWasmDID) -> Result<PromiseDocumentHistory> {
+    let did: IotaDID = did.into_serde().wasm_result()?;
     let client: Rc<IotaClient> = self.client.clone();
 
     let promise: Promise = future_to_promise(async move {

--- a/bindings/wasm/src/tangle/network.rs
+++ b/bindings/wasm/src/tangle/network.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use identity::iota::Network;
@@ -27,6 +27,11 @@ impl WasmNetwork {
   #[wasm_bindgen]
   pub fn devnet() -> WasmNetwork {
     Self(Network::Devnet)
+  }
+
+  #[wasm_bindgen(getter)]
+  pub fn name(&self) -> String {
+    self.0.name_str().to_owned()
   }
 
   /// Returns the node URL of the Tangle network.

--- a/bindings/wasm/tests/wasm.rs
+++ b/bindings/wasm/tests/wasm.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 
 use identity::iota::IotaDID;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 use identity_wasm::crypto::Digest;
@@ -14,6 +15,8 @@ use identity_wasm::crypto::KeyType;
 use identity_wasm::did::WasmDID;
 use identity_wasm::did::WasmDIDUrl;
 use identity_wasm::did::WasmDocument;
+use identity_wasm::did::WasmMethodScope;
+use identity_wasm::did::WasmVerificationMethod;
 use identity_wasm::error::WasmError;
 
 #[wasm_bindgen_test]
@@ -120,13 +123,104 @@ fn test_did_url() {
 #[wasm_bindgen_test]
 fn test_document_new() {
   let keypair: KeyPair = KeyPair::new(KeyType::Ed25519).unwrap();
-  let mut document: WasmDocument = WasmDocument::new(&keypair, None, None).unwrap();
+  let document: WasmDocument = WasmDocument::new(&keypair, None, None).unwrap();
+  assert_eq!(document.id().network_name(), "main");
+  assert!(document.default_signing_method().is_ok());
+}
 
+#[wasm_bindgen_test]
+fn test_document_sign_self() {
+  let keypair: KeyPair = KeyPair::new(KeyType::Ed25519).unwrap();
+
+  // Sign with DIDUrl method query.
+  {
+    let mut document: WasmDocument = WasmDocument::new(&keypair, None, None).unwrap();
+    document
+      .sign_self(
+        &keypair,
+        &JsValue::from(document.default_signing_method().unwrap().id()).unchecked_into(),
+      )
+      .unwrap();
+    assert!(WasmDocument::verify_document(&document, &document).is_ok());
+  }
+
+  // Sign with string method query.
+  {
+    let mut document: WasmDocument = WasmDocument::new(&keypair, None, None).unwrap();
+    document
+      .sign_self(
+        &keypair,
+        &JsValue::from_str(&document.default_signing_method().unwrap().id().to_string()).unchecked_into(),
+      )
+      .unwrap();
+    assert!(WasmDocument::verify_document(&document, &document).is_ok());
+  }
+}
+
+#[wasm_bindgen_test]
+fn test_document_resolve_method() {
+  let keypair: KeyPair = KeyPair::new(KeyType::Ed25519).unwrap();
+  let mut document: WasmDocument = WasmDocument::new(&keypair, None, None).unwrap();
+  let default_method: WasmVerificationMethod = document.default_signing_method().unwrap();
+  let new_method: WasmVerificationMethod =
+    WasmVerificationMethod::new(&KeyPair::new(KeyType::Ed25519).unwrap(), "new-key").unwrap();
   document
-    .sign_self(&keypair, document.default_signing_method().unwrap().id().to_string())
+    .insert_method(&new_method, WasmMethodScope::authentication())
     .unwrap();
 
-  assert!(WasmDocument::verify_document(&document, &document).is_ok());
+  // Resolve with DIDUrl method query.
+  assert_eq!(
+    document
+      .resolve_method(&JsValue::from(default_method.id()).unchecked_into())
+      .unwrap()
+      .id()
+      .to_string(),
+    default_method.id().to_string()
+  );
+  assert_eq!(
+    document
+      .resolve_method(&JsValue::from(new_method.id()).unchecked_into())
+      .unwrap()
+      .id()
+      .to_string(),
+    new_method.id().to_string()
+  );
+
+  // Resolve with string method query.
+  assert_eq!(
+    document
+      .resolve_method(&JsValue::from_str(&default_method.id().to_string()).unchecked_into())
+      .unwrap()
+      .id()
+      .to_string(),
+    default_method.id().to_string()
+  );
+  assert_eq!(
+    document
+      .resolve_method(&JsValue::from_str(&new_method.id().to_string()).unchecked_into())
+      .unwrap()
+      .id()
+      .to_string(),
+    new_method.id().to_string()
+  );
+
+  // Resolve with string fragment method query.
+  assert_eq!(
+    document
+      .resolve_method(&JsValue::from_str(&default_method.id().fragment().unwrap()).unchecked_into())
+      .unwrap()
+      .id()
+      .to_string(),
+    default_method.id().to_string()
+  );
+  assert_eq!(
+    document
+      .resolve_method(&JsValue::from_str(&new_method.id().fragment().unwrap()).unchecked_into())
+      .unwrap()
+      .id()
+      .to_string(),
+    new_method.id().to_string()
+  );
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
# Description of change

This adds the `UMethodQuery` and `UDID` (naming convention open to change) Typescript union types. This pattern allows us to create analogues for generic types in function parameters, such as `MethodQuery` which takes either an `IotaDIDUrl` or `String`. This is to enhance the developer-friendliness of our Wasm API by removing unnecessary `toString` invocations and allowing pseudo-generic, polymorphic function parameters.

~~`export type UMethodQuery = DIDUrl | string;`~~
~~`export type UDID = DID | string;`~~

Edit: this PR no longer exports the union types to Typescript, instead it injects the union into the function parameter definitions directly.

E.g.
```ts
signSelf(key_pair: KeyPair, method_query: DIDUrl | string): void;
```

With this change, all of the following work:
```ts
doc.signSelf("did:iota:example#sign-0");                // CURRENT
doc.signSelf(doc.defaultSigningMethod().id.toString()); // CURRENT
doc.signSelf(doc.defaultSigningMethod().id);            // NEW

doc.resolveMethod("did:iota:example#sign-0");                // CURRENT
doc.resolveMethod(doc.defaultSigningMethod().id.toString()); // CURRENT
doc.resolveMethod(doc.defaultSigningMethod().id);            // NEW

let resolved = await client.resolve("did:iota:example"); // CURRENT
let resolved = await client.resolve(doc.id.toString());  // CURRENT
let resolved = await client.resolve(doc.id);             // NEW

let history = await client.resolveHistory("did:iota:example"); // CURRENT
let history = await client.resolveHistory(doc.id.toString());  // CURRENT
let history = await client.resolveHistory(doc.id);             // NEW
```

The alternative for `Client::resolve` and `Client::resolveHistory` would be to enforce taking in a `WasmDID` only, but error handling is more unwieldy than in Rust and users may extract DIDs as strings from JSON objects like credentials. The proposed pattern would still be useful for `UMethodQuery` which matches the behaviour in Rust. Note this is only possible when all types in the union serialise to the same representation, since we use `serde` to handle the conversion. Different union types are possible but would require an intermediary untagged enum to handle deserialisation with this method.

### Added

- `UDID` union type to take either `DID` or a `string` as a parameter.
- `UMethodQuery` union type to take either `DIDUrl` or a `string` as a parameter.
- `WasmNetwork::name` getter.

### Changed

- `Document::resolveMethod` parameter changed from `string` to `UMethodQuery`.
- `Document::revokeMerkleKey` parameter changed from `string` to `UMethodQuery`.
- `Document::signSelf` parameter changed from `string` to `UMethodQuery`.
- `Document::diff` parameter changed from `string` to `UMethodQuery`.
- `Client::resolve` parameter changed from `string` to `UDID`.
- `Client::resolveHistory` parameter changed from `string` to `UDID`.
- `WasmDID::network` is no longer a getter, just a regular function.
- `WasmDID` JSON representation changed to match `IotaDID`.
- `WasmDIDUrl` JSON representation changed to match `IotaDID`.

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Wasm tests and examples pass locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
