### PR TITLE
Fix cargo check with `--no-default-features`

### DIFF
--- a/identity_account/Cargo.toml
+++ b/identity_account/Cargo.toml
@@ -30,10 +30,9 @@ rusty-fork = { version = "0.3" }
 tokio = { version = "1.17.0", default-features = false, features = ["macros", "rt", "rt-multi-thread", "sync"] }
 
 [features]
-default = ["stronghold", "async", "send-sync-storage", "encryption", "revocation-bitmap"]
+default = ["stronghold", "send-sync-storage", "encryption", "revocation-bitmap"]
 mem-client = []
 stronghold = ["identity_account_storage/stronghold"]
-async = ["identity_iota_client/async"]
 send-sync-storage = ["identity_account_storage/send-sync-storage"]
 # Enables encryption and decryption functionality.
 encryption = ["identity_account_storage/encryption"]

--- a/identity_account/src/account/account.rs
+++ b/identity_account/src/account/account.rs
@@ -557,7 +557,8 @@ mod account_revocation {
   use crate::account::PublishOptions;
   use crate::Result;
   use identity_did::did::DID;
-  use identity_iota_client::tangle::{Client, SharedPtr};
+  use identity_iota_client::tangle::Client;
+  use identity_iota_client::tangle::SharedPtr;
   use identity_iota_core::did::IotaDIDUrl;
 
   impl<C> Account<C>
@@ -600,10 +601,13 @@ mod account_encryption {
   use super::Account;
   use crate::Error;
   use crate::Result;
+  use identity_account_storage::types::CekAlgorithm;
+  use identity_account_storage::types::EncryptedData;
+  use identity_account_storage::types::EncryptionAlgorithm;
   use identity_account_storage::types::KeyLocation;
-  use identity_account_storage::types::{CekAlgorithm, EncryptedData, EncryptionAlgorithm};
   use identity_core::crypto::PublicKey;
-  use identity_iota_client::tangle::{Client, SharedPtr};
+  use identity_iota_client::tangle::Client;
+  use identity_iota_client::tangle::SharedPtr;
   use identity_iota_core::document::IotaVerificationMethod;
 
   impl<C> Account<C>

--- a/identity_account/src/account/account.rs
+++ b/identity_account/src/account/account.rs
@@ -20,8 +20,10 @@ use identity_account_storage::types::EncryptionAlgorithm;
 use identity_account_storage::types::KeyLocation;
 use identity_core::crypto::KeyType;
 use identity_core::crypto::ProofOptions;
+#[cfg(feature = "encryption")]
 use identity_core::crypto::PublicKey;
 use identity_core::crypto::SetSignature;
+#[cfg(feature = "revocation-bitmap")]
 use identity_did::did::DID;
 use identity_iota_client::chain::DocumentChain;
 use identity_iota_client::document::ResolvedIotaDocument;
@@ -318,6 +320,7 @@ where
 
   /// If the document has a [`RevocationBitmap`][identity_did::revocation::RevocationBitmap] service identified by
   /// `fragment`, revoke all credentials with a `revocationBitmapIndex` in `credential_indices`.
+  #[cfg(feature = "revocation-bitmap")]
   pub async fn revoke_credentials(&mut self, fragment: &str, credential_indices: &[u32]) -> Result<()> {
     // Find the service to be updated.
     let mut service_id: IotaDIDUrl = self.did().to_url();
@@ -332,6 +335,7 @@ where
 
   /// If the document has a [`RevocationBitmap`][identity_did::revocation::RevocationBitmap] service identified by
   /// `fragment`, unrevoke all credentials with a `revocationBitmapIndex` in `credential_indices`.
+  #[cfg(feature = "revocation-bitmap")]
   pub async fn unrevoke_credentials(&mut self, fragment: &str, credential_indices: &[u32]) -> Result<()> {
     // Find the service to be updated.
     let mut service_id: IotaDIDUrl = self.did().to_url();

--- a/identity_account/src/account/account.rs
+++ b/identity_account/src/account/account.rs
@@ -581,7 +581,6 @@ mod account_revocation {
 
     /// If the document has a [`RevocationBitmap`][identity_did::revocation::RevocationBitmap] service identified by
     /// `fragment`, unrevoke all credentials with a `revocationBitmapIndex` in `credential_indices`.
-    #[cfg(feature = "revocation-bitmap")]
     pub async fn unrevoke_credentials(&mut self, fragment: &str, credential_indices: &[u32]) -> Result<()> {
       // Find the service to be updated.
       let mut service_id: IotaDIDUrl = self.did().to_url();
@@ -617,7 +616,6 @@ mod account_encryption {
     /// Encrypts the given `plaintext` with the specified `encryption_algorithm` and `cek_algorithm`.
     ///
     /// Returns an [`EncryptedData`] instance.
-    #[cfg(feature = "encryption")]
     pub async fn encrypt_data(
       &self,
       plaintext: &[u8],
@@ -644,7 +642,6 @@ mod account_encryption {
     /// `cek_algorithm`.
     ///
     /// Returns the decrypted text.
-    #[cfg(feature = "encryption")]
     pub async fn decrypt_data(
       &self,
       data: EncryptedData,

--- a/identity_account_storage/src/storage/memstore.rs
+++ b/identity_account_storage/src/storage/memstore.rs
@@ -1,14 +1,17 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use core::convert::TryFrom;
 use core::fmt::Debug;
 use core::fmt::Formatter;
 
 use async_trait::async_trait;
+#[cfg(feature = "encryption")]
 use crypto::ciphers::aes::Aes256Gcm;
+#[cfg(feature = "encryption")]
 use crypto::ciphers::traits::Aead;
+#[cfg(feature = "encryption")]
 use crypto::hashes::sha::Sha256;
+#[cfg(feature = "encryption")]
 use crypto::hashes::Digest;
 use hashbrown::HashMap;
 use identity_core::crypto::Ed25519;
@@ -17,6 +20,7 @@ use identity_core::crypto::KeyType;
 use identity_core::crypto::PrivateKey;
 use identity_core::crypto::PublicKey;
 use identity_core::crypto::Sign;
+#[cfg(feature = "encryption")]
 use identity_core::crypto::X25519;
 use identity_iota_core::did::IotaDID;
 use identity_iota_core::document::IotaDocument;
@@ -413,6 +417,7 @@ impl Storage for MemStore {
   }
 }
 
+#[cfg(feature = "encryption")]
 fn try_encrypt(
   key: &[u8],
   algorithm: &EncryptionAlgorithm,
@@ -441,6 +446,7 @@ fn try_encrypt(
   }
 }
 
+#[cfg(feature = "encryption")]
 fn try_decrypt(key: &[u8], algorithm: &EncryptionAlgorithm, data: &EncryptedData) -> Result<Vec<u8>> {
   match algorithm {
     EncryptionAlgorithm::AES256GCM => {
@@ -461,6 +467,7 @@ fn try_decrypt(key: &[u8], algorithm: &EncryptionAlgorithm, data: &EncryptedData
 }
 
 /// The Concat KDF (using SHA-256) as defined in Section 5.8.1 of NIST.800-56A
+#[cfg(feature = "encryption")]
 fn concat_kdf(
   alg: &'static str,
   len: usize,
@@ -530,6 +537,7 @@ impl Default for MemStore {
 }
 
 /// Generate a random content encryption key of suitable length for `encryption_algorithm`.
+#[cfg(feature = "encryption")]
 fn generate_content_encryption_key(encryption_algorithm: EncryptionAlgorithm) -> Result<Vec<u8>> {
   let mut bytes: Vec<u8> = vec![0; encryption_algorithm.key_length()];
   crypto::utils::rand::fill(bytes.as_mut()).map_err(Error::EncryptionFailure)?;

--- a/identity_account_storage/src/storage/traits.rs
+++ b/identity_account_storage/src/storage/traits.rs
@@ -14,8 +14,11 @@ use identity_iota_core::tangle::NetworkName;
 
 use crate::error::Result;
 use crate::identity::ChainState;
+#[cfg(feature = "encryption")]
 use crate::types::CekAlgorithm;
+#[cfg(feature = "encryption")]
 use crate::types::EncryptedData;
+#[cfg(feature = "encryption")]
 use crate::types::EncryptionAlgorithm;
 use crate::types::KeyLocation;
 use crate::types::Signature;

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -31,10 +31,7 @@ name = "benchmark"
 harness = false
 
 [features]
-default = ["async", "account", "stronghold", "send-sync-storage", "unstable-encryption", "revocation-bitmap"]
-
-# Enables async runtime support (Tokio).
-async = ["identity_iota_client/async"]
+default = ["account", "stronghold", "send-sync-storage", "unstable-encryption", "revocation-bitmap"]
 
 # Enables support for secure storage of DID Documents
 account = ["identity_account", "identity_account_storage"]

--- a/identity_iota/src/lib.rs
+++ b/identity_iota/src/lib.rs
@@ -56,6 +56,7 @@ pub mod did {
 
   pub use identity_did::document::*;
   pub use identity_did::error::*;
+  #[cfg(feature = "revocation-bitmap")]
   pub use identity_did::revocation::*;
   pub use identity_did::service::*;
   pub use identity_did::utils::*;

--- a/identity_iota_client/Cargo.toml
+++ b/identity_iota_client/Cargo.toml
@@ -32,7 +32,7 @@ thiserror = { version = "1.0", default-features = false }
 
 [dependencies.iota-client]
 version = "1.2.0"
-features = ["tls"]
+features = ["async", "tls"]
 default-features = false
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies.iota-client]
@@ -50,10 +50,7 @@ proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 tokio = { version = "1.17.0", default-features = false, features = ["macros"] }
 
 [features]
-default = ["async", "revocation-bitmap"]
-
-# Enables async runtime support (Tokio)
-async = ["iota-client/async"]
+default = ["revocation-bitmap"]
 
 # Enables revocation with `RevocationBitmap2022`.
 revocation-bitmap = ["identity_iota_core/revocation-bitmap"]

--- a/identity_iota_client/src/credential/credential_validator.rs
+++ b/identity_iota_client/src/credential/credential_validator.rs
@@ -282,9 +282,6 @@ impl CredentialValidator {
         .unwrap_or(Ok(()))
     });
 
-    #[cfg(feature = "revocation-bitmap")]
-    let revocation_validation = std::iter::once_with(|| Self::check_status(credential, issuers, options.status));
-
     let validation_units_iter = issuance_date_validation
       .chain(expiry_date_validation)
       .chain(structure_validation)
@@ -292,7 +289,10 @@ impl CredentialValidator {
       .chain(signature_validation);
 
     #[cfg(feature = "revocation-bitmap")]
-    let validation_units_iter = validation_units_iter.chain(revocation_validation);
+    let validation_units_iter = {
+      let revocation_validation = std::iter::once_with(|| Self::check_status(credential, issuers, options.status));
+      validation_units_iter.chain(revocation_validation)
+    };
 
     let validation_units_error_iter = validation_units_iter.filter_map(|result| result.err());
     let validation_errors: Vec<ValidationError> = match fail_fast {


### PR DESCRIPTION
# Description of change

Fixes the following commands not suceeding:

```
cargo check --no-default-features -p identity_iota
cargo check --no-default-features -p identity_iota_client
cargo check --no-default-features -p identity_account
cargo check --no-default-features -p identity_account_storage
```

- The `revocation-bitmap` feature flag was not properly gating all types and functions in `identity_iota_client` and `identity_account`.
- The `encryption` feature flag was not properly gating all types and functions in `identity_account_storage` and `identity_account`.

iota.rs requires either the `async` or `sync` feature to be activated, so the `async` feature was removed and the `async` feature of iota.rs is now activated unconditionally.

Code was moved to modules which can be feature-gated with a single `#[cfg(...)]` where possible. It's not possible for trait declarations or implementations, afaik.

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Ran the above commands successfully.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
