### PR TITLE
Fix MSRV

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The individual libraries are developed to be agnostic about the utilized [Distri
 
 ## Prerequisites
 
-- [Rust](https://www.rust-lang.org/) (>= 1.56.1)
-- [Cargo](https://doc.rust-lang.org/cargo/) (>= 1.56.0)
+- [Rust](https://www.rust-lang.org/) (>= 1.57.0)
+- [Cargo](https://doc.rust-lang.org/cargo/) (>= 1.57.0)
 
 ## Getting Started
 


### PR DESCRIPTION
# Description of change
Bumps the minimum supported Rust version (MSRV) to `1.57.0`. 

Technically the Rust library builds under `1.56.0`, but the Wasm bindings require `1.57.0` or later. Instead of specifying this in the Readme file in the bindings we follow the KISS/ Occam's razor principle and just add this requirement to the main README file. 


## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
This command (called from the `bindings/wasm` directory) completes successfully 
```
cargo +1.57.0 check --target wasm32-unknown-unknown
```
while 
```
 cargo +1.56.1 check --target wasm32-unknown-unknown
```
fails with an error message indicating that an unstable feature is in use. 

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
