### PR TITLE
Remove diff chain example from documentation to fix wiki

### DIFF
--- a/documentation/docs/advanced/did_messages.mdx
+++ b/documentation/docs/advanced/did_messages.mdx
@@ -15,8 +15,6 @@ keywords:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
-import diff_chain_js from  '!!raw-loader!./../../../bindings/wasm/examples/src/diff_chain.js';
-import diff_chain_rs from  '!!raw-loader!./../../../examples/low-level-api/diff_chain.rs';
 
 TODO: Explain the concept of DID Messages and how they can be used to optimize DID updates.
 
@@ -37,26 +35,3 @@ Once a new Integration chain transaction is created, it will take all Diff Chain
 The improved performance and ability to handle frequently updated DID Documents is especially beneficial for Verifiable Credential Revocation.
 
 TODO: mention future revocation scheme replacement for MerkleKeyCollection.
-
-## Example of Utilizing a Diff Chain
-
-This example is a basic introduction on how you can create a diff message and publish it to the tangle.
-
-<Tabs
-groupId="programming-languages"
-defaultValue="rust"
-values={[
-{label: 'Rust', value: 'rust'},
-{label: 'Node.js', value: 'nodejs'},
-]
-}>
-<TabItem value="rust">
-<CodeBlock className="language-rust">
-{diff_chain_rs}
-</CodeBlock>
-</TabItem>
-<TabItem value='nodejs'>
-<CodeBlock className="language-javascript">
-{diff_chain_js}
-</CodeBlock></TabItem>
-</Tabs>


### PR DESCRIPTION
# Description of change
Removes the reference to the `diff_chain` example from the documentation, which removed in #759. This is causing the wiki to break.

```js
Module not found: Error: Can't resolve './../../../bindings/wasm/examples/src/diff_chain.js' in 'C:\Work\iota\identity.rs\documentation\local-wiki\iota-wiki\external\identity.rs\documentation\docs\advanced'
Module not found: Error: Can't resolve './../../../examples/low-level-api/diff_chain.rs' in 'C:\Work\iota\identity.rs\documentation\local-wiki\iota-wiki\external\identity.rs\documentation\docs\advanced'
client (webpack 5.69.1) compiled with 2 errors and 1 warning
```

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
The documentation runs without error now: `npm run setup && npm run start` 

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
