### PR TITLE
Enable `doc_cfg` on `docsrs` feature

### DIFF
--- a/identity_iota/src/lib.rs
+++ b/identity_iota/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![allow(deprecated)]
 #![doc = include_str!("./../README.md")]


### PR DESCRIPTION
# Description of change

Fixes the failing build of `identity_iota` on docs.rs. This command succeeds now:

```
RUSTDOCFLAGS='--cfg docsrs' cargo +nightly doc --all-features --no-deps --open
```

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

## How the change has been tested

Built the docs successfully.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
