### PR TITLE
Fix hotfix PR action, remove `release-branch`

### DIFF
--- a/.github/workflows/shared-create-hotfix-pr.yml
+++ b/.github/workflows/shared-create-hotfix-pr.yml
@@ -1,7 +1,7 @@
 name: Shared / Create Hotfix PR
 
-# This workflow creates a Pull Request meant for creating releases. 
-# A changelog, including the new version, is generated and version strings in relevant files are replaced. 
+# This workflow creates a Pull Request meant for creating releases.
+# A changelog, including the new version, is generated and version strings in relevant files are replaced.
 # All these changes are committed and submitted as a Pull Request.
 
 on:
@@ -47,7 +47,7 @@ on:
       GPG_PASSPHRASE:
         description: "GPG private passphrase for signing commits and tags"
         required: true
-        
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -112,7 +112,7 @@ jobs:
           echo UNRELATED_TAGS=$UNRELATED_TAGS
 
           # set variables
-          FIRST="--release-branch ${{ inputs.branch }} --exclude-tags "
+          FIRST="--exclude-tags "
           SECOND=$UNRELATED_TAGS
           OPTIONAL_ARG=$FIRST$SECOND
           echo OPTIONAL_ARG=$OPTIONAL_ARG
@@ -124,7 +124,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           changelog-path: ${{ inputs.changelog-path }}
           changelog-config-path: ${{ inputs.changelog-config-path }}
-          future-release: ${{ env.HOTFIX_TAG }} 
+          future-release: ${{ env.HOTFIX_TAG }}
           optional-arg: ${{env.OPTIONAL_ARG}}
 
       - name: Check Changelog For Modification
@@ -149,7 +149,7 @@ jobs:
         uses: './.github/actions/release/bump-versions'
         with:
           release-target: ${{inputs.release-target}}
-          version: ${{ env.HOTFIX_VERSION }} 
+          version: ${{ env.HOTFIX_VERSION }}
 
       - name: Commit changes
         run: |
@@ -159,13 +159,13 @@ jobs:
             exit 1
           fi
           git commit -m "changelog and versions"
-          
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@67df31e08a133c6a77008b89689677067fef169e
         with:
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          branch: hotfix/${{ env.HOTFIX_TAG }} 
+          branch: hotfix/${{ env.HOTFIX_TAG }}
           delete-branch: true
           title: 'Hotfix ${{ env.HOTFIX_TAG }}'
           body: |


### PR DESCRIPTION
# Description of change
Temporarily remove the `--release-branch` argument for `github-changelog-generator` to include the PRs to `dev` pushed to `support/wasm-v0.5` in the changelog. This is just to fix the immediate problem for the `wasm-v0.5.1` hotfix release. See #800 for more information.

NOTE: does NOT fix this on `dev` to avoid unforeseen consequences for now, until @eike-hass can review.

## Links to any relevant issues
See #800

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tested the change locally with `github-changelog-generator`:

```
docker run -w "/github/workspace" -v C:\Work\iota\identity.rs:"/github/workspace" --rm eiha/github-changelog-generator:latest --output ./bindings/wasm/CHANGELOG.md --config-file ./bindin
gs/wasm/.github_changelog_generator --user iotaledger --project identity.rs  --future-release wasm-v0.5.1   --release-branch support/wasm-v0.5 --exclude-tags v0.1.0,v0.2.0,v0.3.0,v0.4.0,v0.5.0,v0.5.0-dev.1,v0.5.0-dev.2,v0.5.0-dev.3,
v0.5.0-dev.4,v0.5.0-dev.5,v0.5.0-dev.6,wasm-v0.4.1,wasm-v0.4.2,wasm-v0.4.3,wasm-v0.5.0-dev.1,wasm-v0.5.0-dev.2,wasm-v0.5.0-dev.3,wasm-v0.5.0-dev.4,wasm-v0.5.0-dev.5,wasm-v0.5.0-dev.6 -t <PASTE_GITHUB_TOKEN_HERE>
```

Ensured `bindings/wasm/CHANGELOG.md` contains a `wasm-v0.5.1` section:

> ## [wasm-v0.5.1](https://github.com/iotaledger/identity.rs/tree/wasm-v0.5.1) (2022-04-06)
> 
> [Full Changelog](https://github.com/iotaledger/identity.rs/compare/wasm-v0.5.0...wasm-v0.5.1)
> 
> ### Patch
> 
> - Fix Account `create_signed_*` function return types [\#794](https://github.com/iotaledger/identity.rs/pull/794)
> - Fix musl-libc target for Stronghold Node.js bindings [\#789](https://github.com/iotaledger/identity.rs/pull/789)
> 

The rest of the changelog from prior releases is regenerated unchanged, as-expected.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
