### PR TITLE
Change `Service` `type` field to allow sets

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -197,9 +197,9 @@ This variant is the default used if no other variant is specified when construct
 <dt><a href="#FirstError">FirstError</a></dt>
 <dd><p>Return after the first error occurs.</p>
 </dd>
-<dt><a href="#MethodRelationship">MethodRelationship</a></dt>
-<dd></dd>
 <dt><a href="#KeyType">KeyType</a></dt>
+<dd></dd>
+<dt><a href="#MethodRelationship">MethodRelationship</a></dt>
 <dd></dd>
 </dl>
 
@@ -222,9 +222,8 @@ publishing to the Tangle.
 **Kind**: global class  
 
 * [Account](#Account)
-    * [.attachMethodRelationships(options)](#Account+attachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.createService(options)](#Account+createService) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.createMethod(options)](#Account+createMethod) ⇒ <code>Promise.&lt;void&gt;</code>
-    * [.detachMethodRelationships(options)](#Account+detachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.did()](#Account+did) ⇒ [<code>DID</code>](#DID)
     * [.autopublish()](#Account+autopublish) ⇒ <code>boolean</code>
     * [.autosave()](#Account+autosave) ⇒ [<code>AutoSave</code>](#AutoSave)
@@ -242,25 +241,23 @@ publishing to the Tangle.
     * [.unrevokeCredentials(fragment, credentialIndices)](#Account+unrevokeCredentials) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.encryptData(plaintext, associated_data, encryption_algorithm, cek_algorithm, public_key)](#Account+encryptData) ⇒ [<code>Promise.&lt;EncryptedData&gt;</code>](#EncryptedData)
     * [.decryptData(data, encryption_algorithm, cek_algorithm, fragment)](#Account+decryptData) ⇒ <code>Promise.&lt;Uint8Array&gt;</code>
+    * [.attachMethodRelationships(options)](#Account+attachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.detachMethodRelationships(options)](#Account+detachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.deleteService(options)](#Account+deleteService) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.setAlsoKnownAs(options)](#Account+setAlsoKnownAs) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.setController(options)](#Account+setController) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.deleteMethod(options)](#Account+deleteMethod) ⇒ <code>Promise.&lt;void&gt;</code>
-    * [.createService(options)](#Account+createService) ⇒ <code>Promise.&lt;void&gt;</code>
 
-<a name="Account+attachMethodRelationships"></a>
+<a name="Account+createService"></a>
 
-### account.attachMethodRelationships(options) ⇒ <code>Promise.&lt;void&gt;</code>
-Attach one or more verification relationships to a method.
-
-Note: the method must exist and be in the set of verification methods;
-it cannot be an embedded method.
+### account.createService(options) ⇒ <code>Promise.&lt;void&gt;</code>
+Adds a new Service to the DID Document.
 
 **Kind**: instance method of [<code>Account</code>](#Account)  
 
 | Param | Type |
 | --- | --- |
-| options | <code>AttachMethodRelationshipOptions</code> | 
+| options | <code>CreateServiceOptions</code> | 
 
 <a name="Account+createMethod"></a>
 
@@ -272,17 +269,6 @@ Adds a new verification method to the DID document.
 | Param | Type |
 | --- | --- |
 | options | <code>CreateMethodOptions</code> | 
-
-<a name="Account+detachMethodRelationships"></a>
-
-### account.detachMethodRelationships(options) ⇒ <code>Promise.&lt;void&gt;</code>
-Detaches the given relationship from the given method, if the method exists.
-
-**Kind**: instance method of [<code>Account</code>](#Account)  
-
-| Param | Type |
-| --- | --- |
-| options | <code>DetachMethodRelationshipOptions</code> | 
 
 <a name="Account+did"></a>
 
@@ -475,6 +461,31 @@ Returns the decrypted text.
 | cek_algorithm | [<code>CekAlgorithm</code>](#CekAlgorithm) | 
 | fragment | <code>string</code> | 
 
+<a name="Account+attachMethodRelationships"></a>
+
+### account.attachMethodRelationships(options) ⇒ <code>Promise.&lt;void&gt;</code>
+Attach one or more verification relationships to a method.
+
+Note: the method must exist and be in the set of verification methods;
+it cannot be an embedded method.
+
+**Kind**: instance method of [<code>Account</code>](#Account)  
+
+| Param | Type |
+| --- | --- |
+| options | <code>AttachMethodRelationshipOptions</code> | 
+
+<a name="Account+detachMethodRelationships"></a>
+
+### account.detachMethodRelationships(options) ⇒ <code>Promise.&lt;void&gt;</code>
+Detaches the given relationship from the given method, if the method exists.
+
+**Kind**: instance method of [<code>Account</code>](#Account)  
+
+| Param | Type |
+| --- | --- |
+| options | <code>DetachMethodRelationshipOptions</code> | 
+
 <a name="Account+deleteService"></a>
 
 ### account.deleteService(options) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -518,17 +529,6 @@ Deletes a verification method if the method exists.
 | Param | Type |
 | --- | --- |
 | options | <code>DeleteMethodOptions</code> | 
-
-<a name="Account+createService"></a>
-
-### account.createService(options) ⇒ <code>Promise.&lt;void&gt;</code>
-Adds a new Service to the DID Document.
-
-**Kind**: instance method of [<code>Account</code>](#Account)  
-
-| Param | Type |
-| --- | --- |
-| options | <code>CreateServiceOptions</code> | 
 
 <a name="AccountBuilder"></a>
 
@@ -4392,7 +4392,7 @@ See: https://www.w3.org/TR/did-core/#services
     * [new Service(service)](#new_Service_new)
     * _instance_
         * [.id()](#Service+id) ⇒ [<code>DIDUrl</code>](#DIDUrl)
-        * [.type()](#Service+type) ⇒ <code>string</code>
+        * [.type()](#Service+type) ⇒ <code>Array.&lt;string&gt;</code>
         * [.serviceEndpoint()](#Service+serviceEndpoint) ⇒ <code>string</code> \| <code>Array.&lt;string&gt;</code> \| <code>Map.&lt;string, Array.&lt;string&gt;&gt;</code>
         * [.properties()](#Service+properties) ⇒ <code>Map.&lt;string, any&gt;</code>
         * [.toJSON()](#Service+toJSON) ⇒ <code>any</code>
@@ -4416,7 +4416,7 @@ Returns a copy of the `Service` id.
 **Kind**: instance method of [<code>Service</code>](#Service)  
 <a name="Service+type"></a>
 
-### service.type() ⇒ <code>string</code>
+### service.type() ⇒ <code>Array.&lt;string&gt;</code>
 Returns a copy of the `Service` type.
 
 **Kind**: instance method of [<code>Service</code>](#Service)  
@@ -4984,13 +4984,13 @@ Return all errors that occur during validation.
 Return after the first error occurs.
 
 **Kind**: global variable  
-<a name="MethodRelationship"></a>
-
-## MethodRelationship
-**Kind**: global variable  
 <a name="KeyType"></a>
 
 ## KeyType
+**Kind**: global variable  
+<a name="MethodRelationship"></a>
+
+## MethodRelationship
 **Kind**: global variable  
 <a name="start"></a>
 

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -24,6 +24,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
 use crate::account::wasm_account::UOneOrManyNumber;
+use crate::common::ArrayString;
 use crate::common::MapStringAny;
 use crate::common::WasmTimestamp;
 use crate::credential::WasmCredential;
@@ -701,7 +702,6 @@ impl From<WasmDocument> for IotaDocument {
   }
 }
 
-/// Duck-typed union to pass either a string or WasmDIDUrl as a parameter.
 #[wasm_bindgen]
 extern "C" {
   #[wasm_bindgen(typescript_type = "DIDUrl | string")]
@@ -718,9 +718,6 @@ extern "C" {
 
   #[wasm_bindgen(typescript_type = "Service[]")]
   pub type ArrayService;
-
-  #[wasm_bindgen(typescript_type = "Array<string>")]
-  pub type ArrayString;
 
   #[wasm_bindgen(typescript_type = "VerificationMethod[]")]
   pub type ArrayVerificationMethods;

--- a/bindings/wasm/tests/account.ts
+++ b/bindings/wasm/tests/account.ts
@@ -4,11 +4,11 @@ const assert = require('assert');
 const {
     AccountBuilder,
     AutoSave,
-    MethodScope,
-    MethodContent,
     KeyType,
-    MethodType,
     KeyPair,
+    MethodContent,
+    MethodScope,
+    MethodType,
 } = require("../node");
 
 function setupAccountBuilder() {
@@ -96,6 +96,38 @@ describe('Account', function () {
             assert.equal(method2.id().fragment(), fragment2);
             assert.equal(method2.type().toString(), MethodType.X25519KeyAgreementKey2019().toString());
             assert.equal(method2.data().tryDecode().toString(), keypair.public().toString());
+        });
+    });
+    describe('#createService()', function () {
+        it('should take one type and endpoint', async () => {
+            const account = await setupAccount();
+
+            // Test single type & endpoint.
+            const fragment1 = "new-service-1";
+            await account.createService({
+                fragment: fragment1,
+                type: "LinkedDomains",
+                endpoint: "https://example.com/"
+            });
+            const service = account.document().resolveService(fragment1);
+            assert.deepStrictEqual(service.id().fragment(), fragment1);
+            assert.deepStrictEqual(service.type(), ["LinkedDomains"]);
+            assert.deepStrictEqual(service.serviceEndpoint(), "https://example.com/");
+        });
+        it('should take multiple types and endpoints', async () => {
+            const account = await setupAccount();
+
+            // Test multiple types & endpoints.
+            const fragment1 = "new-service-1";
+            await account.createService({
+                fragment: fragment1,
+                type: ["LinkedDomains", "ExampleType"],
+                endpoint: ["https://example.com/", "https://iota.org/"]
+            });
+            const service = account.document().resolveService(fragment1);
+            assert.deepStrictEqual(service.id().fragment(), fragment1);
+            assert.deepStrictEqual(service.type(), ["LinkedDomains", "ExampleType"]);
+            assert.deepStrictEqual(service.serviceEndpoint(), ["https://example.com/", "https://iota.org/"]);
         });
     });
 });

--- a/bindings/wasm/tests/document.ts
+++ b/bindings/wasm/tests/document.ts
@@ -1,0 +1,50 @@
+export {};
+
+const assert = require('assert');
+const {
+    Document,
+    KeyType,
+    KeyPair,
+    Service,
+} = require("../node");
+
+describe('Document', function () {
+    describe('#insertService()', function () {
+        it('should take one type', async () => {
+            const keypair = new KeyPair(KeyType.Ed25519);
+            const doc = new Document(keypair);
+
+            // Test single type.
+            const fragment1 = "new-service-1";
+            doc.insertService(new Service({
+                id: doc.id().toUrl().join('#' + fragment1),
+                type: "LinkedDomains",
+                serviceEndpoint: {
+                    "origins": ["https://iota.org/", "https://example.com/"]
+                },
+            }));
+            const service = doc.resolveService(fragment1);
+            assert.deepStrictEqual(service.id().fragment(), fragment1);
+            assert.deepStrictEqual(service.type(), ["LinkedDomains"]);
+            assert.deepStrictEqual(service.serviceEndpoint(), new Map<string, string[]>([
+                ["origins", ["https://iota.org/", "https://example.com/"]],
+            ]));
+        });
+        it('should take multiple types', async () => {
+            const keypair = new KeyPair(KeyType.Ed25519);
+            const doc = new Document(keypair);
+
+            // Test multiple types.
+            const fragment1 = "new-service-1";
+            doc.insertService(new Service({
+                id: doc.id().toUrl().join('#' + fragment1),
+                type: ["LinkedDomains", "ExampleType"],
+                serviceEndpoint: ["https://example.com/", "https://iota.org/"],
+            }));
+            const service = doc.resolveService(fragment1);
+            assert.deepStrictEqual(service.id().fragment(), fragment1);
+            assert.deepStrictEqual(service.type(), ["LinkedDomains", "ExampleType"]);
+            assert.deepStrictEqual(service.serviceEndpoint(), ["https://example.com/", "https://iota.org/"]);
+        });
+    });
+});

--- a/identity_account/src/tests/updates.rs
+++ b/identity_account/src/tests/updates.rs
@@ -621,7 +621,7 @@ async fn test_insert_service() -> Result<()> {
 
   let update: Update = Update::CreateService {
     fragment: fragment.clone(),
-    type_: "LinkedDomains".to_owned(),
+    types: vec!["LinkedDomains".to_owned()],
     endpoint: ServiceEndpoint::One(Url::parse("https://iota.org").unwrap()),
     properties: None,
   };
@@ -652,7 +652,7 @@ async fn test_remove_service() -> Result<()> {
 
   let update: Update = Update::CreateService {
     fragment: fragment.clone(),
-    type_: "LinkedDomains".to_owned(),
+    types: vec!["LinkedDomains".to_owned()],
     endpoint: ServiceEndpoint::One(Url::parse("https://iota.org").unwrap()),
     properties: None,
   };

--- a/identity_account/src/updates/update.rs
+++ b/identity_account/src/updates/update.rs
@@ -82,7 +82,7 @@ pub(crate) enum Update {
   },
   CreateService {
     fragment: String,
-    type_: String,
+    types: Vec<String>,
     endpoint: ServiceEndpoint,
     properties: Option<Object>,
   },
@@ -198,7 +198,7 @@ impl Update {
       }
       Self::CreateService {
         fragment,
-        type_,
+        types,
         endpoint,
         properties,
       } => {
@@ -214,7 +214,7 @@ impl Update {
         let service: IotaService = Service::builder(properties.unwrap_or_default())
           .id(did_url)
           .service_endpoint(endpoint)
-          .type_(type_)
+          .types(types)
           .build()?;
 
         document.insert_service(service);
@@ -343,16 +343,27 @@ impl_update_builder!(
 /// Create a new service on an identity.
 ///
 /// # Parameters
-/// - `type_`: the type of the service, e.g. `"LinkedDomains"`, required.
+/// - `types`: the type/s of the service, e.g. `"LinkedDomains"`, required.
 /// - `fragment`: the identifier of the service in the document, required.
 /// - `endpoint`: the `ServiceEndpoint` of the service, required.
 /// - `properties`: additional properties of the service, optional.
 CreateService {
   @required fragment String,
-  @required type_ String,
+  @required types Vec<String>,
   @required endpoint ServiceEndpoint,
   @optional properties Object,
 });
+
+impl<'account, C> CreateServiceBuilder<'account, C>
+where
+  C: SharedPtr<Client>,
+{
+  #[must_use]
+  pub fn type_(mut self, value: impl Into<String>) -> Self {
+    self.types.get_or_insert_with(Default::default).push(value.into());
+    self
+  }
+}
 
 impl_update_builder!(
 /// Delete a service on an identity.

--- a/identity_core/src/common/key_comparable.rs
+++ b/identity_core/src/common/key_comparable.rs
@@ -9,3 +9,37 @@ pub trait KeyComparable {
   /// Returns a reference to the key.
   fn key(&self) -> &Self::Key;
 }
+
+/// Macro to implement the `KeyComparable` trait for primitive types.
+///
+/// This approach is used to avoid conflicts from a blanket implementation where the type is the
+/// key itself.
+macro_rules! impl_key_comparable {
+    ($($t:ty)*) => ($(
+        impl KeyComparable for $t {
+            type Key = $t;
+            #[inline]
+            fn key(&self) -> &Self::Key { self }
+        }
+    )*)
+}
+
+impl_key_comparable! {
+    str bool char usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64
+}
+
+impl KeyComparable for &str {
+  type Key = str;
+
+  fn key(&self) -> &Self::Key {
+    self
+  }
+}
+
+impl KeyComparable for String {
+  type Key = str;
+
+  fn key(&self) -> &Self::Key {
+    self
+  }
+}

--- a/identity_core/src/common/one_or_set.rs
+++ b/identity_core/src/common/one_or_set.rs
@@ -151,7 +151,7 @@ where
   pub fn contains<U>(&self, item: &U) -> bool
   where
     T: KeyComparable,
-    U: KeyComparable<Key = T::Key>,
+    U: KeyComparable<Key = T::Key> + ?Sized,
   {
     match &self.0 {
       OneOrSetInner::One(inner) => inner.key() == item.key(),
@@ -439,16 +439,16 @@ mod tests {
   fn test_contains() {
     // One.
     let one: OneOrSet<MockKeyU8> = OneOrSet::new_one(MockKeyU8(1));
-    assert!(one.contains(&1));
-    assert!(!one.contains(&2));
-    assert!(!one.contains(&3));
+    assert!(one.contains(&1u8));
+    assert!(!one.contains(&2u8));
+    assert!(!one.contains(&3u8));
 
     // Set.
     let set: OneOrSet<MockKeyU8> = OneOrSet::new_set((1..=3).map(MockKeyU8).collect()).unwrap();
-    assert!(set.contains(&1));
-    assert!(set.contains(&2));
-    assert!(set.contains(&3));
-    assert!(!set.contains(&4));
+    assert!(set.contains(&1u8));
+    assert!(set.contains(&2u8));
+    assert!(set.contains(&3u8));
+    assert!(!set.contains(&4u8));
   }
 
   #[test]

--- a/identity_core/src/common/ordered_set.rs
+++ b/identity_core/src/common/ordered_set.rs
@@ -118,7 +118,7 @@ impl<T> OrderedSet<T> {
   pub fn contains<U>(&self, item: &U) -> bool
   where
     T: KeyComparable,
-    U: KeyComparable<Key = T::Key>,
+    U: KeyComparable<Key = T::Key> + ?Sized,
   {
     self.0.iter().any(|other| other.key() == item.key())
   }
@@ -312,22 +312,6 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
-
-  impl KeyComparable for &str {
-    type Key = str;
-
-    fn key(&self) -> &Self::Key {
-      self
-    }
-  }
-
-  impl KeyComparable for u8 {
-    type Key = u8;
-
-    fn key(&self) -> &Self::Key {
-      self
-    }
-  }
 
   #[test]
   fn test_ordered_set_works() {

--- a/identity_credential/src/validator/credential_validator.rs
+++ b/identity_credential/src/validator/credential_validator.rs
@@ -9,7 +9,6 @@ use identity_core::common::OneOrMany;
 use identity_core::common::Timestamp;
 use identity_core::common::Url;
 use identity_did::did::CoreDID;
-use identity_did::did::CoreDIDUrl;
 use identity_did::did::DID;
 #[cfg(feature = "revocation-bitmap")]
 use identity_did::revocation::RevocationBitmap;
@@ -208,7 +207,7 @@ impl CredentialValidator {
     issuer: &DOC,
     status: RevocationBitmapStatus,
   ) -> ValidationUnitResult {
-    let issuer_service_url: CoreDIDUrl = status.id().map_err(ValidationError::InvalidStatus)?;
+    let issuer_service_url: identity_did::did::CoreDIDUrl = status.id().map_err(ValidationError::InvalidStatus)?;
 
     // Check whether index is revoked.
     let revocation_bitmap: RevocationBitmap = issuer
@@ -762,7 +761,7 @@ mod tests {
     }
 
     // Add a RevocationBitmap status to the credential.
-    let service_url: CoreDIDUrl = issuer_doc.id().to_url().join("#revocation-service").unwrap();
+    let service_url: identity_did::did::CoreDIDUrl = issuer_doc.id().to_url().join("#revocation-service").unwrap();
     let index: u32 = 42;
     credential.credential_status = Some(RevocationBitmapStatus::new(service_url.clone(), index).into());
 

--- a/identity_credential/src/validator/validator_document.rs
+++ b/identity_credential/src/validator/validator_document.rs
@@ -4,8 +4,8 @@
 use identity_core::crypto::GetSignature;
 use identity_did::did::DID;
 use identity_did::document::Document;
+#[cfg(feature = "revocation-bitmap")]
 use identity_did::revocation::RevocationBitmap;
-use identity_did::utils::DIDUrlQuery;
 use identity_did::verifiable::VerifierOptions;
 
 use self::private::Sealed;
@@ -45,7 +45,10 @@ pub trait ValidatorDocument: Sealed {
   /// Fails if the referenced service is not found, or is not a
   /// valid `RevocationBitmap2022` service.
   #[cfg(feature = "revocation-bitmap")]
-  fn resolve_revocation_bitmap(&self, query: DIDUrlQuery<'_>) -> identity_did::Result<RevocationBitmap>;
+  fn resolve_revocation_bitmap(
+    &self,
+    query: identity_did::utils::DIDUrlQuery<'_>,
+  ) -> identity_did::Result<RevocationBitmap>;
 }
 
 mod private {
@@ -82,7 +85,10 @@ impl ValidatorDocument for &dyn ValidatorDocument {
   }
 
   #[cfg(feature = "revocation-bitmap")]
-  fn resolve_revocation_bitmap(&self, query: DIDUrlQuery<'_>) -> identity_did::Result<RevocationBitmap> {
+  fn resolve_revocation_bitmap(
+    &self,
+    query: identity_did::utils::DIDUrlQuery<'_>,
+  ) -> identity_did::Result<RevocationBitmap> {
     (*self).resolve_revocation_bitmap(query)
   }
 }
@@ -100,7 +106,10 @@ where
   }
 
   #[cfg(feature = "revocation-bitmap")]
-  fn resolve_revocation_bitmap(&self, query: DIDUrlQuery<'_>) -> identity_did::Result<RevocationBitmap> {
+  fn resolve_revocation_bitmap(
+    &self,
+    query: identity_did::utils::DIDUrlQuery<'_>,
+  ) -> identity_did::Result<RevocationBitmap> {
     self
       .resolve_service(query)
       .ok_or(identity_did::Error::InvalidService(

--- a/identity_did/src/diff/diff_service.rs
+++ b/identity_did/src/diff/diff_service.rs
@@ -93,7 +93,7 @@ where
     // Use builder to enforce invariants.
     ServiceBuilder::new(properties)
       .id(id)
-      .types(&type_)
+      .types(type_)
       .service_endpoint(service_endpoint)
       .build()
       .map_err(Error::merge)
@@ -123,7 +123,7 @@ where
     // Use builder to enforce invariants.
     ServiceBuilder::new(properties)
       .id(id)
-      .types(&type_)
+      .types(type_)
       .service_endpoint(service_endpoint)
       .build()
       .map_err(Error::convert)

--- a/identity_did/src/revocation/bitmap.rs
+++ b/identity_did/src/revocation/bitmap.rs
@@ -145,7 +145,7 @@ impl<D: DID + Sized, T> TryFrom<&Service<D, T>> for RevocationBitmap {
   type Error = Error;
 
   fn try_from(service: &Service<D, T>) -> Result<Self> {
-    if service.type_() != Self::TYPE {
+    if !service.type_().contains(Self::TYPE) {
       return Err(Error::InvalidService("invalid type - expected `RevocationBitmap2022`"));
     }
 

--- a/identity_did/src/service/builder.rs
+++ b/identity_did/src/service/builder.rs
@@ -54,8 +54,8 @@ where
   ///
   /// NOTE: the entries must be unique.
   #[must_use]
-  pub fn types(mut self, values: &[String]) -> Self {
-    self.type_ = values.to_vec();
+  pub fn types(mut self, values: impl Into<Vec<String>>) -> Self {
+    self.type_ = values.into();
     self
   }
 

--- a/identity_did/src/service/service.rs
+++ b/identity_did/src/service/service.rs
@@ -219,7 +219,7 @@ mod tests {
     // Set of types.
     let service2: Service = Service::builder(Object::new())
       .id(CoreDIDUrl::parse("did:example:123#service").unwrap())
-      .types(&["LinkedDomains".to_owned(), "OtherService2022".to_owned()])
+      .types(["LinkedDomains".to_owned(), "OtherService2022".to_owned()])
       .service_endpoint(Url::parse("https://iota.org/").unwrap())
       .build()
       .unwrap();

--- a/identity_did/src/service/service.rs
+++ b/identity_did/src/service/service.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 
 use identity_core::common::KeyComparable;
 use identity_core::common::Object;
+use identity_core::common::OneOrSet;
 use identity_core::convert::FmtJson;
 
 use crate::did::CoreDID;
@@ -32,7 +33,7 @@ where
   #[serde(deserialize_with = "deserialize_id_with_fragment")]
   pub(crate) id: DIDUrl<D>,
   #[serde(rename = "type")]
-  pub(crate) type_: String,
+  pub(crate) type_: OneOrSet<String>,
   #[serde(rename = "serviceEndpoint")]
   pub(crate) service_endpoint: ServiceEndpoint,
   #[serde(flatten)]
@@ -72,7 +73,7 @@ where
 
     Ok(Self {
       id,
-      type_: builder.type_.ok_or(Error::InvalidService("missing type"))?,
+      type_: OneOrSet::try_from(builder.type_).map_err(|_| Error::InvalidService("invalid type"))?,
       service_endpoint: builder
         .service_endpoint
         .ok_or(Error::InvalidService("missing endpoint"))?,
@@ -98,12 +99,12 @@ where
   }
 
   /// Returns a reference to the `Service` type.
-  pub fn type_(&self) -> &str {
-    &*self.type_
+  pub fn type_(&self) -> &OneOrSet<String> {
+    &self.type_
   }
 
   /// Returns a mutable reference to the `Service` type.
-  pub fn type_mut(&mut self) -> &mut String {
+  pub fn type_mut(&mut self) -> &mut OneOrSet<String> {
     &mut self.type_
   }
 
@@ -198,13 +199,52 @@ mod tests {
   use identity_core::convert::ToJson;
 
   #[test]
-  fn test_service_serde() {
-    // Single endpoint
+  fn test_service_types_serde() {
+    // Single type.
+    let service1: Service = Service::builder(Object::new())
+      .id(CoreDIDUrl::parse("did:example:123#service").unwrap())
+      .type_("LinkedDomains")
+      .service_endpoint(Url::parse("https://iota.org/").unwrap())
+      .build()
+      .unwrap();
+    assert_eq!(service1.type_, OneOrSet::new_one("LinkedDomains".to_owned()));
+    assert!(service1.type_.contains("LinkedDomains"));
+    assert!(!service1.type_.contains("NotEntry"));
+    assert!(!service1.type_.contains(""));
+
+    let expected1 = r#"{"id":"did:example:123#service","type":"LinkedDomains","serviceEndpoint":"https://iota.org/"}"#;
+    assert_eq!(service1.to_json().unwrap(), expected1);
+    assert_eq!(Service::from_json(expected1).unwrap(), service1);
+
+    // Set of types.
+    let service2: Service = Service::builder(Object::new())
+      .id(CoreDIDUrl::parse("did:example:123#service").unwrap())
+      .types(&["LinkedDomains".to_owned(), "OtherService2022".to_owned()])
+      .service_endpoint(Url::parse("https://iota.org/").unwrap())
+      .build()
+      .unwrap();
+    assert_eq!(
+      service2.type_,
+      OneOrSet::try_from(vec!["LinkedDomains".to_owned(), "OtherService2022".to_owned()]).unwrap()
+    );
+    assert!(service2.type_.contains("LinkedDomains"));
+    assert!(service2.type_.contains("OtherService2022"));
+    assert!(!service2.type_.contains("NotEntry"));
+    assert!(!service2.type_.contains(""));
+
+    let expected2 = r#"{"id":"did:example:123#service","type":["LinkedDomains","OtherService2022"],"serviceEndpoint":"https://iota.org/"}"#;
+    assert_eq!(service2.to_json().unwrap(), expected2);
+    assert_eq!(Service::from_json(expected2).unwrap(), service2)
+  }
+
+  #[test]
+  fn test_service_endpoint_serde() {
+    // Single endpoint.
     {
       let service: Service = Service::builder(Object::new())
         .id(CoreDIDUrl::parse("did:example:123#service").unwrap())
-        .type_("LinkedDomains".to_owned())
-        .service_endpoint(Url::parse("https://iota.org/").unwrap().into())
+        .type_("LinkedDomains")
+        .service_endpoint(Url::parse("https://iota.org/").unwrap())
         .build()
         .unwrap();
       let expected = r#"{"id":"did:example:123#service","type":"LinkedDomains","serviceEndpoint":"https://iota.org/"}"#;
@@ -212,7 +252,7 @@ mod tests {
       assert_eq!(Service::from_json(expected).unwrap(), service);
     }
 
-    // Set of endpoints
+    // Set of endpoints.
     {
       let endpoint: ServiceEndpoint = ServiceEndpoint::Set(
         OrderedSet::try_from(vec![
@@ -224,7 +264,7 @@ mod tests {
       );
       let service: Service = Service::builder(Object::new())
         .id(CoreDIDUrl::parse("did:example:123#service").unwrap())
-        .type_("LinkedDomains".to_owned())
+        .type_("LinkedDomains")
         .service_endpoint(endpoint)
         .build()
         .unwrap();


### PR DESCRIPTION
# Description of change

Changes the `Service.type` field from `String` to `OneOrSet<String>` (Wasm `string | string[]`) to match the [W3C DID specification](https://www.w3.org/TR/did-core/#service-properties).

> `type` A [string](https://infra.spec.whatwg.org/#string) or a [set](https://infra.spec.whatwg.org/#ordered-set) of [strings](https://infra.spec.whatwg.org/#string).

## Changed

- Change `Service` `type` field from `String` to `OneOrSet<String>`.
- Impl `KeyComparable` for standard types, so they can be used with `OneOrSet`.

## Links to any relevant issues
Addresses second part of #447, previously missed.

See https://github.com/iotaledger/identity.rs/issues/447#issuecomment-1181654228

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
New unit tests pass for both `account.update_identity().create_service()` and `document.insert_service()`, including in Wasm bindings, and also tested manually with an example.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
