### PR TITLE
Make Wasm support dependent on `target_arch` rather than feature

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -228,10 +228,6 @@ jobs:
         run: npm run build:examples
         working-directory: bindings/wasm
 
-      - name: Run tests
-        run: cargo test --release
-        working-directory: bindings/wasm
-
       - name: Run Wasm unit tests and examples
         run: npm run test
         working-directory: bindings/wasm

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
+          target: wasm32-unknown-unknown
           override: true
           components: clippy
 

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --manifest-path ./bindings/wasm/Cargo.toml --all-targets --all-features -- -D warnings
+          args: --manifest-path ./bindings/wasm/Cargo.toml --target wasm32-unknown-unknown --all-targets --all-features -- -D warnings
           name: wasm
 
       - name: libjose clippy check

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -27,12 +27,11 @@ wasm-bindgen-futures = { version = "0.4", default-features = false }
 version = "=0.5.0-dev.4"
 path = "../../identity"
 default-features = false
-features = ["wasm"]
 
 [dev-dependencies]
 wasm-bindgen-test = { version = "0.3" }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", target_os = "wasi"))'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 parking_lot = { version = "0.11.2", features = ["wasm-bindgen"] }
 

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -31,7 +31,7 @@ default-features = false
 [dev-dependencies]
 wasm-bindgen-test = { version = "0.3" }
 
-[target.'cfg(all(target_arch = "wasm32", target_os = "wasi"))'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 parking_lot = { version = "0.11.2", features = ["wasm-bindgen"] }
 

--- a/bindings/wasm/src/common/timestamp.rs
+++ b/bindings/wasm/src/common/timestamp.rs
@@ -8,7 +8,7 @@ use crate::error::Result;
 use crate::error::WasmResult;
 
 #[wasm_bindgen(js_name = Timestamp, inspectable)]
-#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 pub struct WasmTimestamp(pub(crate) Timestamp);
 
 #[wasm_bindgen(js_class = Timestamp)]

--- a/bindings/wasm/src/common/timestamp.rs
+++ b/bindings/wasm/src/common/timestamp.rs
@@ -8,7 +8,6 @@ use crate::error::Result;
 use crate::error::WasmResult;
 
 #[wasm_bindgen(js_name = Timestamp, inspectable)]
-#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 pub struct WasmTimestamp(pub(crate) Timestamp);
 
 #[wasm_bindgen(js_class = Timestamp)]

--- a/identity-account/Cargo.toml
+++ b/identity-account/Cargo.toml
@@ -57,6 +57,5 @@ stronghold = [
   "actix",
   "tokio/rt-multi-thread",
 ]
-wasm = ["identity-iota/wasm"]
 async = ["identity-iota/async"]
 default = ["stronghold", "async"]

--- a/identity-account/src/tests/account.rs
+++ b/identity-account/src/tests/account.rs
@@ -496,7 +496,7 @@ async fn network_resilient_test(
 
 // Ensure that a future that contains an account is `Send` at compile-time.
 #[tokio::test]
-async fn assert_account_futures_are_send() -> Result<()> {
+async fn test_assert_account_futures_are_send() -> Result<()> {
   fn assert_future_send<T: std::future::Future + Send>(_: T) {}
 
   let mut account: Account = AccountBuilder::default()

--- a/identity-account/src/tests/account.rs
+++ b/identity-account/src/tests/account.rs
@@ -495,10 +495,12 @@ async fn network_resilient_test(
 }
 
 // Ensure that a future that contains an account is `Send` at compile-time.
-async fn _assert_account_send() -> Result<()> {
+#[tokio::test]
+async fn assert_account_futures_are_send() -> Result<()> {
   fn assert_future_send<T: std::future::Future + Send>(_: T) {}
 
   let mut account: Account = AccountBuilder::default()
+    .testmode(true)
     .create_identity(IdentitySetup::default())
     .await?;
 

--- a/identity-account/src/tests/account.rs
+++ b/identity-account/src/tests/account.rs
@@ -493,3 +493,18 @@ async fn network_resilient_test(
   }
   Ok(())
 }
+
+// Ensure that a future that contains an account is `Send` at compile-time.
+async fn _assert_account_send() -> Result<()> {
+  fn assert_future_send<T: std::future::Future + Send>(_: T) {}
+
+  let mut account: Account = AccountBuilder::default()
+    .testmode(true)
+    .autopublish(false)
+    .create_identity(IdentitySetup::default())
+    .await?;
+
+  assert_future_send(account.update_identity().create_method().apply());
+
+  Ok(())
+}

--- a/identity-account/src/tests/account.rs
+++ b/identity-account/src/tests/account.rs
@@ -499,8 +499,6 @@ async fn _assert_account_send() -> Result<()> {
   fn assert_future_send<T: std::future::Future + Send>(_: T) {}
 
   let mut account: Account = AccountBuilder::default()
-    .testmode(true)
-    .autopublish(false)
     .create_identity(IdentitySetup::default())
     .await?;
 

--- a/identity-comm/Cargo.toml
+++ b/identity-comm/Cargo.toml
@@ -24,4 +24,4 @@ thiserror = { version = "1.0" }
 uuid = { version = "0.8", features = ["serde", "v4"], default-features = false }
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
-uuid = { version = "0.8", features = ["serde", "v4", "wasm-bindgen"], default-features = false }
+uuid = { version = "*", features = ["wasm-bindgen"], default-features = false }

--- a/identity-comm/Cargo.toml
+++ b/identity-comm/Cargo.toml
@@ -23,6 +23,5 @@ strum = { version = "0.21", features = ["derive"] }
 thiserror = { version = "1.0" }
 uuid = { version = "0.8", features = ["serde", "v4"], default-features = false }
 
-[features]
-# Enables Web Assembly support
-wasm = ["uuid/wasm-bindgen"]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
+uuid = { version = "0.8", features = ["serde", "v4", "wasm-bindgen"], default-features = false }

--- a/identity-core/Cargo.toml
+++ b/identity-core/Cargo.toml
@@ -42,8 +42,6 @@ quickcheck = { version = "1.0" }
 quickcheck_macros = { version = "1.0" }
 rand = { version = "0.8" }
 
-[features]
-
 [package.metadata.docs.rs]
 # To build locally:
 # RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --workspace --open

--- a/identity-core/Cargo.toml
+++ b/identity-core/Cargo.toml
@@ -33,7 +33,7 @@ version = "0.7"
 default-features = false
 features = ["blake2b", "ed25519", "random", "sha"]
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
 js-sys = { version = "0.3.55", default-features = false }
 
 [dev-dependencies]

--- a/identity-core/Cargo.toml
+++ b/identity-core/Cargo.toml
@@ -15,7 +15,6 @@ base64 = { version = "0.13", default-features = false, features = ["std"] }
 bs58 = { version = "0.4", default-features = false, features = ["std"] }
 hex = { version = "0.4", default-features = false }
 identity-diff = { version = "=0.5.0-dev.4", path = "../identity-diff", default-features = false }
-js-sys = { version = "0.3.55", default-features = false, optional = true }
 multibase = { version = "0.9", default-features = false, features = ["std"] }
 roaring = { version = "0.7", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
@@ -34,6 +33,9 @@ version = "0.7"
 default-features = false
 features = ["blake2b", "ed25519", "random", "sha"]
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = { version = "0.3.55", default-features = false }
+
 [dev-dependencies]
 proptest = "1.0.0"
 quickcheck = { version = "1.0" }
@@ -41,7 +43,6 @@ quickcheck_macros = { version = "1.0" }
 rand = { version = "0.8" }
 
 [features]
-wasm = ["js-sys"]
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/identity-core/src/common/timestamp.rs
+++ b/identity-core/src/common/timestamp.rs
@@ -40,7 +40,7 @@ impl Timestamp {
   /// fractional seconds truncated.
   ///
   /// See the [`datetime` DID-core specification](https://www.w3.org/TR/did-core/#production).
-  #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasm")))]
+  #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
   pub fn now_utc() -> Self {
     Self(truncate_fractional_seconds(OffsetDateTime::now_utc()))
   }
@@ -49,7 +49,7 @@ impl Timestamp {
   /// fractional seconds truncated.
   ///
   /// See the [`datetime` DID-core specification](https://www.w3.org/TR/did-core/#production).
-  #[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasm"))]
+  #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
   pub fn now_utc() -> Self {
     let milliseconds_since_unix_epoch: i64 = js_sys::Date::now() as i64;
     let seconds: i64 = milliseconds_since_unix_epoch / 1000;

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -31,12 +31,12 @@ thiserror = { version = "1.0", default-features = false }
 
 [dependencies.iota-client]
 git = "https://github.com/iotaledger/iota.rs"
-rev = "c3c16d14449cb4f4b49cb3362daa12344d6f2aef"
+rev = "7f5ae8f5b27f5948d8e1b4717419cc1321d862da"
 default-features = false
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies.iota-client]
 git = "https://github.com/iotaledger/iota.rs"
-rev = "c3c16d14449cb4f4b49cb3362daa12344d6f2aef"
+rev = "7f5ae8f5b27f5948d8e1b4717419cc1321d862da"
 default-features = false
 features = ["wasm"]
 

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -33,7 +33,6 @@ thiserror = { version = "1.0", default-features = false }
 git = "https://github.com/iotaledger/iota.rs"
 rev = "c3c16d14449cb4f4b49cb3362daa12344d6f2aef"
 default-features = false
-features = []
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies.iota-client]
 git = "https://github.com/iotaledger/iota.rs"

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = { version = "1.0", default-features = false }
 [dependencies.iota-client]
 git = "https://github.com/iotaledger/iota.rs"
 rev = "7f5ae8f5b27f5948d8e1b4717419cc1321d862da"
+features = ["tls"]
 default-features = false
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies.iota-client]

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -31,9 +31,15 @@ thiserror = { version = "1.0", default-features = false }
 
 [dependencies.iota-client]
 git = "https://github.com/iotaledger/iota.rs"
-rev = "c7d1cc4bae4ef00f16314239463ce115f8c6b35a"
+rev = "c3c16d14449cb4f4b49cb3362daa12344d6f2aef"
 default-features = false
-features = ["pow-fallback"]
+features = []
+
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies.iota-client]
+git = "https://github.com/iotaledger/iota.rs"
+rev = "c3c16d14449cb4f4b49cb3362daa12344d6f2aef"
+default-features = false
+features = ["wasm"]
 
 [dependencies.iota-crypto]
 version = "0.7"
@@ -48,9 +54,6 @@ default = ["async"]
 
 # Enables async runtime support (Tokio)
 async = ["iota-client/async"]
-
-# Enables Web Assembly support
-wasm = ["iota-client/wasm"]
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -33,9 +33,6 @@ default = ["async"]
 # Enables async runtime support (Tokio)
 async = ["identity-iota/async"]
 
-# Enables Web Assembly support
-wasm = ["identity-iota/wasm", "identity-comm/wasm", "identity-core/wasm"]
-
 # Enables support for secure storage of DID Documents
 account = ["identity-account"]
 


### PR DESCRIPTION
# Description of change

Essentially, this changes all `cfg(feature = "wasm")` occurrences to `cfg(all(target_arch = "wasm32", not(target_os = "wasi")))` and removes the `wasm` feature from all crates. Since we only have two occurrences of those in code, most of this applies to various `Cargo.toml`s. The motivation is to enable `Future`s that contain an `Account` to be `Send`. This is not the case in current `dev`, because of `iota_client::Client`. An example that does not compile under current `dev`:

```rust
fn assert_future_send<T: std::future::Future + Send>(_: T) {}

let mut account: Account = AccountBuilder::default()
  .create_identity(IdentitySetup::default())
  .await?;

assert_future_send(account.update_identity().create_method().apply());
```

which fails with:

```
error: generator cannot be sent between threads safely
   --> identity-account/src/tests/account.rs:505:22
    |
505 |   assert_future_send(account.update_identity().create_method().apply());
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `apply` is not `Send`
    |
    = help: within `impl futures::Future<Output = std::result::Result<(), error::Error>>`, the trait `std::marker::Send` is not implemented for `std::sync::RwLockWriteGuard<'_, iota_client::builder::NetworkInfo>`
note: required by a bound in `tests::account::_assert_account_send::{closure#0}::assert_future_send`
   --> identity-account/src/tests/account.rs:499:50
    |
499 |   fn assert_future_send<T: std::future::Future + Send>(_: T) {}
    |                                                  ^^^^ required by this bound in `tests::account::_assert_account_send::{closure#0}::assert_future_send`
```

This compiles under this PR (partly because of changes in [iota.rs/804](https://github.com/iotaledger/iota.rs/pull/804), which this PR depends upon) but subsequent errors are of similar sort. This was added as a static assertion ("compile time test") to prevent a future regression.

Note that this only fails when running `cargo check --all-features` (which is what CI does), while omitting the `wasm` feature does not produce this error. The issue is that checking this assertion test under the `wasm` feature is not what we want, because in Wasm we don't require the future to be `Send`, but we do on other targets. Thus, moving conditional compilation for Wasm to target_arch rather than feature seems to be more in line with how `cfg`s are supposed to work.

It's noteworthy that this same type of fix could be used to fix iota.rs, which would not require us to make the change. However, for the just-mentioned reasons, it seems like an improvement to our crates, to prevent future issues target-feature inconsistencies that might not be related to iota.rs.

**Important**: This points iota.rs to a not-yet-merged commit, so this PR should only be merged after [iota.rs/804](https://github.com/iotaledger/iota.rs/pull/804) has been merged.

This is marked as a breaking change, since the wasm feature was removed from various crates.

This will require #597 to change it's `cfg_attr`s, and likely introduce a separate feature for non-`Send`-`Storage` (FYI @HenriqueNogara).

Unsure if this PR should also make use of the now-runtime configurable POW fallback on iota.rs, which the above mentioned PR changed.

Thanks to @cycraig for suggesting this idea initially!

### Added

- static assertion to ensure `Future`s containing an `Account` are `Send`

### Changed

- `multiple_identities` example to showcase concurrent updates to two accounts
- GitHub workflows to only run `cargo check --target wasm32-unknown-unknown` for the Wasm bindings

### Removed

- Remove the unnecessary `cargo test` in the Wasm bindings which does not do anything because there are no tests. This still runs the `wasm_bindgen_test`s in CI through `npm run test`.

## Links to any relevant issues

None

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
