### PR TITLE
Change `DIDUrl::join` to borrow self

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -1426,7 +1426,7 @@ Sets the `query` component of the `DIDUrl`.
 <a name="DIDUrl+join"></a>
 
 ### didUrl.join(segment) ⇒ [<code>DIDUrl</code>](#DIDUrl)
-Append a string representing a path, query, and/or fragment to this `DIDUrl`.
+Append a string representing a path, query, and/or fragment, returning a new `DIDUrl`.
 
 Must begin with a valid delimiter character: '/', '?', '#'. Overwrites the existing URL
 segment and any following segments in order of path, query, then fragment.

--- a/bindings/wasm/src/did/wasm_did_url.rs
+++ b/bindings/wasm/src/did/wasm_did_url.rs
@@ -79,7 +79,7 @@ impl WasmDIDUrl {
   /// - joining a query will clear the fragment.
   /// - joining a fragment will only overwrite the fragment.
   #[wasm_bindgen]
-  pub fn join(self, segment: &str) -> Result<WasmDIDUrl> {
+  pub fn join(&self, segment: &str) -> Result<WasmDIDUrl> {
     self.0.join(segment).map(WasmDIDUrl::from).wasm_result()
   }
 

--- a/bindings/wasm/src/did/wasm_did_url.rs
+++ b/bindings/wasm/src/did/wasm_did_url.rs
@@ -69,7 +69,7 @@ impl WasmDIDUrl {
     self.0.set_query(value.as_deref()).wasm_result()
   }
 
-  /// Append a string representing a path, query, and/or fragment to this `DIDUrl`.
+  /// Append a string representing a path, query, and/or fragment, returning a new `DIDUrl`.
   ///
   /// Must begin with a valid delimiter character: '/', '?', '#'. Overwrites the existing URL
   /// segment and any following segments in order of path, query, then fragment.

--- a/identity-did/Cargo.toml
+++ b/identity-did/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/iotaledger/identity.rs"
 description = "An implementation of the Decentralized Identifiers standard."
 
 [dependencies]
-async-trait = { version = "0.1", default-features = false }
 did_url = { version = "0.1", default-features = false, features = ["std", "serde"] }
 form_urlencoded = { version = "1.0.1", default-features = false }
 identity-core = { version = "=0.5.0", path = "../identity-core" }

--- a/identity-did/src/did/did_url.rs
+++ b/identity-did/src/did/did_url.rs
@@ -393,7 +393,7 @@ where
   /// - joining a path will overwrite the path and clear the query and fragment.
   /// - joining a query will overwrite the query and clear the fragment.
   /// - joining a fragment will only overwrite the fragment.
-  pub fn join(self, segment: impl AsRef<str>) -> Result<Self, DIDError> {
+  pub fn join(&self, segment: impl AsRef<str>) -> Result<Self, DIDError> {
     let segment: &str = segment.as_ref();
 
     // Accept only a relative path, query, or fragment to reject altering the method id segment.
@@ -662,13 +662,13 @@ mod tests {
   #[test]
   fn test_join_valid() {
     let did_url = CoreDIDUrl::parse("did:example:1234567890").unwrap();
-    assert_eq!(did_url.clone().join("/path").unwrap().to_string(), "did:example:1234567890/path");
-    assert_eq!(did_url.clone().join("?query").unwrap().to_string(), "did:example:1234567890?query");
-    assert_eq!(did_url.clone().join("#fragment").unwrap().to_string(), "did:example:1234567890#fragment");
+    assert_eq!(did_url.join("/path").unwrap().to_string(), "did:example:1234567890/path");
+    assert_eq!(did_url.join("?query").unwrap().to_string(), "did:example:1234567890?query");
+    assert_eq!(did_url.join("#fragment").unwrap().to_string(), "did:example:1234567890#fragment");
 
-    assert_eq!(did_url.clone().join("/path?query").unwrap().to_string(), "did:example:1234567890/path?query");
-    assert_eq!(did_url.clone().join("/path#fragment").unwrap().to_string(), "did:example:1234567890/path#fragment");
-    assert_eq!(did_url.clone().join("?query#fragment").unwrap().to_string(), "did:example:1234567890?query#fragment");
+    assert_eq!(did_url.join("/path?query").unwrap().to_string(), "did:example:1234567890/path?query");
+    assert_eq!(did_url.join("/path#fragment").unwrap().to_string(), "did:example:1234567890/path#fragment");
+    assert_eq!(did_url.join("?query#fragment").unwrap().to_string(), "did:example:1234567890?query#fragment");
 
     let did_url = did_url.join("/path?query#fragment").unwrap();
     assert_eq!(did_url.to_string(), "did:example:1234567890/path?query#fragment");
@@ -684,9 +684,9 @@ mod tests {
     assert!(CoreDIDUrl::parse("did:example:1234567890#invalid{fragment}").is_err());
 
     let did_url = CoreDIDUrl::parse("did:example:1234567890").unwrap();
-    assert!(did_url.clone().join("noleadingdelimiter").is_err());
-    assert!(did_url.clone().join("/invalid{path}").is_err());
-    assert!(did_url.clone().join("?invalid{query}").is_err());
+    assert!(did_url.join("noleadingdelimiter").is_err());
+    assert!(did_url.join("/invalid{path}").is_err());
+    assert!(did_url.join("?invalid{query}").is_err());
     assert!(did_url.join("#invalid{fragment}").is_err());
   }
 

--- a/identity-did/src/did/did_url.rs
+++ b/identity-did/src/did/did_url.rs
@@ -384,7 +384,7 @@ where
     self.url.query_pairs()
   }
 
-  /// Append a string representing a `path`, `query`, and/or `fragment` to this [`DIDUrl`].
+  /// Append a string representing a `path`, `query`, and/or `fragment`, returning a new [`DIDUrl`].
   ///
   /// Must begin with a valid delimiter character: '/', '?', '#'. Overwrites the existing URL
   /// segment and any following segments in order of path, query, then fragment.


### PR DESCRIPTION
# Description of change
Changes `DIDUrl::join` to borrow `self` instead of consuming it, as discussed in #805.

Technically a breaking change since explicit functions calls with e.g. `DIDUrl::join(url, "blah")` would need to change to e.g. `DIDUrl::join(&url, "blah")`.

## Links to any relevant issues
See discussion #805.

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Minor change, existing unit tests cover it.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
