### PR TITLE
Fix `WasmTimestamp` JSON serialization

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -2520,9 +2520,11 @@ Creates a new `SignatureOptions` with default options.
         * [.toRFC3339()](#Timestamp+toRFC3339) ⇒ <code>string</code>
         * [.checkedAdd(duration)](#Timestamp+checkedAdd) ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
         * [.checkedSub(duration)](#Timestamp+checkedSub) ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
+        * [.toJSON()](#Timestamp+toJSON) ⇒ <code>any</code>
     * _static_
         * [.parse(input)](#Timestamp.parse) ⇒ [<code>Timestamp</code>](#Timestamp)
         * [.nowUTC()](#Timestamp.nowUTC) ⇒ [<code>Timestamp</code>](#Timestamp)
+        * [.fromJSON(json)](#Timestamp.fromJSON) ⇒ [<code>Timestamp</code>](#Timestamp)
 
 <a name="Timestamp+toRFC3339"></a>
 
@@ -2556,6 +2558,12 @@ Returns `null` if the operation leads to a timestamp not in the valid range for 
 | --- | --- |
 | duration | [<code>Duration</code>](#Duration) | 
 
+<a name="Timestamp+toJSON"></a>
+
+### timestamp.toJSON() ⇒ <code>any</code>
+Serializes a `Timestamp` as a JSON object.
+
+**Kind**: instance method of [<code>Timestamp</code>](#Timestamp)  
 <a name="Timestamp.parse"></a>
 
 ### Timestamp.parse(input) ⇒ [<code>Timestamp</code>](#Timestamp)
@@ -2573,6 +2581,17 @@ Parses a `Timestamp` from the provided input string.
 Creates a new `Timestamp` with the current date and time.
 
 **Kind**: static method of [<code>Timestamp</code>](#Timestamp)  
+<a name="Timestamp.fromJSON"></a>
+
+### Timestamp.fromJSON(json) ⇒ [<code>Timestamp</code>](#Timestamp)
+Deserializes a `Timestamp` from a JSON object.
+
+**Kind**: static method of [<code>Timestamp</code>](#Timestamp)  
+
+| Param | Type |
+| --- | --- |
+| json | <code>any</code> | 
+
 <a name="VerificationMethod"></a>
 
 ## VerificationMethod

--- a/bindings/wasm/src/common/timestamp.rs
+++ b/bindings/wasm/src/common/timestamp.rs
@@ -47,6 +47,18 @@ impl WasmTimestamp {
   pub fn checked_sub(self, duration: WasmDuration) -> Option<WasmTimestamp> {
     self.0.checked_sub(duration.0).map(WasmTimestamp)
   }
+
+  /// Serializes a `Timestamp` as a JSON object.
+  #[wasm_bindgen(js_name = toJSON)]
+  pub fn to_json(&self) -> Result<JsValue> {
+    JsValue::from_serde(&self.0).wasm_result()
+  }
+
+  /// Deserializes a `Timestamp` from a JSON object.
+  #[wasm_bindgen(js_name = fromJSON)]
+  pub fn from_json(json: &JsValue) -> Result<WasmTimestamp> {
+    json.into_serde().map(Self).wasm_result()
+  }
 }
 
 impl From<Timestamp> for WasmTimestamp {

--- a/bindings/wasm/tests/wasm.rs
+++ b/bindings/wasm/tests/wasm.rs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::borrow::Cow;
+use identity::core::Timestamp;
 
 use identity::iota::IotaDID;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
+use identity_wasm::common::WasmTimestamp;
 
 use identity_wasm::crypto::Digest;
 use identity_wasm::crypto::KeyCollection;
@@ -257,6 +259,20 @@ fn test_did_serde() {
     let de: IotaDID = js_string.into_serde().unwrap();
     assert_eq!(de, expected);
   }
+}
+
+#[wasm_bindgen_test]
+fn test_timestamp_serde() {
+  let expected_str: &str = "2022-12-25T13:58:03Z";
+  let timestamp: Timestamp = Timestamp::parse(expected_str).unwrap();
+  let wasm_timestamp: WasmTimestamp = WasmTimestamp::from(timestamp);
+
+  let ser: String = wasm_timestamp.to_json().unwrap().into_serde().unwrap();
+  assert_eq!(ser, expected_str);
+  let de: Timestamp = JsValue::from_str(&ser).into_serde().unwrap();
+  assert_eq!(de, timestamp);
+  let wasm_de: WasmTimestamp = WasmTimestamp::from_json(&JsValue::from_str(&ser)).unwrap();
+  assert_eq!(wasm_de.to_rfc3339(), expected_str);
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
# Description of change
Add `toJSON` and `fromJSON` implementations for `WasmTimestamp` to fix a bug where attempting to deserialize timestamp parameters passed as Typescript interfaces/unions throws an error (or calling `JSON.stringify` on one).

Error this PR fixes:

```js
Err > Error [serde_json::Error]: invalid type: map, expected a string at line 1 column 11
    at module.exports.__wbg_new_55259b13834a484c (C:\Work\iota\identity.rs\bindings\wasm\node\identity_wasm.js:5489:15)
    at wasm://wasm/00dd5272:wasm-function[5171]:0x2385c9
    at wasm://wasm/00dd5272:wasm-function[4821]:0x22f864
    at wasm://wasm/00dd5272:wasm-function[4155]:0x21a620
    at wasm://wasm/00dd5272:wasm-function[4497]:0x225bcd
    at new SignatureOptions (C:\Work\iota\identity.rs\bindings\wasm\node\identity_wasm.js:4803:18)
    at a (C:\Work\iota\identity.rs\bindings\wasm\examples\dist\node.js:1:2413)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async C:\Work\iota\identity.rs\bindings\wasm\examples\dist\node.js:1:8680 
```

This PR:

```ts
console.log(JSON.stringify(Timestamp.nowUTC());
// "2022-03-03T13:58:03Z"
```

Thanks @olivereanderson for identifying this bug!



## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Added unit test and manually ran example which deserializes `WasmTimestamp` via `ISignatureOptions`.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
