### PR TITLE
Install cargo-edit for Wasm releases, fix version bump in CI

### DIFF
--- a/.github/actions/release/bump-versions/action.yml
+++ b/.github/actions/release/bump-versions/action.yml
@@ -25,9 +25,8 @@ runs:
         command: install
         args: --version ^0.2 cargo-workspaces
 
-    - name: Install cargo-edit # to use cargo add
+    - name: Install cargo-edit # to use cargo add adn set-version
       uses: actions-rs/cargo@v1
-      if: ${{inputs.release-target == 'rust'}}
       with:
         command: install
         args: -f --no-default-features --features "add set-version" --version ^0.8 cargo-edit

--- a/.github/actions/release/bump-versions/action.yml
+++ b/.github/actions/release/bump-versions/action.yml
@@ -25,7 +25,7 @@ runs:
         command: install
         args: --version ^0.2 cargo-workspaces
 
-    - name: Install cargo-edit # to use cargo add adn set-version
+    - name: Install cargo-edit # to use cargo add and set-version
       uses: actions-rs/cargo@v1
       with:
         command: install

--- a/.github/actions/release/bump-versions/action.yml
+++ b/.github/actions/release/bump-versions/action.yml
@@ -43,9 +43,9 @@ runs:
       if: ${{inputs.release-target == 'rust'}}
       working-directory: bindings/stronghold-nodejs
       run: |
-        cargo add identity-core@=${{ inputs.version }} --path=../../identity
-        cargo add identity-iota-core@=${{ inputs.version }} --path=../../identity
-        cargo add identity-account-storage@=${{ inputs.version }} --path=../../identity
+        cargo add identity-core@=${{ inputs.version }} --path=../../identity-core
+        cargo add identity-iota-core@=${{ inputs.version }} --path=../../identity-iota-core
+        cargo add identity-account-storage@=${{ inputs.version }} --path=../../identity-account-storage
     
     - name: Bump Rust crate version
       shell: bash


### PR DESCRIPTION
# Description of change
Enable `cargo-edit` in `bump-versions` for the Wasm release since we rely on `set-version`.
Also fixes an issue with the version bump, where sub crates where set to the root crate accidentally.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
