### PR TITLE
Generify `Account::client` over `Rc`, `Arc`

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -114,9 +114,9 @@ See <code>IVerifierOptions</code>.</p>
 ## Members
 
 <dl>
-<dt><a href="#KeyType">KeyType</a></dt>
-<dd></dd>
 <dt><a href="#DIDMessageEncoding">DIDMessageEncoding</a></dt>
+<dd></dd>
+<dt><a href="#KeyType">KeyType</a></dt>
 <dd></dd>
 <dt><a href="#MethodRelationship">MethodRelationship</a></dt>
 <dd></dd>
@@ -3519,13 +3519,13 @@ Throws an error if any of the options are invalid.
 Creates a new `VerifierOptions` with default options.
 
 **Kind**: static method of [<code>VerifierOptions</code>](#VerifierOptions)  
-<a name="KeyType"></a>
-
-## KeyType
-**Kind**: global variable  
 <a name="DIDMessageEncoding"></a>
 
 ## DIDMessageEncoding
+**Kind**: global variable  
+<a name="KeyType"></a>
+
+## KeyType
 **Kind**: global variable  
 <a name="MethodRelationship"></a>
 

--- a/bindings/wasm/src/account/wasm_account/account.rs
+++ b/bindings/wasm/src/account/wasm_account/account.rs
@@ -1,7 +1,6 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::cell::Ref;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -14,6 +13,7 @@ use identity::account::Storage;
 use identity::crypto::SetSignature;
 use identity::crypto::SignatureOptions;
 use identity::did::verifiable::VerifiableProperties;
+use identity::iota::Client;
 use identity::iota::IotaDID;
 use identity::iota::IotaDocument;
 use js_sys::Promise;
@@ -33,20 +33,21 @@ use crate::did::WasmResolvedDocument;
 use crate::error::Result;
 use crate::error::WasmResult;
 
+pub(crate) type AccountRc = Account<Rc<Client>>;
+
 /// An account manages one identity.
 ///
 /// It handles private keys, writing to storage and
 /// publishing to the Tangle.
 #[wasm_bindgen(js_name = Account)]
-pub struct WasmAccount(pub(crate) Rc<RefCell<Account>>);
+pub struct WasmAccount(pub(crate) Rc<RefCell<AccountRc>>);
 
 #[wasm_bindgen(js_class = Account)]
 impl WasmAccount {
   /// Returns the {@link DID} of the managed identity.
   #[wasm_bindgen(js_name = did)]
   pub fn did(&self) -> WasmDID {
-    let account: Ref<Account> = self.0.borrow();
-    WasmDID::from(account.did().clone())
+    WasmDID::from(self.0.borrow().did().clone())
   }
 
   /// Returns whether auto-publish is enabled.
@@ -71,7 +72,7 @@ impl WasmAccount {
   /// Resolves the DID Document associated with this `Account` from the Tangle.
   #[wasm_bindgen(js_name = resolveIdentity)]
   pub fn resolve_identity(&self) -> PromiseResolvedDocument {
-    let account = self.0.clone();
+    let account: Rc<RefCell<AccountRc>> = self.0.clone();
 
     let promise: Promise = future_to_promise(async move {
       account
@@ -97,11 +98,12 @@ impl WasmAccount {
 
     // Drop account should release the DIDLease because we cannot take ownership of the Rc.
     // Note that this will still fail if anyone else has a reference to the Account.
+    // TODO: remove this since DIDLease no longer exists?
     std::mem::drop(self.0);
 
     future_to_promise(async move {
       // Create a new account since `delete_identity` consumes it.
-      let account: Result<Account> = AccountBuilder::new()
+      let account: Result<AccountRc> = AccountBuilder::new()
         .storage(AccountStorage::Custom(storage))
         .load_identity(did)
         .await
@@ -246,8 +248,8 @@ impl WasmAccount {
   }
 }
 
-impl From<Account> for WasmAccount {
-  fn from(account: Account) -> WasmAccount {
+impl From<AccountRc> for WasmAccount {
+  fn from(account: AccountRc) -> WasmAccount {
     WasmAccount(Rc::new(RefCell::new(account)))
   }
 }

--- a/bindings/wasm/src/account/wasm_account/account.rs
+++ b/bindings/wasm/src/account/wasm_account/account.rs
@@ -96,11 +96,6 @@ impl WasmAccount {
     let did: IotaDID = self.0.borrow().did().to_owned();
     let storage: Arc<dyn Storage> = Arc::clone(self.0.borrow().storage());
 
-    // Drop account should release the DIDLease because we cannot take ownership of the Rc.
-    // Note that this will still fail if anyone else has a reference to the Account.
-    // TODO: remove this since DIDLease no longer exists?
-    std::mem::drop(self.0);
-
     future_to_promise(async move {
       // Create a new account since `delete_identity` consumes it.
       let account: Result<AccountRc> = AccountBuilder::new()

--- a/bindings/wasm/src/account/wasm_account/update/attach_method_relationships.rs
+++ b/bindings/wasm/src/account/wasm_account/update/attach_method_relationships.rs
@@ -5,17 +5,18 @@ use std::cell::RefCell;
 use std::cell::RefMut;
 use std::rc::Rc;
 
-use identity::account::Account;
 use identity::account::AttachMethodRelationshipBuilder;
 use identity::account::IdentityUpdater;
 use identity::account::UpdateError::MissingRequiredField;
 use identity::core::OneOrMany;
 use identity::did::MethodRelationship;
+use identity::iota::Client;
 use js_sys::Promise;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::future_to_promise;
 
+use crate::account::wasm_account::account::AccountRc;
 use crate::account::wasm_account::WasmAccount;
 use crate::common::PromiseVoid;
 use crate::did::WasmMethodRelationship;
@@ -44,14 +45,14 @@ impl WasmAccount {
       .ok_or(MissingRequiredField("fragment"))
       .wasm_result()?;
 
-    let account: Rc<RefCell<Account>> = Rc::clone(&self.0);
+    let account: Rc<RefCell<AccountRc>> = Rc::clone(&self.0);
     let promise: Promise = future_to_promise(async move {
       if relationships.is_empty() {
         return Ok(JsValue::undefined());
       }
-      let mut account: RefMut<Account> = account.borrow_mut();
-      let mut updater: IdentityUpdater<'_> = account.update_identity();
-      let mut attach_relationship: AttachMethodRelationshipBuilder<'_> =
+      let mut account: RefMut<AccountRc> = account.borrow_mut();
+      let mut updater: IdentityUpdater<'_, Rc<Client>> = account.update_identity();
+      let mut attach_relationship: AttachMethodRelationshipBuilder<'_, Rc<Client>> =
         updater.attach_method_relationship().fragment(fragment);
 
       for relationship in relationships {

--- a/bindings/wasm/src/account/wasm_account/update/create_method.rs
+++ b/bindings/wasm/src/account/wasm_account/update/create_method.rs
@@ -5,19 +5,20 @@ use std::cell::RefCell;
 use std::cell::RefMut;
 use std::rc::Rc;
 
-use identity::account::Account;
 use identity::account::CreateMethodBuilder;
 use identity::account::IdentityUpdater;
 use identity::account::MethodSecret;
 use identity::account::UpdateError::MissingRequiredField;
 use identity::did::MethodScope;
 use identity::did::MethodType;
+use identity::iota::Client;
 use js_sys::Promise;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::future_to_promise;
 
 use crate::account::types::WasmMethodSecret;
+use crate::account::wasm_account::account::AccountRc;
 use crate::account::wasm_account::WasmAccount;
 use crate::common::PromiseVoid;
 use crate::did::WasmMethodScope;
@@ -41,11 +42,11 @@ impl WasmAccount {
 
     let method_secret: Option<MethodSecret> = options.methodSecret().map(|ms| ms.0);
 
-    let account: Rc<RefCell<Account>> = Rc::clone(&self.0);
+    let account: Rc<RefCell<AccountRc>> = Rc::clone(&self.0);
     let promise: Promise = future_to_promise(async move {
-      let mut account: RefMut<Account> = account.borrow_mut();
-      let mut updater: IdentityUpdater<'_> = account.update_identity();
-      let mut create_method: CreateMethodBuilder<'_> = updater.create_method().fragment(fragment);
+      let mut account: RefMut<AccountRc> = account.borrow_mut();
+      let mut updater: IdentityUpdater<'_, Rc<Client>> = account.update_identity();
+      let mut create_method: CreateMethodBuilder<'_, Rc<Client>> = updater.create_method().fragment(fragment);
 
       if let Some(type_) = method_type {
         create_method = create_method.type_(type_);

--- a/bindings/wasm/src/account/wasm_account/update/detach_method_relationships.rs
+++ b/bindings/wasm/src/account/wasm_account/update/detach_method_relationships.rs
@@ -5,17 +5,18 @@ use std::cell::RefCell;
 use std::cell::RefMut;
 use std::rc::Rc;
 
-use identity::account::Account;
 use identity::account::DetachMethodRelationshipBuilder;
 use identity::account::IdentityUpdater;
 use identity::account::UpdateError::MissingRequiredField;
 use identity::core::OneOrMany;
 use identity::did::MethodRelationship;
+use identity::iota::Client;
 use js_sys::Promise;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::future_to_promise;
 
+use crate::account::wasm_account::account::AccountRc;
 use crate::account::wasm_account::WasmAccount;
 use crate::common::PromiseVoid;
 use crate::did::WasmMethodRelationship;
@@ -41,15 +42,15 @@ impl WasmAccount {
       .ok_or(MissingRequiredField("fragment"))
       .wasm_result()?;
 
-    let account: Rc<RefCell<Account>> = Rc::clone(&self.0);
+    let account: Rc<RefCell<AccountRc>> = Rc::clone(&self.0);
 
     let promise: Promise = future_to_promise(async move {
       if relationships.is_empty() {
         return Ok(JsValue::undefined());
       }
-      let mut account: RefMut<Account> = account.borrow_mut();
-      let mut updater: IdentityUpdater<'_> = account.update_identity();
-      let mut detach_relationship: DetachMethodRelationshipBuilder<'_> =
+      let mut account: RefMut<AccountRc> = account.borrow_mut();
+      let mut updater: IdentityUpdater<'_, Rc<Client>> = account.update_identity();
+      let mut detach_relationship: DetachMethodRelationshipBuilder<'_, Rc<Client>> =
         updater.detach_method_relationship().fragment(fragment);
 
       for relationship in relationships {

--- a/bindings/wasm/src/account/wasm_account/update/set_also_known_as.rs
+++ b/bindings/wasm/src/account/wasm_account/update/set_also_known_as.rs
@@ -1,21 +1,22 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use identity::core::OneOrMany;
+use identity::core::OrderedSet;
+use identity::core::Url;
+use js_sys::Promise;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::future_to_promise;
+
+use crate::account::wasm_account::account::AccountRc;
 use crate::account::wasm_account::WasmAccount;
 use crate::common::PromiseVoid;
 use crate::error::Result;
 use crate::error::WasmResult;
-use identity::account::Account;
-use identity::core::OneOrMany;
-use identity::core::OrderedSet;
-use identity::core::Url;
-
-use js_sys::Promise;
-use std::cell::RefCell;
-use std::rc::Rc;
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::future_to_promise;
 
 #[wasm_bindgen(js_class = Account)]
 impl WasmAccount {
@@ -31,7 +32,7 @@ impl WasmAccount {
       }
     }
 
-    let account: Rc<RefCell<Account>> = Rc::clone(&self.0);
+    let account: Rc<RefCell<AccountRc>> = Rc::clone(&self.0);
     let promise: Promise = future_to_promise(async move {
       account
         .borrow_mut()

--- a/bindings/wasm/src/account/wasm_account/update/set_controller.rs
+++ b/bindings/wasm/src/account/wasm_account/update/set_controller.rs
@@ -1,21 +1,23 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::account::wasm_account::WasmAccount;
-use crate::common::PromiseVoid;
-use crate::error::Result;
-use crate::error::WasmResult;
-use identity::account::Account;
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use identity::core::OneOrMany;
 use identity::core::OneOrSet;
 use identity::core::OrderedSet;
 use identity::iota::IotaDID;
 use js_sys::Promise;
-use std::cell::RefCell;
-use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::future_to_promise;
+
+use crate::account::wasm_account::account::AccountRc;
+use crate::account::wasm_account::WasmAccount;
+use crate::common::PromiseVoid;
+use crate::error::Result;
+use crate::error::WasmResult;
 
 #[wasm_bindgen(js_class = Account)]
 impl WasmAccount {
@@ -43,7 +45,7 @@ impl WasmAccount {
       None
     };
 
-    let account: Rc<RefCell<Account>> = Rc::clone(&self.0);
+    let account: Rc<RefCell<AccountRc>> = Rc::clone(&self.0);
 
     let promise: Promise = future_to_promise(async move {
       account

--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -3,7 +3,6 @@
 
 use std::fmt::Debug;
 use std::ops::Deref;
-use std::rc::Rc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -22,8 +21,8 @@ use identity_iota::tangle::Client;
 use identity_iota::tangle::MessageId;
 use identity_iota::tangle::MessageIdExt;
 use identity_iota::tangle::PublishType;
+use identity_iota::tangle::SharedPtr;
 
-use crate::account::account::private::Sealed;
 use crate::account::AccountBuilder;
 use crate::account::PublishOptions;
 use crate::identity::ChainState;
@@ -40,28 +39,6 @@ use crate::Result;
 use super::config::AccountSetup;
 use super::config::AutoSave;
 use super::AccountConfig;
-
-// TODO: move SharedPtr to `identity-iota`.
-/// Sealed trait to generalize over `Arc<T>` and `Rc<T>`.
-///
-/// Replace by higher-kinded type when `CoerceUnsized` is stabilized, otherwise we cannot
-/// support unsized types like dynamic traits.
-pub trait SharedPtr<T>: Clone + From<T> + Deref<Target = T> + Sealed {}
-
-impl<T> SharedPtr<T> for Rc<T> {}
-
-impl<T> SharedPtr<T> for Arc<T> {}
-
-mod private {
-  use std::rc::Rc;
-  use std::sync::Arc;
-
-  pub trait Sealed {}
-
-  impl<T> Sealed for Rc<T> {}
-
-  impl<T> Sealed for Arc<T> {}
-}
 
 /// An account manages one identity.
 ///

--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -1,6 +1,9 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fmt::Debug;
+use std::ops::Deref;
+use std::rc::Rc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -20,6 +23,7 @@ use identity_iota::tangle::MessageId;
 use identity_iota::tangle::MessageIdExt;
 use identity_iota::tangle::PublishType;
 
+use crate::account::account::private::Sealed;
 use crate::account::AccountBuilder;
 use crate::account::PublishOptions;
 use crate::identity::ChainState;
@@ -37,32 +41,60 @@ use super::config::AccountSetup;
 use super::config::AutoSave;
 use super::AccountConfig;
 
+// TODO: move SharedPtr to `identity-iota`.
+/// Sealed trait to generalize over `Arc<T>` and `Rc<T>`.
+///
+/// Replace by higher-kinded type when `CoerceUnsized` is stabilized, otherwise we cannot
+/// support unsized types like dynamic traits.
+pub trait SharedPtr<T>: Clone + From<T> + Deref<Target = T> + Sealed {}
+
+impl<T> SharedPtr<T> for Rc<T> {}
+
+impl<T> SharedPtr<T> for Arc<T> {}
+
+mod private {
+  use std::rc::Rc;
+  use std::sync::Arc;
+
+  pub trait Sealed {}
+
+  impl<T> Sealed for Rc<T> {}
+
+  impl<T> Sealed for Arc<T> {}
+}
+
 /// An account manages one identity.
 ///
 /// It handles private keys, writing to storage and
 /// publishing to the Tangle.
 #[derive(Debug)]
-pub struct Account {
+pub struct Account<C = Arc<Client>>
+where
+  C: SharedPtr<Client>,
+{
   config: AccountConfig,
   storage: Arc<dyn Storage>,
-  client: Arc<Client>,
+  client: C,
   actions: AtomicUsize,
   chain_state: ChainState,
   state: IdentityState,
 }
 
-impl Account {
+impl<C> Account<C>
+where
+  C: SharedPtr<Client>,
+{
   // ===========================================================================
   // Constructors
   // ===========================================================================
 
   /// Creates a new [AccountBuilder].
-  pub fn builder() -> AccountBuilder {
+  pub fn builder() -> AccountBuilder<C> {
     AccountBuilder::new()
   }
 
   /// Creates a new `Account` instance with the given `config`.
-  async fn with_setup(setup: AccountSetup, chain_state: ChainState, state: IdentityState) -> Result<Self> {
+  async fn with_setup(setup: AccountSetup<C>, chain_state: ChainState, state: IdentityState) -> Result<Self> {
     Ok(Self {
       config: setup.config,
       storage: setup.storage,
@@ -79,11 +111,11 @@ impl Account {
   /// is automatically determined by the [`Client`] used to publish it.
   ///
   /// See [`IdentitySetup`] to customize the identity creation.
-  pub(crate) async fn create_identity(account_setup: AccountSetup, identity_setup: IdentitySetup) -> Result<Self> {
+  pub(crate) async fn create_identity(account_setup: AccountSetup<C>, identity_setup: IdentitySetup) -> Result<Self> {
     let state: IdentityState = create_identity(
       identity_setup,
-      account_setup.client.network().name(),
-      account_setup.storage.as_ref(),
+      account_setup.client.deref().network().name(),
+      account_setup.storage.deref(),
     )
     .await?;
 
@@ -102,7 +134,7 @@ impl Account {
   ///
   /// Callers are expected **not** to load the same [`IotaDID`] into more than one account,
   /// as that would cause race conditions when updating the identity.
-  pub(crate) async fn load_identity(setup: AccountSetup, did: IotaDID) -> Result<Self> {
+  pub(crate) async fn load_identity(setup: AccountSetup<C>, did: IotaDID) -> Result<Self> {
     // Ensure the DID matches the client network.
     if did.network_str() != setup.client.network().name_str() {
       return Err(Error::IotaError(identity_iota::Error::IncompatibleNetwork(format!(
@@ -193,7 +225,7 @@ impl Account {
   ///
   /// On this type, various operations can be executed
   /// that modify an identity, such as creating services or methods.
-  pub fn update_identity(&mut self) -> IdentityUpdater<'_> {
+  pub fn update_identity(&mut self) -> IdentityUpdater<'_, C> {
     IdentityUpdater::new(self)
   }
 
@@ -219,7 +251,7 @@ impl Account {
   /// Note: This will remove all associated document updates and key material - recovery is NOT POSSIBLE!
   pub async fn delete_identity(self) -> Result<()> {
     // Remove all associated keys and events
-    self.storage().as_ref().purge(self.did()).await?;
+    self.storage().deref().purge(self.did()).await?;
 
     // Write the changes to disk
     self.save(false).await?;
@@ -242,7 +274,7 @@ impl Account {
     let location: KeyLocation = state.method_location(method.key_type(), fragment.to_owned())?;
 
     state
-      .sign_data(self.did(), self.storage().as_ref(), &location, data, options)
+      .sign_data(self.did(), self.storage().deref(), &location, data, options)
       .await?;
 
     Ok(())
@@ -303,7 +335,7 @@ impl Account {
     // This should be mapped to a fatal error in the future.
     self
       .storage()
-      .as_ref()
+      .deref()
       .state(self.did())
       .await?
       .ok_or(Error::IdentityNotFound)
@@ -311,9 +343,7 @@ impl Account {
 
   pub(crate) async fn process_update(&mut self, update: Update) -> Result<()> {
     let did = self.did().to_owned();
-    let storage = Arc::clone(&self.storage);
-
-    update.process(&did, &mut self.state, storage.as_ref()).await?;
+    update.process(&did, &mut self.state, self.storage.deref()).await?;
 
     self.increment_actions();
 
@@ -353,7 +383,7 @@ impl Account {
     signing_state
       .sign_data(
         self.did(),
-        self.storage().as_ref(),
+        self.storage().deref(),
         &signing_key_location,
         document,
         SignatureOptions::default(),
@@ -497,7 +527,7 @@ impl Account {
     old_state
       .sign_data(
         self.did(),
-        self.storage().as_ref(),
+        self.storage().deref(),
         &signing_key_location,
         &mut diff,
         SignatureOptions::default(),
@@ -530,10 +560,10 @@ impl Account {
   async fn save(&self, force: bool) -> Result<()> {
     match self.config.autosave {
       AutoSave::Every => {
-        self.storage().as_ref().flush_changes().await?;
+        self.storage().deref().flush_changes().await?;
       }
       AutoSave::Batch(step) if force || (step != 0 && self.actions() % step == 0) => {
-        self.storage().as_ref().flush_changes().await?;
+        self.storage().deref().flush_changes().await?;
       }
       AutoSave::Batch(_) | AutoSave::Never => {}
     }

--- a/identity-account/src/account/builder.rs
+++ b/identity-account/src/account/builder.rs
@@ -13,6 +13,7 @@ use identity_iota::tangle::Client;
 use identity_iota::tangle::ClientBuilder;
 
 use crate::account::Account;
+use crate::account::SharedPtr;
 use crate::error::Result;
 use crate::identity::IdentitySetup;
 use crate::storage::MemStore;
@@ -45,15 +46,21 @@ pub enum AccountStorage {
 /// This means a builder can be reconfigured in-between account creations, without affecting
 /// the configuration of previously built accounts.
 #[derive(Debug)]
-pub struct AccountBuilder {
+pub struct AccountBuilder<C = Arc<Client>>
+where
+  C: SharedPtr<Client>,
+{
   config: AccountConfig,
   storage_template: Option<AccountStorage>,
   storage: Option<Arc<dyn Storage>>,
   client_builder: Option<ClientBuilder>,
-  client: Option<Arc<Client>>,
+  client: Option<C>,
 }
 
-impl AccountBuilder {
+impl<C> AccountBuilder<C>
+where
+  C: SharedPtr<Client>,
+{
   /// Creates a new `AccountBuilder`.
   pub fn new() -> Self {
     Self {
@@ -135,7 +142,7 @@ impl AccountBuilder {
   /// NOTE: this overwrites any [`ClientBuilder`] previously set by
   /// [`AccountBuilder::client_builder`].
   #[must_use]
-  pub fn client(mut self, client: Arc<Client>) -> Self {
+  pub fn client(mut self, client: C) -> Self {
     self.client = Some(client);
     self.client_builder = None;
     self
@@ -156,24 +163,24 @@ impl AccountBuilder {
   /// to [`AccountBuilder::client_builder`].
   ///
   /// If neither is set, instantiates and stores a default [`Client`].
-  async fn get_or_build_client(&mut self) -> Result<Arc<Client>> {
+  async fn get_or_build_client(&mut self) -> Result<C> {
     if let Some(client) = &self.client {
-      Ok(Arc::clone(client))
+      Ok(C::clone(client))
     } else if let Some(client_builder) = self.client_builder.take() {
-      let client: Arc<Client> = Arc::new(client_builder.build().await?);
-      self.client = Some(Arc::clone(&client));
+      let client: C = C::from(client_builder.build().await?);
+      self.client = Some(C::clone(&client));
       Ok(client)
     } else {
-      let client: Arc<Client> = Arc::new(Client::new().await?);
-      self.client = Some(Arc::clone(&client));
+      let client: C = C::from(Client::new().await?);
+      self.client = Some(C::clone(&client));
       Ok(client)
     }
   }
 
-  async fn build_setup(&mut self) -> Result<AccountSetup> {
-    let client: Arc<Client> = self.get_or_build_client().await?;
+  async fn build_setup(&mut self) -> Result<AccountSetup<C>> {
+    let client: C = self.get_or_build_client().await?;
 
-    Ok(AccountSetup::new(
+    Ok(AccountSetup::<C>::new(
       self.get_storage().await?,
       client,
       self.config.clone(),
@@ -187,8 +194,8 @@ impl AccountBuilder {
   /// by the [`Client`] used to publish it.
   ///
   /// See [`IdentitySetup`] to customize the identity creation.
-  pub async fn create_identity(&mut self, input: IdentitySetup) -> Result<Account> {
-    let setup: AccountSetup = self.build_setup().await?;
+  pub async fn create_identity(&mut self, input: IdentitySetup) -> Result<Account<C>> {
+    let setup: AccountSetup<C> = self.build_setup().await?;
     Account::create_identity(setup, input).await
   }
 
@@ -199,13 +206,16 @@ impl AccountBuilder {
   ///
   /// Callers are expected **not** to load the same [`IotaDID`] into more than one account,
   /// as that would cause race conditions when updating the identity.
-  pub async fn load_identity(&mut self, did: IotaDID) -> Result<Account> {
-    let setup: AccountSetup = self.build_setup().await?;
+  pub async fn load_identity(&mut self, did: IotaDID) -> Result<Account<C>> {
+    let setup: AccountSetup<C> = self.build_setup().await?;
     Account::load_identity(setup, did).await
   }
 }
 
-impl Default for AccountBuilder {
+impl<C> Default for AccountBuilder<C>
+where
+  C: SharedPtr<Client>,
+{
   fn default() -> Self {
     Self::new()
   }

--- a/identity-account/src/account/builder.rs
+++ b/identity-account/src/account/builder.rs
@@ -11,9 +11,9 @@ use zeroize::Zeroize;
 use identity_iota::did::IotaDID;
 use identity_iota::tangle::Client;
 use identity_iota::tangle::ClientBuilder;
+use identity_iota::tangle::SharedPtr;
 
 use crate::account::Account;
-use crate::account::SharedPtr;
 use crate::error::Result;
 use crate::identity::IdentitySetup;
 use crate::storage::MemStore;

--- a/identity-account/src/account/config.rs
+++ b/identity-account/src/account/config.rs
@@ -4,8 +4,8 @@
 use std::sync::Arc;
 
 use identity_iota::tangle::Client;
+use identity_iota::tangle::SharedPtr;
 
-use crate::account::SharedPtr;
 use crate::storage::Storage;
 
 /// A wrapper that holds configuration for an [`Account`] instantiation.

--- a/identity-account/src/account/config.rs
+++ b/identity-account/src/account/config.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use identity_iota::tangle::Client;
 
+use crate::account::SharedPtr;
 use crate::storage::Storage;
 
 /// A wrapper that holds configuration for an [`Account`] instantiation.
@@ -15,16 +16,22 @@ use crate::storage::Storage;
 ///
 /// [`Account`]([crate::account::Account])
 #[derive(Clone, Debug)]
-pub(crate) struct AccountSetup {
+pub(crate) struct AccountSetup<C = Arc<Client>>
+where
+  C: SharedPtr<Client>,
+{
   pub(crate) storage: Arc<dyn Storage>,
-  pub(crate) client: Arc<Client>,
+  pub(crate) client: C,
   pub(crate) config: AccountConfig,
 }
 
-impl AccountSetup {
+impl<C> AccountSetup<C>
+where
+  C: SharedPtr<Client>,
+{
   /// Create a new setup from the given [`Storage`] implementation
   /// and with defaults for [`Config`] and [`Client`].
-  pub(crate) fn new(storage: Arc<dyn Storage>, client: Arc<Client>, config: AccountConfig) -> Self {
+  pub(crate) fn new(storage: Arc<dyn Storage>, client: C, config: AccountConfig) -> Self {
     Self {
       storage,
       client,

--- a/identity-account/src/identity/identity_updater.rs
+++ b/identity-account/src/identity/identity_updater.rs
@@ -1,17 +1,26 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use identity_iota::tangle::Client;
+
 use crate::account::Account;
+use crate::account::SharedPtr;
 
 /// A struct created by the [`Account::update_identity`] method, that
 /// allows executing various updates on the identity it was created on.
 #[derive(Debug)]
-pub struct IdentityUpdater<'account> {
-  pub(crate) account: &'account mut Account,
+pub struct IdentityUpdater<'account, C>
+where
+  C: SharedPtr<Client>,
+{
+  pub(crate) account: &'account mut Account<C>,
 }
 
-impl<'account> IdentityUpdater<'account> {
-  pub(crate) fn new(account: &'account mut Account) -> Self {
+impl<'account, C> IdentityUpdater<'account, C>
+where
+  C: SharedPtr<Client>,
+{
+  pub(crate) fn new(account: &'account mut Account<C>) -> Self {
     Self { account }
   }
 }

--- a/identity-account/src/identity/identity_updater.rs
+++ b/identity-account/src/identity/identity_updater.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use identity_iota::tangle::Client;
+use identity_iota::tangle::SharedPtr;
 
 use crate::account::Account;
-use crate::account::SharedPtr;
 
 /// A struct created by the [`Account::update_identity`] method, that
 /// allows executing various updates on the identity it was created on.

--- a/identity-account/src/updates/macros.rs
+++ b/identity-account/src/updates/macros.rs
@@ -36,7 +36,7 @@ macro_rules! impl_update_builder {
       #[derive(Debug)]
       pub struct [<$ident Builder>]<'account, C>
       where
-        C: crate::account::SharedPtr<Client>,
+        C: identity_iota::tangle::SharedPtr<Client>,
       {
         account: &'account mut Account<C>,
         $(
@@ -46,7 +46,7 @@ macro_rules! impl_update_builder {
 
       impl<'account, C> [<$ident Builder>]<'account, C>
       where
-        C: crate::account::SharedPtr<Client>,
+        C: identity_iota::tangle::SharedPtr<Client>,
       {
         $(
           #[must_use]
@@ -58,7 +58,7 @@ macro_rules! impl_update_builder {
 
         pub fn new(account: &'account mut Account<C>) -> [<$ident Builder>]<'account, C>
       where
-        C: crate::account::SharedPtr<Client>,
+        C: identity_iota::tangle::SharedPtr<Client>,
         {
           [<$ident Builder>] {
             account,
@@ -81,7 +81,7 @@ macro_rules! impl_update_builder {
 
       impl<'account, C> $crate::identity::IdentityUpdater<'account, C>
       where
-        C: crate::account::SharedPtr<Client>,
+        C: identity_iota::tangle::SharedPtr<Client>,
       {
         /// Creates a new builder to modify the identity. See the documentation of the return type for details.
         pub fn [<$ident:snake>](&'account mut self) -> [<$ident Builder>]<'account, C> {

--- a/identity-account/src/updates/macros.rs
+++ b/identity-account/src/updates/macros.rs
@@ -34,14 +34,20 @@ macro_rules! impl_update_builder {
     paste::paste! {
       $(#[$doc])*
       #[derive(Debug)]
-      pub struct [<$ident Builder>]<'account> {
-        account: &'account mut Account,
+      pub struct [<$ident Builder>]<'account, C>
+      where
+        C: crate::account::SharedPtr<Client>,
+      {
+        account: &'account mut Account<C>,
         $(
           $field: Option<$ty>,
         )*
       }
 
-      impl<'account> [<$ident Builder>]<'account> {
+      impl<'account, C> [<$ident Builder>]<'account, C>
+      where
+        C: crate::account::SharedPtr<Client>,
+      {
         $(
           #[must_use]
           pub fn $field<VALUE: Into<$ty>>(mut self, value: VALUE) -> Self {
@@ -50,7 +56,10 @@ macro_rules! impl_update_builder {
           }
         )*
 
-        pub fn new(account: &'account mut Account) -> [<$ident Builder>]<'account> {
+        pub fn new(account: &'account mut Account<C>) -> [<$ident Builder>]<'account, C>
+      where
+        C: crate::account::SharedPtr<Client>,
+        {
           [<$ident Builder>] {
             account,
             $(
@@ -70,9 +79,12 @@ macro_rules! impl_update_builder {
         }
       }
 
-      impl<'account> $crate::identity::IdentityUpdater<'account> {
+      impl<'account, C> $crate::identity::IdentityUpdater<'account, C>
+      where
+        C: crate::account::SharedPtr<Client>,
+      {
         /// Creates a new builder to modify the identity. See the documentation of the return type for details.
-        pub fn [<$ident:snake>](&'account mut self) -> [<$ident Builder>]<'account> {
+        pub fn [<$ident:snake>](&'account mut self) -> [<$ident Builder>]<'account, C> {
           [<$ident Builder>]::new(self.account)
         }
       }

--- a/identity-account/src/updates/update.rs
+++ b/identity-account/src/updates/update.rs
@@ -28,9 +28,9 @@ use identity_iota::document::IotaService;
 use identity_iota::document::IotaVerificationMethod;
 use identity_iota::tangle::Client;
 use identity_iota::tangle::NetworkName;
+use identity_iota::tangle::SharedPtr;
 
 use crate::account::Account;
-use crate::account::SharedPtr;
 use crate::error::Result;
 use crate::identity::IdentitySetup;
 use crate::identity::IdentityState;

--- a/identity-account/src/updates/update.rs
+++ b/identity-account/src/updates/update.rs
@@ -26,9 +26,11 @@ use identity_iota::did::IotaDIDUrl;
 use identity_iota::document::IotaDocument;
 use identity_iota::document::IotaService;
 use identity_iota::document::IotaVerificationMethod;
+use identity_iota::tangle::Client;
 use identity_iota::tangle::NetworkName;
 
 use crate::account::Account;
+use crate::account::SharedPtr;
 use crate::error::Result;
 use crate::identity::IdentitySetup;
 use crate::identity::IdentityState;
@@ -370,7 +372,10 @@ AttachMethodRelationship {
   @default relationships Vec<MethodRelationship>,
 });
 
-impl<'account> AttachMethodRelationshipBuilder<'account> {
+impl<'account, C> AttachMethodRelationshipBuilder<'account, C>
+where
+  C: SharedPtr<Client>,
+{
   #[must_use]
   pub fn relationship(mut self, value: MethodRelationship) -> Self {
     self.relationships.get_or_insert_with(Default::default).push(value);
@@ -389,7 +394,10 @@ DetachMethodRelationship {
   @default relationships Vec<MethodRelationship>,
 });
 
-impl<'account> DetachMethodRelationshipBuilder<'account> {
+impl<'account, C> DetachMethodRelationshipBuilder<'account, C>
+where
+  C: SharedPtr<Client>,
+{
   #[must_use]
   pub fn relationship(mut self, value: MethodRelationship) -> Self {
     self.relationships.get_or_insert_with(Default::default).push(value);

--- a/identity-iota/src/tangle/client.rs
+++ b/identity-iota/src/tangle/client.rs
@@ -30,8 +30,7 @@ use crate::tangle::TangleRef;
 use crate::tangle::TangleResolve;
 
 /// Client for performing IOTA Identity operations on the Tangle.
-#[cfg_attr(all(target_arch = "wasm32", not(target_os = "wasi")), derive(Debug, Clone))]
-#[cfg_attr(not(all(target_arch = "wasm32", not(target_os = "wasi"))), derive(Debug))]
+#[derive(Debug)]
 pub struct Client {
   pub(crate) client: IotaClient,
   pub(crate) network: Network,

--- a/identity-iota/src/tangle/mod.rs
+++ b/identity-iota/src/tangle/mod.rs
@@ -25,6 +25,7 @@ pub use self::publish::PublishType;
 pub use self::receipt::Receipt;
 pub use self::resolver::Resolver;
 pub use self::resolver::ResolverBuilder;
+pub use self::traits::SharedPtr;
 pub use self::traits::TangleRef;
 pub use self::traits::TangleResolve;
 

--- a/identity-iota/src/tangle/resolver.rs
+++ b/identity-iota/src/tangle/resolver.rs
@@ -19,6 +19,7 @@ use crate::error::Result;
 use crate::tangle::Client;
 use crate::tangle::ClientBuilder;
 use crate::tangle::NetworkName;
+use crate::tangle::SharedPtr;
 use crate::tangle::TangleResolve;
 
 /// A `Resolver` supports resolving DID Documents across different Tangle networks using
@@ -27,16 +28,16 @@ use crate::tangle::TangleResolve;
 /// Also provides convenience functions for resolving DID Documents associated with
 /// verifiable [`Credentials`][Credential] and [`Presentations`][Presentation].
 #[derive(Debug)]
-pub struct Resolver<T = Arc<Client>>
+pub struct Resolver<C = Arc<Client>>
 where
-  T: Clone + AsRef<Client> + From<Client>,
+  C: SharedPtr<Client>,
 {
-  client_map: HashMap<NetworkName, T>,
+  client_map: HashMap<NetworkName, C>,
 }
 
-impl<T> Resolver<T>
+impl<C> Resolver<C>
 where
-  T: Clone + AsRef<Client> + From<Client>,
+  C: SharedPtr<Client>,
 {
   /// Constructs a new [`Resolver`] with a default [`Client`] for
   /// the [`Mainnet`](crate::tangle::Network::Mainnet).
@@ -45,8 +46,8 @@ where
   pub async fn new() -> Result<Self> {
     let client: Client = Client::new().await?;
 
-    let mut client_map: HashMap<NetworkName, T> = HashMap::new();
-    client_map.insert(client.network.name(), T::from(client));
+    let mut client_map: HashMap<NetworkName, C> = HashMap::new();
+    client_map.insert(client.network.name(), C::from(client));
     Ok(Self { client_map })
   }
 
@@ -56,12 +57,12 @@ where
   }
 
   /// Returns the [`Client`] corresponding to the given [`NetworkName`] if one exists.
-  pub fn get_client(&self, network_name: &NetworkName) -> Option<&T> {
+  pub fn get_client(&self, network_name: &NetworkName) -> Option<&C> {
     self.client_map.get(network_name)
   }
 
   /// Returns the [`Client`] corresponding to the [`NetworkName`] on the given ['IotaDID'].
-  fn get_client_for_did(&self, did: &IotaDID) -> Result<&T> {
+  fn get_client_for_did(&self, did: &IotaDID) -> Result<&C> {
     self.get_client(&did.network()?.name()).ok_or_else(|| {
       Error::DIDNotFound(format!(
         "DID network '{}' does not match any resolver client network",
@@ -72,13 +73,13 @@ where
 
   /// Fetches the [`IotaDocument`] of the given [`IotaDID`].
   pub async fn resolve(&self, did: &IotaDID) -> Result<ResolvedIotaDocument> {
-    let client: &Client = self.get_client_for_did(did)?.as_ref();
+    let client: &Client = self.get_client_for_did(did)?.deref();
     client.read_document(did).await
   }
 
   /// Fetches the [`DocumentHistory`] of the given [`IotaDID`].
   pub async fn resolve_history(&self, did: &IotaDID) -> Result<DocumentHistory> {
-    let client: &Client = self.get_client_for_did(did)?.as_ref();
+    let client: &Client = self.get_client_for_did(did)?.deref();
     client.resolve_history(did).await
   }
 
@@ -87,7 +88,7 @@ where
   ///
   /// NOTE: the document must have been published to the Tangle and have a valid message id.
   pub async fn resolve_diff_history(&self, document: &ResolvedIotaDocument) -> Result<ChainHistory<DiffMessage>> {
-    let client: &Client = self.get_client_for_did(document.document.id())?.as_ref();
+    let client: &Client = self.get_client_for_did(document.document.id())?.deref();
     client.resolve_diff_history(document).await
   }
 
@@ -133,22 +134,22 @@ where
 
 /// Builder for configuring [`Clients`][Client] when constructing a [`Resolver`].
 #[derive(Default)]
-pub struct ResolverBuilder<T = Arc<Client>>
+pub struct ResolverBuilder<C = Arc<Client>>
 where
-  T: Clone + AsRef<Client> + From<Client>,
+  C: SharedPtr<Client>,
 {
-  clients: HashMap<NetworkName, ClientOrBuilder<T>>,
+  clients: HashMap<NetworkName, ClientOrBuilder<C>>,
 }
 
 #[allow(clippy::large_enum_variant)]
-enum ClientOrBuilder<T> {
-  Client(T),
+enum ClientOrBuilder<C> {
+  Client(C),
   Builder(ClientBuilder),
 }
 
-impl<T> ResolverBuilder<T>
+impl<C> ResolverBuilder<C>
 where
-  T: Clone + AsRef<Client> + From<Client>,
+  C: SharedPtr<Client>,
 {
   /// Constructs a new [`ResolverBuilder`] with no [`Clients`][Client] configured.
   pub fn new() -> Self {
@@ -161,10 +162,10 @@ where
   ///
   /// NOTE: replaces any previous [`Client`] or [`ClientBuilder`] with the same [`NetworkName`].
   #[must_use]
-  pub fn client(mut self, client: T) -> Self {
+  pub fn client(mut self, client: C) -> Self {
     self
       .clients
-      .insert(client.as_ref().network.name(), ClientOrBuilder::Client(client));
+      .insert(client.deref().network.name(), ClientOrBuilder::Client(client));
     self
   }
 
@@ -179,12 +180,12 @@ where
   }
 
   /// Constructs a new [`Resolver`] based on the builder configuration.
-  pub async fn build(self) -> Result<Resolver<T>> {
-    let mut client_map: HashMap<NetworkName, T> = HashMap::new();
+  pub async fn build(self) -> Result<Resolver<C>> {
+    let mut client_map: HashMap<NetworkName, C> = HashMap::new();
     for (network_name, client_or_builder) in self.clients {
-      let client: T = match client_or_builder {
+      let client: C = match client_or_builder {
         ClientOrBuilder::Client(client) => client,
-        ClientOrBuilder::Builder(builder) => T::from(builder.build().await?),
+        ClientOrBuilder::Builder(builder) => C::from(builder.build().await?),
       };
       client_map.insert(network_name, client);
     }

--- a/identity-iota/src/tangle/traits.rs
+++ b/identity-iota/src/tangle/traits.rs
@@ -1,9 +1,14 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Deref;
+use std::rc::Rc;
+use std::sync::Arc;
+
 use crate::did::IotaDID;
 use crate::document::ResolvedIotaDocument;
 use crate::error::Result;
+use crate::tangle::traits::private::Sealed;
 use crate::tangle::MessageId;
 
 pub trait TangleRef {
@@ -19,7 +24,28 @@ pub trait TangleRef {
 }
 
 // TODO: remove TangleResolve with ClientMap refactor?
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait(? Send)]
 pub trait TangleResolve {
   async fn resolve(&self, did: &IotaDID) -> Result<ResolvedIotaDocument>;
+}
+
+// Replace by higher-kinded type when `CoerceUnsized` is stabilized, otherwise we cannot
+// support unsized types like dynamic traits.
+// See: https://github.com/iotaledger/identity.rs/pull/707
+/// Sealed trait to generalize over `Arc<T>` and `Rc<T>` for sized types.
+pub trait SharedPtr<T>: Clone + From<T> + Deref<Target = T> + Sealed {}
+
+impl<T> SharedPtr<T> for Rc<T> {}
+
+impl<T> SharedPtr<T> for Arc<T> {}
+
+mod private {
+  use std::rc::Rc;
+  use std::sync::Arc;
+
+  pub trait Sealed {}
+
+  impl<T> Sealed for Rc<T> {}
+
+  impl<T> Sealed for Arc<T> {}
 }

--- a/identity-iota/src/tangle/traits.rs
+++ b/identity-iota/src/tangle/traits.rs
@@ -24,7 +24,7 @@ pub trait TangleRef {
 }
 
 // TODO: remove TangleResolve with ClientMap refactor?
-#[async_trait::async_trait(? Send)]
+#[async_trait::async_trait(?Send)]
 pub trait TangleResolve {
   async fn resolve(&self, did: &IotaDID) -> Result<ResolvedIotaDocument>;
 }


### PR DESCRIPTION
# Description of change

This changes the `Account` and its related structs to be generic over `Arc<Client>` and `Rc<Client>` so that we can use `WasmClient` directly without needing to clone the internal `Client`.

Unfortunately, to make a long story short: we cannot implement a higher kinded type for `Arc`/`Rc` over unsized types, namely `dyn Storage` in the `Account`, due to the lack of [`CoerceUnsized`](https://doc.rust-lang.org/std/ops/trait.CoerceUnsized.html) in stable Rust. 

I believe that without implementing `CoerceUnsized` for whatever `SharedPtrUnsized` trait we come up with, we will be unable to circumvent the type-mismatch error when trying to pass a concrete instance like `Arc<MemStore>`. 
Example:

```rust
AccountSetup::new(
	Arc::new(MemStore::new()),
	Arc::new(
	  ClientBuilder::new()
		.network(network)
		.node_sync_disabled()
		.build()
		.await
		.unwrap(),
	),
	AccountConfig::new(),
)
```

```rust
error[E0271]: type mismatch resolving `<account::account::ArcPtr as account::account::SharedPtrUnsized<(dyn storage::traits::Storage + 'static)>>::Ptr == std::sync::Arc<storage::memstore::MemStore>`
  --> identity-account\src\tests\updates.rs:39:3
   |
39 | /   AccountSetup::new(
40 | |     Arc::new(MemStore::new()),
41 | |     Arc::new(
42 | |       ClientBuilder::new()
...  |
49 | |     AccountConfig::new().testmode(true),
50 | |   )
   | |___^ type mismatch resolving `<account::account::ArcPtr as account::account::SharedPtrUnsized<(dyn storage::traits::Storage + 'static)>>::Ptr == std::sync::Arc<storage::memstore::MemStore>`
   |
note: expected this to be `std::sync::Arc<(dyn storage::traits::Storage + 'static)>`
  --> identity-account\src\account\account.rs:72:14
   |
72 |   type Ptr = Arc<T>;
   |              ^^^^^^
   = note: expected struct `std::sync::Arc<(dyn storage::traits::Storage + 'static)>`
              found struct `std::sync::Arc<storage::memstore::MemStore>`
```

The [`archery`](https://crates.io/crates/archery) crate also suffers from this limitation. There is [no indication that `CoerceUnsized` will be stabilized any time soon](https://github.com/rust-lang/rust/issues/27732).

https://stackoverflow.com/questions/69500407/trait-object-causing-type-mismatch
https://doc.rust-lang.org/std/ops/trait.CoerceUnsized.html

Given the above, I chose to implement the same "poor-man's higher kinded type" approach I used for the `Resolver` in #594, which only works for `Arc<Client>`/`Rc<Client>` due to the same issue.

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tests and examples pass locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
