### PR TITLE
Fixed typo "verfiers" -> "verifiers" in `examples/account/revoke_vc.rs`

### DIFF
--- a/examples/account/revoke_vc.rs
+++ b/examples/account/revoke_vc.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
   // Create a new empty revocation bitmap. No credential is revoked yet.
   let revocation_bitmap: RevocationBitmap = RevocationBitmap::new();
 
-  // Add the RevocationBitmap as a service endpoint to allow verfiers to check the credential status.
+  // Add the RevocationBitmap as a service endpoint to allow verifiers to check the credential status.
   issuer
     .update_identity()
     .create_service()


### PR DESCRIPTION
# Description of change
Fixes a small typo in the `revoke_vc.rs` example. 

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

## How the change has been tested
Just a typo fix in a comment so no need to test this. 

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
