### PR TITLE
Enable retries for `txm` tests

### DIFF
--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -25,7 +25,7 @@
     "test:node": "mocha ./examples/dist/tests/node/*.js --parallel --jobs 4 --retries 3 --exit",
     "test:browser:parallel": "cypress-parallel -s test:browser -t 4 -d cypress/integration -a '\"--quiet\"'",
     "test:browser": "cypress run --headless",
-    "test:readme": "txm README.md",
+    "test:readme": "mocha ./tests/txm_readme.js --retries 3 --timeout 180000 --exit",
     "test:unit": "wasm-pack test --node",
     "cypress": "cypress open"
   },

--- a/bindings/wasm/tests/txm_readme.js
+++ b/bindings/wasm/tests/txm_readme.js
@@ -1,0 +1,7 @@
+const {execSync} = require('child_process')
+
+describe("Test TXM", function () {
+    it("README examples pass", async () => {
+        execSync("txm README.md")
+    });
+})


### PR DESCRIPTION
# Description of change
Use mocha to run txm Readme tests in order to use mochas retries functionality.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Forced random failure locally, tests still complete.
CI still passes.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
