### PR TITLE
Use Replits for VC examples in the wiki

### DIFF
--- a/documentation/docs/verifiable_credentials/create.mdx
+++ b/documentation/docs/verifiable_credentials/create.mdx
@@ -9,12 +9,8 @@ keywords:
 - Create
 - sign
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
-import create_vc_js from  '!!raw-loader!./../../../bindings/wasm/examples-account/src/create_vc.ts';
 import create_vc_rs from  '!!raw-loader!./../../../examples/account/create_vc.rs';
-import account_sign_vp_rs from  '!!raw-loader!./../../../examples/account/signing.rs';
+import CodeSnippet from '../../src/components/CodeSnippetComponent'
 
 
 TODO: Explain how a VC is created and verified.
@@ -26,29 +22,9 @@ The issuer signs a UniversityDegreeCredential type verifiable credential with Al
 This Verifiable Credential can be verified by anyone, allowing Alice to take control of it and share it with anyone.
 
 
-### Account Module (Recommended)
-
-<CodeBlock className="language-rust">
-    {account_sign_vp_rs}
-</CodeBlock>
-
-### Low-level API
-
-<Tabs
-    groupId="programming-languages"
-    defaultValue="rust"
-    values={[
-        {label: 'Rust', value: 'rust'},
-        {label: 'Node.js', value: 'nodejs'},
-    ]
-    }>
-    <TabItem value="rust">
-        <CodeBlock className="language-rust">
-            {create_vc_rs}
-        </CodeBlock>
-    </TabItem>
-    <TabItem value='nodejs'>
-        <CodeBlock className="language-javascript">
-            {create_vc_js}
-        </CodeBlock></TabItem>
-</Tabs>
+<CodeSnippet 
+    nodeReplitLink="https://repl.it/@IOTAFoundation/create-vc?lite=true"
+    rustContent={create_vc_rs}
+    nodeGithubLink = "https://github.com/iotaledger/identity.rs/blob/dev/bindings/wasm/examples-account/src/create_vc.ts"
+    rustGithubLink = "https://github.com/iotaledger/identity.rs/blob/dev/examples/account/create_vc.rs"
+/>

--- a/documentation/docs/verifiable_credentials/create.mdx
+++ b/documentation/docs/verifiable_credentials/create.mdx
@@ -12,8 +12,8 @@ keywords:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
-import create_vc_js from  '!!raw-loader!./../../../bindings/wasm/examples/src/create_vc.js';
-import create_vc_rs from  '!!raw-loader!./../../../examples/low-level-api/create_vc.rs';
+import create_vc_js from  '!!raw-loader!./../../../bindings/wasm/examples-account/src/create_vc.ts';
+import create_vc_rs from  '!!raw-loader!./../../../examples/account/create_vc.rs';
 import account_sign_vp_rs from  '!!raw-loader!./../../../examples/account/signing.rs';
 
 

--- a/documentation/docs/verifiable_credentials/revoke.mdx
+++ b/documentation/docs/verifiable_credentials/revoke.mdx
@@ -11,8 +11,8 @@ keywords:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
-import revoke_vc_js from  '!!raw-loader!./../../../bindings/wasm/examples/src/revoke_vc.js';
-import revoke_vc_rs from  '!!raw-loader!./../../../examples/low-level-api/revoke_vc.rs';
+import revoke_vc_js from  '!!raw-loader!./../../../bindings/wasm/examples-account/src/revoke_vc.ts';
+import revoke_vc_rs from  '!!raw-loader!./../../../examples/account/revoke_vc.rs';
 
 TODO: Explain how Verifiable Credentials are revoked using `credentialStatus` and e.g. `RevocationList2020`.
 

--- a/documentation/docs/verifiable_credentials/revoke.mdx
+++ b/documentation/docs/verifiable_credentials/revoke.mdx
@@ -8,11 +8,8 @@ keywords:
 - credentials
 - revoke
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
-import revoke_vc_js from  '!!raw-loader!./../../../bindings/wasm/examples-account/src/revoke_vc.ts';
 import revoke_vc_rs from  '!!raw-loader!./../../../examples/account/revoke_vc.rs';
+import CodeSnippet from '../../src/components/CodeSnippetComponent'
 
 TODO: Explain how Verifiable Credentials are revoked using `credentialStatus` and e.g. `RevocationList2020`.
 
@@ -20,22 +17,10 @@ TODO: Explain how Verifiable Credentials are revoked using `credentialStatus` an
 
 This example shows how you can revoke a [Verifiable Credential(VC)](overview) by removing a verification method (public key) from the DID Document of the Issuer. This means the VC can no longer be validated. This would invalidate every VC signed with the same public key, meaning the Issuer would have to sign every VC with a different key.
 
-<Tabs
-groupId="programming-languages"
-defaultValue="rust"
-values={[
-{label: 'Rust', value: 'rust'},
-{label: 'Node.js', value: 'nodejs'},
-]
-}>
-<TabItem value="rust">
-<CodeBlock className="language-rust">
-{revoke_vc_rs}
-</CodeBlock>
-</TabItem>
-<TabItem value='nodejs'>
-<CodeBlock className="language-javascript">
-{revoke_vc_js}
-</CodeBlock></TabItem>
-</Tabs>
 
+<CodeSnippet 
+    nodeReplitLink="https://repl.it/@IOTAFoundation/revoke-vc?lite=true"
+    rustContent={revoke_vc_rs}
+    nodeGithubLink = "https://github.com/iotaledger/identity.rs/blob/dev/bindings/wasm/examples-account/src/revoke_vc.ts"
+    rustGithubLink = "https://github.com/iotaledger/identity.rs/blob/dev/examples/account/revoke_vc.rs"
+/>

--- a/documentation/docs/verifiable_credentials/verifiable_presentations.mdx
+++ b/documentation/docs/verifiable_credentials/verifiable_presentations.mdx
@@ -7,13 +7,8 @@ keywords:
 - verifiable
 - presentations
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
-import create_vp_js from  '!!raw-loader!./../../../bindings/wasm/examples-account/src/create_vp.ts';
 import create_vp_rs from  '!!raw-loader!./../../../examples/account/create_vp.rs';
-import account_sign_vp_rs from  '!!raw-loader!./../../../examples/account/signing.rs';
-
+import CodeSnippet from '../../src/components/CodeSnippetComponent'
 
 TODO: Explain the need for and
 
@@ -21,29 +16,11 @@ TODO: Explain the need for and
 
 This example shows how you can create and validate a Verifiable Presentation. A Verifiable Presentation is the format in which you can share a (collection of) Verifiable Credential(s). It is signed by the subject, to prove control over the Verifiable Credential with a nonce or timestamp.
 
-### Account Module (Recommended)
 
-<CodeBlock className="language-rust">
-    {account_sign_vp_rs}
-</CodeBlock>
 
-### Low-level API
-
-<Tabs
-groupId="programming-languages"
-defaultValue="rust"
-values={[
-{label: 'Rust', value: 'rust'},
-{label: 'Node.js', value: 'nodejs'},
-]
-}>
-<TabItem value="rust">
-<CodeBlock className="language-rust">
-{create_vp_rs}
-</CodeBlock>
-</TabItem>
-<TabItem value='nodejs'>
-<CodeBlock className="language-javascript">
-{create_vp_js}
-</CodeBlock></TabItem>
-</Tabs>
+<CodeSnippet 
+    nodeReplitLink="https://repl.it/@IOTAFoundation/create-vp?lite=true"
+    rustContent={create_vp_rs}
+    nodeGithubLink = "https://github.com/iotaledger/identity.rs/blob/dev/bindings/wasm/examples-account/src/create_vp.ts"
+    rustGithubLink = "https://github.com/iotaledger/identity.rs/blob/dev/examples/account/create_vp.rs"
+/>

--- a/documentation/docs/verifiable_credentials/verifiable_presentations.mdx
+++ b/documentation/docs/verifiable_credentials/verifiable_presentations.mdx
@@ -10,8 +10,8 @@ keywords:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
-import create_vp_js from  '!!raw-loader!./../../../bindings/wasm/examples/src/create_vp.js';
-import create_vp_rs from  '!!raw-loader!./../../../examples/low-level-api/create_vp.rs';
+import create_vp_js from  '!!raw-loader!./../../../bindings/wasm/examples-account/src/create_vp.ts';
+import create_vp_rs from  '!!raw-loader!./../../../examples/account/create_vp.rs';
 import account_sign_vp_rs from  '!!raw-loader!./../../../examples/account/signing.rs';
 
 


### PR DESCRIPTION
# Description of change
Replace outdated links caused by https://github.com/iotaledger/identity.rs/pull/795 in the wiki and use Replits for VC examples.
