### PR TITLE
Update iota.rs to include timeout bugfix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 members = [
   "identity",
-  "identity-comm",
+  # "identity-comm",
   "identity-account",
   "identity-account-storage",
   "identity-core",

--- a/identity-comm/Cargo.toml
+++ b/identity-comm/Cargo.toml
@@ -15,7 +15,7 @@ identity-core = { path = "../identity-core", version = "=0.5.0-dev.4" }
 identity-credential = { path = "../identity-credential", version = "=0.5.0-dev.4" }
 identity-did = { path = "../identity-did", version = "=0.5.0-dev.4" }
 identity-iota = { path = "../identity-iota", version = "=0.5.0-dev.4", default-features = false }
-libjose = { path = "../libjose", version = "=0.1.0" }
+# libjose = { path = "../libjose", version = "=0.1.0" }
 paste = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -32,13 +32,13 @@ thiserror = { version = "1.0", default-features = false }
 
 [dependencies.iota-client]
 git = "https://github.com/iotaledger/iota.rs"
-rev = "2b3c768c441754627996b2ce391e8266d43635dc"
+rev = "7d7ae32da03d3375318c181c2428a36de530d1a3"
 features = ["tls"]
 default-features = false
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies.iota-client]
 git = "https://github.com/iotaledger/iota.rs"
-rev = "2b3c768c441754627996b2ce391e8266d43635dc"
+rev = "7d7ae32da03d3375318c181c2428a36de530d1a3"
 default-features = false
 features = ["wasm"]
 

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["iota", "tangle", "identity"]
 license = "Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/iotaledger/identity.rs"
-description = "An IOTA Tangle intergration for the identity-rs library."
+description = "An IOTA Tangle integration for the identity.rs library."
 
 [dependencies]
 async-trait = { version = "0.1", default-features = false }

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -32,13 +32,13 @@ thiserror = { version = "1.0", default-features = false }
 
 [dependencies.iota-client]
 git = "https://github.com/iotaledger/iota.rs"
-rev = "7f5ae8f5b27f5948d8e1b4717419cc1321d862da"
+rev = "2b3c768c441754627996b2ce391e8266d43635dc"
 features = ["tls"]
 default-features = false
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies.iota-client]
 git = "https://github.com/iotaledger/iota.rs"
-rev = "7f5ae8f5b27f5948d8e1b4717419cc1321d862da"
+rev = "2b3c768c441754627996b2ce391e8266d43635dc"
 default-features = false
 features = ["wasm"]
 

--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -14,7 +14,7 @@ description = "Tools for working with Self-sovereign Identity."
 [dependencies]
 identity-account = { version = "=0.5.0-dev.4", path = "../identity-account", default-features = false, optional = true }
 identity-account-storage = { version = "=0.5.0-dev.4", path = "../identity-account-storage", default-features = false, optional = true }
-identity-comm = { version = "=0.5.0-dev.4", path = "../identity-comm", optional = true }
+# identity-comm = { version = "=0.5.0-dev.4", path = "../identity-comm", optional = true }
 identity-core = { version = "=0.5.0-dev.4", path = "../identity-core", default-features = false }
 identity-credential = { version = "=0.5.0-dev.4", path = "../identity-credential" }
 identity-did = { version = "=0.5.0-dev.4", path = "../identity-did" }
@@ -42,7 +42,7 @@ account = ["identity-account", "identity-account-storage"]
 stronghold = ["identity-account/stronghold", "identity-account-storage/stronghold"]
 
 # Enables support for DID Communication
-comm = ["identity-comm"]
+# comm = ["identity-comm"]
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/identity/src/lib.rs
+++ b/identity/src/lib.rs
@@ -116,17 +116,17 @@ pub mod account_storage {
   pub use identity_account_storage::utils::*;
 }
 
-#[cfg(feature = "comm")]
-#[cfg_attr(docsrs, doc(cfg(feature = "comm")))]
-pub mod comm {
-  //! DID Communications Message Specification
-  //!
-  //! [Specification](https://github.com/iotaledger/identity.rs/tree/dev/docs/DID%20Communications%20Research%20and%20Specification)
+// #[cfg(feature = "comm")]
+// #[cfg_attr(docsrs, doc(cfg(feature = "comm")))]
+// pub mod comm {
+//   //! DID Communications Message Specification
+//   //!
+//   //! [Specification](https://github.com/iotaledger/identity.rs/tree/dev/docs/DID%20Communications%20Research%20and%20Specification)
 
-  pub use identity_comm::envelope::*;
-  pub use identity_comm::error::*;
-  pub use identity_comm::message::*;
-}
+//   pub use identity_comm::envelope::*;
+//   pub use identity_comm::error::*;
+//   pub use identity_comm::message::*;
+// }
 
 pub mod prelude {
   //! Prelude of commonly used types


### PR DESCRIPTION
# Description of change

Update iota.rs to the latest `dev` commit in order to include the timeout bugfix from iotaledger/iota.rs#848. Previously, the `requet_timeout` builder option was essentially ignored, and since this is the only option we expose, the fix is important to us.

This also comments out the currently unused `identity-comm` crate, because `libjose`'s `rsa = 0.5` dependency requires `zeroize < 1.5`, which is incompatible with the `iota.rs` requirement of (now) `1.5.3` of said crate. `identity-comm` is currently unused and will need a refactor anyway.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Ran a local test (not added to the code base) to make sure the fix works for us:

```rust
#[tokio::test]
async fn test_timeout() {
  let client = ClientBuilder::new()
    .request_timeout(std::time::Duration::from_millis(1))
    .build()
    .await
    .unwrap();

  let error = client.publish_json("index", &[0u8; 32]).await.unwrap_err();

  assert!(matches!(error, crate::Error::ClientError(iota_client::Error::ReqwestError(_))));
}
```


## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
