### PR TITLE
Remove redundant `impl Display` for `OneOrMany` 

### DIFF
--- a/identity-core/src/common/one_or_many.rs
+++ b/identity-core/src/common/one_or_many.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt::Debug;
-use core::fmt::Display;
 use core::fmt::Formatter;
 
 use core::hash::Hash;
@@ -110,19 +109,6 @@ where
     match self {
       Self::One(inner) => Debug::fmt(inner, f),
       Self::Many(inner) => Debug::fmt(inner, f),
-    }
-  }
-}
-
-impl<T> Display for OneOrMany<T>
-where
-  T: Display,
-  Vec<T>: Display,
-{
-  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-    match self {
-      Self::One(inner) => Display::fmt(inner, f),
-      Self::Many(inner) => Display::fmt(inner, f),
     }
   }
 }


### PR DESCRIPTION
# Description of change
This PR removes the `Display` implementation on `OneOrMany`. 

This is non-breaking as our implementation only takes effect whenever `Vec<T>: Display` which cannot happen as `Vec<T>` does not implement display regardless of `T`. See https://doc.rust-lang.org/std/vec/struct.Vec.html#trait-implementations and https://doc.rust-lang.org/std/fmt/trait.Display.html#implementors. 

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
tests run locally. 

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
