### PR TITLE
Fix `Uint8Array` references

### DIFF
--- a/bindings/stronghold-nodejs/src/account/storage/stronghold.rs
+++ b/bindings/stronghold-nodejs/src/account/storage/stronghold.rs
@@ -162,6 +162,6 @@ impl TryIntoBytes for Vec<u32> {
       .into_iter()
       .map(u8::try_from)
       .collect::<std::result::Result<Vec<u8>, _>>()
-      .map_err(|err| Error::from_reason(format!("invalid data type, expected UInt8Array: {}", err)))
+      .map_err(|err| Error::from_reason(format!("invalid data type, expected Uint8Array: {}", err)))
   }
 }

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -2155,13 +2155,13 @@ Signs the `message` with the given `Key`.
 <a name="Ed25519PrivateKey+publicKey"></a>
 
 ### ed25519PrivateKey.publicKey() ⇒ <code>Uint8Array</code>
-Returns the PublicKey as a `UInt8Array`.
+Returns the PublicKey as a `Uint8Array`.
 
 **Kind**: instance method of [<code>Ed25519PrivateKey</code>](#Ed25519PrivateKey)  
 <a name="Ed25519PrivateKey.fromBase58"></a>
 
 ### Ed25519PrivateKey.fromBase58(private_key) ⇒ [<code>Ed25519PrivateKey</code>](#Ed25519PrivateKey)
-Create a new `Ed25519PrivateKey` from a 'UInt8Array'.
+Create a new `Ed25519PrivateKey` from a 'Uint8Array'.
 
 **Kind**: static method of [<code>Ed25519PrivateKey</code>](#Ed25519PrivateKey)  
 
@@ -2452,13 +2452,13 @@ Returns the `KeyType` of the `KeyPair` object.
 <a name="KeyPair+public"></a>
 
 ### keyPair.public() ⇒ <code>Uint8Array</code>
-Returns a copy of the public key as a `UInt8Array`.
+Returns a copy of the public key as a `Uint8Array`.
 
 **Kind**: instance method of [<code>KeyPair</code>](#KeyPair)  
 <a name="KeyPair+private"></a>
 
 ### keyPair.private() ⇒ <code>Uint8Array</code>
-Returns a copy of the private key as a `UInt8Array`.
+Returns a copy of the private key as a `Uint8Array`.
 
 **Kind**: instance method of [<code>KeyPair</code>](#KeyPair)  
 <a name="KeyPair+toJSON"></a>
@@ -2533,7 +2533,7 @@ Supported verification method data formats.
 <a name="MethodData+tryDecode"></a>
 
 ### methodData.tryDecode() ⇒ <code>Uint8Array</code>
-Returns a `UInt8Array` containing the decoded bytes of the `MethodData`.
+Returns a `Uint8Array` containing the decoded bytes of the `MethodData`.
 
 This is generally a public key identified by a `MethodData` value.
 
@@ -2683,7 +2683,7 @@ Serializes a `MethodSecret` as a JSON object.
 <a name="MethodSecret.ed25519"></a>
 
 ### MethodSecret.ed25519(privateKey) ⇒ [<code>MethodSecret</code>](#MethodSecret)
-Creates an Ed25519 [MethodSecret](#MethodSecret) from a `UInt8Array`.
+Creates an Ed25519 [MethodSecret](#MethodSecret) from a `Uint8Array`.
 
 **Kind**: static method of [<code>MethodSecret</code>](#MethodSecret)  
 
@@ -2694,7 +2694,7 @@ Creates an Ed25519 [MethodSecret](#MethodSecret) from a `UInt8Array`.
 <a name="MethodSecret.x25519"></a>
 
 ### MethodSecret.x25519(privateKey) ⇒ [<code>MethodSecret</code>](#MethodSecret)
-Creates an X25519 [MethodSecret](#MethodSecret) from a `UInt8Array`.
+Creates an X25519 [MethodSecret](#MethodSecret) from a `Uint8Array`.
 
 **Kind**: static method of [<code>MethodSecret</code>](#MethodSecret)  
 

--- a/bindings/wasm/src/account/storage/traits.rs
+++ b/bindings/wasm/src/account/storage/traits.rs
@@ -28,7 +28,7 @@ use crate::error::JsValueResult;
 extern "C" {
   #[wasm_bindgen(typescript_type = "Promise<void>")]
   pub type PromiseUnit;
-  #[wasm_bindgen(typescript_type = "Promise<UInt8Array>")]
+  #[wasm_bindgen(typescript_type = "Promise<Uint8Array>")]
   pub type PromisePublicKey;
   #[wasm_bindgen(typescript_type = "Promise<Signature>")]
   pub type PromiseSignature;
@@ -216,17 +216,17 @@ interface Storage {
 
   /** Creates a new keypair at the specified `location`,
    * and returns its public key.*/
-  keyNew: (did: DID, keyLocation: KeyLocation) => Promise<UInt8Array>;
+  keyNew: (did: DID, keyLocation: KeyLocation) => Promise<Uint8Array>;
 
   /** Inserts a private key at the specified `location`,
    * and returns its public key.*/
-  keyInsert: (did: DID, keyLocation: KeyLocation, privateKey: UInt8Array) => Promise<UInt8Array>;
+  keyInsert: (did: DID, keyLocation: KeyLocation, privateKey: Uint8Array) => Promise<Uint8Array>;
 
   /** Returns `true` if a keypair exists at the specified `location`.*/
   keyExists: (did: DID, keyLocation: KeyLocation) => Promise<boolean>;
 
   /** Retrieves the public key from the specified `location`.*/
-  keyGet: (did: DID, keyLocation: KeyLocation) => Promise<UInt8Array>;
+  keyGet: (did: DID, keyLocation: KeyLocation) => Promise<Uint8Array>;
 
   /** Deletes the keypair specified by the given `location`. Nothing happens if the key is not found.*/
   keyDel: (did: DID, keyLocation: KeyLocation) => Promise<void>;

--- a/bindings/wasm/src/account/types/method_secret.rs
+++ b/bindings/wasm/src/account/types/method_secret.rs
@@ -31,14 +31,14 @@ pub struct WasmMethodSecret(WasmMethodSecretInner);
 
 #[wasm_bindgen(js_class = MethodSecret)]
 impl WasmMethodSecret {
-  /// Creates an Ed25519 {@link MethodSecret} from a `UInt8Array`.
+  /// Creates an Ed25519 {@link MethodSecret} from a `Uint8Array`.
   #[allow(non_snake_case)]
   #[wasm_bindgen(js_name = ed25519)]
   pub fn ed25519(privateKey: Vec<u8>) -> WasmMethodSecret {
     Self(WasmMethodSecretInner::Ed25519(privateKey))
   }
 
-  /// Creates an X25519 {@link MethodSecret} from a `UInt8Array`.
+  /// Creates an X25519 {@link MethodSecret} from a `Uint8Array`.
   #[allow(non_snake_case)]
   #[wasm_bindgen(js_name = x25519)]
   pub fn x25519(privateKey: Vec<u8>) -> WasmMethodSecret {

--- a/bindings/wasm/src/core/secret_key.rs
+++ b/bindings/wasm/src/core/secret_key.rs
@@ -14,7 +14,7 @@ pub struct WasmEd25519PrivateKey(pub(crate) ed25519::SecretKey);
 
 #[wasm_bindgen(js_class = Ed25519PrivateKey)]
 impl WasmEd25519PrivateKey {
-  /// Create a new `Ed25519PrivateKey` from a 'UInt8Array'.
+  /// Create a new `Ed25519PrivateKey` from a 'Uint8Array'.
   #[wasm_bindgen(js_name = "fromBase58")]
   pub fn from_key(private_key: Vec<u8>) -> Result<WasmEd25519PrivateKey> {
     let private_key: PrivateKey = private_key.into();
@@ -24,7 +24,7 @@ impl WasmEd25519PrivateKey {
     Ok(WasmEd25519PrivateKey(ed25519::SecretKey::from_bytes(private_key_bytes)))
   }
 
-  /// Returns the PublicKey as a `UInt8Array`.
+  /// Returns the PublicKey as a `Uint8Array`.
   #[wasm_bindgen(js_name = publicKey)]
   pub fn public_key(&self) -> Vec<u8> {
     let public: ed25519::PublicKey = self.0.public_key();

--- a/bindings/wasm/src/crypto/key_pair.rs
+++ b/bindings/wasm/src/crypto/key_pair.rs
@@ -57,13 +57,13 @@ impl WasmKeyPair {
     WasmKeyType::from(self.0.type_())
   }
 
-  /// Returns a copy of the public key as a `UInt8Array`.
+  /// Returns a copy of the public key as a `Uint8Array`.
   #[wasm_bindgen]
   pub fn public(&self) -> Vec<u8> {
     self.0.public().as_ref().to_vec()
   }
 
-  /// Returns a copy of the private key as a `UInt8Array`.
+  /// Returns a copy of the private key as a `Uint8Array`.
   #[wasm_bindgen]
   pub fn private(&self) -> Vec<u8> {
     self.0.private().as_ref().to_vec()

--- a/bindings/wasm/src/did/wasm_method_data.rs
+++ b/bindings/wasm/src/did/wasm_method_data.rs
@@ -26,7 +26,7 @@ impl WasmMethodData {
     Self(MethodData::new_multibase(data))
   }
 
-  /// Returns a `UInt8Array` containing the decoded bytes of the `MethodData`.
+  /// Returns a `Uint8Array` containing the decoded bytes of the `MethodData`.
   ///
   /// This is generally a public key identified by a `MethodData` value.
   ///


### PR DESCRIPTION
# Description of change
Fixes a typo where `UInt8Array` is used as a type instead of [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) (note the lowercase `i` in the correct version).

This was causing a Typescript error/warning: `TS2552: Cannot find name 'UInt8Array'. Did you mean 'Uint8Array'?`

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tests and examples pass locally without the above warning.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
