### PR TITLE
Fix Account `create_signed_*` function return types

### DIFF
--- a/bindings/wasm/src/account/wasm_account/account.rs
+++ b/bindings/wasm/src/account/wasm_account/account.rs
@@ -140,7 +140,7 @@ impl WasmAccount {
     let account = self.0.clone();
     let options: ProofOptions = options.0.clone();
 
-    let mut credential = credential.0.clone();
+    let mut credential: Credential = credential.0.clone();
     future_to_promise(async move {
       account
         .as_ref()
@@ -164,7 +164,7 @@ impl WasmAccount {
     let account = self.0.clone();
     let options: ProofOptions = options.0.clone();
 
-    let mut document = document.0.clone();
+    let mut document: IotaDocument = document.0.clone();
     future_to_promise(async move {
       account
         .as_ref()

--- a/bindings/wasm/src/account/wasm_account/account.rs
+++ b/bindings/wasm/src/account/wasm_account/account.rs
@@ -9,6 +9,7 @@ use identity::account::Account;
 use identity::account::AccountBuilder;
 use identity::account::PublishOptions;
 use identity::account_storage::Storage;
+use identity::credential::Credential;
 use identity::credential::Presentation;
 use identity::crypto::ProofOptions;
 

--- a/bindings/wasm/src/credential/presentation.rs
+++ b/bindings/wasm/src/credential/presentation.rs
@@ -83,3 +83,9 @@ impl WasmPresentation {
 }
 
 impl_wasm_clone!(WasmPresentation, Presentation);
+
+impl From<Presentation> for WasmPresentation {
+  fn from(presentation: Presentation) -> WasmPresentation {
+    Self(presentation)
+  }
+}


### PR DESCRIPTION
# Description of change
The return type of creating signed objects in the Account does not match the TypeScript types. 

For example 

```javascript
    // Created a signed credential by the issuer. 
    const signedVc = await issuer.createSignedCredential(
        "#newKey",
        unsignedVc,
        ProofOptions.default(),
    );
``` 
should return a `Credential` according to the method signature: 

```javascript
  createSignedCredential(fragment: string, credential: Credential, options: ProofOptions): Promise<Credential>;
```

but the actual return type is `Object` due to a mistake in using `unchecked_into` which should be tested manually every time it's used. 

This PR fixes this issues and the correct type is returned in the following fucntions:

`create_signed_credential`
`create_signed_document`
`create_signed_presentation`
`create_signed_data`

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix