### PR TITLE
Fix IOTA Discord link on GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Official IOTA Discord
-    url: https://discord.com/channels/397872799483428865/443602228813627392
+    url: https://discord.iota.org/
     about: "Contact the maintainers by joining the #identity channel on the IOTA Discord."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Official Discord
-    url: https://discord.iota.org/
-    about: Contact the maintainers by joining the official Discord. Look for the channel #identity-discussion. 
+  - name: Official IOTA Discord
+    url: https://discord.com/channels/397872799483428865/443602228813627392
+    about: "Contact the maintainers by joining the #identity channel on the IOTA Discord."


### PR DESCRIPTION
# Description of change

Fix the Discord channel description which wasn't showing up on GitHub because `#` is a comment in YAML.

Do we have to merge this into `main` for it to take effect on GitHub :thinking:?

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
