### PR TITLE
Fix panic when parsing an `IotaDID` with more than 2 method id segments

### DIFF
--- a/identity-iota-core/src/did/iota_did.rs
+++ b/identity-iota-core/src/did/iota_did.rs
@@ -118,7 +118,7 @@ impl IotaDID {
   pub fn check_method_id<D: DID>(did: &D) -> Result<()> {
     let segments: Vec<&str> = did.method_id().split(':').collect();
 
-    if segments.is_empty() || segments.len() > 3 {
+    if segments.is_empty() || segments.len() > 2 {
       return Err(Error::InvalidDID(DIDError::InvalidMethodId));
     }
 
@@ -397,6 +397,7 @@ mod tests {
     assert!(IotaDID::parse("did:iota:").is_err());
     // Too many components is invalid.
     assert!(IotaDID::parse(format!("did:iota:custom:shard-1:random:{}", TAG)).is_err());
+    assert!(IotaDID::parse(format!("did:iota:custom:random:{}", TAG)).is_err());
     // Explicit empty network name is invalid (omitting it is still fine)
     assert!(IotaDID::parse(format!("did:iota::{}", TAG)).is_err());
     // Invalid network name is invalid.


### PR DESCRIPTION
# Description of change

This currently panics: `IotaDID::parse(format!("did:iota:custom:random:{}", TAG)`, due to entering unreachable code in `Segments::network`. To fix this, `IotaDID::check_method_id` should return an error when the number of segments **of the method id** is `> 2` instead of `> 3`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Added a test.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
