### PR TITLE
Bump examples version

### DIFF
--- a/.github/actions/publish/publish-rust/action.yml
+++ b/.github/actions/publish/publish-rust/action.yml
@@ -31,12 +31,4 @@ runs:
       run: |
         echo "dry-run: '${{ inputs.dry-run }}'"
         echo "version: '${{ inputs.version }}'"
-        if [[ "${{ inputs.dry-run }}" != "true" && "${{ inputs.dry-run }}" != "false" ]]; then 
-          echo "Invalid dry-run input"
-          exit 1
-        fi
-        if [[ "${{ inputs.dry-run }}" != "true" ]]; then 
-          echo "Publishing!"
-        fi
-        #cargo release --workspace --token ${{ inputs.crates-token }} --isolated --no-dev-version --no-push --no-tag --verbose $(if [ "${{ inputs.dry-run }}" != "true" ]; then echo --execute --no-confirm; fi) ${{ inputs.version }}
-        cargo release --workspace --token ${{ inputs.crates-token }} --isolated --no-dev-version --no-push --no-tag --verbose --execute --no-confirm ${{ inputs.version }}
+        cargo release --workspace --token ${{ inputs.crates-token }} --isolated --no-dev-version --no-push --no-tag --verbose $(if [ "${{ inputs.dry-run }}" = "false" ]; then echo --execute --no-confirm; fi) ${{ inputs.version }}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.1.0"
+version = "0.6.0"
 edition = "2021"
 publish = false
 release = false


### PR DESCRIPTION
# Description of change
Bump examples to `0.6.0` to try prevent `cargo-release` from needing a git username and email.

Fix shell comparison. Remove bash syntax.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix
