### PR TITLE
Fix Stronghold nodejs binding dist artifact

### DIFF
--- a/.github/actions/publish/publish-stronghold-nodejs/action.yml
+++ b/.github/actions/publish/publish-stronghold-nodejs/action.yml
@@ -24,11 +24,17 @@ runs:
       working-directory: bindings/stronghold-nodejs
       run: npm ci --ignore-scripts --legacy-peer-deps
 
-    - name: Download all artifacts
+    - name: Download binary artifacts
       uses: actions/download-artifact@v2
       with:
         name: ${{ inputs.input-artifact-name }}
         path: bindings/stronghold-nodejs/artifacts
+
+    - name: Download dist artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ inputs.input-artifact-name }}-dist
+        path: bindings/stronghold-nodejs/dist
 
     - name: Create npm folder
       shell: sh

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -204,5 +204,8 @@ jobs:
     uses: iotaledger/identity.rs/.github/workflows/shared-build-and-test-stronghold-nodejs.yml@dev
     with:
       input-artifact-name: identity-wasm-bindings-build
+      upload-binaries-as-artifacts: true # TODO: remove
+      output-artifact-name: identity-stronghold-nodejs-bindings-build # TODO: remove
+
 
      

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -201,11 +201,6 @@ jobs:
       - build-wasm
     if: ${{ needs.check-for-run-condition.outputs.should-run == 'true' }}
     # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-build-and-test-stronghold-nodejs.yml@fix/add-stronghold-bindings-dist # TODO: change to dev
+    uses: iotaledger/identity.rs/.github/workflows/shared-build-and-test-stronghold-nodejs.yml@dev
     with:
       input-artifact-name: identity-wasm-bindings-build
-      upload-binaries-as-artifacts: true # TODO: remove
-      output-artifact-name: identity-stronghold-nodejs-bindings-build # TODO: remove
-
-
-     

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -201,7 +201,7 @@ jobs:
       - build-wasm
     if: ${{ needs.check-for-run-condition.outputs.should-run == 'true' }}
     # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-build-and-test-stronghold-nodejs.yml@dev
+    uses: iotaledger/identity.rs/.github/workflows/shared-build-and-test-stronghold-nodejs.yml@fix/add-stronghold-bindings-dist # TODO: change to dev
     with:
       input-artifact-name: identity-wasm-bindings-build
       upload-binaries-as-artifacts: true # TODO: remove

--- a/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
+++ b/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
@@ -136,6 +136,7 @@ jobs:
           run: ${{ matrix.settings.test-docker }}
           working-directory: ./
 
+        # Optionally uploads binary artifact for current matrix target for later release.
         - name: Upload binary artifact
           if: ${{inputs.upload-binaries-as-artifacts}}
           uses: actions/upload-artifact@v2
@@ -145,6 +146,7 @@ jobs:
             if-no-files-found: error
             retention-days: 1
 
+        # Optionally uploads js / ts dist artifact for later release. Since js is cross-platform it only needs to be uploaded from one matrix target.
         - name: Upload dist artifact
           if: ${{inputs.upload-binaries-as-artifacts && matrix.settings.generate-dist}}
           uses: actions/upload-artifact@v2

--- a/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
+++ b/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
@@ -56,6 +56,7 @@ jobs:
               test: |
                 npm run test
             - host: ubuntu-latest
+              generate-dist: true
               target: x86_64-unknown-linux-gnu
               architecture: x64
               build: |
@@ -135,12 +136,23 @@ jobs:
           run: ${{ matrix.settings.test-docker }}
           working-directory: ./
 
-        - name: Upload artifact
+        - name: Upload binary artifact
           if: ${{inputs.upload-binaries-as-artifacts}}
           uses: actions/upload-artifact@v2
           with:
             name: ${{ inputs.output-artifact-name }}
             path: ${{ env.WORKING_DIRECTORY }}/dist/${{ env.APP_NAME }}.*.node
+            if-no-files-found: error
+            retention-days: 1
+
+        - name: Upload dist artifact
+          if: ${{inputs.upload-binaries-as-artifacts && matrix.settings.generate-dist}}
+          uses: actions/upload-artifact@v2
+          with:
+            name: ${{ inputs.output-artifact-name }}-dist
+            path: |
+              ${{ env.WORKING_DIRECTORY }}/dist/
+              !${{ env.WORKING_DIRECTORY }}/dist/${{ env.APP_NAME }}.*.node
             if-no-files-found: error
             retention-days: 1
 


### PR DESCRIPTION
# Description of change
Use pre-generated dist from build step for stronghold nodejs bindings publish. In the current setup the js dist files do not get included in the package. Weirdly my understanding is the "official" napi.rs CI build has the same problem https://github.com/napi-rs/napi-rs/blob/main/cli/src/new/ci-template.ts.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Partially locally, partially can only be tested in CI.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
