### PR TITLE
Change `also_known_as` type to `OrderedSet`

### DIFF
--- a/identity-did/src/diff/diff_document.rs
+++ b/identity-did/src/diff/diff_document.rs
@@ -137,11 +137,11 @@ where
       .transpose()?
       .or_else(|| self.controller().cloned());
 
-    let also_known_as: Vec<Url> = diff
+    let also_known_as: OrderedSet<Url> = diff
       .also_known_as
-      .map(|value| self.also_known_as().to_vec().merge(value))
+      .map(|value| self.also_known_as().merge(value))
       .transpose()?
-      .unwrap_or_else(|| self.also_known_as().to_vec());
+      .unwrap_or_else(|| self.also_known_as().clone());
 
     let verification_method: OrderedSet<VerificationMethod<U>> = diff
       .verification_method
@@ -222,7 +222,7 @@ where
       .transpose()?
       .ok_or_else(|| Error::convert("Missing field `document.controller`"))?;
 
-    let also_known_as: Vec<Url> = diff
+    let also_known_as: OrderedSet<Url> = diff
       .also_known_as
       .map(Diff::from_diff)
       .transpose()?
@@ -406,7 +406,7 @@ mod test {
   fn test_also_known_as() {
     let doc = document();
     let mut new = doc.clone();
-    new.also_known_as_mut().push("diff:diff:1234".parse().unwrap());
+    new.also_known_as_mut().append("diff:diff:1234".parse().unwrap());
     assert_ne!(doc, new);
     let diff = doc.diff(&new).unwrap();
     let merge = doc.merge(diff).unwrap();

--- a/identity-did/src/document/core_document.rs
+++ b/identity-did/src/document/core_document.rs
@@ -59,8 +59,8 @@ pub struct CoreDocument<T = Object, U = Object, V = Object> {
   pub(crate) id: CoreDID,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub(crate) controller: Option<CoreDID>,
-  #[serde(default = "Default::default", rename = "alsoKnownAs", skip_serializing_if = "Vec::is_empty")]
-  pub(crate) also_known_as: Vec<Url>,
+  #[serde(default = "Default::default", rename = "alsoKnownAs", skip_serializing_if = "OrderedSet::is_empty")]
+  pub(crate) also_known_as: OrderedSet<Url>,
   #[serde(default = "Default::default", rename = "verificationMethod", skip_serializing_if = "OrderedSet::is_empty")]
   pub(crate) verification_method: OrderedSet<VerificationMethod<U>>,
   #[serde(default = "Default::default", skip_serializing_if = "OrderedSet::is_empty")]
@@ -92,7 +92,7 @@ impl<T, U, V> CoreDocument<T, U, V> {
     Ok(Self {
       id: builder.id.ok_or(Error::BuilderInvalidDocumentId)?,
       controller: builder.controller,
-      also_known_as: builder.also_known_as,
+      also_known_as: builder.also_known_as.try_into()?,
       verification_method: builder.verification_method.try_into()?,
       authentication: builder.authentication.try_into()?,
       assertion_method: builder.assertion_method.try_into()?,
@@ -125,12 +125,12 @@ impl<T, U, V> CoreDocument<T, U, V> {
   }
 
   /// Returns a reference to the `CoreDocument` alsoKnownAs set.
-  pub fn also_known_as(&self) -> &[Url] {
+  pub fn also_known_as(&self) -> &OrderedSet<Url> {
     &self.also_known_as
   }
 
   /// Returns a mutable reference to the `CoreDocument` alsoKnownAs set.
-  pub fn also_known_as_mut(&mut self) -> &mut Vec<Url> {
+  pub fn also_known_as_mut(&mut self) -> &mut OrderedSet<Url> {
     &mut self.also_known_as
   }
 

--- a/identity-iota/src/document/iota_document.rs
+++ b/identity-iota/src/document/iota_document.rs
@@ -256,15 +256,20 @@ impl IotaDocument {
     unsafe { IotaDID::new_unchecked_ref(self.document.id()) }
   }
 
-  /// Returns a reference to the `IotaDocument` controller.
+  /// Returns a reference to the [`IotaDocument`] controller.
   pub fn controller(&self) -> Option<&IotaDID> {
     // SAFETY: Validity of controller checked in DID Document constructors.
     unsafe { self.document.controller().map(|did| IotaDID::new_unchecked_ref(did)) }
   }
 
-  /// Returns a reference to the [`CoreDocument`] alsoKnownAs set.
-  pub fn also_known_as(&self) -> &[Url] {
+  /// Returns a reference to the [`IotaDocument`] alsoKnownAs set.
+  pub fn also_known_as(&self) -> &OrderedSet<Url> {
     self.document.also_known_as()
+  }
+
+  /// Returns a mutable reference to the [`IotaDocument`] alsoKnownAs set.
+  pub fn also_known_as_mut(&mut self) -> &mut OrderedSet<Url> {
+    self.document.also_known_as_mut()
   }
 
   /// Returns the first [`IotaVerificationMethod`] with a capability invocation relationship


### PR DESCRIPTION
# Description of change
Changes the `CoreDocument::also_known_as` field from `Vec<Url>` to `OrderedSet<Url>` to comply with the DID specification: https://www.w3.org/TR/did-core/#also-known-as 

> The alsoKnownAs property is OPTIONAL. If present, the value MUST be a [set](https://infra.spec.whatwg.org/#ordered-set) where each item in the set is a [URI](https://www.w3.org/TR/did-core/#dfn-uri) conforming to [[RFC3986]](https://www.w3.org/TR/did-core/#bib-rfc3986).

where "set" is defined to be an `OrderedSet`: https://infra.spec.whatwg.org/#ordered-set .

Besides the API changes, this may break DID Documents which have duplicate entries in their `alsoKnownAs` section.
This also adds `IotaDocument::also_known_as_mut()` since previously there was no safe way to update the field from `IotaDocument` without going through the unsafe `core_document_mut`.

### Changed

- Change `CoreDocument::also_known_as` field from `Vec<Url>` to `OrderedSet<Url>`.
- Change `CoreDocument::also_known_as()` method return from `&[Url]` to `&OrderedSet<Url>`.
- Change `CoreDocument::aslo_known_as_mut()` method return from `&mut Vec<Url>` to `&mut OrderedSet<Url>`.
- Change `IotaDocument::also_known_as()` method return from `&[Url]` to `&OrderedSet<Url>`.

### Added

- Add `IotaDocument::also_known_as_mut()` method.

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Unit tests and examples pass locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
