### PR TITLE
After publication, overwrite `Account` document with published one

### DIFF
--- a/bindings/wasm/src/account/wasm_account/account.rs
+++ b/bindings/wasm/src/account/wasm_account/account.rs
@@ -65,9 +65,9 @@ impl WasmAccount {
 
   /// Returns a copy of the document managed by the `Account`.
   ///
-  /// Note that the returned document only has a valid signature after publication.
-  /// In general for use cases where the signature is required, it is advisable to resolve the
-  /// document from tangle, for instance by using `resolve_identity`.
+  /// Note: the returned document only has a valid signature after publishing an integration chain update.
+  /// In general, for use cases where the signature is required, it is advisable to resolve the
+  /// document from the Tangle.
   #[wasm_bindgen]
   pub fn document(&self) -> WasmDocument {
     let document: IotaDocument = self.0.borrow().document().clone();

--- a/bindings/wasm/src/account/wasm_account/account.rs
+++ b/bindings/wasm/src/account/wasm_account/account.rs
@@ -64,6 +64,10 @@ impl WasmAccount {
   }
 
   /// Returns a copy of the document managed by the `Account`.
+  ///
+  /// Note that the returned document only has a valid signature after publication.
+  /// In general for use cases where the signature is required, it is advisable to resolve the
+  /// document from tangle, for instance by using `resolve_identity`.
   #[wasm_bindgen]
   pub fn document(&self) -> WasmDocument {
     let document: IotaDocument = self.0.borrow().document().clone();

--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -176,6 +176,10 @@ where
 
   /// Returns the DID document of the identity, which this account manages,
   /// with all updates applied.
+  ///
+  /// Note that the returned document only has a valid signature after publication.
+  /// In general for use cases where the signature is required, it is advisable to resolve the
+  /// document from tangle, for instance by using [`Account::resolve_identity`].
   pub fn document(&self) -> &IotaDocument {
     &self.document
   }
@@ -448,6 +452,8 @@ where
     };
 
     self.chain_state.set_last_integration_message_id(message_id);
+    // Overwrite the internal document with the published one, that has a signature.
+    self.document = new_doc;
 
     Ok(())
   }

--- a/identity-account/src/account/account.rs
+++ b/identity-account/src/account/account.rs
@@ -177,9 +177,9 @@ where
   /// Returns the DID document of the identity, which this account manages,
   /// with all updates applied.
   ///
-  /// Note that the returned document only has a valid signature after publication.
-  /// In general for use cases where the signature is required, it is advisable to resolve the
-  /// document from tangle, for instance by using [`Account::resolve_identity`].
+  /// Note: the returned document only has a valid signature after publishing an integration chain update.
+  /// In general, for use cases where the signature is required, it is advisable to resolve the
+  /// document from the Tangle.
   pub fn document(&self) -> &IotaDocument {
     &self.document
   }

--- a/identity-account/src/tests/account.rs
+++ b/identity-account/src/tests/account.rs
@@ -376,6 +376,7 @@ async fn test_account_has_document_with_valid_signature_after_publication() {
   let initial_doc: IotaDocument = account.document().to_owned();
   initial_doc.verify_document(account.document()).unwrap();
 
+  // Rotate signing methods.
   account
     .update_identity()
     .create_method()
@@ -394,7 +395,7 @@ async fn test_account_has_document_with_valid_signature_after_publication() {
     .await
     .unwrap();
 
-  // We have to force an integratino update here, because in test mode,
+  // We have to force an integration update here, because in test mode,
   // the account still publishes a diff update otherwise.
   account
     .publish_with_options(PublishOptions::default().force_integration_update(true))

--- a/identity-account/src/tests/account.rs
+++ b/identity-account/src/tests/account.rs
@@ -363,6 +363,62 @@ async fn test_account_publish_options_force_integration() {
 }
 
 #[tokio::test]
+async fn test_account_has_document_with_valid_signature_after_publication() {
+  let config = AccountConfig::default().autopublish(false).testmode(true);
+  let client = ClientBuilder::new().node_sync_disabled().build().await.unwrap();
+  let account_setup = AccountSetup::new(Arc::new(MemStore::new()), Arc::new(client), config);
+  let mut account = Account::create_identity(account_setup, IdentitySetup::new())
+    .await
+    .unwrap();
+
+  account.publish().await.unwrap();
+
+  let initial_doc: IotaDocument = account.document().to_owned();
+  initial_doc.verify_document(account.document()).unwrap();
+
+  account
+    .update_identity()
+    .create_method()
+    .content(MethodContent::GenerateEd25519)
+    .fragment("another-sign")
+    .scope(MethodScope::capability_invocation())
+    .apply()
+    .await
+    .unwrap();
+
+  account
+    .update_identity()
+    .delete_method()
+    .fragment(IotaDocument::DEFAULT_METHOD_FRAGMENT)
+    .apply()
+    .await
+    .unwrap();
+
+  // We have to force an integratino update here, because in test mode,
+  // the account still publishes a diff update otherwise.
+  account
+    .publish_with_options(PublishOptions::default().force_integration_update(true))
+    .await
+    .unwrap();
+
+  // Account document has a valid signature with respect to the initial doc.
+  initial_doc.verify_document(account.document()).unwrap();
+
+  account
+    .update_identity()
+    .create_method()
+    .content(MethodContent::GenerateEd25519)
+    .fragment("test-key-2")
+    .scope(MethodScope::authentication())
+    .apply()
+    .await
+    .unwrap();
+
+  // If we don't publish, the document will not be signed.
+  initial_doc.verify_document(account.document()).unwrap_err();
+}
+
+#[tokio::test]
 async fn test_account_sync_no_changes() -> Result<()> {
   network_resilient_test(2, |n| {
     Box::pin(async move {


### PR DESCRIPTION
# Description of change

In the account, after publication, we have created a version of the internal document with a signature, but we currently discard it. Instead, we should set it internally, so `Account::document` returns this document with a valid signature.

## Links to any relevant issues

n/a, came up on Discord.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

A test was added to check the behavior.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
