### PR TITLE
Add Rust documentation check to GitHub Actions

### DIFF
--- a/.github/workflows/test-docs-build.yml
+++ b/.github/workflows/test-docs-build.yml
@@ -12,7 +12,7 @@ on:
       - epic/*
       - support/*
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -21,8 +21,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Test Build
+
+      - name: Test Wiki Build
         # TODO Add 'yarn build' as last line once broken links are fixed
         run: |
           cd documentation
           yarn install --immutable
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Test Rust Documentation
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        with:
+          command: doc
+          args: --all-features --no-deps --workspace

--- a/.github/workflows/test-docs-build.yml
+++ b/.github/workflows/test-docs-build.yml
@@ -31,13 +31,14 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
 
       - name: Test Rust Documentation
         uses: actions-rs/cargo@v1
         env:
-          RUSTDOCFLAGS: "-D warnings"
+          RUSTDOCFLAGS: "-D warnings --cfg docsrs"
         with:
           command: doc
+          toolchain: nightly
           args: --all-features --no-deps --workspace

--- a/.github/workflows/test-docs-build.yml
+++ b/.github/workflows/test-docs-build.yml
@@ -28,7 +28,7 @@ jobs:
           cd documentation
           yarn install --immutable
 
-      - name: Install stable toolchain
+      - name: Install Rust nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly

--- a/identity_iota_client/README.md
+++ b/identity_iota_client/README.md
@@ -9,4 +9,4 @@ This crate provides interfaces for publishing and resolving DID Documents to and
 Convenience methods for validating [Verifiable Credentials](https://wiki.iota.org/identity.rs/concepts/verifiable_credentials/overview) and [Verifiable Presentations](https://wiki.iota.org/identity.rs/concepts/verifiable_credentials/verifiable_presentations) are also provided:
 
 - [`CredentialValidator`](crate::credential::CredentialValidator)
-- [`PresentationValidator`](crate::tangle::PresentationValidator)
+- [`PresentationValidator`](crate::credential::PresentationValidator)

--- a/identity_iota_client/README.md
+++ b/identity_iota_client/README.md
@@ -9,4 +9,4 @@ This crate provides interfaces for publishing and resolving DID Documents to and
 Convenience methods for validating [Verifiable Credentials](https://wiki.iota.org/identity.rs/concepts/verifiable_credentials/overview) and [Verifiable Presentations](https://wiki.iota.org/identity.rs/concepts/verifiable_credentials/verifiable_presentations) are also provided:
 
 - [`CredentialValidator`](crate::credential::CredentialValidator)
-- [`PresentationValidator`](crate::credential::PresentationValidator)
+- [`PresentationValidator`](crate::tangle::PresentationValidator)


### PR DESCRIPTION
# Description of change
Build Rust documentation in CI to catch broken links early. The new check is relatively fast at ~5 minutes, so should not slow down the overall CI, especially when run in parallel with much larger jobs.

## Type of change

- [x] Chore/Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

- Successful CI run: https://github.com/iotaledger/identity.rs/runs/7255904825?check_suite_focus=true
- **Failed CI run** (to show it catches broken intra-doc links, even from a README.md file): https://github.com/iotaledger/identity.rs/runs/7256033459?check_suite_focus=true

To test locally, change one of the documentation links in a Rust file to be incorrect. 
Then run:
```bash
RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps --workspace
```

It should print an error similar to the one below and exit with code 1:
```rust
error: unresolved link to `crate::validator::PresentationValidator`
 --> identity_iota_client\src\lib.rs:6:1
  |
6 | #![doc = include_str!("./../README.md")]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`
  = note: the link appears in this line:

          - [`PresentationValidator`](crate::validator::PresentationValidator)
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  = note: no item named `validator` in module `identity_iota_client`

error: could not document `identity_iota_client`
```

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
