### PR TITLE
Fix Rust publish boolean parameter

### DIFF
--- a/.github/actions/publish/publish-rust/action.yml
+++ b/.github/actions/publish/publish-rust/action.yml
@@ -31,8 +31,8 @@ runs:
       run: |
         echo "dry-run: '${{ inputs.dry-run }}'"
         echo "version: '${{ inputs.version }}'"
-        if [[ ${{ inputs.dry-run }} != 'true' && ${{ inputs.dry-run }} != 'false' ]]; then 
+        if [[ "${{ inputs.dry-run }}" != 'true' && "${{ inputs.dry-run }}" != 'false' ]]; then 
           echo "Invalid dry-run input"
           exit 1
         fi
-        cargo release --workspace --token ${{ inputs.crates-token }} --isolated --no-dev-version --no-push --no-tag --verbose $(if [ ${{ inputs.dry-run }} == 'false' ]; then echo --execute --no-confirm; fi) ${{ inputs.version }}
+        cargo release --workspace --token ${{ inputs.crates-token }} --isolated --no-dev-version --no-push --no-tag --verbose $(if [ "${{ inputs.dry-run }}" == 'false' ]; then echo --execute --no-confirm; fi) ${{ inputs.version }}


### PR DESCRIPTION
# Description of change
Wraps the `dry-run` input parameter in a string for the comparison to work. Stupid boolean logic inference.

## Links to any relevant issues
Part of #869.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
They haven't been. We test in production.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
