### PR TITLE
Remove Wasm prepublish step

### DIFF
--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -18,7 +18,6 @@
     "build:docs": "node ./build/docs",
     "build:examples": "webpack --config ./examples/webpack.config.js --mode=production",
     "build": "npm run build:web && npm run build:nodejs && npm run build:docs",
-    "prepublishOnly": "npm run build",
     "example:node": "node examples/dist/node.js",
     "example:browser": "http-server ./examples/dist/ -c-1 -o ",
     "example:account": "ts-node ./examples-account/src/node.ts",


### PR DESCRIPTION
# Description of change
Removes the npm `prepublishOnly` script from the Wasm bindings, which interferes with the release process.


## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tested with a dummy release locally.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
