### PR TITLE
Bump examples version in GitHub Actions

### DIFF
--- a/.github/actions/release/bump-versions/action.yml
+++ b/.github/actions/release/bump-versions/action.yml
@@ -53,6 +53,14 @@ runs:
       run: |
         cargo workspaces version --force "*" --no-git-commit --exact custom ${{ inputs.version }} -y
 
+    # cargo workspaces ignores examples/ but cargo release still tries to version it during publishing.
+    - name: Bump Rust examples version
+      shell: bash
+      if: ${{inputs.release-target == 'rust'}}
+      working-directory: examples
+      run: |
+        cargo set-version ${{ inputs.version }}
+
     - name: Bump Wasm bindings crate version
       shell: bash
       if: ${{inputs.release-target == 'wasm'}}


### PR DESCRIPTION
# Description of change
Also bump the `examples/Cargo.toml` version when bumping the version on other Rust crates.

This is because the publish action uses `cargo release` which attempts (and fails) to bump the `examples/Cargo.toml` version itself, while `cargo workspaces` which we use in the release action ignores the `examples` when versioning (rightly so).

This PR uses the same code for bumping the Stronghold bindings version, so it should work just fine.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
"We test in production":tm:.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
