### PR TITLE
Use chocolatey instead of scoop in CI

### DIFF
--- a/.github/actions/rust/sccache/setup-sccache/action.yml
+++ b/.github/actions/rust/sccache/setup-sccache/action.yml
@@ -37,11 +37,7 @@ runs:
       if: inputs.os == 'windows-latest'
       shell: pwsh
       run: |
-        Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-        # use preinstalled 7-zip to avoid unreliable installs
-        scoop config '7ZIPEXTRACT_USE_EXTERNAL' $true
-        scoop install sccache
-        echo "${HOME}/scoop/apps/sccache/current" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        choco install sccache
   
     - name: Start sccache
       if: inputs.os == 'macos-latest' || inputs.os == 'ubuntu-latest'


### PR DESCRIPTION
# Description of change
Use chocolatey instead of scoop to install sccache on windows runners.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
