### PR TITLE
Remove unused `Account` milestone option

### DIFF
--- a/examples/account/config.rs
+++ b/examples/account/config.rs
@@ -40,7 +40,6 @@ async fn main() -> Result<()> {
     .autosave(AutoSave::Every) // save immediately after every action
     .autosave(AutoSave::Batch(10)) // save after every 10 actions
     .autopublish(true) // publish to the tangle automatically on every update
-    .milestone(4) // save a snapshot every 4 actions
     .storage(AccountStorage::Memory) // use the default in-memory storage
     .client_builder(
       // Configure a client for the private network

--- a/identity-account/src/account/builder.rs
+++ b/identity-account/src/account/builder.rs
@@ -83,13 +83,6 @@ impl AccountBuilder {
     self
   }
 
-  /// Save a state snapshot every N actions.
-  #[must_use]
-  pub fn milestone(mut self, value: u32) -> Self {
-    self.config = self.config.milestone(value);
-    self
-  }
-
   /// Set whether the account is in testmode or not.
   /// In testmode, the account skips publishing to the tangle.
   #[cfg(test)]

--- a/identity-account/src/account/config.rs
+++ b/identity-account/src/account/config.rs
@@ -39,11 +39,9 @@ pub(crate) struct AccountConfig {
   pub(crate) autosave: AutoSave,
   pub(crate) autopublish: bool,
   pub(crate) testmode: bool,
-  pub(crate) milestone: u32,
 }
 
 impl AccountConfig {
-  const MILESTONE: u32 = 1;
 
   /// Creates a new default [`Config`].
   pub(crate) fn new() -> Self {
@@ -51,7 +49,6 @@ impl AccountConfig {
       autosave: AutoSave::Every,
       autopublish: true,
       testmode: false,
-      milestone: Self::MILESTONE,
     }
   }
 
@@ -73,12 +70,6 @@ impl AccountConfig {
   /// Default: `true`
   pub(crate) fn autopublish(mut self, value: bool) -> Self {
     self.autopublish = value;
-    self
-  }
-
-  /// Save a state snapshot every N actions.
-  pub(crate) fn milestone(mut self, value: u32) -> Self {
-    self.milestone = value;
     self
   }
 

--- a/identity-account/src/account/config.rs
+++ b/identity-account/src/account/config.rs
@@ -42,7 +42,6 @@ pub(crate) struct AccountConfig {
 }
 
 impl AccountConfig {
-
   /// Creates a new default [`Config`].
   pub(crate) fn new() -> Self {
     Self {


### PR DESCRIPTION
# Description of change
Removes the `milestone` option from `AccountConfig` and `AccountBuilder` as it is unused in the codebase.

It was previously used or intended to control how often the `Account` state is written to storage:
```rust
/// Save a state snapshot every N actions.
pub(crate) fn milestone(mut self, value: u32) -> Self {
  self.milestone = value;
  self
}
```
However, the `Account` does not do so, and simply saves the state on `publish` and `fetch_state`.

## Links to any relevant issues
From this review comment: https://github.com/iotaledger/identity.rs/pull/574#discussion_r800235123

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tests and examples pass, this field was unused.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
