### PR TITLE
Support verification methods with the same fragment

### DIFF
--- a/identity-did/src/verification/method_query.rs
+++ b/identity-did/src/verification/method_query.rs
@@ -19,24 +19,52 @@ use crate::did::DID;
 pub struct MethodQuery<'query>(Cow<'query, str>);
 
 impl<'query> MethodQuery<'query> {
-  pub(crate) fn matches(&self, did: &CoreDIDUrl) -> bool {
-    match self.fragment().zip(did.fragment()) {
+  /// Returns whether this query matches the given DIDUrl.
+  pub(crate) fn matches(&self, did_url: &CoreDIDUrl) -> bool {
+    // Ensure the DID matches if included in the query.
+    if let Some(did_str) = self.did_str() {
+      if did_str != did_url.did().as_str() {
+        return false;
+      }
+    }
+
+    // Compare fragments.
+    match self.fragment().zip(did_url.fragment()) {
       Some((a, b)) => a == b,
       None => false,
     }
   }
 
-  fn fragment(&self) -> Option<&str> {
-    let query = self.0.as_ref();
-    if query.starts_with(CoreDID::SCHEME) && !query.ends_with('#') {
-      // Extract the fragment from a full DID-like string
-      query.rfind('#').map(|index| &query[index + 1..])
-    } else if let Some(stripped) = query.strip_prefix('#') {
-      // Remove the leading `#` if it was in the query
-      Some(stripped)
-    } else {
-      Some(query)
+  /// Extract the DID portion of the query if it exists.
+  fn did_str(&self) -> Option<&str> {
+    let query: &str = self.0.as_ref();
+    if !query.starts_with(CoreDID::SCHEME) {
+      return None;
     }
+
+    // Find end of DID section.
+    // did:example:123/path?service=agent&relativeRef=/credentials#degree
+    let mut end_pos: usize = query.len();
+    end_pos = end_pos.min(query.find('?').unwrap_or(end_pos));
+    end_pos = end_pos.min(query.find('/').unwrap_or(end_pos));
+    end_pos = end_pos.min(query.find('#').unwrap_or(end_pos));
+    query.get(0..end_pos)
+  }
+
+  /// Extract the query fragment if it exists.
+  fn fragment(&self) -> Option<&str> {
+    let query: &str = self.0.as_ref();
+    let fragment_maybe: Option<&str> = if query.starts_with(CoreDID::SCHEME) {
+      // Extract the fragment from a full DID-Url-like string.
+      query.rfind('#').and_then(|index| query.get(index + 1..))
+    } else if let Some(fragment_delimiter_index) = query.rfind('#') {
+      // Extract the fragment from a relative DID-Url.
+      query.get(fragment_delimiter_index + 1..)
+    } else {
+      // Assume the entire string is a fragment.
+      Some(query)
+    };
+    fragment_maybe.filter(|fragment| !fragment.is_empty())
   }
 }
 
@@ -80,5 +108,118 @@ impl<'query> From<&'query RelativeDIDUrl> for MethodQuery<'query> {
 impl<'query> From<&'query Signature> for MethodQuery<'query> {
   fn from(other: &'query Signature) -> Self {
     Self(Cow::Borrowed(other.verification_method()))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::ops::Not;
+
+  use super::*;
+
+  #[test]
+  fn test_did_str() {
+    assert!(MethodQuery::from("").did_str().is_none());
+    assert!(MethodQuery::from("fragment").did_str().is_none());
+    assert!(MethodQuery::from("#fragment").did_str().is_none());
+    assert!(MethodQuery::from("?query").did_str().is_none());
+    assert!(MethodQuery::from("/path").did_str().is_none());
+    assert!(MethodQuery::from("/path?query#fragment").did_str().is_none());
+    assert!(MethodQuery::from("method:missingscheme123").did_str().is_none());
+    assert!(MethodQuery::from("iota:example").did_str().is_none());
+    assert_eq!(
+      MethodQuery::from("did:iota:example").did_str(),
+      Some("did:iota:example")
+    );
+    assert_eq!(
+      MethodQuery::from("did:iota:example#fragment").did_str(),
+      Some("did:iota:example")
+    );
+    assert_eq!(
+      MethodQuery::from("did:iota:example?query").did_str(),
+      Some("did:iota:example")
+    );
+    assert_eq!(
+      MethodQuery::from("did:iota:example/path").did_str(),
+      Some("did:iota:example")
+    );
+    assert_eq!(
+      MethodQuery::from("did:iota:example/path?query#fragment").did_str(),
+      Some("did:iota:example")
+    );
+    assert_eq!(
+      MethodQuery::from("did:iota:example/path?query&relativeRef=/#fragment").did_str(),
+      Some("did:iota:example")
+    );
+  }
+
+  #[test]
+  fn test_fragment() {
+    assert!(MethodQuery::from("").fragment().is_none());
+    assert_eq!(MethodQuery::from("fragment").fragment(), Some("fragment"));
+    assert_eq!(MethodQuery::from("#fragment").fragment(), Some("fragment"));
+    assert_eq!(MethodQuery::from("/path?query#fragment").fragment(), Some("fragment"));
+    assert!(MethodQuery::from("did:iota:example").fragment().is_none());
+    assert_eq!(
+      MethodQuery::from("did:iota:example#fragment").fragment(),
+      Some("fragment")
+    );
+    assert!(MethodQuery::from("did:iota:example?query").fragment().is_none());
+    assert!(MethodQuery::from("did:iota:example/path").fragment().is_none());
+    assert_eq!(
+      MethodQuery::from("did:iota:example/path?query#fragment").fragment(),
+      Some("fragment")
+    );
+    assert_eq!(
+      MethodQuery::from("did:iota:example/path?query&relativeRef=/#fragment").fragment(),
+      Some("fragment")
+    );
+  }
+
+  #[test]
+  fn test_matches() {
+    let did_base: CoreDIDUrl = CoreDIDUrl::parse("did:iota:example").unwrap();
+    let did_path: CoreDIDUrl = CoreDIDUrl::parse("did:iota:example/path").unwrap();
+    let did_query: CoreDIDUrl = CoreDIDUrl::parse("did:iota:example?query").unwrap();
+    let did_fragment: CoreDIDUrl = CoreDIDUrl::parse("did:iota:example#fragment").unwrap();
+    let did_url: CoreDIDUrl = CoreDIDUrl::parse("did:iota:example/path?query#fragment").unwrap();
+    let did_url_complex: CoreDIDUrl = CoreDIDUrl::parse("did:iota:example/path?query&relativeRef=/#fragment").unwrap();
+
+    // Invalid: empty query should not match anything.
+    let empty_query: MethodQuery = MethodQuery::from("");
+    assert!(empty_query.matches(&did_base).not());
+    assert!(empty_query.matches(&did_path).not());
+    assert!(empty_query.matches(&did_query).not());
+    assert!(empty_query.matches(&did_fragment).not());
+    assert!(empty_query.matches(&did_url).not());
+    assert!(empty_query.matches(&did_url_complex).not());
+
+    // Invalid: query with DID and no fragment should not match anything.
+    let empty_query: MethodQuery = MethodQuery::from("");
+    assert!(empty_query.matches(&did_base).not());
+    assert!(empty_query.matches(&did_path).not());
+    assert!(empty_query.matches(&did_query).not());
+    assert!(empty_query.matches(&did_fragment).not());
+    assert!(empty_query.matches(&did_url).not());
+    assert!(empty_query.matches(&did_url_complex).not());
+
+    assert_eq!(MethodQuery::from("fragment").fragment(), Some("fragment"));
+    assert_eq!(MethodQuery::from("#fragment").fragment(), Some("fragment"));
+    assert_eq!(MethodQuery::from("/path?query#fragment").fragment(), Some("fragment"));
+    assert!(MethodQuery::from("did:iota:example").fragment().is_none());
+    assert_eq!(
+      MethodQuery::from("did:iota:example#fragment").fragment(),
+      Some("fragment")
+    );
+    assert!(MethodQuery::from("did:iota:example?query").fragment().is_none());
+    assert!(MethodQuery::from("did:iota:example/path").fragment().is_none());
+    assert_eq!(
+      MethodQuery::from("did:iota:example/path?query#fragment").fragment(),
+      Some("fragment")
+    );
+    assert_eq!(
+      MethodQuery::from("did:iota:example/path?query&relativeRef=/#fragment").fragment(),
+      Some("fragment")
+    );
   }
 }

--- a/identity-did/src/verification/method_query.rs
+++ b/identity-did/src/verification/method_query.rs
@@ -182,44 +182,116 @@ mod tests {
     let did_path: CoreDIDUrl = CoreDIDUrl::parse("did:iota:example/path").unwrap();
     let did_query: CoreDIDUrl = CoreDIDUrl::parse("did:iota:example?query").unwrap();
     let did_fragment: CoreDIDUrl = CoreDIDUrl::parse("did:iota:example#fragment").unwrap();
+    let did_different_fragment: CoreDIDUrl = CoreDIDUrl::parse("did:iota:example#differentfragment").unwrap();
     let did_url: CoreDIDUrl = CoreDIDUrl::parse("did:iota:example/path?query#fragment").unwrap();
     let did_url_complex: CoreDIDUrl = CoreDIDUrl::parse("did:iota:example/path?query&relativeRef=/#fragment").unwrap();
 
-    // Invalid: empty query should not match anything.
-    let empty_query: MethodQuery = MethodQuery::from("");
-    assert!(empty_query.matches(&did_base).not());
-    assert!(empty_query.matches(&did_path).not());
-    assert!(empty_query.matches(&did_query).not());
-    assert!(empty_query.matches(&did_fragment).not());
-    assert!(empty_query.matches(&did_url).not());
-    assert!(empty_query.matches(&did_url_complex).not());
+    // INVALID: empty query should not match anything.
+    {
+      let query_empty = MethodQuery::from("");
+      assert!(query_empty.matches(&did_base).not());
+      assert!(query_empty.matches(&did_path).not());
+      assert!(query_empty.matches(&did_query).not());
+      assert!(query_empty.matches(&did_fragment).not());
+      assert!(query_empty.matches(&did_different_fragment).not());
+      assert!(query_empty.matches(&did_url).not());
+      assert!(query_empty.matches(&did_url_complex).not());
+    }
 
-    // Invalid: query with DID and no fragment should not match anything.
-    let empty_query: MethodQuery = MethodQuery::from("");
-    assert!(empty_query.matches(&did_base).not());
-    assert!(empty_query.matches(&did_path).not());
-    assert!(empty_query.matches(&did_query).not());
-    assert!(empty_query.matches(&did_fragment).not());
-    assert!(empty_query.matches(&did_url).not());
-    assert!(empty_query.matches(&did_url_complex).not());
+    // VALID: query with only a fragment should match the same fragment.
+    {
+      let query_fragment_only = MethodQuery::from("fragment");
+      assert!(query_fragment_only.matches(&did_base).not());
+      assert!(query_fragment_only.matches(&did_path).not());
+      assert!(query_fragment_only.matches(&did_query).not());
+      assert!(query_fragment_only.matches(&did_fragment));
+      assert!(query_fragment_only.matches(&did_different_fragment).not());
+      assert!(query_fragment_only.matches(&did_url));
+      assert!(query_fragment_only.matches(&did_url_complex));
+    }
 
-    assert_eq!(MethodQuery::from("fragment").fragment(), Some("fragment"));
-    assert_eq!(MethodQuery::from("#fragment").fragment(), Some("fragment"));
-    assert_eq!(MethodQuery::from("/path?query#fragment").fragment(), Some("fragment"));
-    assert!(MethodQuery::from("did:iota:example").fragment().is_none());
-    assert_eq!(
-      MethodQuery::from("did:iota:example#fragment").fragment(),
-      Some("fragment")
-    );
-    assert!(MethodQuery::from("did:iota:example?query").fragment().is_none());
-    assert!(MethodQuery::from("did:iota:example/path").fragment().is_none());
-    assert_eq!(
-      MethodQuery::from("did:iota:example/path?query#fragment").fragment(),
-      Some("fragment")
-    );
-    assert_eq!(
-      MethodQuery::from("did:iota:example/path?query&relativeRef=/#fragment").fragment(),
-      Some("fragment")
-    );
+    // VALID: query with differentfragment should only match the same fragment.
+    {
+      let query_different_fragment = MethodQuery::from("differentfragment");
+      assert!(query_different_fragment.matches(&did_base).not());
+      assert!(query_different_fragment.matches(&did_path).not());
+      assert!(query_different_fragment.matches(&did_query).not());
+      assert!(query_different_fragment.matches(&did_fragment).not());
+      assert!(query_different_fragment.matches(&did_different_fragment));
+      assert!(query_different_fragment.matches(&did_url).not());
+      assert!(query_different_fragment.matches(&did_url_complex).not());
+    }
+
+    // VALID: query with a #fragment should match the same fragment.
+    {
+      let query_fragment_delimiter = MethodQuery::from("#fragment");
+      assert!(query_fragment_delimiter.matches(&did_base).not());
+      assert!(query_fragment_delimiter.matches(&did_path).not());
+      assert!(query_fragment_delimiter.matches(&did_query).not());
+      assert!(query_fragment_delimiter.matches(&did_fragment));
+      assert!(query_fragment_delimiter.matches(&did_different_fragment).not());
+      assert!(query_fragment_delimiter.matches(&did_url));
+      assert!(query_fragment_delimiter.matches(&did_url_complex));
+    }
+
+    // VALID: query with a relative DID Url should match the same fragment.
+    {
+      let query_relative_did_url = MethodQuery::from("/path?query#fragment");
+      assert!(query_relative_did_url.matches(&did_base).not());
+      assert!(query_relative_did_url.matches(&did_path).not());
+      assert!(query_relative_did_url.matches(&did_query).not());
+      assert!(query_relative_did_url.matches(&did_fragment));
+      assert!(query_relative_did_url.matches(&did_different_fragment).not());
+      assert!(query_relative_did_url.matches(&did_url));
+      assert!(query_relative_did_url.matches(&did_url_complex));
+    }
+
+    // INVALID: query with DID and no fragment should not match anything.
+    {
+      let query_did = MethodQuery::from("did:iota:example");
+      assert!(query_did.matches(&did_base).not());
+      assert!(query_did.matches(&did_path).not());
+      assert!(query_did.matches(&did_query).not());
+      assert!(query_did.matches(&did_fragment).not());
+      assert!(query_did.matches(&did_different_fragment).not());
+      assert!(query_did.matches(&did_url).not());
+      assert!(query_did.matches(&did_url_complex).not());
+    }
+
+    // VALID: query with a DID fragment should match the same fragment.
+    {
+      let query_did_fragment = MethodQuery::from("did:iota:example#fragment");
+      assert!(query_did_fragment.matches(&did_base).not());
+      assert!(query_did_fragment.matches(&did_path).not());
+      assert!(query_did_fragment.matches(&did_query).not());
+      assert!(query_did_fragment.matches(&did_fragment));
+      assert!(query_did_fragment.matches(&did_different_fragment).not());
+      assert!(query_did_fragment.matches(&did_url));
+      assert!(query_did_fragment.matches(&did_url_complex));
+    }
+
+    // VALID: query with a DID Url with a fragment should match the same fragment.
+    {
+      let query_did_fragment = MethodQuery::from("did:iota:example/path?query#fragment");
+      assert!(query_did_fragment.matches(&did_base).not());
+      assert!(query_did_fragment.matches(&did_path).not());
+      assert!(query_did_fragment.matches(&did_query).not());
+      assert!(query_did_fragment.matches(&did_fragment));
+      assert!(query_did_fragment.matches(&did_different_fragment).not());
+      assert!(query_did_fragment.matches(&did_url));
+      assert!(query_did_fragment.matches(&did_url_complex));
+    }
+
+    // VALID: query with a complex DID Url with a fragment should match the same fragment.
+    {
+      let query_did_fragment = MethodQuery::from("did:iota:example/path?query&relativeRef=/#fragment");
+      assert!(query_did_fragment.matches(&did_base).not());
+      assert!(query_did_fragment.matches(&did_path).not());
+      assert!(query_did_fragment.matches(&did_query).not());
+      assert!(query_did_fragment.matches(&did_fragment));
+      assert!(query_did_fragment.matches(&did_different_fragment).not());
+      assert!(query_did_fragment.matches(&did_url));
+      assert!(query_did_fragment.matches(&did_url_complex));
+    }
   }
 }


### PR DESCRIPTION
# Description of change
This updates `MethodQuery` to match on the DID as well as the fragment when the query includes a full DID-Url.

This fixes the following edge-cases:
- adding a method to a document with an ID field of a different DID (typically a controller DID Document) but the same fragment as an existing method.
- resolving such a method by specifying its full ID (previously would return the first method that matched the fragment).
- verifying a document signed with such a method.

The specification seems to allow adding methods and services to a DID Document which reference a different DID. We added support for signatures from such methods in #458 but duplicate fragments was still an edge-case.

NOTE: this affects all functions that resolve methods (including verifying signatures since that resolves the method used to sign) since it affects the core behaviour of `OrderedSet`.

### Example

The following document has a signing method from a controller DID document (this is a workaround since we do not support signatures from controllers simply referenced as the controller of the DID Document). The signature was created by the private key corresponding to the controller method.

Note how both methods have the same `#sign-0` fragment. This is not advised but should still be legal according to the specification. 

Before this PR the document would fail verification since the library would incorrectly resolve `did:iota:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1M#sign-0` as the signing method instead of `did:iota:A73GoJ7N6qHEdSfoist6YR4MCDteuhiinUmaMV9vSUcZ#sign-0` despite the full ID being specified in `"verificationMethod"`.

```json
{
  "doc": {
    "id": "did:iota:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1M",
    "capabilityInvocation": [
      {
        "id": "did:iota:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1M#sign-0",
        "controller": "did:iota:HGE4tecHWL2YiZv5qAGtH7gaeQcaz2Z1CR15GWmMjY1M",
        "type": "Ed25519VerificationKey2018",
        "publicKeyMultibase": "zFJsXMk9UqpJf3ZTKnfEQAhvBrVLKMSx9ZeYwQME6c6tT"
      },
      {
        "id": "did:iota:A73GoJ7N6qHEdSfoist6YR4MCDteuhiinUmaMV9vSUcZ#sign-0",
        "controller": "did:iota:A73GoJ7N6qHEdSfoist6YR4MCDteuhiinUmaMV9vSUcZ",
        "type": "Ed25519VerificationKey2018",
        "publicKeyMultibase": "zEh7rBAVQAFEXXK63Aiku4eqgWJhw5z1VYiVA9tmbveJP"
      }
    ]
  },
  "meta": {
    "created": "2022-01-25T14:11:46Z",
    "updated": "2022-01-25T14:11:46Z",
    "proof": {
      "type": "JcsEd25519Signature2020",
      "verificationMethod": "did:iota:A73GoJ7N6qHEdSfoist6YR4MCDteuhiinUmaMV9vSUcZ#sign-0",
      "signatureValue": "5njR8zSD1setBb135o2SNZ6Zjc58s8xot9nRt5MF2kX9JZXQUxWNxoudJisawG74cXKibSSQdxN11PcsiW5ujqYw"
    }
  }
}
```

## Links to any relevant issues
Fixes issue #457.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tests and Wasm examples pass locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
