### PR TITLE
Fix Stronghold bindings build for musl

### DIFF
--- a/.github/Dockerfile.alpine
+++ b/.github/Dockerfile.alpine
@@ -1,5 +1,0 @@
-FROM node:16-alpine
-
-# libc6-compat for gcc compatibility
-RUN apk --no-cache add libc6-compat
-RUN ln -s /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -202,6 +202,6 @@ jobs:
       - build-wasm
     if: ${{ needs.check-for-run-condition.outputs.should-run == 'true' }}
     # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-build-and-test-stronghold-nodejs.yml@dev
+    uses: iotaledger/identity.rs/.github/workflows/shared-build-and-test-stronghold-nodejs.yml@fix/musl-ci
     with:
       input-artifact-name: identity-wasm-bindings-build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -202,6 +202,6 @@ jobs:
       - build-wasm
     if: ${{ needs.check-for-run-condition.outputs.should-run == 'true' }}
     # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-build-and-test-stronghold-nodejs.yml@fix/musl-ci
+    uses: iotaledger/identity.rs/.github/workflows/shared-build-and-test-stronghold-nodejs.yml@dev
     with:
       input-artifact-name: identity-wasm-bindings-build

--- a/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
+++ b/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
@@ -66,6 +66,8 @@ jobs:
               test: |
                 npm run test
             - host: ubuntu-latest
+              # Use container to build musl as `rand::thread_rng()` or `rand::random()` (in our code or dependencies)
+              # causes the '__register_atfork' symbol to not be found at runtime when cross-compiled.
               container: rust:1.60-alpine
               target: x86_64-unknown-linux-musl
               architecture: x64

--- a/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
+++ b/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
@@ -67,10 +67,11 @@ jobs:
               test: |
                 npm run test
             - host: ubuntu-latest
-              container: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+              container: rust:1.60-alpine
               target: x86_64-unknown-linux-musl
               architecture: x64
               build: |
+                apk add build-base
                 export NPM_BUILD_NAPI_ARGS=--target=x86_64-unknown-linux-musl
                 npm run build && strip dist/*.node
               test: |

--- a/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
+++ b/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
@@ -30,7 +30,6 @@ jobs:
       defaults:
         run:
           working-directory: bindings/stronghold-nodejs
-          shell: bash
       env:
         DEBUG: napi:*
         APP_NAME: identity-stronghold-nodejs
@@ -42,7 +41,6 @@ jobs:
           settings:
             - host: macos-latest
               container: null
-              shell: bash
               target: x86_64-apple-darwin
               architecture: x64
               build: |
@@ -52,7 +50,6 @@ jobs:
                 npm run test
             - host: windows-latest
               container: null
-              shell: pwsh
               target: x86_64-pc-windows-msvc
               architecture: x64
               build: |
@@ -61,7 +58,6 @@ jobs:
                 npm run test:examples
             - host: ubuntu-latest
               container: null
-              shell: bash
               generate-dist: true
               target: x86_64-unknown-linux-gnu
               architecture: x64
@@ -71,11 +67,12 @@ jobs:
                 npm run test
             - host: ubuntu-latest
               container: rust:1.60-alpine
-              shell: sh
               target: x86_64-unknown-linux-musl
               architecture: x64
+              setup: |
+                # build-base required for libsodium compilation.
+                apk add --no-cache build-base
               build: |
-                apk add build-base
                 export NPM_BUILD_NAPI_ARGS=--target=x86_64-unknown-linux-musl
                 npm run build && strip dist/*.node
               test: |
@@ -83,7 +80,6 @@ jobs:
                 npm run test:examples
             - host: macos-latest
               container: null
-              shell: bash
               target: aarch64-apple-darwin
               build: |
                 export NPM_BUILD_NAPI_ARGS=--target=aarch64-apple-darwin
@@ -111,6 +107,10 @@ jobs:
             job: ${{ github.job }}
             target: ${{ matrix.settings.target }}
 
+        - name: Setup
+          if: ${{ matrix.settings.setup }}
+          run: ${{ matrix.settings.setup }}
+
         - name: Download bindings/wasm artifacts
           uses: actions/download-artifact@v2
           with:
@@ -118,27 +118,22 @@ jobs:
             path: bindings/wasm
 
         - name: Prepare Wasm bindings link
-          shell: ${{ matrix.shell }}
           run: |
             npm ci
             npm link
           working-directory: ./bindings/wasm
 
         - name: Install dependencies
-          shell: ${{ matrix.shell }}
           # ignore peer dependencies, because in the case of publishing the identity-wasm peer dependency is not released yet
           run: npm ci --ignore-scripts --legacy-peer-deps && npm link @iota/identity-wasm
 
         - name: Build
-          shell: ${{ matrix.shell }}
           run: ${{ matrix.settings.build }}
 
         - name: List packages
-          shell: ${{ matrix.shell }}
           run: ls -R .
 
         - name: Test bindings
-          shell: ${{ matrix.shell }}
           if: ${{ inputs.run-tests && matrix.settings.test }}
           run: ${{ matrix.settings.test }}
 

--- a/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
+++ b/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
@@ -70,8 +70,9 @@ jobs:
               target: x86_64-unknown-linux-musl
               architecture: x64
               setup: |
+                # actions/setup-node@v2 does not work for musl, install manually.
                 # build-base required for libsodium compilation.
-                apk add --no-cache build-base
+                apk add --no-cache nodejs npm build-base
               build: |
                 export NPM_BUILD_NAPI_ARGS=--target=x86_64-unknown-linux-musl
                 npm run build && strip dist/*.node

--- a/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
+++ b/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
@@ -68,7 +68,7 @@ jobs:
             - host: ubuntu-latest
               # Use container to build musl as `rand::thread_rng()` or `rand::random()` (in our code or dependencies)
               # causes the '__register_atfork' symbol to not be found at runtime when cross-compiled.
-              container: rust:1.60-alpine
+              container: rust:1-alpine
               target: x86_64-unknown-linux-musl
               architecture: x64
               setup: |

--- a/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
+++ b/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
@@ -42,6 +42,7 @@ jobs:
           settings:
             - host: macos-latest
               container: null
+              shell: bash
               target: x86_64-apple-darwin
               architecture: x64
               build: |
@@ -51,6 +52,7 @@ jobs:
                 npm run test
             - host: windows-latest
               container: null
+              shell: pwsh
               target: x86_64-pc-windows-msvc
               architecture: x64
               build: |
@@ -59,6 +61,7 @@ jobs:
                 npm run test:examples
             - host: ubuntu-latest
               container: null
+              shell: bash
               generate-dist: true
               target: x86_64-unknown-linux-gnu
               architecture: x64
@@ -68,6 +71,7 @@ jobs:
                 npm run test
             - host: ubuntu-latest
               container: rust:1.60-alpine
+              shell: sh
               target: x86_64-unknown-linux-musl
               architecture: x64
               build: |
@@ -79,6 +83,7 @@ jobs:
                 npm run test:examples
             - host: macos-latest
               container: null
+              shell: bash
               target: aarch64-apple-darwin
               build: |
                 export NPM_BUILD_NAPI_ARGS=--target=aarch64-apple-darwin
@@ -113,22 +118,27 @@ jobs:
             path: bindings/wasm
 
         - name: Prepare Wasm bindings link
+          shell: ${{ matrix.shell }}
           run: |
             npm ci
             npm link
           working-directory: ./bindings/wasm
 
         - name: Install dependencies
+          shell: ${{ matrix.shell }}
           # ignore peer dependencies, because in the case of publishing the identity-wasm peer dependency is not released yet
           run: npm ci --ignore-scripts --legacy-peer-deps && npm link @iota/identity-wasm
 
         - name: Build
+          shell: ${{ matrix.shell }}
           run: ${{ matrix.settings.build }}
 
         - name: List packages
+          shell: ${{ matrix.shell }}
           run: ls -R .
 
         - name: Test bindings
+          shell: ${{ matrix.shell }}
           if: ${{ inputs.run-tests && matrix.settings.test }}
           run: ${{ matrix.settings.test }}
 

--- a/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
+++ b/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
@@ -70,8 +70,6 @@ jobs:
               container: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
               target: x86_64-unknown-linux-musl
               architecture: x64
-              setup: |
-                sudo apt-get install -y musl-tools
               build: |
                 export NPM_BUILD_NAPI_ARGS=--target=x86_64-unknown-linux-musl
                 npm run build && strip dist/*.node
@@ -118,10 +116,6 @@ jobs:
             npm ci
             npm link
           working-directory: ./bindings/wasm
-
-        - name: Setup
-          if: ${{ matrix.settings.setup }}
-          run: ${{ matrix.settings.setup }}
 
         - name: Install dependencies
           # ignore peer dependencies, because in the case of publishing the identity-wasm peer dependency is not released yet

--- a/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
+++ b/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
@@ -97,7 +97,6 @@ jobs:
           uses: actions/setup-node@v2
           with:
             node-version: 16
-            check-latest: true
             architecture: ${{ matrix.settings.architecture }}
 
         - name: Setup Rust and cache

--- a/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
+++ b/.github/workflows/shared-build-and-test-stronghold-nodejs.yml
@@ -41,6 +41,7 @@ jobs:
         matrix:
           settings:
             - host: macos-latest
+              container: null
               target: x86_64-apple-darwin
               architecture: x64
               build: |
@@ -49,6 +50,7 @@ jobs:
               test: |
                 npm run test
             - host: windows-latest
+              container: null
               target: x86_64-pc-windows-msvc
               architecture: x64
               build: |
@@ -56,6 +58,7 @@ jobs:
               test: |
                 npm run test:examples
             - host: ubuntu-latest
+              container: null
               generate-dist: true
               target: x86_64-unknown-linux-gnu
               architecture: x64
@@ -63,19 +66,20 @@ jobs:
                 npm run build && strip dist/*.node
               test: |
                 npm run test
-            # TODO: Disabled until we have a fix for building Rust code for musl that includes rand::thread_rng.
-            # - host: ubuntu-latest
-            #   target: x86_64-unknown-linux-musl
-            #   architecture: x64
-            #   setup: |
-            #    sudo apt-get install -y musl-tools
-            #   build: |
-            #    export NPM_BUILD_NAPI_ARGS=--target=x86_64-unknown-linux-musl
-            #    npm run build && strip dist/*.node
-            #   test-docker: |
-            #    docker build -f .github/Dockerfile.alpine -t tester .github
-            #    docker run --rm -v $(pwd):/build -w /build/bindings/stronghold-nodejs tester sh -c "ldd dist/identity-stronghold-nodejs.linux-x64-musl.node || true && npm run test:examples"
+            - host: ubuntu-latest
+              container: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+              target: x86_64-unknown-linux-musl
+              architecture: x64
+              setup: |
+                sudo apt-get install -y musl-tools
+              build: |
+                export NPM_BUILD_NAPI_ARGS=--target=x86_64-unknown-linux-musl
+                npm run build && strip dist/*.node
+              test: |
+                ldd dist/identity-stronghold-nodejs.linux-x64-musl.node || true 
+                npm run test:examples
             - host: macos-latest
+              container: null
               target: aarch64-apple-darwin
               build: |
                 export NPM_BUILD_NAPI_ARGS=--target=aarch64-apple-darwin
@@ -85,6 +89,7 @@ jobs:
                 echo "let's hope for the best"
       name: stable - ${{ matrix.settings.target }} - node@16
       runs-on: ${{ matrix.settings.host }}
+      container: ${{ matrix.settings.container }}
       steps:
         - uses: actions/checkout@v2
 
@@ -131,11 +136,6 @@ jobs:
         - name: Test bindings
           if: ${{ inputs.run-tests && matrix.settings.test }}
           run: ${{ matrix.settings.test }}
-
-        - name: Test bindings in docker
-          if: ${{ inputs.run-tests && matrix.settings.test-docker }}
-          run: ${{ matrix.settings.test-docker }}
-          working-directory: ./
 
         # Optionally uploads binary artifact for current matrix target for later release.
         - name: Upload binary artifact

--- a/bindings/stronghold-nodejs/package.json
+++ b/bindings/stronghold-nodejs/package.json
@@ -14,7 +14,8 @@
         "aarch64-apple-darwin",
         "x86_64-apple-darwin",
         "x86_64-pc-windows-msvc",
-        "x86_64-unknown-linux-gnu"
+        "x86_64-unknown-linux-gnu",
+        "x86_64-unknown-linux-musl"
       ]
     }
   },

--- a/identity-account-storage/src/storage/stronghold.rs
+++ b/identity-account-storage/src/storage/stronghold.rs
@@ -462,7 +462,6 @@ fn location_key_type(location: &KeyLocation) -> procedures::KeyType {
 }
 
 fn random_location(key_type: KeyType) -> KeyLocation {
-  // NOTE: do not use rand::thread_rng() or rand::random(), breaks musl-libc cross-compilation.
   let fragment: String = rand::distributions::Alphanumeric.sample_string(&mut OsRng, 32);
   let public_key: [u8; 32] = OsRng.sample(rand::distributions::Standard);
 


### PR DESCRIPTION
# Description of change
Use an Alpine container ([`rust:1-alpine`](https://hub.docker.com/layers/rust/library/rust/1-alpine/images/sha256-e1ddd35b6a802ac8587f8fbc34ce752be20b5c116df2b2f1a90488f0bc3bd439?context=explore)) to build and test the Stronghold napi bindings. Re-enables the musl target.

We could pin to e.g. `rust:1.60-alpine` but the current Rust step pulls in the latest stable version anyway, so `rust:1-alpine` matches that behaviour.

## Links to any relevant issues
Fixes #837

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Works locally and passes in GitHub Actions: https://github.com/iotaledger/identity.rs/actions/runs/2283180473

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
