### PR TITLE
Implement `ECDH-ES+A256KW` for `Storage` encryption

### DIFF
--- a/bindings/wasm/package-lock.json
+++ b/bindings/wasm/package-lock.json
@@ -2908,20 +2908,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -9376,13 +9362,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/bindings/wasm/src/account/types/cek_algorithm.rs
+++ b/bindings/wasm/src/account/types/cek_algorithm.rs
@@ -23,6 +23,12 @@ impl WasmCekAlgorithm {
     Self(CekAlgorithm::ECDH_ES(agreement.clone().into()))
   }
 
+  /// Elliptic Curve Diffie-Hellman Ephemeral Static key agreement using Concat KDF.
+  #[wasm_bindgen(js_name = EcdhEsA256Kw)]
+  pub fn ecdh_es_a256kw(agreement: &WasmAgreementInfo) -> WasmCekAlgorithm {
+    Self(CekAlgorithm::ECDH_ES_A256KW(agreement.clone().into()))
+  }
+
   /// Serializes `CekAlgorithm` as a JSON object.
   #[wasm_bindgen(js_name = toJSON)]
   pub fn to_json(&self) -> Result<JsValue> {

--- a/bindings/wasm/src/account/types/encryption_algorithm.rs
+++ b/bindings/wasm/src/account/types/encryption_algorithm.rs
@@ -22,6 +22,12 @@ impl WasmEncryptionAlgorithm {
     Self(EncryptionAlgorithm::AES256GCM)
   }
 
+  /// Returns the length of the cipher's key.
+  #[wasm_bindgen(js_name = keyLength)]
+  pub fn key_length(&self) -> usize {
+    self.0.key_length()
+  }
+
   /// Serializes `EncryptionAlgorithm` as a JSON object.
   #[wasm_bindgen(js_name = toJSON)]
   pub fn to_json(&self) -> Result<JsValue> {

--- a/identity-account-storage/Cargo.toml
+++ b/identity-account-storage/Cargo.toml
@@ -36,7 +36,7 @@ features = ["hmac", "pbkdf", "sha", "std", "aes"]
 
 [dependencies.iota_stronghold]
 git = "https://github.com/iotaledger/stronghold.rs"
-rev = "629466da83a677925904b2e733ef7bfad5a42864"
+rev = "ff8b29cda8a2528824d89a29f579f46821288fab"
 optional = true
 
 [dev-dependencies]

--- a/identity-account-storage/Cargo.toml
+++ b/identity-account-storage/Cargo.toml
@@ -19,6 +19,7 @@ hashbrown = { version = "0.11", features = ["serde"] }
 identity-core = { version = "=0.5.0", path = "../identity-core", default-features = false }
 identity-did = { version = "=0.5.0", path = "../identity-did", default-features = false }
 identity-iota-core = { version = "=0.5.0", path = "../identity-iota-core", default-features = false }
+iota-crypto = { version = ">=0.7, <0.10", default-features = false, features = ["hmac", "pbkdf", "sha", "std", "aes", "aes-kw"] }
 iota_stronghold = { version = "0.5.1", default-features = false, features = ["std"], optional = true }
 once_cell = { version = "1.7", default-features = false, features = ["std"], optional = true }
 parking_lot = { version = "0.12" }
@@ -29,11 +30,6 @@ strum = { version = "0.24.0", default-features = false, features = ["std", "deri
 thiserror = { version = "1.0" }
 tokio = { version = "1.17.0", default-features = false, features = ["sync", "fs"], optional = true }
 zeroize = { version = "1.4" }
-
-[dependencies.iota-crypto]
-version = ">=0.7, <0.10"
-default-features = false
-features = ["hmac", "pbkdf", "sha", "std", "aes", "aes-kw"]
 
 [dev-dependencies]
 hex = { version = "0.4.3" }

--- a/identity-account-storage/Cargo.toml
+++ b/identity-account-storage/Cargo.toml
@@ -19,6 +19,7 @@ hashbrown = { version = "0.11", features = ["serde"] }
 identity-core = { version = "=0.5.0", path = "../identity-core", default-features = false }
 identity-did = { version = "=0.5.0", path = "../identity-did", default-features = false }
 identity-iota-core = { version = "=0.5.0", path = "../identity-iota-core", default-features = false }
+iota_stronghold = { version = "0.5.1", default-features = false, features = ["std"], optional = true }
 once_cell = { version = "1.7", default-features = false, features = ["std"], optional = true }
 parking_lot = { version = "0.12" }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
@@ -33,11 +34,6 @@ zeroize = { version = "1.4" }
 version = ">=0.7, <0.10"
 default-features = false
 features = ["hmac", "pbkdf", "sha", "std", "aes"]
-
-[dependencies.iota_stronghold]
-git = "https://github.com/iotaledger/stronghold.rs"
-rev = "ff8b29cda8a2528824d89a29f579f46821288fab"
-optional = true
 
 [dev-dependencies]
 hex = { version = "0.4.3" }

--- a/identity-account-storage/Cargo.toml
+++ b/identity-account-storage/Cargo.toml
@@ -33,7 +33,7 @@ zeroize = { version = "1.4" }
 [dependencies.iota-crypto]
 version = ">=0.7, <0.10"
 default-features = false
-features = ["hmac", "pbkdf", "sha", "std", "aes"]
+features = ["hmac", "pbkdf", "sha", "std", "aes", "aes-kw"]
 
 [dev-dependencies]
 hex = { version = "0.4.3" }

--- a/identity-account-storage/src/storage/memstore.rs
+++ b/identity-account-storage/src/storage/memstore.rs
@@ -40,6 +40,8 @@ use crate::types::EncryptionAlgorithm;
 use crate::types::KeyLocation;
 use crate::types::Signature;
 use crate::utils::Shared;
+#[cfg(feature = "encryption")]
+use crypto::ciphers::aes_kw::Aes256Kw;
 
 // The map from DIDs to chain states.
 type ChainStates = HashMap<IotaDID, ChainState>;
@@ -292,7 +294,30 @@ impl Storage for MemStore {
         )?;
         Ok(encrypted_data)
       }
-      CekAlgorithm::ECDH_ES_A256KW(_) => unimplemented!(),
+      CekAlgorithm::ECDH_ES_A256KW(agreement) => {
+        let keypair: KeyPair = KeyPair::new(KeyType::X25519)?;
+        let shared_secret: [u8; 32] = X25519::key_exchange(keypair.private(), &public_key)?;
+        let derived_secret: Vec<u8> = concat_kdf(cek_algorithm.name(), Aes256Kw::KEY_LENGTH, &shared_secret, agreement)
+          .map_err(Error::EncryptionFailure)?;
+
+        let cek: Vec<u8> = generate_content_encryption_key(*encryption_algorithm)?;
+
+        let mut encrypted_cek: Vec<u8> = vec![0; cek.len() + Aes256Kw::BLOCK];
+        let aes_kw: Aes256Kw<'_> = Aes256Kw::new(derived_secret.as_ref());
+        aes_kw
+          .wrap_key(cek.as_ref(), &mut encrypted_cek)
+          .map_err(Error::EncryptionFailure)?;
+
+        let encrypted_data = try_encrypt(
+          &cek,
+          encryption_algorithm,
+          &plaintext,
+          associated_data,
+          encrypted_cek,
+          keypair.public().as_ref().to_vec(),
+        )?;
+        Ok(encrypted_data)
+      }
     }
   }
 
@@ -327,9 +352,21 @@ impl Storage for MemStore {
                 .map_err(Error::DecryptionFailure)?;
             try_decrypt(&derived_secret, encryption_algorithm, &data)
           }
-          CekAlgorithm::ECDH_ES_A256KW(_) => unimplemented!(),
-        }
+          CekAlgorithm::ECDH_ES_A256KW(agreement) => {
+            let shared_secret: [u8; 32] = X25519::key_exchange(key_pair.private(), &public_key)?;
+            let derived_secret: Vec<u8> =
+              concat_kdf(cek_algorithm.name(), Aes256Kw::KEY_LENGTH, &shared_secret, agreement)
+                .map_err(Error::DecryptionFailure)?;
 
+            let mut cek: Vec<u8> = vec![0; data.encrypted_cek().len() - Aes256Kw::BLOCK];
+            let aes_kw: Aes256Kw<'_> = Aes256Kw::new(derived_secret.as_ref());
+            aes_kw
+              .unwrap_key(data.encrypted_cek(), &mut cek)
+              .map_err(Error::DecryptionFailure)?;
+
+            try_decrypt(&cek, encryption_algorithm, &data)
+          }
+        }
       }
     }
   }
@@ -481,6 +518,18 @@ impl Default for MemStore {
   }
 }
 
+fn generate_content_encryption_key(encryption_algorithm: EncryptionAlgorithm) -> Result<Vec<u8>> {
+  random_bytes(encryption_algorithm.key_length())
+}
+
+fn random_bytes(size: usize) -> Result<Vec<u8>> {
+  let mut bytes: Vec<u8> = vec![0; size];
+
+  crypto::utils::rand::fill(bytes.as_mut()).map_err(Error::EncryptionFailure)?;
+
+  Ok(bytes)
+}
+
 #[cfg(test)]
 mod tests {
   use crate::storage::Storage;
@@ -542,7 +591,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn test_encryption() {
+  async fn test_memstore_encryption() {
     StorageTestSuite::encryption_test(test_memstore(), test_memstore())
       .await
       .unwrap()

--- a/identity-account-storage/src/storage/memstore.rs
+++ b/identity-account-storage/src/storage/memstore.rs
@@ -358,13 +358,16 @@ impl Storage for MemStore {
               concat_kdf(cek_algorithm.name(), Aes256Kw::KEY_LENGTH, &shared_secret, agreement)
                 .map_err(Error::DecryptionFailure)?;
 
-            let cek_len: usize = data.encrypted_cek.len().checked_sub(Aes256Kw::BLOCK).ok_or_else(|| {
-              Error::DecryptionFailure(crypto::Error::BufferSize {
-                name: "plaintext cek",
-                needs: Aes256Kw::BLOCK,
-                has: data.encrypted_cek.len(),
-              })
-            })?;
+            let cek_len: usize =
+              data
+                .encrypted_cek
+                .len()
+                .checked_sub(Aes256Kw::BLOCK)
+                .ok_or(Error::DecryptionFailure(crypto::Error::BufferSize {
+                  name: "plaintext cek",
+                  needs: Aes256Kw::BLOCK,
+                  has: data.encrypted_cek.len(),
+                }))?;
 
             let mut cek: Vec<u8> = vec![0; cek_len];
             let aes_kw: Aes256Kw<'_> = Aes256Kw::new(derived_secret.as_ref());

--- a/identity-account-storage/src/storage/memstore.rs
+++ b/identity-account-storage/src/storage/memstore.rs
@@ -358,7 +358,15 @@ impl Storage for MemStore {
               concat_kdf(cek_algorithm.name(), Aes256Kw::KEY_LENGTH, &shared_secret, agreement)
                 .map_err(Error::DecryptionFailure)?;
 
-            let mut cek: Vec<u8> = vec![0; data.encrypted_cek.len() - Aes256Kw::BLOCK];
+            let cek_len: usize = data.encrypted_cek.len().checked_sub(Aes256Kw::BLOCK).ok_or_else(|| {
+              Error::DecryptionFailure(crypto::Error::BufferSize {
+                name: "plaintext cek",
+                needs: Aes256Kw::BLOCK,
+                has: data.encrypted_cek.len(),
+              })
+            })?;
+
+            let mut cek: Vec<u8> = vec![0; cek_len];
             let aes_kw: Aes256Kw<'_> = Aes256Kw::new(derived_secret.as_ref());
             aes_kw
               .unwrap_key(data.encrypted_cek.as_ref(), &mut cek)

--- a/identity-account-storage/src/storage/memstore.rs
+++ b/identity-account-storage/src/storage/memstore.rs
@@ -526,15 +526,10 @@ impl Default for MemStore {
   }
 }
 
+/// Generate a random content encryption key of suitable length for `encryption_algorithm`.
 fn generate_content_encryption_key(encryption_algorithm: EncryptionAlgorithm) -> Result<Vec<u8>> {
-  random_bytes(encryption_algorithm.key_length())
-}
-
-fn random_bytes(size: usize) -> Result<Vec<u8>> {
-  let mut bytes: Vec<u8> = vec![0; size];
-
+  let mut bytes: Vec<u8> = vec![0; encryption_algorithm.key_length()];
   crypto::utils::rand::fill(bytes.as_mut()).map_err(Error::EncryptionFailure)?;
-
   Ok(bytes)
 }
 

--- a/identity-account-storage/src/storage/memstore.rs
+++ b/identity-account-storage/src/storage/memstore.rs
@@ -292,6 +292,7 @@ impl Storage for MemStore {
         )?;
         Ok(encrypted_data)
       }
+      CekAlgorithm::ECDH_ES_A256KW(_) => unimplemented!(),
     }
   }
 
@@ -326,7 +327,9 @@ impl Storage for MemStore {
                 .map_err(Error::DecryptionFailure)?;
             try_decrypt(&derived_secret, encryption_algorithm, &data)
           }
+          CekAlgorithm::ECDH_ES_A256KW(_) => unimplemented!(),
         }
+
       }
     }
   }

--- a/identity-account-storage/src/storage/memstore.rs
+++ b/identity-account-storage/src/storage/memstore.rs
@@ -358,10 +358,10 @@ impl Storage for MemStore {
               concat_kdf(cek_algorithm.name(), Aes256Kw::KEY_LENGTH, &shared_secret, agreement)
                 .map_err(Error::DecryptionFailure)?;
 
-            let mut cek: Vec<u8> = vec![0; data.encrypted_cek().len() - Aes256Kw::BLOCK];
+            let mut cek: Vec<u8> = vec![0; data.encrypted_cek.len() - Aes256Kw::BLOCK];
             let aes_kw: Aes256Kw<'_> = Aes256Kw::new(derived_secret.as_ref());
             aes_kw
-              .unwrap_key(data.encrypted_cek(), &mut cek)
+              .unwrap_key(data.encrypted_cek.as_ref(), &mut cek)
               .map_err(Error::DecryptionFailure)?;
 
             try_decrypt(&cek, encryption_algorithm, &data)

--- a/identity-account-storage/src/storage/stronghold.rs
+++ b/identity-account-storage/src/storage/stronghold.rs
@@ -643,6 +643,7 @@ fn generate_content_encryption_key(client: &Client, encryption_algorithm: &Encry
   let _len: usize = encryption_algorithm.key_length();
 
   // TODO: X25519 happens to match Aes256Gcm::KEY_LENGTH, but a proper solution is required.
+  // See https://github.com/iotaledger/stronghold.rs/issues/374
   let location: KeyLocation = random_location(KeyType::X25519);
   generate_private_key(client, &location)?;
 

--- a/identity-account-storage/src/storage/stronghold.rs
+++ b/identity-account-storage/src/storage/stronghold.rs
@@ -640,11 +640,9 @@ async fn diffie_hellman_with_concat_kdf(
 
 /// Generate a random content encryption key with the required length for `encryption_algorithm`.
 fn generate_content_encryption_key(client: &Client, encryption_algorithm: &EncryptionAlgorithm) -> Result<Location> {
-  let _len: usize = match encryption_algorithm {
-    EncryptionAlgorithm::AES256GCM => Aes256Gcm::KEY_LENGTH,
-  };
+  let _len: usize = encryption_algorithm.key_length();
 
-  // TODO: X25519 happens to match Aes256Gcm::KEY_LENGTH, but a better solution is required.
+  // TODO: X25519 happens to match Aes256Gcm::KEY_LENGTH, but a proper solution is required.
   let location: KeyLocation = random_location(KeyType::X25519);
   generate_private_key(client, &location)?;
 

--- a/identity-account-storage/src/storage/stronghold.rs
+++ b/identity-account-storage/src/storage/stronghold.rs
@@ -357,8 +357,7 @@ impl Storage for Stronghold {
           shared_secret,
         )
         .await?;
-        let decrypted_data: Result<Vec<u8>> = aead_decrypt(&client, encryption_algorithm, derived_secret, data).await;
-        decrypted_data
+        aead_decrypt(&client, encryption_algorithm, derived_secret, data).await
       }
       CekAlgorithm::ECDH_ES_A256KW(agreement) => {
         let shared_secret: Location = diffie_hellman(&client, private_key, public_key).await?;
@@ -373,8 +372,7 @@ impl Storage for Stronghold {
 
         let cek: Location = aes_256_unwrap_key(&client, data.encrypted_cek.as_slice(), derived_secret)?;
 
-        let decrypted_data: Result<Vec<u8>> = aead_decrypt(&client, encryption_algorithm, cek, data).await;
-        decrypted_data
+        aead_decrypt(&client, encryption_algorithm, cek, data).await
       }
     }
   }
@@ -662,6 +660,7 @@ fn aes_256_wrap_key(client: &Client, encryption_key: Location, cek: Location) ->
   Ok(encrypted_cek)
 }
 
+/// Unwrap the given `encrypted_key` using `decryption_key`.
 fn aes_256_unwrap_key(client: &Client, encrypted_key: impl AsRef<[u8]>, decryption_key: Location) -> Result<Location> {
   let output: Location = random_stronghold_location();
 

--- a/identity-account-storage/src/storage/stronghold.rs
+++ b/identity-account-storage/src/storage/stronghold.rs
@@ -319,7 +319,7 @@ impl Storage for Stronghold {
           &client,
           encryption_algorithm,
           cek,
-          data,
+          plaintext,
           associated_data,
           encrypted_cek,
           ephemeral_public_key.as_ref().to_vec(),
@@ -371,7 +371,7 @@ impl Storage for Stronghold {
         )
         .await?;
 
-        let cek: Location = aes_256_unwrap_key(&client, data.encrypted_cek(), derived_secret)?;
+        let cek: Location = aes_256_unwrap_key(&client, data.encrypted_cek.as_slice(), derived_secret)?;
 
         let decrypted_data: Result<Vec<u8>> = aead_decrypt(&client, encryption_algorithm, cek, data).await;
         decrypted_data
@@ -749,7 +749,8 @@ pub(crate) fn random_location(key_type: KeyType) -> KeyLocation {
 }
 
 pub(crate) fn random_stronghold_location() -> Location {
-  let record_path: [u8; 32] = rand::thread_rng().gen();
+  let mut thread_rng: rand::rngs::ThreadRng = rand::thread_rng();
+  let record_path: [u8; 32] = rand::Rng::gen(&mut thread_rng);
   Location::generic(VAULT_PATH.to_vec(), record_path.to_vec())
 }
 

--- a/identity-account-storage/src/storage/stronghold.rs
+++ b/identity-account-storage/src/storage/stronghold.rs
@@ -747,7 +747,7 @@ pub(crate) fn random_location(key_type: KeyType) -> KeyLocation {
   KeyLocation::new(key_type, fragment, &public_key)
 }
 
-pub(crate) fn random_stronghold_location() -> Location {
+fn random_stronghold_location() -> Location {
   let mut thread_rng: rand::rngs::ThreadRng = rand::thread_rng();
   let record_path: [u8; 32] = rand::Rng::gen(&mut thread_rng);
   Location::generic(VAULT_PATH.to_vec(), record_path.to_vec())

--- a/identity-account-storage/src/storage/test_suite.rs
+++ b/identity-account-storage/src/storage/test_suite.rs
@@ -522,7 +522,7 @@ impl StorageTestSuite {
     ] {
       let network: NetworkName = Network::Mainnet.name();
 
-      // Both Bob and Alice must have a DID
+      // Both Alice (Sender) and Bob (Receiver) must have a DID.
       let (alice_did, _): (IotaDID, KeyLocation) = alice_storage
         .did_create(network.clone(), &random_string(), None)
         .await
@@ -533,7 +533,7 @@ impl StorageTestSuite {
         .await
         .context("did_create returned an error")?;
 
-      // The target of the message must share an X25519 public key
+      // The target of the message must share an X25519 public key.
       let bob_fragment: String = random_string();
       let bob_location: KeyLocation = bob_storage
         .key_generate(&bob_did, KeyType::X25519, &bob_fragment)
@@ -544,10 +544,8 @@ impl StorageTestSuite {
         .await
         .context("key_public returned an error")?;
 
-      // Alice encrypts the message to be sent to bob
-      // let agreement: AgreementInfo = AgreementInfo::new(b"Alice".to_vec(), b"Bob".to_vec(), Vec::new(), Vec::new());
+      // Alice encrypts the message to be sent to Bob.
       let encryption_algorithm: EncryptionAlgorithm = EncryptionAlgorithm::AES256GCM;
-      // let cek_algorithm: CekAlgorithm = CekAlgorithm::ECDH_ES(agreement);
       let plaintext: &[u8] = b"This msg will be encrypted and decrypted";
 
       let encrypted_data: EncryptedData = alice_storage
@@ -562,7 +560,7 @@ impl StorageTestSuite {
         .await
         .context("data_encrypt returned an error")?;
 
-      // Bob must be able to decrypt the message using the shared secret
+      // Bob must be able to decrypt the message using the shared secret.
       let decrypted_msg: Vec<u8> = bob_storage
         .data_decrypt(
           &bob_did,

--- a/identity-account-storage/src/storage/test_suite.rs
+++ b/identity-account-storage/src/storage/test_suite.rs
@@ -514,65 +514,73 @@ impl StorageTestSuite {
 
   #[named]
   pub async fn encryption_test(alice_storage: impl Storage, bob_storage: impl Storage) -> anyhow::Result<()> {
-    let network: NetworkName = Network::Mainnet.name();
-
-    // Both Bob and Alice must have a DID
-    let (alice_did, _): (IotaDID, KeyLocation) = alice_storage
-      .did_create(network.clone(), &random_string(), None)
-      .await
-      .context("did_create returned an error")?;
-
-    let (bob_did, _): (IotaDID, KeyLocation) = bob_storage
-      .did_create(network.clone(), &random_string(), None)
-      .await
-      .context("did_create returned an error")?;
-
-    // The target of the message must share an X25519 public key
-    let bob_fragment: String = random_string();
-    let bob_location: KeyLocation = bob_storage
-      .key_generate(&bob_did, KeyType::X25519, &bob_fragment)
-      .await
-      .context("key_generate returned an error")?;
-    let bob_public_key: PublicKey = bob_storage
-      .key_public(&bob_did, &bob_location)
-      .await
-      .context("key_public returned an error")?;
-
-    // Alice encrypts the message to be sent to bob
     let agreement: AgreementInfo = AgreementInfo::new(b"Alice".to_vec(), b"Bob".to_vec(), Vec::new(), Vec::new());
-    let encryption_algorithm: EncryptionAlgorithm = EncryptionAlgorithm::AES256GCM;
-    let cek_algorithm: CekAlgorithm = CekAlgorithm::ECDH_ES(agreement);
-    let plaintext: &[u8] = b"This msg will be encrypted and decrypted";
 
-    let encrypted_data: EncryptedData = alice_storage
-      .data_encrypt(
-        &alice_did,
-        plaintext.to_vec(),
-        b"associated_data".to_vec(),
-        &encryption_algorithm,
-        &cek_algorithm,
-        bob_public_key,
-      )
-      .await
-      .context("data_encrypt returned an error")?;
+    for cek_algorithm in [
+      CekAlgorithm::ECDH_ES(agreement.clone()),
+      CekAlgorithm::ECDH_ES_A256KW(agreement),
+    ] {
+      let network: NetworkName = Network::Mainnet.name();
 
-    // Bob must be able to decrypt the message using the shared secret
-    let decrypted_msg: Vec<u8> = bob_storage
-      .data_decrypt(
-        &bob_did,
-        encrypted_data,
-        &encryption_algorithm,
-        &cek_algorithm,
-        &bob_location,
-      )
-      .await
-      .context("data_decrypt returned an error")?;
+      // Both Bob and Alice must have a DID
+      let (alice_did, _): (IotaDID, KeyLocation) = alice_storage
+        .did_create(network.clone(), &random_string(), None)
+        .await
+        .context("did_create returned an error")?;
 
-    ensure_eq!(
-      plaintext,
-      &decrypted_msg,
-      "decrypted message does not match the original message"
-    );
+      let (bob_did, _): (IotaDID, KeyLocation) = bob_storage
+        .did_create(network.clone(), &random_string(), None)
+        .await
+        .context("did_create returned an error")?;
+
+      // The target of the message must share an X25519 public key
+      let bob_fragment: String = random_string();
+      let bob_location: KeyLocation = bob_storage
+        .key_generate(&bob_did, KeyType::X25519, &bob_fragment)
+        .await
+        .context("key_generate returned an error")?;
+      let bob_public_key: PublicKey = bob_storage
+        .key_public(&bob_did, &bob_location)
+        .await
+        .context("key_public returned an error")?;
+
+      // Alice encrypts the message to be sent to bob
+      // let agreement: AgreementInfo = AgreementInfo::new(b"Alice".to_vec(), b"Bob".to_vec(), Vec::new(), Vec::new());
+      let encryption_algorithm: EncryptionAlgorithm = EncryptionAlgorithm::AES256GCM;
+      // let cek_algorithm: CekAlgorithm = CekAlgorithm::ECDH_ES(agreement);
+      let plaintext: &[u8] = b"This msg will be encrypted and decrypted";
+
+      let encrypted_data: EncryptedData = alice_storage
+        .data_encrypt(
+          &alice_did,
+          plaintext.to_vec(),
+          b"associated_data".to_vec(),
+          &encryption_algorithm,
+          &cek_algorithm,
+          bob_public_key,
+        )
+        .await
+        .context("data_encrypt returned an error")?;
+
+      // Bob must be able to decrypt the message using the shared secret
+      let decrypted_msg: Vec<u8> = bob_storage
+        .data_decrypt(
+          &bob_did,
+          encrypted_data,
+          &encryption_algorithm,
+          &cek_algorithm,
+          &bob_location,
+        )
+        .await
+        .context("data_decrypt returned an error")?;
+
+      ensure_eq!(
+        plaintext,
+        &decrypted_msg,
+        "decrypted message does not match the original message"
+      );
+    }
+
     Ok(())
   }
 }

--- a/identity-account-storage/src/stronghold/tests.rs
+++ b/identity-account-storage/src/stronghold/tests.rs
@@ -249,7 +249,7 @@ async fn test_stronghold_did_purge() {
 }
 
 #[tokio::test]
-async fn test_encryption() {
+async fn test_stronghold_encryption() {
   StorageTestSuite::encryption_test(test_stronghold().await, test_stronghold().await)
     .await
     .unwrap()

--- a/identity-account-storage/src/types/encryption/cek_algorithm.rs
+++ b/identity-account-storage/src/types/encryption/cek_algorithm.rs
@@ -11,6 +11,7 @@ use serde::Serialize;
 pub enum CekAlgorithm {
   /// Elliptic Curve Diffie-Hellman Ephemeral Static key agreement using Concat KDF.
   ECDH_ES(AgreementInfo),
+  ECDH_ES_A256KW(AgreementInfo),
 }
 
 impl CekAlgorithm {
@@ -18,6 +19,7 @@ impl CekAlgorithm {
   pub const fn name(&self) -> &'static str {
     match self {
       CekAlgorithm::ECDH_ES(_agreement) => "ECDH-ES",
+      CekAlgorithm::ECDH_ES_A256KW(_) => "ECDH-ES+A256KW",
     }
   }
 }

--- a/identity-account-storage/src/types/encryption/cek_algorithm.rs
+++ b/identity-account-storage/src/types/encryption/cek_algorithm.rs
@@ -11,6 +11,7 @@ use serde::Serialize;
 pub enum CekAlgorithm {
   /// Elliptic Curve Diffie-Hellman Ephemeral Static key agreement using Concat KDF.
   ECDH_ES(AgreementInfo),
+  /// Elliptic Curve Diffie-Hellman Ephemeral Static key agreement using Concat KDF with AES256 key wrapping.
   ECDH_ES_A256KW(AgreementInfo),
 }
 
@@ -18,7 +19,7 @@ impl CekAlgorithm {
   /// Returns the JWE algorithm as a `str` slice.
   pub const fn name(&self) -> &'static str {
     match self {
-      CekAlgorithm::ECDH_ES(_agreement) => "ECDH-ES",
+      CekAlgorithm::ECDH_ES(_) => "ECDH-ES",
       CekAlgorithm::ECDH_ES_A256KW(_) => "ECDH-ES+A256KW",
     }
   }

--- a/identity-account-storage/src/types/encryption/encryption_algorithm.rs
+++ b/identity-account-storage/src/types/encryption/encryption_algorithm.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use crypto::ciphers::aes::Aes256Gcm;
+use crypto::ciphers::traits::Aead;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -10,4 +12,13 @@ use serde::Serialize;
 pub enum EncryptionAlgorithm {
   /// AES GCM using 256-bit key.
   AES256GCM,
+}
+
+impl EncryptionAlgorithm {
+  /// Returns the length of the cipher's key.
+  pub const fn key_length(&self) -> usize {
+    match self {
+      EncryptionAlgorithm::AES256GCM => Aes256Gcm::KEY_LENGTH,
+    }
+  }
 }


### PR DESCRIPTION
# Description of change

Implements `ECDH-ES+A256KW` in the `Storage` encryption API, for use in `DIDComm`.

## Links to any relevant issues

Part of #841

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

`StorageTestSuite` was modified to also test the newly added `CekAlgorithm`.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
