### PR TITLE
Unpin iota-crypto version

### DIFF
--- a/identity-account-storage/Cargo.toml
+++ b/identity-account-storage/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { version = "1.17.0", default-features = false, features = ["sync"], opt
 zeroize = { version = "1.4" }
 
 [dependencies.iota-crypto]
-version = "=0.9.1"
+version = ">=0.7, <0.10"
 default-features = false
 features = ["blake2b", "hmac", "pbkdf", "sha", "std"]
 

--- a/identity-core/Cargo.toml
+++ b/identity-core/Cargo.toml
@@ -24,7 +24,7 @@ url = { version = "2.2", default-features = false, features = ["serde"] }
 zeroize = { version = "1.4", default-features = false }
 
 [dependencies.iota-crypto]
-version = "=0.9.1"
+version = ">=0.7, <0.10"
 default-features = false
 features = ["ed25519", "random", "sha", "x25519"]
 

--- a/identity-iota-core/Cargo.toml
+++ b/identity-iota-core/Cargo.toml
@@ -20,7 +20,7 @@ strum = { version = "0.24.0", default-features = false, features = ["std", "deri
 thiserror = { version = "1.0", default-features = false }
 
 [dependencies.iota-crypto]
-version = "=0.9.1"
+version = ">=0.7, <0.10"
 default-features = false
 features = ["blake2b"]
 

--- a/identity-iota/Cargo.toml
+++ b/identity-iota/Cargo.toml
@@ -43,7 +43,7 @@ default-features = false
 features = ["wasm"]
 
 [dependencies.iota-crypto]
-version = "=0.9.1"
+version = ">=0.7, <0.10"
 default-features = false
 features = ["blake2b"]
 


### PR DESCRIPTION
# Description of change
This PR specifies the `iota-crypto` dependencies used by this library to be in the range `0.7` up to (but NOT including) `0.10`.  https://github.com/iotaledger/identity.rs/pull/822 pinned the version to `0.9.1` which was necessary because `0.9.2` introduced a breaking change causing builds to fail. Now `0.9.2` has been yanked from crates.io and pinning is therefore no longer necessary. 

## Open questions
Before #822, we specified version `^0.7` for `iota-crypto` in our crates except for libjose (the reason `0.9.2` still got pulled was because of transitive dependencies (which pinning to `0.9.1` then prevented)), but as #822 demonstrated our library also worked with `0.9.1` and I have also tested with `0.8`. Hence the question is do we use the range specified in this PR, or go back to `^0.7` or use `^0.9` which is now OK due to `0.9.2` being yanked? 


## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
