### PR TITLE
Fix brittle agent test

### DIFF
--- a/identity_agent/Cargo.toml
+++ b/identity_agent/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["iota", "tangle", "identity", "p2p", "agent"]
 license = "Apache-2.0"
 readme = "./README.md"
 repository = "https://github.com/iotaledger/identity.rs"
-description = "A peer-to-peer communication framework for building digital agents on IOTA Identity"
+description = "A peer-to-peer communication framework for building SSI agents on IOTA Identity"
 
 [dependencies]
 async-trait = { version = "0.1", default-features = false }

--- a/identity_agent/src/tests/handler.rs
+++ b/identity_agent/src/tests/handler.rs
@@ -180,9 +180,9 @@ async fn test_handlers_can_communicate_bidirectionally() -> AgentResult<()> {
     .await
     .unwrap();
 
-  let addr: Multiaddr = agent2.addresses().await.unwrap().into_iter().next().unwrap();
+  let addrs: Vec<Multiaddr> = agent2.addresses().await.unwrap();
 
-  agent1.add_agent_address(agent2.agent_id(), addr).await.unwrap();
+  agent1.add_agent_addresses(agent2.agent_id(), addrs).await.unwrap();
 
   agent1.send_request(agent2.agent_id(), Dummy(42)).await.unwrap();
 


### PR DESCRIPTION
# Description of change

Fixes an agent test that appears to be brittle on some systems or platforms or situations - it's unclear what exactly the problem is. 

The order of addresses and addresses themselves returned from `Agent::addresses` aren't the same across executions, so the occassional failures appear to come from times when the first address that is picked isn't dialable.
This is fixed by adding all addresses for an agent, which allows libp2p to attempt a dial for all of them.

Also fixes the crate description to match the README.

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

The test was run on the affected system and appears to work consistently now.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
