### PR TITLE
Fix stronghold triples

### DIFF
--- a/bindings/stronghold-nodejs/package.json
+++ b/bindings/stronghold-nodejs/package.json
@@ -9,6 +9,7 @@
   "napi": {
     "name": "identity-stronghold-nodejs",
     "triples": {
+      "defaults": false,
       "additional": [
         "aarch64-apple-darwin",
         "x86_64-apple-darwin",

--- a/bindings/stronghold-nodejs/package.json
+++ b/bindings/stronghold-nodejs/package.json
@@ -11,11 +11,7 @@
     "triples": {
       "defaults": false,
       "additional": [
-        "aarch64-apple-darwin",
-        "x86_64-apple-darwin",
-        "x86_64-pc-windows-msvc",
-        "x86_64-unknown-linux-musl",
-        "x86_64-unknown-linux-gnu"
+        "x86_64-unknown-linux-musl"
       ]
     }
   },


### PR DESCRIPTION
# Description of change
Sets NAPI.rs default triples to false to prevent double publishes.
Also temporarily disables triples already published.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Can only be tested in CI.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
