### PR TITLE
Activate `account`, `stronghold` and `send-sync-storage` features by default

### DIFF
--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -30,7 +30,7 @@ name = "benchmark"
 harness = false
 
 [features]
-default = ["async"]
+default = ["async", "account", "stronghold", "send-sync-storage"]
 
 # Enables async runtime support (Tokio).
 async = ["identity-iota/async"]


### PR DESCRIPTION
# Description of change

Activate these features by default, as these are the recommended ways to use the framework.

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

None.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
