### PR TITLE
Improve Napi-Wasm error conversion

### DIFF
--- a/bindings/stronghold-nodejs/src/error.rs
+++ b/bindings/stronghold-nodejs/src/error.rs
@@ -15,24 +15,37 @@ pub trait NapiResult<T> {
 
 impl<T> NapiResult<T> for AccountStorageResult<T> {
   fn napi_result(self) -> Result<T> {
-    self.map_err(|account_storage_error| Error::from_reason(account_storage_error.to_string()))
+    self.map_err(|account_storage_error| Error::from_reason(error_chain_fmt(&account_storage_error)))
   }
 }
 
 impl<T> NapiResult<T> for CoreResult<T> {
   fn napi_result(self) -> Result<T> {
-    self.map_err(|core_error| Error::from_reason(core_error.to_string()))
+    self.map_err(|core_error| Error::from_reason(error_chain_fmt(&core_error)))
   }
 }
 
 impl<T> NapiResult<T> for IotaCoreResult<T> {
   fn napi_result(self) -> Result<T> {
-    self.map_err(|iota_core_error| Error::from_reason(iota_core_error.to_string()))
+    self.map_err(|iota_core_error| Error::from_reason(error_chain_fmt(&iota_core_error)))
   }
 }
 
 impl<T> NapiResult<T> for SerdeResult<T> {
   fn napi_result(self) -> Result<T> {
-    self.map_err(|serde_error| Error::from_reason(serde_error.to_string()))
+    self.map_err(|serde_error| Error::from_reason(error_chain_fmt(&serde_error)))
   }
+}
+
+// the following function is inspired by https://www.lpalmieri.com/posts/error-handling-rust/#error-source
+fn error_chain_fmt(err: &impl std::error::Error) -> String {
+  let mut error = err.to_string() + ".";
+
+  let mut current = err.source();
+  while let Some(cause) = current {
+    error = format!("{error} Caused by: {}.", cause);
+    current = cause.source();
+  }
+
+  error
 }

--- a/bindings/wasm/src/account/storage/traits.rs
+++ b/bindings/wasm/src/account/storage/traits.rs
@@ -116,7 +116,7 @@ impl Storage for WasmStorage {
 
     let promise: Promise = Promise::resolve(&self.did_create(network.as_ref(), fragment, private_key));
     let result: JsValueResult = JsFuture::from(promise).await.into();
-    let did_location_tuple: js_sys::Array = js_sys::Array::from(&result.account_err()?);
+    let did_location_tuple: js_sys::Array = js_sys::Array::from(&result.to_account_error()?);
     let mut did_location_tuple: js_sys::ArrayIter = did_location_tuple.iter();
 
     let did: IotaDID = did_location_tuple
@@ -149,7 +149,7 @@ impl Storage for WasmStorage {
   async fn did_list(&self) -> AccountStorageResult<Vec<IotaDID>> {
     let promise: Promise = Promise::resolve(&self.did_list());
     let result: JsValueResult = JsFuture::from(promise).await.into();
-    let js_value: JsValue = result.account_err()?;
+    let js_value: JsValue = result.to_account_error()?;
 
     js_value
       .into_serde()
@@ -161,7 +161,7 @@ impl Storage for WasmStorage {
       Promise::resolve(&self.key_generate(did.clone().into(), key_type.into(), fragment.to_owned()));
     let result: JsValueResult = JsFuture::from(promise).await.into();
     let location: KeyLocation = result
-      .account_err()?
+      .to_account_error()?
       .into_serde()
       .map_err(|err| AccountStorageError::SerializationError(err.to_string()))?;
 
@@ -186,7 +186,7 @@ impl Storage for WasmStorage {
   async fn key_public(&self, did: &IotaDID, location: &KeyLocation) -> AccountStorageResult<PublicKey> {
     let promise: Promise = Promise::resolve(&self.key_public(did.clone().into(), location.clone().into()));
     let result: JsValueResult = JsFuture::from(promise).await.into();
-    let public_key: Vec<u8> = result.account_err().map(uint8array_to_bytes)??;
+    let public_key: Vec<u8> = result.to_account_error().map(uint8array_to_bytes)??;
     Ok(public_key.into())
   }
 
@@ -199,7 +199,7 @@ impl Storage for WasmStorage {
   async fn key_sign(&self, did: &IotaDID, location: &KeyLocation, data: Vec<u8>) -> AccountStorageResult<Signature> {
     let promise: Promise = Promise::resolve(&self.key_sign(did.clone().into(), location.clone().into(), data));
     let result: JsValueResult = JsFuture::from(promise).await.into();
-    let js_value: JsValue = result.account_err()?;
+    let js_value: JsValue = result.to_account_error()?;
     let signature: Signature = js_value
       .into_serde()
       .map_err(|err| AccountStorageError::SerializationError(err.to_string()))?;
@@ -215,7 +215,7 @@ impl Storage for WasmStorage {
   async fn chain_state_get(&self, did: &IotaDID) -> AccountStorageResult<Option<ChainState>> {
     let promise: Promise = Promise::resolve(&self.chain_state_get(did.clone().into()));
     let result: JsValueResult = JsFuture::from(promise).await.into();
-    let js_value: JsValue = result.account_err()?;
+    let js_value: JsValue = result.to_account_error()?;
     if js_value.is_null() || js_value.is_undefined() {
       return Ok(None);
     }
@@ -234,7 +234,7 @@ impl Storage for WasmStorage {
   async fn document_get(&self, did: &IotaDID) -> AccountStorageResult<Option<IotaDocument>> {
     let promise: Promise = Promise::resolve(&self.document_get(did.clone().into()));
     let result: JsValueResult = JsFuture::from(promise).await.into();
-    let js_value: JsValue = result.account_err()?;
+    let js_value: JsValue = result.to_account_error()?;
     if js_value.is_null() || js_value.is_undefined() {
       return Ok(None);
     }


### PR DESCRIPTION
# Description of change

Improve the conversion of errors in Napi when going from Rust to JS. This simply includes the entire error chain in the error string, which is necessary because the new stronghold errors do not include the source errors in their string representation, as per our error guidelines.

As an example, when opening a stronghold with an incorrect password:

**Current dev**

```
Error: snapshot operation `read` on path `test_strongholds/test.stronghodl` failed
```

**This PR**

```
Error: snapshot operation `read` on path `test_strongholds/test.stronghodl` failed. Caused by: Inner error occured(corrupted file: Decryption failed: error in algorithm XCHACHA20-POLY1305).
```

For formatting, the Napi code uses a modified version of the `error_chain_fmt` function from Wasm.

## Links to any relevant issues

[Our error guidelines](https://github.com/iotaledger/identity.rs/issues/534).

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Ran a local test to see if the error strings look as expected.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
