### PR TITLE
Update iota.rs to lower `zeroize` version requirement

### DIFF
--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -32,13 +32,13 @@ thiserror = { version = "1.0", default-features = false }
 
 [dependencies.iota-client]
 git = "https://github.com/iotaledger/iota.rs"
-rev = "7d7ae32da03d3375318c181c2428a36de530d1a3"
+rev = "994d4073452abcf311a56e929b0617645620bd92"
 features = ["tls"]
 default-features = false
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies.iota-client]
 git = "https://github.com/iotaledger/iota.rs"
-rev = "7d7ae32da03d3375318c181c2428a36de530d1a3"
+rev = "994d4073452abcf311a56e929b0617645620bd92"
 default-features = false
 features = ["wasm"]
 


### PR DESCRIPTION
# Description of change

Updates iota.rs to a version where the crate's `zeroize` requirement is below version `1.5`. This is required for RustCrypto dependencies which, at their current version, have a `<1.5` requirement for `zeroize`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Tested the new version of iota.rs manually in the `feat/identity-actor` branch, where `libp2p` has transitive dependencies on crypto crates with the above-mentioned issue.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
