### PR TITLE
Replace Type `Promise<any>` with `Promise<void>`

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -117,29 +117,29 @@ publishing to the Tangle.
 **Kind**: global class  
 
 * [Account](#Account)
-    * [.deleteMethod(options)](#Account+deleteMethod) ⇒ <code>Promise.&lt;undefined&gt;</code>
-    * [.deleteService(options)](#Account+deleteService) ⇒ <code>Promise.&lt;undefined&gt;</code>
-    * [.createService(options)](#Account+createService) ⇒ <code>Promise.&lt;undefined&gt;</code>
+    * [.deleteMethod(options)](#Account+deleteMethod) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.deleteService(options)](#Account+deleteService) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.createService(options)](#Account+createService) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.did()](#Account+did) ⇒ [<code>DID</code>](#DID)
     * [.autopublish()](#Account+autopublish) ⇒ <code>boolean</code>
     * [.autosave()](#Account+autosave) ⇒ [<code>AutoSave</code>](#AutoSave)
     * [.document()](#Account+document) ⇒ [<code>Document</code>](#Document)
     * [.resolveIdentity()](#Account+resolveIdentity) ⇒ [<code>Promise.&lt;ResolvedDocument&gt;</code>](#ResolvedDocument)
-    * [.deleteIdentity()](#Account+deleteIdentity) ⇒ <code>Promise.&lt;undefined&gt;</code>
-    * [.publish(publish_options)](#Account+publish) ⇒ <code>Promise.&lt;undefined&gt;</code>
+    * [.deleteIdentity()](#Account+deleteIdentity) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.publish(publish_options)](#Account+publish) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.createSignedCredential(fragment, credential, signature_options)](#Account+createSignedCredential) ⇒ [<code>Promise.&lt;Credential&gt;</code>](#Credential)
     * [.createSignedDocument(fragment, document, signature_options)](#Account+createSignedDocument) ⇒ [<code>Promise.&lt;Document&gt;</code>](#Document)
     * [.createSignedPresentation(fragment, presentation, signature_options)](#Account+createSignedPresentation) ⇒ [<code>Promise.&lt;Presentation&gt;</code>](#Presentation)
-    * [.createSignedData(fragment, data, signature_options)](#Account+createSignedData) ⇒ <code>Promise.&lt;undefined&gt;</code>
-    * [.updateDocumentUnchecked(document)](#Account+updateDocumentUnchecked) ⇒ <code>Promise.&lt;undefined&gt;</code>
-    * [.fetchState()](#Account+fetchState) ⇒ <code>Promise.&lt;undefined&gt;</code>
-    * [.createMethod(options)](#Account+createMethod) ⇒ <code>Promise.&lt;undefined&gt;</code>
-    * [.attachMethodRelationships(options)](#Account+attachMethodRelationships) ⇒ <code>Promise.&lt;undefined&gt;</code>
-    * [.detachMethodRelationships(options)](#Account+detachMethodRelationships) ⇒ <code>Promise.&lt;undefined&gt;</code>
+    * [.createSignedData(fragment, data, signature_options)](#Account+createSignedData) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.updateDocumentUnchecked(document)](#Account+updateDocumentUnchecked) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.fetchState()](#Account+fetchState) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.createMethod(options)](#Account+createMethod) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.attachMethodRelationships(options)](#Account+attachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.detachMethodRelationships(options)](#Account+detachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
 
 <a name="Account+deleteMethod"></a>
 
-### account.deleteMethod(options) ⇒ <code>Promise.&lt;undefined&gt;</code>
+### account.deleteMethod(options) ⇒ <code>Promise.&lt;void&gt;</code>
 Deletes a verification method if the method exists.
 
 **Kind**: instance method of [<code>Account</code>](#Account)  
@@ -150,7 +150,7 @@ Deletes a verification method if the method exists.
 
 <a name="Account+deleteService"></a>
 
-### account.deleteService(options) ⇒ <code>Promise.&lt;undefined&gt;</code>
+### account.deleteService(options) ⇒ <code>Promise.&lt;void&gt;</code>
 Deletes a Service if it exists.
 
 **Kind**: instance method of [<code>Account</code>](#Account)  
@@ -161,7 +161,7 @@ Deletes a Service if it exists.
 
 <a name="Account+createService"></a>
 
-### account.createService(options) ⇒ <code>Promise.&lt;undefined&gt;</code>
+### account.createService(options) ⇒ <code>Promise.&lt;void&gt;</code>
 Adds a new Service to the DID Document.
 
 **Kind**: instance method of [<code>Account</code>](#Account)  
@@ -202,7 +202,7 @@ Resolves the DID Document associated with this `Account` from the Tangle.
 **Kind**: instance method of [<code>Account</code>](#Account)  
 <a name="Account+deleteIdentity"></a>
 
-### account.deleteIdentity() ⇒ <code>Promise.&lt;undefined&gt;</code>
+### account.deleteIdentity() ⇒ <code>Promise.&lt;void&gt;</code>
 Removes the identity from the local storage entirely.
 
 Note: This will remove all associated document updates and key material - recovery is NOT POSSIBLE!
@@ -210,7 +210,7 @@ Note: This will remove all associated document updates and key material - recove
 **Kind**: instance method of [<code>Account</code>](#Account)  
 <a name="Account+publish"></a>
 
-### account.publish(publish_options) ⇒ <code>Promise.&lt;undefined&gt;</code>
+### account.publish(publish_options) ⇒ <code>Promise.&lt;void&gt;</code>
 Push all unpublished changes to the tangle in a single message.
 
 **Kind**: instance method of [<code>Account</code>](#Account)  
@@ -260,7 +260,7 @@ Signs a [Presentation](#Presentation) the key specified by `fragment`.
 
 <a name="Account+createSignedData"></a>
 
-### account.createSignedData(fragment, data, signature_options) ⇒ <code>Promise.&lt;undefined&gt;</code>
+### account.createSignedData(fragment, data, signature_options) ⇒ <code>Promise.&lt;void&gt;</code>
 Signs arbitrary `data` with the key specified by `fragment`.
 
 **Kind**: instance method of [<code>Account</code>](#Account)  
@@ -273,7 +273,7 @@ Signs arbitrary `data` with the key specified by `fragment`.
 
 <a name="Account+updateDocumentUnchecked"></a>
 
-### account.updateDocumentUnchecked(document) ⇒ <code>Promise.&lt;undefined&gt;</code>
+### account.updateDocumentUnchecked(document) ⇒ <code>Promise.&lt;void&gt;</code>
 Overwrites the [Document](#Document) this account manages, **without doing any validation**.
 
 ### WARNING
@@ -290,7 +290,7 @@ understand the implications!
 
 <a name="Account+fetchState"></a>
 
-### account.fetchState() ⇒ <code>Promise.&lt;undefined&gt;</code>
+### account.fetchState() ⇒ <code>Promise.&lt;void&gt;</code>
 Fetches the latest changes from the tangle and **overwrites** the local document.
 
 If a DID is managed from distributed accounts, this should be called before making changes
@@ -299,7 +299,7 @@ to the identity, to avoid publishing updates that would be ignored.
 **Kind**: instance method of [<code>Account</code>](#Account)  
 <a name="Account+createMethod"></a>
 
-### account.createMethod(options) ⇒ <code>Promise.&lt;undefined&gt;</code>
+### account.createMethod(options) ⇒ <code>Promise.&lt;void&gt;</code>
 Adds a new verification method to the DID document.
 
 **Kind**: instance method of [<code>Account</code>](#Account)  
@@ -310,7 +310,7 @@ Adds a new verification method to the DID document.
 
 <a name="Account+attachMethodRelationships"></a>
 
-### account.attachMethodRelationships(options) ⇒ <code>Promise.&lt;undefined&gt;</code>
+### account.attachMethodRelationships(options) ⇒ <code>Promise.&lt;void&gt;</code>
 Attach one or more verification relationships to a method.
 
 Note: the method must exist and be in the set of verification methods;
@@ -324,7 +324,7 @@ it cannot be an embedded method.
 
 <a name="Account+detachMethodRelationships"></a>
 
-### account.detachMethodRelationships(options) ⇒ <code>Promise.&lt;undefined&gt;</code>
+### account.detachMethodRelationships(options) ⇒ <code>Promise.&lt;void&gt;</code>
 Detaches the given relationship from the given method, if the method exists.
 
 **Kind**: instance method of [<code>Account</code>](#Account)  

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -88,9 +88,9 @@ See <code>IVerifierOptions</code>.</p>
 ## Members
 
 <dl>
-<dt><a href="#DIDMessageEncoding">DIDMessageEncoding</a></dt>
-<dd></dd>
 <dt><a href="#KeyType">KeyType</a></dt>
+<dd></dd>
+<dt><a href="#DIDMessageEncoding">DIDMessageEncoding</a></dt>
 <dd></dd>
 <dt><a href="#MethodRelationship">MethodRelationship</a></dt>
 <dd></dd>
@@ -117,29 +117,29 @@ publishing to the Tangle.
 **Kind**: global class  
 
 * [Account](#Account)
-    * [.deleteMethod(options)](#Account+deleteMethod) ⇒ <code>Promise.&lt;any&gt;</code>
-    * [.deleteService(options)](#Account+deleteService) ⇒ <code>Promise.&lt;any&gt;</code>
-    * [.createService(options)](#Account+createService) ⇒ <code>Promise.&lt;any&gt;</code>
+    * [.deleteMethod(options)](#Account+deleteMethod) ⇒ <code>Promise.&lt;undefined&gt;</code>
+    * [.deleteService(options)](#Account+deleteService) ⇒ <code>Promise.&lt;undefined&gt;</code>
+    * [.createService(options)](#Account+createService) ⇒ <code>Promise.&lt;undefined&gt;</code>
     * [.did()](#Account+did) ⇒ [<code>DID</code>](#DID)
     * [.autopublish()](#Account+autopublish) ⇒ <code>boolean</code>
     * [.autosave()](#Account+autosave) ⇒ [<code>AutoSave</code>](#AutoSave)
     * [.document()](#Account+document) ⇒ [<code>Document</code>](#Document)
     * [.resolveIdentity()](#Account+resolveIdentity) ⇒ [<code>Promise.&lt;ResolvedDocument&gt;</code>](#ResolvedDocument)
-    * [.deleteIdentity()](#Account+deleteIdentity) ⇒ <code>Promise.&lt;any&gt;</code>
-    * [.publish(publish_options)](#Account+publish) ⇒ <code>Promise.&lt;any&gt;</code>
+    * [.deleteIdentity()](#Account+deleteIdentity) ⇒ <code>Promise.&lt;undefined&gt;</code>
+    * [.publish(publish_options)](#Account+publish) ⇒ <code>Promise.&lt;undefined&gt;</code>
     * [.createSignedCredential(fragment, credential, signature_options)](#Account+createSignedCredential) ⇒ [<code>Promise.&lt;Credential&gt;</code>](#Credential)
     * [.createSignedDocument(fragment, document, signature_options)](#Account+createSignedDocument) ⇒ [<code>Promise.&lt;Document&gt;</code>](#Document)
     * [.createSignedPresentation(fragment, presentation, signature_options)](#Account+createSignedPresentation) ⇒ [<code>Promise.&lt;Presentation&gt;</code>](#Presentation)
-    * [.createSignedData(fragment, data, signature_options)](#Account+createSignedData) ⇒ <code>Promise.&lt;any&gt;</code>
-    * [.updateDocumentUnchecked(document)](#Account+updateDocumentUnchecked) ⇒ <code>Promise.&lt;any&gt;</code>
-    * [.fetchState()](#Account+fetchState) ⇒ <code>Promise.&lt;any&gt;</code>
-    * [.createMethod(options)](#Account+createMethod) ⇒ <code>Promise.&lt;any&gt;</code>
-    * [.attachMethodRelationships(options)](#Account+attachMethodRelationships) ⇒ <code>Promise.&lt;any&gt;</code>
-    * [.detachMethodRelationships(options)](#Account+detachMethodRelationships) ⇒ <code>Promise.&lt;any&gt;</code>
+    * [.createSignedData(fragment, data, signature_options)](#Account+createSignedData) ⇒ <code>Promise.&lt;undefined&gt;</code>
+    * [.updateDocumentUnchecked(document)](#Account+updateDocumentUnchecked) ⇒ <code>Promise.&lt;undefined&gt;</code>
+    * [.fetchState()](#Account+fetchState) ⇒ <code>Promise.&lt;undefined&gt;</code>
+    * [.createMethod(options)](#Account+createMethod) ⇒ <code>Promise.&lt;undefined&gt;</code>
+    * [.attachMethodRelationships(options)](#Account+attachMethodRelationships) ⇒ <code>Promise.&lt;undefined&gt;</code>
+    * [.detachMethodRelationships(options)](#Account+detachMethodRelationships) ⇒ <code>Promise.&lt;undefined&gt;</code>
 
 <a name="Account+deleteMethod"></a>
 
-### account.deleteMethod(options) ⇒ <code>Promise.&lt;any&gt;</code>
+### account.deleteMethod(options) ⇒ <code>Promise.&lt;undefined&gt;</code>
 Deletes a verification method if the method exists.
 
 **Kind**: instance method of [<code>Account</code>](#Account)  
@@ -150,7 +150,7 @@ Deletes a verification method if the method exists.
 
 <a name="Account+deleteService"></a>
 
-### account.deleteService(options) ⇒ <code>Promise.&lt;any&gt;</code>
+### account.deleteService(options) ⇒ <code>Promise.&lt;undefined&gt;</code>
 Deletes a Service if it exists.
 
 **Kind**: instance method of [<code>Account</code>](#Account)  
@@ -161,7 +161,7 @@ Deletes a Service if it exists.
 
 <a name="Account+createService"></a>
 
-### account.createService(options) ⇒ <code>Promise.&lt;any&gt;</code>
+### account.createService(options) ⇒ <code>Promise.&lt;undefined&gt;</code>
 Adds a new Service to the DID Document.
 
 **Kind**: instance method of [<code>Account</code>](#Account)  
@@ -202,7 +202,7 @@ Resolves the DID Document associated with this `Account` from the Tangle.
 **Kind**: instance method of [<code>Account</code>](#Account)  
 <a name="Account+deleteIdentity"></a>
 
-### account.deleteIdentity() ⇒ <code>Promise.&lt;any&gt;</code>
+### account.deleteIdentity() ⇒ <code>Promise.&lt;undefined&gt;</code>
 Removes the identity from the local storage entirely.
 
 Note: This will remove all associated document updates and key material - recovery is NOT POSSIBLE!
@@ -210,7 +210,7 @@ Note: This will remove all associated document updates and key material - recove
 **Kind**: instance method of [<code>Account</code>](#Account)  
 <a name="Account+publish"></a>
 
-### account.publish(publish_options) ⇒ <code>Promise.&lt;any&gt;</code>
+### account.publish(publish_options) ⇒ <code>Promise.&lt;undefined&gt;</code>
 Push all unpublished changes to the tangle in a single message.
 
 **Kind**: instance method of [<code>Account</code>](#Account)  
@@ -260,7 +260,7 @@ Signs a [Presentation](#Presentation) the key specified by `fragment`.
 
 <a name="Account+createSignedData"></a>
 
-### account.createSignedData(fragment, data, signature_options) ⇒ <code>Promise.&lt;any&gt;</code>
+### account.createSignedData(fragment, data, signature_options) ⇒ <code>Promise.&lt;undefined&gt;</code>
 Signs arbitrary `data` with the key specified by `fragment`.
 
 **Kind**: instance method of [<code>Account</code>](#Account)  
@@ -273,7 +273,7 @@ Signs arbitrary `data` with the key specified by `fragment`.
 
 <a name="Account+updateDocumentUnchecked"></a>
 
-### account.updateDocumentUnchecked(document) ⇒ <code>Promise.&lt;any&gt;</code>
+### account.updateDocumentUnchecked(document) ⇒ <code>Promise.&lt;undefined&gt;</code>
 Overwrites the [Document](#Document) this account manages, **without doing any validation**.
 
 ### WARNING
@@ -290,7 +290,7 @@ understand the implications!
 
 <a name="Account+fetchState"></a>
 
-### account.fetchState() ⇒ <code>Promise.&lt;any&gt;</code>
+### account.fetchState() ⇒ <code>Promise.&lt;undefined&gt;</code>
 Fetches the latest changes from the tangle and **overwrites** the local document.
 
 If a DID is managed from distributed accounts, this should be called before making changes
@@ -299,7 +299,7 @@ to the identity, to avoid publishing updates that would be ignored.
 **Kind**: instance method of [<code>Account</code>](#Account)  
 <a name="Account+createMethod"></a>
 
-### account.createMethod(options) ⇒ <code>Promise.&lt;any&gt;</code>
+### account.createMethod(options) ⇒ <code>Promise.&lt;undefined&gt;</code>
 Adds a new verification method to the DID document.
 
 **Kind**: instance method of [<code>Account</code>](#Account)  
@@ -310,7 +310,7 @@ Adds a new verification method to the DID document.
 
 <a name="Account+attachMethodRelationships"></a>
 
-### account.attachMethodRelationships(options) ⇒ <code>Promise.&lt;any&gt;</code>
+### account.attachMethodRelationships(options) ⇒ <code>Promise.&lt;undefined&gt;</code>
 Attach one or more verification relationships to a method.
 
 Note: the method must exist and be in the set of verification methods;
@@ -324,7 +324,7 @@ it cannot be an embedded method.
 
 <a name="Account+detachMethodRelationships"></a>
 
-### account.detachMethodRelationships(options) ⇒ <code>Promise.&lt;any&gt;</code>
+### account.detachMethodRelationships(options) ⇒ <code>Promise.&lt;undefined&gt;</code>
 Detaches the given relationship from the given method, if the method exists.
 
 **Kind**: instance method of [<code>Account</code>](#Account)  
@@ -2677,13 +2677,13 @@ Throws an error if any of the options are invalid.
 Creates a new `VerifierOptions` with default options.
 
 **Kind**: static method of [<code>VerifierOptions</code>](#VerifierOptions)  
-<a name="DIDMessageEncoding"></a>
-
-## DIDMessageEncoding
-**Kind**: global variable  
 <a name="KeyType"></a>
 
 ## KeyType
+**Kind**: global variable  
+<a name="DIDMessageEncoding"></a>
+
+## DIDMessageEncoding
 **Kind**: global variable  
 <a name="MethodRelationship"></a>
 

--- a/bindings/wasm/src/account/update/attach_method_relationships.rs
+++ b/bindings/wasm/src/account/update/attach_method_relationships.rs
@@ -19,8 +19,10 @@ use identity::did::MethodRelationship;
 
 use crate::account::wasm_account::WasmAccount;
 use crate::account::wasm_method_relationship::WasmMethodRelationship;
+use crate::common::PromiseUndefined;
 use crate::error::Result;
 use crate::error::WasmResult;
+use wasm_bindgen::JsCast;
 
 #[wasm_bindgen(js_class = Account)]
 impl WasmAccount {
@@ -29,7 +31,7 @@ impl WasmAccount {
   /// Note: the method must exist and be in the set of verification methods;
   /// it cannot be an embedded method.
   #[wasm_bindgen(js_name = attachMethodRelationships)]
-  pub fn attach_method_relationships(&mut self, options: &AttachMethodRelationshipOptions) -> Result<Promise> {
+  pub fn attach_method_relationships(&mut self, options: &AttachMethodRelationshipOptions) -> Result<PromiseUndefined> {
     let relationships: Vec<MethodRelationship> = options
       .relationships()
       .into_serde::<OneOrMany<WasmMethodRelationship>>()
@@ -65,7 +67,7 @@ impl WasmAccount {
         .map(|_| JsValue::undefined())
     });
 
-    Ok(promise)
+    Ok(promise.unchecked_into::<PromiseUndefined>())
   }
 }
 

--- a/bindings/wasm/src/account/update/attach_method_relationships.rs
+++ b/bindings/wasm/src/account/update/attach_method_relationships.rs
@@ -19,7 +19,7 @@ use identity::did::MethodRelationship;
 
 use crate::account::wasm_account::WasmAccount;
 use crate::account::wasm_method_relationship::WasmMethodRelationship;
-use crate::common::PromiseUndefined;
+use crate::common::PromiseVoid;
 use crate::error::Result;
 use crate::error::WasmResult;
 use wasm_bindgen::JsCast;
@@ -31,7 +31,7 @@ impl WasmAccount {
   /// Note: the method must exist and be in the set of verification methods;
   /// it cannot be an embedded method.
   #[wasm_bindgen(js_name = attachMethodRelationships)]
-  pub fn attach_method_relationships(&mut self, options: &AttachMethodRelationshipOptions) -> Result<PromiseUndefined> {
+  pub fn attach_method_relationships(&mut self, options: &AttachMethodRelationshipOptions) -> Result<PromiseVoid> {
     let relationships: Vec<MethodRelationship> = options
       .relationships()
       .into_serde::<OneOrMany<WasmMethodRelationship>>()
@@ -67,7 +67,7 @@ impl WasmAccount {
         .map(|_| JsValue::undefined())
     });
 
-    Ok(promise.unchecked_into::<PromiseUndefined>())
+    Ok(promise.unchecked_into::<PromiseVoid>())
   }
 }
 

--- a/bindings/wasm/src/account/update/create_method.rs
+++ b/bindings/wasm/src/account/update/create_method.rs
@@ -21,7 +21,7 @@ use crate::account::wasm_method_secret::WasmMethodSecret;
 use crate::did::WasmMethodScope;
 use crate::did::WasmMethodType;
 
-use crate::common::PromiseUndefined;
+use crate::common::PromiseVoid;
 use crate::error::Result;
 use crate::error::WasmResult;
 use wasm_bindgen::JsCast;
@@ -30,7 +30,7 @@ use wasm_bindgen::JsCast;
 impl WasmAccount {
   /// Adds a new verification method to the DID document.
   #[wasm_bindgen(js_name = createMethod)]
-  pub fn create_method(&mut self, options: &CreateMethodOptions) -> Result<PromiseUndefined> {
+  pub fn create_method(&mut self, options: &CreateMethodOptions) -> Result<PromiseVoid> {
     let method_type: Option<MethodType> = options.methodType().map(|m| m.0);
 
     let fragment: String = options
@@ -63,7 +63,7 @@ impl WasmAccount {
       create_method.apply().await.wasm_result().map(|_| JsValue::undefined())
     });
 
-    Ok(promise.unchecked_into::<PromiseUndefined>())
+    Ok(promise.unchecked_into::<PromiseVoid>())
   }
 }
 

--- a/bindings/wasm/src/account/update/create_method.rs
+++ b/bindings/wasm/src/account/update/create_method.rs
@@ -21,14 +21,16 @@ use crate::account::wasm_method_secret::WasmMethodSecret;
 use crate::did::WasmMethodScope;
 use crate::did::WasmMethodType;
 
+use crate::common::PromiseUndefined;
 use crate::error::Result;
 use crate::error::WasmResult;
+use wasm_bindgen::JsCast;
 
 #[wasm_bindgen(js_class = Account)]
 impl WasmAccount {
   /// Adds a new verification method to the DID document.
   #[wasm_bindgen(js_name = createMethod)]
-  pub fn create_method(&mut self, options: &CreateMethodOptions) -> Result<Promise> {
+  pub fn create_method(&mut self, options: &CreateMethodOptions) -> Result<PromiseUndefined> {
     let method_type: Option<MethodType> = options.methodType().map(|m| m.0);
 
     let fragment: String = options
@@ -61,7 +63,7 @@ impl WasmAccount {
       create_method.apply().await.wasm_result().map(|_| JsValue::undefined())
     });
 
-    Ok(promise)
+    Ok(promise.unchecked_into::<PromiseUndefined>())
   }
 }
 

--- a/bindings/wasm/src/account/update/create_service.rs
+++ b/bindings/wasm/src/account/update/create_service.rs
@@ -17,14 +17,16 @@ use identity::core::Url;
 
 use crate::account::wasm_account::WasmAccount;
 
+use crate::common::PromiseUndefined;
 use crate::error::Result;
 use crate::error::WasmResult;
+use wasm_bindgen::JsCast;
 
 #[wasm_bindgen(js_class = Account)]
 impl WasmAccount {
   /// Adds a new Service to the DID Document.
   #[wasm_bindgen(js_name = createService)]
-  pub fn create_service(&mut self, options: &CreateServiceOptions) -> Result<Promise> {
+  pub fn create_service(&mut self, options: &CreateServiceOptions) -> Result<PromiseUndefined> {
     let service_type: String = options.type_().ok_or(MissingRequiredField("type")).wasm_result()?;
 
     let fragment: String = options
@@ -55,7 +57,7 @@ impl WasmAccount {
       create_service.apply().await.wasm_result().map(|_| JsValue::undefined())
     });
 
-    Ok(promise)
+    Ok(promise.unchecked_into::<PromiseUndefined>())
   }
 }
 

--- a/bindings/wasm/src/account/update/create_service.rs
+++ b/bindings/wasm/src/account/update/create_service.rs
@@ -17,7 +17,7 @@ use identity::core::Url;
 
 use crate::account::wasm_account::WasmAccount;
 
-use crate::common::PromiseUndefined;
+use crate::common::PromiseVoid;
 use crate::error::Result;
 use crate::error::WasmResult;
 use wasm_bindgen::JsCast;
@@ -26,7 +26,7 @@ use wasm_bindgen::JsCast;
 impl WasmAccount {
   /// Adds a new Service to the DID Document.
   #[wasm_bindgen(js_name = createService)]
-  pub fn create_service(&mut self, options: &CreateServiceOptions) -> Result<PromiseUndefined> {
+  pub fn create_service(&mut self, options: &CreateServiceOptions) -> Result<PromiseVoid> {
     let service_type: String = options.type_().ok_or(MissingRequiredField("type")).wasm_result()?;
 
     let fragment: String = options
@@ -57,7 +57,7 @@ impl WasmAccount {
       create_service.apply().await.wasm_result().map(|_| JsValue::undefined())
     });
 
-    Ok(promise.unchecked_into::<PromiseUndefined>())
+    Ok(promise.unchecked_into::<PromiseVoid>())
   }
 }
 

--- a/bindings/wasm/src/account/update/delete_method.rs
+++ b/bindings/wasm/src/account/update/delete_method.rs
@@ -8,14 +8,16 @@ use wasm_bindgen_futures::future_to_promise;
 use identity::account::UpdateError::MissingRequiredField;
 
 use crate::account::wasm_account::WasmAccount;
+use crate::common::PromiseUndefined;
 use crate::error::Result;
 use crate::error::WasmResult;
+use wasm_bindgen::JsCast;
 
 #[wasm_bindgen(js_class = Account)]
 impl WasmAccount {
   /// Deletes a verification method if the method exists.
   #[wasm_bindgen(js_name = deleteMethod)]
-  pub fn delete_method(&mut self, options: &DeleteMethodOptions) -> Result<Promise> {
+  pub fn delete_method(&mut self, options: &DeleteMethodOptions) -> Result<PromiseUndefined> {
     let fragment: String = options
       .fragment()
       .ok_or(MissingRequiredField("fragment"))
@@ -34,7 +36,7 @@ impl WasmAccount {
         .map(|_| JsValue::undefined())
     });
 
-    Ok(promise)
+    Ok(promise.unchecked_into::<PromiseUndefined>())
   }
 }
 
@@ -50,7 +52,7 @@ extern "C" {
 #[wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = r#"
 /**
- * Optoins for deleting a method on an identity.
+ * Options for deleting a method on an identity.
  */
 export type DeleteMethodOptions = {
     /**

--- a/bindings/wasm/src/account/update/delete_method.rs
+++ b/bindings/wasm/src/account/update/delete_method.rs
@@ -8,7 +8,7 @@ use wasm_bindgen_futures::future_to_promise;
 use identity::account::UpdateError::MissingRequiredField;
 
 use crate::account::wasm_account::WasmAccount;
-use crate::common::PromiseUndefined;
+use crate::common::PromiseVoid;
 use crate::error::Result;
 use crate::error::WasmResult;
 use wasm_bindgen::JsCast;
@@ -17,7 +17,7 @@ use wasm_bindgen::JsCast;
 impl WasmAccount {
   /// Deletes a verification method if the method exists.
   #[wasm_bindgen(js_name = deleteMethod)]
-  pub fn delete_method(&mut self, options: &DeleteMethodOptions) -> Result<PromiseUndefined> {
+  pub fn delete_method(&mut self, options: &DeleteMethodOptions) -> Result<PromiseVoid> {
     let fragment: String = options
       .fragment()
       .ok_or(MissingRequiredField("fragment"))
@@ -36,7 +36,7 @@ impl WasmAccount {
         .map(|_| JsValue::undefined())
     });
 
-    Ok(promise.unchecked_into::<PromiseUndefined>())
+    Ok(promise.unchecked_into::<PromiseVoid>())
   }
 }
 

--- a/bindings/wasm/src/account/update/delete_service.rs
+++ b/bindings/wasm/src/account/update/delete_service.rs
@@ -8,14 +8,16 @@ use wasm_bindgen_futures::future_to_promise;
 use identity::account::UpdateError::MissingRequiredField;
 
 use crate::account::wasm_account::WasmAccount;
+use crate::common::PromiseUndefined;
 use crate::error::Result;
 use crate::error::WasmResult;
+use wasm_bindgen::JsCast;
 
 #[wasm_bindgen(js_class = Account)]
 impl WasmAccount {
   /// Deletes a Service if it exists.
   #[wasm_bindgen(js_name = deleteService)]
-  pub fn delete_service(&mut self, options: &DeleteServiceOptions) -> Result<Promise> {
+  pub fn delete_service(&mut self, options: &DeleteServiceOptions) -> Result<PromiseUndefined> {
     let fragment: String = options
       .fragment()
       .ok_or(MissingRequiredField("fragment"))
@@ -36,7 +38,7 @@ impl WasmAccount {
         .map(|_| JsValue::undefined())
     });
 
-    Ok(promise)
+    Ok(promise.unchecked_into::<PromiseUndefined>())
   }
 }
 

--- a/bindings/wasm/src/account/update/delete_service.rs
+++ b/bindings/wasm/src/account/update/delete_service.rs
@@ -8,7 +8,7 @@ use wasm_bindgen_futures::future_to_promise;
 use identity::account::UpdateError::MissingRequiredField;
 
 use crate::account::wasm_account::WasmAccount;
-use crate::common::PromiseUndefined;
+use crate::common::PromiseVoid;
 use crate::error::Result;
 use crate::error::WasmResult;
 use wasm_bindgen::JsCast;
@@ -17,7 +17,7 @@ use wasm_bindgen::JsCast;
 impl WasmAccount {
   /// Deletes a Service if it exists.
   #[wasm_bindgen(js_name = deleteService)]
-  pub fn delete_service(&mut self, options: &DeleteServiceOptions) -> Result<PromiseUndefined> {
+  pub fn delete_service(&mut self, options: &DeleteServiceOptions) -> Result<PromiseVoid> {
     let fragment: String = options
       .fragment()
       .ok_or(MissingRequiredField("fragment"))
@@ -38,7 +38,7 @@ impl WasmAccount {
         .map(|_| JsValue::undefined())
     });
 
-    Ok(promise.unchecked_into::<PromiseUndefined>())
+    Ok(promise.unchecked_into::<PromiseVoid>())
   }
 }
 

--- a/bindings/wasm/src/account/update/detach_method_relationships.rs
+++ b/bindings/wasm/src/account/update/detach_method_relationships.rs
@@ -18,7 +18,7 @@ use identity::did::MethodRelationship;
 
 use crate::account::wasm_account::WasmAccount;
 use crate::account::wasm_method_relationship::WasmMethodRelationship;
-use crate::common::PromiseUndefined;
+use crate::common::PromiseVoid;
 use crate::error::Result;
 use crate::error::WasmResult;
 use wasm_bindgen::JsCast;
@@ -27,7 +27,7 @@ use wasm_bindgen::JsCast;
 impl WasmAccount {
   /// Detaches the given relationship from the given method, if the method exists.
   #[wasm_bindgen(js_name = detachMethodRelationships)]
-  pub fn detach_method_relationships(&mut self, options: &DetachMethodRelationshipOptions) -> Result<PromiseUndefined> {
+  pub fn detach_method_relationships(&mut self, options: &DetachMethodRelationshipOptions) -> Result<PromiseVoid> {
     let relationships: Vec<MethodRelationship> = options
       .relationships()
       .into_serde::<OneOrMany<WasmMethodRelationship>>()
@@ -63,7 +63,7 @@ impl WasmAccount {
         .wasm_result()
         .map(|_| JsValue::undefined())
     });
-    Ok(promise.unchecked_into::<PromiseUndefined>())
+    Ok(promise.unchecked_into::<PromiseVoid>())
   }
 }
 

--- a/bindings/wasm/src/account/update/detach_method_relationships.rs
+++ b/bindings/wasm/src/account/update/detach_method_relationships.rs
@@ -18,14 +18,16 @@ use identity::did::MethodRelationship;
 
 use crate::account::wasm_account::WasmAccount;
 use crate::account::wasm_method_relationship::WasmMethodRelationship;
+use crate::common::PromiseUndefined;
 use crate::error::Result;
 use crate::error::WasmResult;
+use wasm_bindgen::JsCast;
 
 #[wasm_bindgen(js_class = Account)]
 impl WasmAccount {
   /// Detaches the given relationship from the given method, if the method exists.
   #[wasm_bindgen(js_name = detachMethodRelationships)]
-  pub fn detach_method_relationships(&mut self, options: &DetachMethodRelationshipOptions) -> Result<Promise> {
+  pub fn detach_method_relationships(&mut self, options: &DetachMethodRelationshipOptions) -> Result<PromiseUndefined> {
     let relationships: Vec<MethodRelationship> = options
       .relationships()
       .into_serde::<OneOrMany<WasmMethodRelationship>>()
@@ -61,7 +63,7 @@ impl WasmAccount {
         .wasm_result()
         .map(|_| JsValue::undefined())
     });
-    Ok(promise)
+    Ok(promise.unchecked_into::<PromiseUndefined>())
   }
 }
 

--- a/bindings/wasm/src/account/wasm_account.rs
+++ b/bindings/wasm/src/account/wasm_account.rs
@@ -1,6 +1,7 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::common::PromiseUndefined;
 use crate::credential::WasmCredential;
 use crate::credential::WasmPresentation;
 use crate::crypto::WasmSignatureOptions;
@@ -90,7 +91,7 @@ impl WasmAccount {
   ///
   /// Note: This will remove all associated document updates and key material - recovery is NOT POSSIBLE!
   #[wasm_bindgen(js_name = deleteIdentity)]
-  pub fn delete_identity(self) -> Promise {
+  pub fn delete_identity(self) -> PromiseUndefined {
     // Get IotaDID and storage from the account.
     let did: IotaDID = self.0.borrow().did().to_owned();
     let storage: Arc<dyn Storage> = Arc::clone(self.0.borrow().storage());
@@ -112,11 +113,12 @@ impl WasmAccount {
         Err(e) => Err(e),
       }
     })
+    .unchecked_into::<PromiseUndefined>()
   }
 
   /// Push all unpublished changes to the tangle in a single message.
   #[wasm_bindgen]
-  pub fn publish(&mut self, publish_options: Option<WasmPublishOptions>) -> Promise {
+  pub fn publish(&mut self, publish_options: Option<WasmPublishOptions>) -> PromiseUndefined {
     let options: PublishOptions = publish_options.map(PublishOptions::from).unwrap_or_default();
     let account = self.0.clone();
     future_to_promise(async move {
@@ -128,6 +130,7 @@ impl WasmAccount {
         .map(|_| JsValue::undefined())
         .wasm_result()
     })
+    .unchecked_into::<PromiseUndefined>()
   }
 
   /// Signs a {@link Credential} with the key specified by `fragment`.
@@ -176,12 +179,17 @@ impl WasmAccount {
     fragment: String,
     data: &JsValue,
     signature_options: &WasmSignatureOptions,
-  ) -> Result<Promise> {
+  ) -> Result<PromiseUndefined> {
     let verifiable_properties: VerifiableProperties = data.into_serde().wasm_result()?;
     Ok(self.create_signed(fragment, verifiable_properties, signature_options))
   }
 
-  fn create_signed<U>(&self, fragment: String, mut data: U, signature_options: &WasmSignatureOptions) -> Promise
+  fn create_signed<U>(
+    &self,
+    fragment: String,
+    mut data: U,
+    signature_options: &WasmSignatureOptions,
+  ) -> PromiseUndefined
   where
     U: serde::Serialize + SetSignature + 'static,
   {
@@ -198,6 +206,7 @@ impl WasmAccount {
         .wasm_result()?;
       JsValue::from_serde(&data).wasm_result()
     })
+    .unchecked_into::<PromiseUndefined>()
   }
 
   /// Overwrites the {@link Document} this account manages, **without doing any validation**.
@@ -208,7 +217,7 @@ impl WasmAccount {
   /// potentially making the identity unusable. Only call this if you fully
   /// understand the implications!
   #[wasm_bindgen(js_name = updateDocumentUnchecked)]
-  pub fn update_document_unchecked(&mut self, document: &WasmDocument) -> Promise {
+  pub fn update_document_unchecked(&mut self, document: &WasmDocument) -> PromiseUndefined {
     let account = self.0.clone();
     let document_copy: IotaDocument = document.0.clone();
     future_to_promise(async move {
@@ -220,6 +229,7 @@ impl WasmAccount {
         .map(|_| JsValue::undefined())
         .wasm_result()
     })
+    .unchecked_into::<PromiseUndefined>()
   }
 
   /// Fetches the latest changes from the tangle and **overwrites** the local document.
@@ -227,7 +237,7 @@ impl WasmAccount {
   /// If a DID is managed from distributed accounts, this should be called before making changes
   /// to the identity, to avoid publishing updates that would be ignored.
   #[wasm_bindgen(js_name = fetchState)]
-  pub fn fetch_state(&mut self) -> Promise {
+  pub fn fetch_state(&mut self) -> PromiseUndefined {
     let account = self.0.clone();
     future_to_promise(async move {
       account
@@ -238,6 +248,7 @@ impl WasmAccount {
         .map(|_| JsValue::undefined())
         .wasm_result()
     })
+    .unchecked_into::<PromiseUndefined>()
   }
 }
 

--- a/bindings/wasm/src/account/wasm_account.rs
+++ b/bindings/wasm/src/account/wasm_account.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::PromiseUndefined;
+use crate::common::PromiseVoid;
 use crate::credential::WasmCredential;
 use crate::credential::WasmPresentation;
 use crate::crypto::WasmSignatureOptions;
@@ -91,7 +91,7 @@ impl WasmAccount {
   ///
   /// Note: This will remove all associated document updates and key material - recovery is NOT POSSIBLE!
   #[wasm_bindgen(js_name = deleteIdentity)]
-  pub fn delete_identity(self) -> PromiseUndefined {
+  pub fn delete_identity(self) -> PromiseVoid {
     // Get IotaDID and storage from the account.
     let did: IotaDID = self.0.borrow().did().to_owned();
     let storage: Arc<dyn Storage> = Arc::clone(self.0.borrow().storage());
@@ -113,12 +113,12 @@ impl WasmAccount {
         Err(e) => Err(e),
       }
     })
-    .unchecked_into::<PromiseUndefined>()
+    .unchecked_into::<PromiseVoid>()
   }
 
   /// Push all unpublished changes to the tangle in a single message.
   #[wasm_bindgen]
-  pub fn publish(&mut self, publish_options: Option<WasmPublishOptions>) -> PromiseUndefined {
+  pub fn publish(&mut self, publish_options: Option<WasmPublishOptions>) -> PromiseVoid {
     let options: PublishOptions = publish_options.map(PublishOptions::from).unwrap_or_default();
     let account = self.0.clone();
     future_to_promise(async move {
@@ -130,7 +130,7 @@ impl WasmAccount {
         .map(|_| JsValue::undefined())
         .wasm_result()
     })
-    .unchecked_into::<PromiseUndefined>()
+    .unchecked_into::<PromiseVoid>()
   }
 
   /// Signs a {@link Credential} with the key specified by `fragment`.
@@ -179,17 +179,12 @@ impl WasmAccount {
     fragment: String,
     data: &JsValue,
     signature_options: &WasmSignatureOptions,
-  ) -> Result<PromiseUndefined> {
+  ) -> Result<PromiseVoid> {
     let verifiable_properties: VerifiableProperties = data.into_serde().wasm_result()?;
     Ok(self.create_signed(fragment, verifiable_properties, signature_options))
   }
 
-  fn create_signed<U>(
-    &self,
-    fragment: String,
-    mut data: U,
-    signature_options: &WasmSignatureOptions,
-  ) -> PromiseUndefined
+  fn create_signed<U>(&self, fragment: String, mut data: U, signature_options: &WasmSignatureOptions) -> PromiseVoid
   where
     U: serde::Serialize + SetSignature + 'static,
   {
@@ -206,7 +201,7 @@ impl WasmAccount {
         .wasm_result()?;
       JsValue::from_serde(&data).wasm_result()
     })
-    .unchecked_into::<PromiseUndefined>()
+    .unchecked_into::<PromiseVoid>()
   }
 
   /// Overwrites the {@link Document} this account manages, **without doing any validation**.
@@ -217,7 +212,7 @@ impl WasmAccount {
   /// potentially making the identity unusable. Only call this if you fully
   /// understand the implications!
   #[wasm_bindgen(js_name = updateDocumentUnchecked)]
-  pub fn update_document_unchecked(&mut self, document: &WasmDocument) -> PromiseUndefined {
+  pub fn update_document_unchecked(&mut self, document: &WasmDocument) -> PromiseVoid {
     let account = self.0.clone();
     let document_copy: IotaDocument = document.0.clone();
     future_to_promise(async move {
@@ -229,7 +224,7 @@ impl WasmAccount {
         .map(|_| JsValue::undefined())
         .wasm_result()
     })
-    .unchecked_into::<PromiseUndefined>()
+    .unchecked_into::<PromiseVoid>()
   }
 
   /// Fetches the latest changes from the tangle and **overwrites** the local document.
@@ -237,7 +232,7 @@ impl WasmAccount {
   /// If a DID is managed from distributed accounts, this should be called before making changes
   /// to the identity, to avoid publishing updates that would be ignored.
   #[wasm_bindgen(js_name = fetchState)]
-  pub fn fetch_state(&mut self) -> PromiseUndefined {
+  pub fn fetch_state(&mut self) -> PromiseVoid {
     let account = self.0.clone();
     future_to_promise(async move {
       account
@@ -248,7 +243,7 @@ impl WasmAccount {
         .map(|_| JsValue::undefined())
         .wasm_result()
     })
-    .unchecked_into::<PromiseUndefined>()
+    .unchecked_into::<PromiseVoid>()
   }
 }
 

--- a/bindings/wasm/src/common/mod.rs
+++ b/bindings/wasm/src/common/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+pub use promise_undefined::*;
 pub use timestamp::*;
 
+mod promise_undefined;
 mod timestamp;

--- a/bindings/wasm/src/common/mod.rs
+++ b/bindings/wasm/src/common/mod.rs
@@ -1,8 +1,8 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-pub use promise_undefined::*;
+pub use promise_void::*;
 pub use timestamp::*;
 
-mod promise_undefined;
+mod promise_void;
 mod timestamp;

--- a/bindings/wasm/src/common/promise_undefined.rs
+++ b/bindings/wasm/src/common/promise_undefined.rs
@@ -1,0 +1,10 @@
+// Copyright 2020-2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+use wasm_bindgen::prelude::*;
+
+// Workaround for Typescript type annotations on async functions that don't return anything.
+#[wasm_bindgen]
+extern "C" {
+  #[wasm_bindgen(typescript_type = "Promise<undefined>")]
+  pub type PromiseUndefined;
+}

--- a/bindings/wasm/src/common/promise_void.rs
+++ b/bindings/wasm/src/common/promise_void.rs
@@ -5,6 +5,6 @@ use wasm_bindgen::prelude::*;
 // Workaround for Typescript type annotations on async functions that don't return anything.
 #[wasm_bindgen]
 extern "C" {
-  #[wasm_bindgen(typescript_type = "Promise<undefined>")]
-  pub type PromiseUndefined;
+  #[wasm_bindgen(typescript_type = "Promise<void>")]
+  pub type PromiseVoid;
 }


### PR DESCRIPTION
# Description of change
Replace return type `Promise<any>` with `Promise<undefined>` for functions that return `JsValue::undefined()`.

## Links to any relevant issues
Relevant to #574  

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix
