### PR TITLE
Avoid the include! macro

### DIFF
--- a/identity_core/src/crypto/proof/jcs_ed25519.rs
+++ b/identity_core/src/crypto/proof/jcs_ed25519.rs
@@ -104,9 +104,9 @@ mod tests {
       output: Object,
     }
 
-    const TV_1_BYTES: &'static [u8] = include_bytes!("../../../tests/fixtures/jcs_ed25519/test_vector_1.json");
-    const TV_2_BYTES: &'static [u8] = include_bytes!("../../../tests/fixtures/jcs_ed25519/test_vector_1.json");
-    const TEST_VECTOR_BYTES: [&'static [u8]; 2] = [TV_1_BYTES, TV_2_BYTES];
+    const TV_1_BYTES: &[u8] = include_bytes!("../../../tests/fixtures/jcs_ed25519/test_vector_1.json");
+    const TV_2_BYTES: &[u8] = include_bytes!("../../../tests/fixtures/jcs_ed25519/test_vector_1.json");
+    const TEST_VECTOR_BYTES: [&[u8]; 2] = [TV_1_BYTES, TV_2_BYTES];
 
     for tv_bytes in TEST_VECTOR_BYTES {
       let TestVector {

--- a/identity_core/src/crypto/proof/jcs_ed25519.rs
+++ b/identity_core/src/crypto/proof/jcs_ed25519.rs
@@ -87,32 +87,42 @@ mod tests {
   use crate::crypto::Verifier as _;
   use crate::json;
   use crate::utils::BaseEncoding;
+  use serde::Deserialize;
 
   type Signer = JcsEd25519<Ed25519<PrivateKey>>;
 
   type Verifier = JcsEd25519<Ed25519<PublicKey>>;
 
-  struct TestVector {
-    public: &'static str,
-    private: &'static str,
-    input: &'static str,
-    output: &'static str,
-  }
-
-  const TVS: &[TestVector] = &include!("../../../tests/fixtures/jcs_ed25519.rs");
-
   #[test]
   fn test_tvs() {
-    for tv in TVS {
-      // The test vectors are from [JcsEd25519Signature2020](https://github.com/decentralized-identity/JcsEd25519Signature2020/tree/master/signature-suite-impls/test-vectors),
-      // and use [Go crypto/ed25519](https://pkg.go.dev/crypto/ed25519#pkg-types)'s convention of representing an Ed25519 private key as: 32-byte seed concatenated with the 32-byte public key (computed from the seed).
-      // We follow the convention from [RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032#section-3.2) and extract the 32-byte seed as the private key.
-      let public: PublicKey = BaseEncoding::decode_base58(tv.public).unwrap().into();
-      let private: PrivateKey = (BaseEncoding::decode_base58(tv.private).unwrap()[..32]).to_vec().into();
-      let badkey: PublicKey = b"IOTA".to_vec().into();
+    // Represents a test vector from [JcsEd25519Signature2020](https://github.com/decentralized-identity/JcsEd25519Signature2020/tree/master/signature-suite-impls/test-vectors),
+    #[derive(Deserialize)]
+    struct TestVector {
+      public: String,
+      private: String,
+      input: Object,
+      output: Object,
+    }
 
-      let input: Object = Object::from_json(tv.input).unwrap();
-      let output: Object = Object::from_json(tv.output).unwrap();
+    const TV_1_BYTES: &'static [u8] = include_bytes!("../../../tests/fixtures/jcs_ed25519/test_vector_1.json");
+    const TV_2_BYTES: &'static [u8] = include_bytes!("../../../tests/fixtures/jcs_ed25519/test_vector_1.json");
+    const TEST_VECTOR_BYTES: [&'static [u8]; 2] = [TV_1_BYTES, TV_2_BYTES];
+
+    for tv_bytes in TEST_VECTOR_BYTES {
+      let TestVector {
+        public,
+        private,
+        input,
+        output,
+      } = TestVector::from_json_slice(tv_bytes).unwrap();
+
+      // The test vectors use [Go crypto/ed25519](https://pkg.go.dev/crypto/ed25519#pkg-types)'s convention of representing an Ed25519 private key as: 32-byte seed concatenated with the 32-byte public key (computed from the seed).
+      // We follow the convention from [RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032#section-3.2) and extract the 32-byte seed as the private key.
+      let public: PublicKey = BaseEncoding::decode_base58(public.as_str()).unwrap().into();
+      let private: PrivateKey = (BaseEncoding::decode_base58(private.as_str()).unwrap()[..32])
+        .to_vec()
+        .into();
+      let badkey: PublicKey = b"IOTA".to_vec().into();
 
       let signature: ProofValue = Signer::sign(&input, &private).unwrap();
 

--- a/identity_core/tests/fixtures/jcs_ed25519/test_vector_1.json
+++ b/identity_core/tests/fixtures/jcs_ed25519/test_vector_1.json
@@ -1,0 +1,18 @@
+{
+    "public": "4CcKDtU1JNGi8U4D8Rv9CHzfmF7xzaxEAPFA54eQjRHF",
+    "private": "z3nisqMdwW7nZdWomCfUyRaezHzKEBfwRbvaMcJAqaMSbmjxuRfS5qz4ff3QAf1A5sZT4ZMcxYoGjN4K1VsDV7b",
+    "input": 
+      {
+        "foo": "bar",
+        "proof": {
+          "type": "JcsEd25519Signature2020"
+        }
+      },
+     "output": {
+        "foo": "bar",
+        "proof": {
+          "signatureValue": "4VCNeCSC4Daru6g7oij3QxUL2CS9FZkCYWRMUKyiLuPPK7GWFrM4YtYYQbmgyUXgGuxyKY5Wn1Mh4mmaRkbah4i4",
+          "type": "JcsEd25519Signature2020"
+        }
+      }
+} 

--- a/identity_core/tests/fixtures/jcs_ed25519/test_vector_2.json
+++ b/identity_core/tests/fixtures/jcs_ed25519/test_vector_2.json
@@ -1,9 +1,7 @@
-[
-  TestVector {
-    public: "4CcKDtU1JNGi8U4D8Rv9CHzfmF7xzaxEAPFA54eQjRHF",
-    private: "z3nisqMdwW7nZdWomCfUyRaezHzKEBfwRbvaMcJAqaMSbmjxuRfS5qz4ff3QAf1A5sZT4ZMcxYoGjN4K1VsDV7b",
-    input: r#"
-      {
+{
+    "public": "4CcKDtU1JNGi8U4D8Rv9CHzfmF7xzaxEAPFA54eQjRHF",
+    "private": "z3nisqMdwW7nZdWomCfUyRaezHzKEBfwRbvaMcJAqaMSbmjxuRfS5qz4ff3QAf1A5sZT4ZMcxYoGjN4K1VsDV7b",
+    "input": {
         "id": "did:example:abcd",
         "publicKey": [
           {
@@ -24,10 +22,8 @@
         "proof": {
           "type": "JcsEd25519Signature2020"
         }
-      }
-    "#,
-    output: r#"
-      {
+      }, 
+    "output": {
         "id": "did:example:abcd",
         "publicKey": [
           {
@@ -50,27 +46,4 @@
           "type": "JcsEd25519Signature2020"
         }
       }
-    "#,
-  },
-  TestVector {
-    public: "4CcKDtU1JNGi8U4D8Rv9CHzfmF7xzaxEAPFA54eQjRHF",
-    private: "z3nisqMdwW7nZdWomCfUyRaezHzKEBfwRbvaMcJAqaMSbmjxuRfS5qz4ff3QAf1A5sZT4ZMcxYoGjN4K1VsDV7b",
-    input: r#"
-      {
-        "foo": "bar",
-        "proof": {
-          "type": "JcsEd25519Signature2020"
-        }
-      }
-    "#,
-    output: r#"
-      {
-        "foo": "bar",
-        "proof": {
-          "signatureValue": "4VCNeCSC4Daru6g7oij3QxUL2CS9FZkCYWRMUKyiLuPPK7GWFrM4YtYYQbmgyUXgGuxyKY5Wn1Mh4mmaRkbah4i4",
-          "type": "JcsEd25519Signature2020"
-        }
-      }
-    "#,
-  }
-]
+}


### PR DESCRIPTION
# Description of change
This PR changes the JCSEd25519 test to deserialize a JSON representation of the official test vectors instead of including their Rust representation with the `include!` macro. This is necessary in order to migrate to [cargo-license-template](https://crates.io/crates/cargo-license-template/0.1.2) as that crate scans all `.rs` files for a license header. A valid alternative would be to rename the included file to have another file extension (like `.in` for instance), but the include macro's [official documentation](https://doc.rust-lang.org/std/macro.include.html) states: 
> Using this macro is often a bad idea, because if the file is parsed as an expression, it is going to be placed in the surrounding code unhygienically. This could result in variables or functions being different from what the file expected if there are variables or functions that have the same name in the current file. 

Hence we might as well avoid invoking this macro altogether. 

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
