### PR TITLE
Wasm bindings for `set_controller(..)` and `set_also_known_as(..)` in the account.

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -117,9 +117,10 @@ publishing to the Tangle.
 **Kind**: global class  
 
 * [Account](#Account)
-    * [.deleteMethod(options)](#Account+deleteMethod) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.deleteService(options)](#Account+deleteService) ⇒ <code>Promise.&lt;void&gt;</code>
-    * [.createService(options)](#Account+createService) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.setController(controllers)](#Account+setController) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.setAlsoKnownAs(options)](#Account+setAlsoKnownAs) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.deleteMethod(options)](#Account+deleteMethod) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.did()](#Account+did) ⇒ [<code>DID</code>](#DID)
     * [.autopublish()](#Account+autopublish) ⇒ <code>boolean</code>
     * [.autosave()](#Account+autosave) ⇒ [<code>AutoSave</code>](#AutoSave)
@@ -134,19 +135,9 @@ publishing to the Tangle.
     * [.updateDocumentUnchecked(document)](#Account+updateDocumentUnchecked) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.fetchState()](#Account+fetchState) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.createMethod(options)](#Account+createMethod) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.createService(options)](#Account+createService) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.attachMethodRelationships(options)](#Account+attachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.detachMethodRelationships(options)](#Account+detachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
-
-<a name="Account+deleteMethod"></a>
-
-### account.deleteMethod(options) ⇒ <code>Promise.&lt;void&gt;</code>
-Deletes a verification method if the method exists.
-
-**Kind**: instance method of [<code>Account</code>](#Account)  
-
-| Param | Type |
-| --- | --- |
-| options | <code>DeleteMethodOptions</code> | 
 
 <a name="Account+deleteService"></a>
 
@@ -159,16 +150,38 @@ Deletes a Service if it exists.
 | --- | --- |
 | options | <code>DeleteServiceOptions</code> | 
 
-<a name="Account+createService"></a>
+<a name="Account+setController"></a>
 
-### account.createService(options) ⇒ <code>Promise.&lt;void&gt;</code>
-Adds a new Service to the DID Document.
+### account.setController(controllers) ⇒ <code>Promise.&lt;void&gt;</code>
+Sets the controllers of the DID document.
 
 **Kind**: instance method of [<code>Account</code>](#Account)  
 
 | Param | Type |
 | --- | --- |
-| options | <code>CreateServiceOptions</code> | 
+| controllers | <code>SetControllerOptions</code> | 
+
+<a name="Account+setAlsoKnownAs"></a>
+
+### account.setAlsoKnownAs(options) ⇒ <code>Promise.&lt;void&gt;</code>
+Sets the controllers of the DID document.
+
+**Kind**: instance method of [<code>Account</code>](#Account)  
+
+| Param | Type |
+| --- | --- |
+| options | <code>SetAlsoKnownAsOptions</code> | 
+
+<a name="Account+deleteMethod"></a>
+
+### account.deleteMethod(options) ⇒ <code>Promise.&lt;void&gt;</code>
+Deletes a verification method if the method exists.
+
+**Kind**: instance method of [<code>Account</code>](#Account)  
+
+| Param | Type |
+| --- | --- |
+| options | <code>DeleteMethodOptions</code> | 
 
 <a name="Account+did"></a>
 
@@ -307,6 +320,17 @@ Adds a new verification method to the DID document.
 | Param | Type |
 | --- | --- |
 | options | <code>CreateMethodOptions</code> | 
+
+<a name="Account+createService"></a>
+
+### account.createService(options) ⇒ <code>Promise.&lt;void&gt;</code>
+Adds a new Service to the DID Document.
+
+**Kind**: instance method of [<code>Account</code>](#Account)  
+
+| Param | Type |
+| --- | --- |
+| options | <code>CreateServiceOptions</code> | 
 
 <a name="Account+attachMethodRelationships"></a>
 

--- a/bindings/wasm/src/account/update/mod.rs
+++ b/bindings/wasm/src/account/update/mod.rs
@@ -8,3 +8,4 @@ mod delete_method;
 mod delete_service;
 mod detach_method_relationships;
 mod set_controller;
+mod set_also_known_as;

--- a/bindings/wasm/src/account/update/mod.rs
+++ b/bindings/wasm/src/account/update/mod.rs
@@ -7,3 +7,4 @@ mod create_service;
 mod delete_method;
 mod delete_service;
 mod detach_method_relationships;
+mod set_controller;

--- a/bindings/wasm/src/account/update/set_controller.rs
+++ b/bindings/wasm/src/account/update/set_controller.rs
@@ -1,0 +1,62 @@
+// Copyright 2020-2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::account::wasm_account::WasmAccount;
+use crate::common::PromiseVoid;
+use crate::error::Result;
+use crate::error::WasmResult;
+use identity::account::Account;
+use identity::core::OneOrSet;
+use identity::iota::IotaDID;
+use js_sys::Promise;
+use std::cell::RefCell;
+use std::rc::Rc;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::future_to_promise;
+
+#[wasm_bindgen(js_class = Account)]
+impl WasmAccount {
+  /// Sets the controllers of the DID document.
+  #[wasm_bindgen(js_name = setController)]
+  pub fn set_controller(&mut self, controllers: &SetControllerOptions) -> Result<PromiseVoid> {
+    let account: Rc<RefCell<Account>> = Rc::clone(&self.0);
+    let controllers: Option<OneOrSet<IotaDID>> = controllers.controllers().into_serde().wasm_result()?;
+
+    let promise: Promise = future_to_promise(async move {
+      account
+        .borrow_mut()
+        .update_identity()
+        .set_controller()
+        .controllers(controllers)
+        .apply()
+        .await
+        .wasm_result()
+        .map(|_| JsValue::undefined())
+    });
+    Ok(promise.unchecked_into::<PromiseVoid>())
+  }
+}
+
+#[wasm_bindgen]
+extern "C" {
+  #[wasm_bindgen(typescript_type = "SetControllerOptions")]
+  pub type SetControllerOptions;
+
+  #[wasm_bindgen(getter, method)]
+  pub fn controllers(this: &SetControllerOptions) -> JsValue;
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_SET_CONTROLLER_OPTION: &'static str = r#"
+/**
+ * Options for setting DID controllers
+ */
+ export type SetControllerOptions = {
+
+    /**
+     * List of DIDs to be set as controllers, use `null` to remove all controllers.
+     */
+    controllers: DID | DID[] | null,
+};
+"#;


### PR DESCRIPTION
# Description of change
Add WASM bindings for setting controllers and the alsoKnownAs property in the account.

## Links to any relevant issues
#647

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Locally testing the methods in TS.
