### PR TITLE
Remove `AccountStorage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ tokio = { version = "1.14", features = ["full"] }
 use std::path::PathBuf;
 
 use identity::account::Account;
-use identity::account::AccountStorage;
 use identity::account::IdentitySetup;
 use identity::account::Result;
 use identity::account_storage::Stronghold;
@@ -103,7 +102,7 @@ async fn main() -> Result<()> {
   // Stronghold settings.
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
-  let stronghold: Stronghold = Stronghold::new(&stronghold_path, Some(password), None); 
+  let stronghold: Stronghold = Stronghold::new(&stronghold_path, Some(password), None).await?;
 
   // Create a new identity with default settings and
   // Stronghold as the storage.

--- a/README.md
+++ b/README.md
@@ -93,20 +93,22 @@ use identity::account::Account;
 use identity::account::AccountStorage;
 use identity::account::IdentitySetup;
 use identity::account::Result;
+use identity::account_storage::Stronghold;
 use identity::iota::ResolvedIotaDocument;
 
 #[tokio::main]
 async fn main() -> Result<()> {
   pretty_env_logger::init();
 
-  // The Stronghold settings for the storage.
+  // Stronghold settings.
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
+  let stronghold: Stronghold = Stronghold::new(&stronghold_path, Some(password), None); 
 
   // Create a new identity with default settings and
   // Stronghold as the storage.
   let account: Account = Account::builder()
-    .storage(AccountStorage::Stronghold(stronghold_path, Some(password)))
+    .storage(stronghold)
     .create_identity(IdentitySetup::default())
     .await?;
 

--- a/bindings/stronghold-nodejs/.license_template
+++ b/bindings/stronghold-nodejs/.license_template
@@ -1,0 +1,2 @@
+// Copyright {20\d{2}(-20\d{2})?} IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0

--- a/bindings/stronghold-nodejs/js/stronghold.ts
+++ b/bindings/stronghold-nodejs/js/stronghold.ts
@@ -10,7 +10,7 @@ export class Stronghold implements Storage {
         this.napiStronghold = await NapiStronghold.new(snapshot, password, dropsave);
     }
 
-    public static async build (snapshot: string, password: string, dropsave?: boolean) {
+    public static async build(snapshot: string, password?: string, dropsave?: boolean) {
         const stronghold = new Stronghold();
         await stronghold.init(snapshot, password, dropsave)
         return stronghold

--- a/bindings/stronghold-nodejs/js/stronghold.ts
+++ b/bindings/stronghold-nodejs/js/stronghold.ts
@@ -6,7 +6,7 @@ export class Stronghold implements Storage {
 
     constructor() {}
 
-    public async init(snapshot: string, password: string, dropsave?: boolean) {
+    public async init(snapshot: string, password?: string, dropsave?: boolean) {
         this.napiStronghold = await NapiStronghold.new(snapshot, password, dropsave);
     }
 

--- a/bindings/stronghold-nodejs/js/stronghold.ts
+++ b/bindings/stronghold-nodejs/js/stronghold.ts
@@ -6,11 +6,11 @@ export class Stronghold implements Storage {
 
     constructor() {}
 
-    public async init(snapshot: string, password?: string, dropsave?: boolean) {
+    public async init(snapshot: string, password: string, dropsave?: boolean) {
         this.napiStronghold = await NapiStronghold.new(snapshot, password, dropsave);
     }
 
-    public static async build(snapshot: string, password?: string, dropsave?: boolean) {
+    public static async build(snapshot: string, password: string, dropsave?: boolean) {
         const stronghold = new Stronghold();
         await stronghold.init(snapshot, password, dropsave)
         return stronghold

--- a/bindings/stronghold-nodejs/src/account/storage/stronghold.rs
+++ b/bindings/stronghold-nodejs/src/account/storage/stronghold.rs
@@ -33,9 +33,9 @@ impl NapiStronghold {
 
   /// Creates an instance of `Stronghold`.
   #[napi]
-  pub async fn new(snapshot: String, password: String, dropsave: Option<bool>) -> Result<NapiStronghold> {
+  pub async fn new(snapshot: String, password: Option<String>, dropsave: Option<bool>) -> Result<NapiStronghold> {
     Ok(NapiStronghold(
-      Stronghold::new(&snapshot, &*password, dropsave).await.napi_result()?,
+      Stronghold::new(&snapshot, password, dropsave).await.napi_result()?,
     ))
   }
 

--- a/bindings/stronghold-nodejs/src/account/storage/stronghold.rs
+++ b/bindings/stronghold-nodejs/src/account/storage/stronghold.rs
@@ -33,7 +33,7 @@ impl NapiStronghold {
 
   /// Creates an instance of `Stronghold`.
   #[napi]
-  pub async fn new(snapshot: String, password: Option<String>, dropsave: Option<bool>) -> Result<NapiStronghold> {
+  pub async fn new(snapshot: String, password: String, dropsave: Option<bool>) -> Result<NapiStronghold> {
     Ok(NapiStronghold(
       Stronghold::new(&snapshot, password, dropsave).await.napi_result()?,
     ))

--- a/bindings/wasm/src/account/wasm_account/account.rs
+++ b/bindings/wasm/src/account/wasm_account/account.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 
 use identity::account::Account;
 use identity::account::AccountBuilder;
-use identity::account::AccountStorage;
 use identity::account::PublishOptions;
 use identity::account_storage::Storage;
 use identity::crypto::SetSignature;
@@ -99,7 +98,7 @@ impl WasmAccount {
     future_to_promise(async move {
       // Create a new account since `delete_identity` consumes it.
       let account: Result<AccountRc> = AccountBuilder::new()
-        .storage(AccountStorage::Custom(storage))
+        .storage_shared(storage)
         .load_identity(did)
         .await
         .wasm_result();

--- a/bindings/wasm/src/account/wasm_account/account_builder.rs
+++ b/bindings/wasm/src/account/wasm_account/account_builder.rs
@@ -3,10 +3,8 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::sync::Arc;
 
 use identity::account::AccountBuilder;
-use identity::account::AccountStorage;
 use identity::account::IdentitySetup;
 use identity::iota::Client;
 use identity::iota::ClientBuilder;
@@ -61,7 +59,7 @@ impl WasmAccountBuilder {
       };
 
       if let Some(storage) = builder_options.storage() {
-        builder = builder.storage(AccountStorage::Custom(Arc::new(storage)));
+        builder = builder.storage(storage);
       }
     }
 

--- a/examples/account/config.rs
+++ b/examples/account/config.rs
@@ -5,10 +5,10 @@
 
 use identity::account::Account;
 use identity::account::AccountBuilder;
-use identity::account::AccountStorage;
 use identity::account::AutoSave;
 use identity::account::IdentitySetup;
 use identity::account::Result;
+use identity::account_storage::MemStore;
 use identity::iota::ClientBuilder;
 use identity::iota::ExplorerUrl;
 use identity::iota_core::IotaDID;
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
     .autosave(AutoSave::Every) // save immediately after every action
     .autosave(AutoSave::Batch(10)) // save after every 10 actions
     .autopublish(true) // publish to the tangle automatically on every update
-    .storage(AccountStorage::Memory) // use the default in-memory storage
+    .storage(MemStore::new()) // use the default in-memory storage
     .client_builder(
       // Configure a client for the private network
       ClientBuilder::new()

--- a/examples/account/create_did.rs
+++ b/examples/account/create_did.rs
@@ -21,8 +21,8 @@ async fn main() -> Result<()> {
   // Stronghold is an encrypted file that manages private keys.
   // It implements best practices for security and is the recommended way of handling private keys.
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
-  let password: String = "my-password".into();
-  let stronghold: Stronghold = Stronghold::new(&stronghold_path, Some(password), None).await?;
+  let password: String = "my-password".to_owned();
+  let stronghold: Stronghold = Stronghold::new(&stronghold_path, password, None).await?;
 
   // Create a new identity using Stronghold as local storage.
   //

--- a/examples/account/create_did.rs
+++ b/examples/account/create_did.rs
@@ -6,9 +6,9 @@
 use std::path::PathBuf;
 
 use identity::account::Account;
-use identity::account::AccountStorage;
 use identity::account::IdentitySetup;
 use identity::account::Result;
+use identity::account_storage::Stronghold;
 use identity::iota::ExplorerUrl;
 use identity::iota_core::IotaDID;
 
@@ -22,13 +22,14 @@ async fn main() -> Result<()> {
   // It implements best practices for security and is the recommended way of handling private keys.
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
+  let stronghold: Stronghold = Stronghold::new(&stronghold_path, Some(password), None).await?;
 
   // Create a new identity using Stronghold as local storage.
   //
   // The creation step generates a keypair, builds an identity
   // and publishes it to the IOTA mainnet.
   let account: Account = Account::builder()
-    .storage(AccountStorage::Stronghold(stronghold_path, Some(password), None))
+    .storage(stronghold)
     .create_identity(IdentitySetup::default())
     .await?;
 

--- a/examples/account/lazy.rs
+++ b/examples/account/lazy.rs
@@ -5,9 +5,9 @@
 use std::path::PathBuf;
 
 use identity::account::Account;
-use identity::account::AccountStorage;
 use identity::account::IdentitySetup;
 use identity::account::Result;
+use identity::account_storage::Stronghold;
 use identity::core::Url;
 use identity::iota::ExplorerUrl;
 use identity::iota_core::IotaDID;
@@ -19,12 +19,13 @@ async fn main() -> Result<()> {
   // Stronghold settings
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
+  let stronghold: Stronghold = Stronghold::new(&stronghold_path, Some(password), None).await?;
 
   // Create a new Account with auto publishing set to false.
   // This means updates are not pushed to the tangle automatically.
   // Rather, when we publish, multiple updates are batched together.
   let mut account: Account = Account::builder()
-    .storage(AccountStorage::Stronghold(stronghold_path, Some(password), None))
+    .storage(stronghold)
     .autopublish(false)
     .create_identity(IdentitySetup::default())
     .await?;

--- a/examples/account/lazy.rs
+++ b/examples/account/lazy.rs
@@ -18,8 +18,8 @@ async fn main() -> Result<()> {
 
   // Stronghold settings
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
-  let password: String = "my-password".into();
-  let stronghold: Stronghold = Stronghold::new(&stronghold_path, Some(password), None).await?;
+  let password: String = "my-password".to_owned();
+  let stronghold: Stronghold = Stronghold::new(&stronghold_path, password, None).await?;
 
   // Create a new Account with auto publishing set to false.
   // This means updates are not pushed to the tangle automatically.

--- a/examples/account/manipulate_did.rs
+++ b/examples/account/manipulate_did.rs
@@ -4,12 +4,13 @@
 //! cargo run --example account_manipulate
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use identity::account::Account;
-use identity::account::AccountStorage;
 use identity::account::IdentitySetup;
 use identity::account::MethodContent;
 use identity::account::Result;
+use identity::account_storage::Stronghold;
 use identity::core::Url;
 use identity::did::MethodRelationship;
 use identity::iota::ExplorerUrl;
@@ -26,10 +27,11 @@ async fn main() -> Result<()> {
   // Stronghold settings
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
+  let stronghold: Stronghold = Stronghold::new(&stronghold_path, Some(password), None).await?;
 
   // Create a new Account with the default configuration
   let mut account: Account = Account::builder()
-    .storage(AccountStorage::Stronghold(stronghold_path, Some(password), None))
+    .storage_shared(Arc::new(stronghold))
     .create_identity(IdentitySetup::default())
     .await?;
 

--- a/examples/account/manipulate_did.rs
+++ b/examples/account/manipulate_did.rs
@@ -25,8 +25,8 @@ async fn main() -> Result<()> {
 
   // Stronghold settings
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
-  let password: String = "my-password".into();
-  let stronghold: Stronghold = Stronghold::new(&stronghold_path, Some(password), None).await?;
+  let password: String = "my-password".to_owned();
+  let stronghold: Stronghold = Stronghold::new(&stronghold_path, password, None).await?;
 
   // Create a new Account with the default configuration
   let mut account: Account = Account::builder()

--- a/examples/account/manipulate_did.rs
+++ b/examples/account/manipulate_did.rs
@@ -4,7 +4,6 @@
 //! cargo run --example account_manipulate
 
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use identity::account::Account;
 use identity::account::IdentitySetup;
@@ -31,7 +30,7 @@ async fn main() -> Result<()> {
 
   // Create a new Account with the default configuration
   let mut account: Account = Account::builder()
-    .storage_shared(Arc::new(stronghold))
+    .storage(stronghold)
     .create_identity(IdentitySetup::default())
     .await?;
 

--- a/examples/account/multiple_identities.rs
+++ b/examples/account/multiple_identities.rs
@@ -7,10 +7,10 @@ use std::path::PathBuf;
 
 use identity::account::Account;
 use identity::account::AccountBuilder;
-use identity::account::AccountStorage;
 use identity::account::IdentitySetup;
 use identity::account::MethodContent;
 use identity::account::Result;
+use identity::account_storage::Stronghold;
 use identity::iota::ExplorerUrl;
 use identity::iota_core::IotaDID;
 
@@ -24,11 +24,11 @@ async fn main() -> Result<()> {
   // It implements best practices for security and is the recommended way of handling private keys.
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
+  let stronghold: Stronghold = Stronghold::new(&stronghold_path, Some(password), None).await?;
 
   // Create an AccountBuilder to make it easier to create multiple identities.
   // Every account created from the builder will use the same storage - stronghold in this case.
-  let mut builder: AccountBuilder =
-    Account::builder().storage(AccountStorage::Stronghold(stronghold_path, Some(password), None));
+  let mut builder: AccountBuilder = Account::builder().storage(stronghold);
 
   // The creation step generates a keypair, builds an identity
   // and publishes it to the IOTA mainnet.

--- a/examples/account/multiple_identities.rs
+++ b/examples/account/multiple_identities.rs
@@ -23,8 +23,8 @@ async fn main() -> Result<()> {
   // Stronghold is an encrypted file that manages private keys.
   // It implements best practices for security and is the recommended way of handling private keys.
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
-  let password: String = "my-password".into();
-  let stronghold: Stronghold = Stronghold::new(&stronghold_path, Some(password), None).await?;
+  let password: String = "my-password".to_owned();
+  let stronghold: Stronghold = Stronghold::new(&stronghold_path, password, None).await?;
 
   // Create an AccountBuilder to make it easier to create multiple identities.
   // Every account created from the builder will use the same storage - stronghold in this case.

--- a/examples/account/signing.rs
+++ b/examples/account/signing.rs
@@ -34,8 +34,8 @@ async fn main() -> Result<()> {
 
   // Stronghold settings
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
-  let password: String = "my-password".into();
-  let stronghold: Stronghold = Stronghold::new(&stronghold_path, Some(password), None).await?;
+  let password: String = "my-password".to_owned();
+  let stronghold: Stronghold = Stronghold::new(&stronghold_path, password, None).await?;
 
   // Create a new Account with stronghold storage.
   let mut account: Account = Account::builder()

--- a/examples/account/signing.rs
+++ b/examples/account/signing.rs
@@ -6,10 +6,10 @@
 use std::path::PathBuf;
 
 use identity::account::Account;
-use identity::account::AccountStorage;
 use identity::account::IdentitySetup;
 use identity::account::MethodContent;
 use identity::account::Result;
+use identity::account_storage::Stronghold;
 use identity::core::json;
 use identity::core::FromJson;
 use identity::core::Url;
@@ -35,10 +35,11 @@ async fn main() -> Result<()> {
   // Stronghold settings
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
+  let stronghold: Stronghold = Stronghold::new(&stronghold_path, Some(password), None).await?;
 
   // Create a new Account with stronghold storage.
   let mut account: Account = Account::builder()
-    .storage(AccountStorage::Stronghold(stronghold_path, Some(password), None))
+    .storage(stronghold)
     .create_identity(IdentitySetup::default())
     .await?;
 

--- a/examples/account/unchecked.rs
+++ b/examples/account/unchecked.rs
@@ -23,8 +23,8 @@ async fn main() -> Result<()> {
   // Stronghold is an encrypted file that manages private keys.
   // It implements best practices for security and is the recommended way of handling private keys.
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
-  let password: String = "my-password".into();
-  let stronghold: Stronghold = Stronghold::new(&stronghold_path, Some(password), None).await?;
+  let password: String = "my-password".to_owned();
+  let stronghold: Stronghold = Stronghold::new(&stronghold_path, password, None).await?;
 
   // Create a new identity using Stronghold as local storage.
   //

--- a/examples/account/unchecked.rs
+++ b/examples/account/unchecked.rs
@@ -6,9 +6,9 @@
 use std::path::PathBuf;
 
 use identity::account::Account;
-use identity::account::AccountStorage;
 use identity::account::IdentitySetup;
 use identity::account::Result;
+use identity::account_storage::Stronghold;
 use identity::core::Timestamp;
 use identity::iota::ExplorerUrl;
 use identity::iota_core::IotaDID;
@@ -24,13 +24,14 @@ async fn main() -> Result<()> {
   // It implements best practices for security and is the recommended way of handling private keys.
   let stronghold_path: PathBuf = "./example-strong.hodl".into();
   let password: String = "my-password".into();
+  let stronghold: Stronghold = Stronghold::new(&stronghold_path, Some(password), None).await?;
 
   // Create a new identity using Stronghold as local storage.
   //
   // The creation step generates a keypair, builds an identity
   // and publishes it to the IOTA mainnet.
   let mut account: Account = Account::builder()
-    .storage(AccountStorage::Stronghold(stronghold_path, Some(password), None))
+    .storage(stronghold)
     .create_identity(IdentitySetup::default())
     .await?;
 

--- a/identity-account-storage/src/storage/stronghold.rs
+++ b/identity-account-storage/src/storage/stronghold.rs
@@ -43,19 +43,15 @@ impl Stronghold {
   /// Arguments:
   ///
   /// * snapshot: path to a local Stronghold file, will be created if it does not exist.
-  /// * password: password for the Stronghold file, optional.
+  /// * password: password for the Stronghold file.
   /// * dropsave: save all changes when the instance is dropped. Default: true.
-  pub async fn new<'a, T, U>(snapshot: &T, password: U, dropsave: Option<bool>) -> Result<Self>
+  pub async fn new<'a, T>(snapshot: &T, mut password: String, dropsave: Option<bool>) -> Result<Self>
   where
     T: AsRef<Path> + ?Sized,
-    U: Into<Option<String>>,
   {
     let snapshot: Snapshot = Snapshot::new(snapshot);
-
-    if let Some(mut password) = password.into() {
-      snapshot.load(derive_encryption_key(&password)).await?;
-      password.zeroize();
-    }
+    snapshot.load(derive_encryption_key(&password)).await?;
+    password.zeroize();
 
     Ok(Self {
       snapshot: Arc::new(snapshot),

--- a/identity-account/Cargo.toml
+++ b/identity-account/Cargo.toml
@@ -22,7 +22,6 @@ paste = { version = "1.0" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 strum = { version = "0.24.0", default-features = false, features = ["std", "derive"] }
 thiserror = { version = "1.0" }
-zeroize = { version = "1.4", optional = true }
 
 [dependencies.iota-crypto]
 version = "0.7"
@@ -38,6 +37,6 @@ tokio = { version = "1.17.0", default-features = false, features = ["macros", "r
 [features]
 default = ["stronghold", "async", "send-sync-storage"]
 mem-client = []
-stronghold = ["identity-account-storage/stronghold", "zeroize"]
+stronghold = ["identity-account-storage/stronghold"]
 async = ["identity-iota/async"]
 send-sync-storage = ["identity-account-storage/send-sync-storage"]

--- a/identity-account/src/tests/account.rs
+++ b/identity-account/src/tests/account.rs
@@ -502,7 +502,7 @@ async fn test_account_sync_diff_msg_update() {
 async fn create_account(network: Network) -> Account {
   Account::builder()
     .storage(
-      Stronghold::new("./example-strong.hodl".into(), Some("my-password".into()), None)
+      Stronghold::new("./example-strong.hodl", Some("my-password".to_owned()), None)
         .await
         .unwrap(),
     )

--- a/identity-account/src/tests/account.rs
+++ b/identity-account/src/tests/account.rs
@@ -57,9 +57,6 @@ async fn test_account_builder() -> Result<()> {
     crate::Error::IdentityNotFound
   ));
 
-  // Release the lease on did1.
-  std::mem::drop(account1);
-
   assert!(builder.load_identity(did1).await.is_ok());
 
   Ok(())
@@ -502,7 +499,7 @@ async fn test_account_sync_diff_msg_update() {
 async fn create_account(network: Network) -> Account {
   Account::builder()
     .storage(
-      Stronghold::new("./example-strong.hodl", Some("my-password".to_owned()), None)
+      Stronghold::new("./example-strong.hodl", "my-password".to_owned(), None)
         .await
         .unwrap(),
     )

--- a/identity-account/src/tests/account.rs
+++ b/identity-account/src/tests/account.rs
@@ -9,6 +9,7 @@ use futures::Future;
 use identity_account_storage::identity::ChainState;
 use identity_account_storage::identity::IdentityState;
 use identity_account_storage::storage::MemStore;
+use identity_account_storage::storage::Stronghold;
 use identity_core::common::Timestamp;
 use identity_core::common::Url;
 use identity_core::crypto::SignatureOptions;
@@ -27,7 +28,6 @@ use crate::account::Account;
 use crate::account::AccountBuilder;
 use crate::account::AccountConfig;
 use crate::account::AccountSetup;
-use crate::account::AccountStorage;
 use crate::account::AutoSave;
 use crate::account::PublishOptions;
 use crate::types::IdentitySetup;
@@ -57,7 +57,7 @@ async fn test_account_builder() -> Result<()> {
     crate::Error::IdentityNotFound
   ));
 
-  // Relase the lease on did1.
+  // Release the lease on did1.
   std::mem::drop(account1);
 
   assert!(builder.load_identity(did1).await.is_ok());
@@ -501,11 +501,11 @@ async fn test_account_sync_diff_msg_update() {
 
 async fn create_account(network: Network) -> Account {
   Account::builder()
-    .storage(AccountStorage::Stronghold(
-      "./example-strong.hodl".into(),
-      Some("my-password".into()),
-      None,
-    ))
+    .storage(
+      Stronghold::new("./example-strong.hodl".into(), Some("my-password".into()), None)
+        .await
+        .unwrap(),
+    )
     .autopublish(false)
     .autosave(AutoSave::Every)
     .client_builder(ClientBuilder::new().network(network.clone()))


### PR DESCRIPTION
# Description of change
Removes `AccountStorage` to simplify passing of `Storage` interfaces to `AccountBuilder`.

Note that there are now two storage setters on `AccountBuilder`: `storage`, which takes any `S: Storage` implementation, and `storage_shared`, which takes `Arc<dyn Storage>`. The reason for this is that I could not find a way to allow a generic parameter to take either `Arc<dyn Storage>` or `impl Storage`. The closest I got was the following:

```rust
pub fn storage<A: Into<Arc<S>>, S: 'static + Storage>(mut self, value: A)
```

Unfortunately the above function does not work when passed an `Arc<storage>`: 

```rust
error[E0282]: type annotations needed
  --> examples\account/manipulate_did.rs:34:6
   |
34 |     .storage(Arc::new(stronghold))
   |      ^^^^^^^ cannot infer type for type parameter `S` declared on the associated function `storage`
```

and the simpler `pub fn storage<A: Into<Arc<dyn Storage>>>(mut self, value: A)` does not work for non-`Arc` values.

We could force users to always pass in an `Arc<dyn Storage>` as we did with the `AccountStorage::Custom(Arc<dyn Storage>)` variant previously, but I felt this was easier to work with in general.

Note also that I did not change the `Stronghold` constructor nor add a `StrongholdOptions` struct mentioned in #552. There are upcoming changes to the `Stronghold` interface anyway where this change may make more sense, and until there are more options than `dropsave` it may be fine for now.

### Added

- Add `AccountBuilder::storage_shared` to take `Arc<dyn Storage>`.

### Changed

- Change `AccountBuilder::storage` to take any `Storage` interface.

### Removed

- Remove `AccountStorage`

## Links to any relevant issues
Fixes #552.

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tests and examples pass locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
