### PR TITLE
Remove `Storage::set_password`

### DIFF
--- a/bindings/stronghold-nodejs/js/stronghold.ts
+++ b/bindings/stronghold-nodejs/js/stronghold.ts
@@ -16,6 +16,10 @@ export class Stronghold implements Storage {
         return stronghold
     }
 
+    public async setPassword(encryptionKey: Uint8Array) {
+        return this.napiStronghold.setPassword(Array.from(encryptionKey))
+    }
+
     public async flushChanges() {
         return this.napiStronghold.flushChanges()
     }

--- a/bindings/stronghold-nodejs/js/stronghold.ts
+++ b/bindings/stronghold-nodejs/js/stronghold.ts
@@ -16,10 +16,6 @@ export class Stronghold implements Storage {
         return stronghold
     }
 
-    public async setPassword(encryptionKey: Uint8Array) {
-        return this.napiStronghold.setPassword(Array.from(encryptionKey))
-    }
-
     public async flushChanges() {
         return this.napiStronghold.flushChanges()
     }

--- a/bindings/stronghold-nodejs/src/account/storage/stronghold.rs
+++ b/bindings/stronghold-nodejs/src/account/storage/stronghold.rs
@@ -54,6 +54,16 @@ impl NapiStronghold {
     self.0.set_dropsave(dropsave);
   }
 
+  /// Sets the account password.
+  #[napi]
+  pub async fn set_password(&self, password: Vec<u32>) -> Result<()> {
+    let password: [u8; 32] = password
+      .try_into_bytes()?
+      .try_into()
+      .map_err(|_| Error::from_reason("Invalid password type. Expected [u8; 32]".to_owned()))?;
+    self.0.set_password(password).await.napi_result()
+  }
+
   /// Write any unsaved changes to disk.
   #[napi]
   pub async fn flush_changes(&self) -> Result<()> {

--- a/bindings/stronghold-nodejs/src/account/storage/stronghold.rs
+++ b/bindings/stronghold-nodejs/src/account/storage/stronghold.rs
@@ -54,16 +54,6 @@ impl NapiStronghold {
     self.0.set_dropsave(dropsave);
   }
 
-  /// Sets the account password.
-  #[napi]
-  pub async fn set_password(&self, password: Vec<u32>) -> Result<()> {
-    let password: [u8; 32] = password
-      .try_into_bytes()?
-      .try_into()
-      .map_err(|_| Error::from_reason("Invalid password type. Expected [u8; 32]".to_owned()))?;
-    self.0.set_password(password).await.napi_result()
-  }
-
   /// Write any unsaved changes to disk.
   #[napi]
   pub async fn flush_changes(&self) -> Result<()> {

--- a/bindings/wasm/examples-account/src/memory_storage.ts
+++ b/bindings/wasm/examples-account/src/memory_storage.ts
@@ -17,8 +17,6 @@ class MemStore implements Storage {
         this._vaults = new Map();
     }
 
-    public async setPassword(_encryptionKey: Uint8Array): Promise<void> {}
-
     public async flushChanges(): Promise<void> {}
 
     public async keyNew(did: DID, keyLocation: KeyLocation): Promise<string> {

--- a/bindings/wasm/src/account/storage/traits.rs
+++ b/bindings/wasm/src/account/storage/traits.rs
@@ -5,7 +5,6 @@ use core::fmt::Debug;
 use core::fmt::Formatter;
 
 use identity::account_storage::ChainState;
-use identity::account_storage::EncryptionKey;
 use identity::account_storage::Error as AccountStorageError;
 use identity::account_storage::IdentityState;
 use identity::account_storage::KeyLocation;
@@ -47,8 +46,6 @@ extern "C" {
 extern "C" {
   pub type WasmStorage;
 
-  #[wasm_bindgen(method, js_name = setPassword)]
-  pub fn set_password(this: &WasmStorage, password: Vec<u8>) -> PromiseUnit;
   #[wasm_bindgen(method, js_name = flushChanges)]
   pub fn flush_changes(this: &WasmStorage) -> PromiseUnit;
   #[wasm_bindgen(method, js_name = keyNew)]
@@ -88,12 +85,6 @@ impl Debug for WasmStorage {
 
 #[async_trait::async_trait(?Send)]
 impl Storage for WasmStorage {
-  /// Sets the account password.
-  async fn set_password(&self, password: EncryptionKey) -> AccountStorageResult<()> {
-    let promise: Promise = Promise::resolve(&self.set_password(password.to_vec()));
-    let result: JsValueResult = JsFuture::from(promise).await.into();
-    result.into()
-  }
 
   /// Write any unsaved changes to disk.
   async fn flush_changes(&self) -> AccountStorageResult<()> {
@@ -226,9 +217,6 @@ impl Storage for WasmStorage {
 const STORAGE: &'static str = r#"
 /** All methods an object must implement to be used as an account storage. */
 interface Storage {
-  /** Sets the account password.*/
-  setPassword: (encryptionKey: Uint8Array) => Promise<void>;
-
   /** Write any unsaved changes to disk.*/
   flushChanges: () => Promise<void>;
 

--- a/bindings/wasm/src/account/storage/traits.rs
+++ b/bindings/wasm/src/account/storage/traits.rs
@@ -85,7 +85,6 @@ impl Debug for WasmStorage {
 
 #[async_trait::async_trait(?Send)]
 impl Storage for WasmStorage {
-
   /// Write any unsaved changes to disk.
   async fn flush_changes(&self) -> AccountStorageResult<()> {
     let promise: Promise = Promise::resolve(&self.flush_changes());

--- a/identity-account-storage/src/storage/memstore.rs
+++ b/identity-account-storage/src/storage/memstore.rs
@@ -27,7 +27,6 @@ use crate::identity::IdentityState;
 use crate::storage::Storage;
 use crate::types::KeyLocation;
 use crate::types::Signature;
-use crate::utils::EncryptionKey;
 use crate::utils::Shared;
 
 type MemVault = HashMap<KeyLocation, KeyPair>;
@@ -65,10 +64,6 @@ impl MemStore {
 #[cfg_attr(not(feature = "send-sync-storage"), async_trait(?Send))]
 #[cfg_attr(feature = "send-sync-storage", async_trait)]
 impl Storage for MemStore {
-  async fn set_password(&self, _password: EncryptionKey) -> Result<()> {
-    Ok(())
-  }
-
   async fn flush_changes(&self) -> Result<()> {
     Ok(())
   }

--- a/identity-account-storage/src/storage/stronghold.rs
+++ b/identity-account-storage/src/storage/stronghold.rs
@@ -30,7 +30,8 @@ use crate::stronghold::Store;
 use crate::stronghold::Vault;
 use crate::types::KeyLocation;
 use crate::types::Signature;
-use crate::utils::{derive_encryption_key, EncryptionKey};
+use crate::utils::derive_encryption_key;
+use crate::utils::EncryptionKey;
 
 #[derive(Debug)]
 pub struct Stronghold {

--- a/identity-account-storage/src/storage/stronghold.rs
+++ b/identity-account-storage/src/storage/stronghold.rs
@@ -30,7 +30,7 @@ use crate::stronghold::Store;
 use crate::stronghold::Vault;
 use crate::types::KeyLocation;
 use crate::types::Signature;
-use crate::utils::derive_encryption_key;
+use crate::utils::{derive_encryption_key, EncryptionKey};
 
 #[derive(Debug)]
 pub struct Stronghold {
@@ -73,6 +73,12 @@ impl Stronghold {
   /// Default: true
   pub fn set_dropsave(&mut self, value: bool) {
     self.dropsave = value;
+  }
+
+  /// Sets the account password.
+  pub async fn set_password(&self, password: EncryptionKey) -> Result<()> {
+    self.snapshot.set_password(password).await?;
+    Ok(())
   }
 }
 

--- a/identity-account-storage/src/storage/stronghold.rs
+++ b/identity-account-storage/src/storage/stronghold.rs
@@ -31,7 +31,6 @@ use crate::stronghold::Vault;
 use crate::types::KeyLocation;
 use crate::types::Signature;
 use crate::utils::derive_encryption_key;
-use crate::utils::EncryptionKey;
 
 #[derive(Debug)]
 pub struct Stronghold {
@@ -80,11 +79,6 @@ impl Stronghold {
 #[cfg_attr(not(feature = "send-sync-storage"), async_trait(?Send))]
 #[cfg_attr(feature = "send-sync-storage", async_trait)]
 impl Storage for Stronghold {
-  async fn set_password(&self, password: EncryptionKey) -> Result<()> {
-    self.snapshot.set_password(password).await?;
-    Ok(())
-  }
-
   async fn flush_changes(&self) -> Result<()> {
     self.snapshot.save().await?;
     Ok(())

--- a/identity-account-storage/src/storage/stronghold.rs
+++ b/identity-account-storage/src/storage/stronghold.rs
@@ -31,7 +31,6 @@ use crate::stronghold::Vault;
 use crate::types::KeyLocation;
 use crate::types::Signature;
 use crate::utils::derive_encryption_key;
-use crate::utils::EncryptionKey;
 
 #[derive(Debug)]
 pub struct Stronghold {

--- a/identity-account-storage/src/storage/stronghold.rs
+++ b/identity-account-storage/src/storage/stronghold.rs
@@ -75,12 +75,6 @@ impl Stronghold {
   pub fn set_dropsave(&mut self, value: bool) {
     self.dropsave = value;
   }
-
-  /// Sets the account password.
-  pub async fn set_password(&self, password: EncryptionKey) -> Result<()> {
-    self.snapshot.set_password(password).await?;
-    Ok(())
-  }
 }
 
 #[cfg_attr(not(feature = "send-sync-storage"), async_trait(?Send))]

--- a/identity-account-storage/src/storage/traits.rs
+++ b/identity-account-storage/src/storage/traits.rs
@@ -14,7 +14,6 @@ use crate::identity::ChainState;
 use crate::identity::IdentityState;
 use crate::types::KeyLocation;
 use crate::types::Signature;
-use crate::utils::EncryptionKey;
 
 #[cfg(not(feature = "send-sync-storage"))]
 mod storage_sub_trait {
@@ -34,9 +33,6 @@ mod storage_sub_trait {
 #[cfg_attr(not(feature = "send-sync-storage"), async_trait(?Send))]
 #[cfg_attr(feature = "send-sync-storage", async_trait)]
 pub trait Storage: storage_sub_trait::StorageSendSyncMaybe + Debug {
-  /// Sets the account password.
-  async fn set_password(&self, password: EncryptionKey) -> Result<()>;
-
   /// Write any unsaved changes to disk.
   async fn flush_changes(&self) -> Result<()>;
 


### PR DESCRIPTION
# Description of change
Remove the `set_password()` function from the account Storage interface.

## Links to any relevant issues
fixes issue #733 

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix