### PR TITLE
Fix stack overflow in `CoreDID` `PartialEq` impl

### DIFF
--- a/identity_did/src/did/did.rs
+++ b/identity_did/src/did/did.rs
@@ -277,12 +277,6 @@ impl PartialEq<&'_ str> for CoreDID {
   }
 }
 
-impl PartialEq<&CoreDID> for CoreDID {
-  fn eq(&self, other: &&CoreDID) -> bool {
-    self == other
-  }
-}
-
 impl KeyComparable for CoreDID {
   type Key = CoreDID;
 


### PR DESCRIPTION
# Description of change

Fixes an infinite recursion when comparing `CoreDID`s. The following example currently causes a stack overflow:

```rust
let example1 = CoreDID::parse("did:example:0x0").unwrap();
let example2 = CoreDID::parse("did:example:0x1").unwrap();
println!("{}", example1 == &example2);
```

The Rust compiler ends up effectively calling:

```rust
<CoreDID as PartialEq<&CoreDID>>::eq(&example1, &&example2)
```

which recurses infinitely. The implementation is:


```rust
impl PartialEq<&CoreDID> for CoreDID {
  fn eq(&self, other: &&CoreDID) -> bool {
    self == other
  }
}
```

Two options for fixing the situation: 1) Using `*other` or 2) removing the impl. We don't use this implementation anywhere, and since this impl has been around for 9 months without anyone running into the problem, there's a good chance no one is using it. Note that this is an additional implementation next to the derived `PartialEq` impl on `CoreDID`. So this PR removes this impl. However, if we don't want this to be a breaking change or think it's a convenient impl, we can also go with option 1.

Edit: CI is failing due to a known ICE: https://github.com/rust-lang/rust/issues/99261

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Ran the above example before and after the change.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
