### PR TITLE
Feature gate `StrongholdError` import

### DIFF
--- a/identity-account/src/error.rs
+++ b/identity-account/src/error.rs
@@ -3,6 +3,7 @@
 
 //! Errors that may occur when working with Identity Accounts.
 
+#[cfg(feature = "stronghold")]
 use crate::stronghold::StrongholdError;
 
 /// Alias for a `Result` with the error type [`Error`].


### PR DESCRIPTION
# Description of change

Feature gate the import to make the account compile if the `stronghold` feature is not activated. This shows one of the limitations of our current CI approach, e.g. using `cargo check --all-features`.

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

n/a

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
