### PR TITLE
Bump MSRV to 1.58

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The individual libraries are developed to be agnostic about the utilized [Distri
 
 ## Prerequisites
 
-- [Rust](https://www.rust-lang.org/) (>= 1.57.0)
-- [Cargo](https://doc.rust-lang.org/cargo/) (>= 1.57.0)
+- [Rust](https://www.rust-lang.org/) (>= 1.58.0)
+- [Cargo](https://doc.rust-lang.org/cargo/) (>= 1.58.0)
 
 ## Getting Started
 


### PR DESCRIPTION
# Description of change

Increase the minimum supported Rust version to `1.58`, since the `StorageTestSuite` introduced in #791 uses the `format_args_implicits` feature which was stabilized in `1.58`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

## How the change has been tested

This succeeds:

```
cargo +1.58.0 check --manifest-path bindings/wasm/Cargo.toml --target wasm32-unknown-unknown
```

while this does not:

```
cargo +1.57.0 check --manifest-path bindings/wasm/Cargo.toml --target wasm32-unknown-unknown
```

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
