### PR TITLE
Fix link for feature discovery in DIDComm protocols

### DIFF
--- a/documentation/docs/specs/didcomm/overview.md
+++ b/documentation/docs/specs/didcomm/overview.md
@@ -56,7 +56,7 @@ In addition to the protocols defined in this specification, we RECOMMEND impleme
 
 | Name | Version | Description |
 | :--- | :---: | :--- | 
-| [Discover Features](https://github.com/decentralized-identity/didcomm-messaging/blob/ef997c9d3cd1cd24eb182ffa2930a095d3b856a9/docs/spec-files/feature_discovery.md) | 1.0 | Describes how agents can query one another to discover which features they support, and to what extent. |
+| [Discover Features](https://github.com/decentralized-identity/didcomm-messaging/blob/ef997c9d3cd1cd24eb182ffa2930a095d3b856a9/docs/spec-files/feature_discovery.md) | 2.0 | Describes how agents can query one another to discover which features they support, and to what extent. |
 | [Trust Ping](https://github.com/decentralized-identity/didcomm-messaging/blob/9039564e143380a0085a788b6dfd20e63873b9ca/docs/spec-files/trustping.md) | 1.0 | A standard way for agents to test connectivity, responsiveness, and security of a DIDComm channel. | 
 
 ## Resources

--- a/documentation/docs/specs/didcomm/overview.md
+++ b/documentation/docs/specs/didcomm/overview.md
@@ -56,7 +56,7 @@ In addition to the protocols defined in this specification, we RECOMMEND impleme
 
 | Name | Version | Description |
 | :--- | :---: | :--- | 
-| [Discover Features](https://github.com/decentralized-identity/didcomm-messaging/blob/9039564e143380a0085a788b6dfd20e63873b9ca/docs/spec-files/feature_discovery.md) | 1.0 | Describes how agents can query one another to discover which features they support, and to what extent. |
+| [Discover Features](https://github.com/decentralized-identity/didcomm-messaging/blob/ef997c9d3cd1cd24eb182ffa2930a095d3b856a9/docs/spec-files/feature_discovery.md) | 1.0 | Describes how agents can query one another to discover which features they support, and to what extent. |
 | [Trust Ping](https://github.com/decentralized-identity/didcomm-messaging/blob/9039564e143380a0085a788b6dfd20e63873b9ca/docs/spec-files/trustping.md) | 1.0 | A standard way for agents to test connectivity, responsiveness, and security of a DIDComm channel. | 
 
 ## Resources

--- a/documentation/docs/specs/didcomm/protocols/connection.md
+++ b/documentation/docs/specs/didcomm/protocols/connection.md
@@ -20,7 +20,7 @@ Allows establishment of a [DIDComm connection](https://identity.foundation/didco
 ### Relationships
 - [Termination](./termination): the DIDComm connection may be gracefully concluded using the [termination protocol](./termination).
 - [Authentication](./authentication): the authentication protocol can be used to authenticate parties participating in the established [connection](./connection).
-- [Feature Discovery](./feature-discovery): feature discovery can be used to learn about the capabilities of the other party after connection.
+- [Feature Discovery](https://github.com/decentralized-identity/didcomm-messaging/blob/9039564e143380a0085a788b6dfd20e63873b9ca/docs/spec-files/feature_discovery.md): feature discovery can be used to learn about the capabilities of the other party after connection.
 
 ### Example Use-Cases
 

--- a/documentation/docs/specs/didcomm/protocols/connection.md
+++ b/documentation/docs/specs/didcomm/protocols/connection.md
@@ -20,7 +20,7 @@ Allows establishment of a [DIDComm connection](https://identity.foundation/didco
 ### Relationships
 - [Termination](./termination): the DIDComm connection may be gracefully concluded using the [termination protocol](./termination).
 - [Authentication](./authentication): the authentication protocol can be used to authenticate parties participating in the established [connection](./connection).
-- [Feature Discovery](https://github.com/decentralized-identity/didcomm-messaging/blob/9039564e143380a0085a788b6dfd20e63873b9ca/docs/spec-files/feature_discovery.md): feature discovery can be used to learn about the capabilities of the other party after connection.
+- [Feature Discovery](https://github.com/decentralized-identity/didcomm-messaging/blob/ef997c9d3cd1cd24eb182ffa2930a095d3b856a9/docs/spec-files/feature_discovery.md): feature discovery can be used to learn about the capabilities of the other party after connection.
 
 ### Example Use-Cases
 


### PR DESCRIPTION
# Description of change
Fixes a link that was pointing to a non-existing feature-discovery document. Replaced the link with the document from the external protocols. 

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
