### PR TITLE
Simplify Wasm JSON conversion code with macro

### DIFF
--- a/.github/workflows/shared-build-wasm.yml
+++ b/.github/workflows/shared-build-wasm.yml
@@ -15,7 +15,7 @@ on:
         description: "Name used for the output build artifact"
         required: true
         type: string
-jobs:  
+jobs:
   build-wasm:
     defaults:
       run:
@@ -55,10 +55,10 @@ jobs:
       # Download a pre-compiled wasm-bindgen binary.
       - name: Install wasm-bindgen-cli
         uses: jetli/wasm-bindgen-action@24ba6f9fff570246106ac3f80f35185600c3f6c9
-        
+
       - name: Setup sccache
-        uses: './.github/actions/rust/sccache/setup-sccache' 
-        with:    
+        uses: './.github/actions/rust/sccache/setup-sccache'
+        with:
           os: ${{matrix.os}}
 
       - name: Set up Node.js
@@ -76,12 +76,16 @@ jobs:
         if: ${{ inputs.run-unit-tests }}
         run: npm run test:unit
 
+      - name: Run Node unit tests
+        if: ${{ inputs.run-unit-tests }}
+        run: npm run test:unit:node
+
       - name: Build Wasm examples
         run: npm run build:examples
 
       - name: Stop sccache
         uses: './.github/actions/rust/sccache/stop-sccache'
-        with:    
+        with:
           os: ${{matrix.os}}
 
       - name: Upload artifact

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -198,9 +198,9 @@ This variant is the default used if no other variant is specified when construct
 <dt><a href="#FirstError">FirstError</a></dt>
 <dd><p>Return after the first error occurs.</p>
 </dd>
-<dt><a href="#KeyType">KeyType</a></dt>
-<dd></dd>
 <dt><a href="#MethodRelationship">MethodRelationship</a></dt>
+<dd></dd>
+<dt><a href="#KeyType">KeyType</a></dt>
 <dd></dd>
 </dl>
 
@@ -244,9 +244,9 @@ publishing to the Tangle.
     * [.unrevokeCredentials(fragment, indices)](#Account+unrevokeCredentials) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.encryptData(plaintext, associated_data, encryption_algorithm, cek_algorithm, public_key)](#Account+encryptData) ⇒ [<code>Promise.&lt;EncryptedData&gt;</code>](#EncryptedData)
     * [.decryptData(data, encryption_algorithm, cek_algorithm, fragment)](#Account+decryptData) ⇒ <code>Promise.&lt;Uint8Array&gt;</code>
+    * [.deleteMethod(options)](#Account+deleteMethod) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.deleteService(options)](#Account+deleteService) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.setAlsoKnownAs(options)](#Account+setAlsoKnownAs) ⇒ <code>Promise.&lt;void&gt;</code>
-    * [.deleteMethod(options)](#Account+deleteMethod) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.setController(options)](#Account+setController) ⇒ <code>Promise.&lt;void&gt;</code>
 
 <a name="Account+createService"></a>
@@ -487,6 +487,17 @@ Returns the decrypted text.
 | cek_algorithm | [<code>CekAlgorithm</code>](#CekAlgorithm) | 
 | fragment | <code>string</code> | 
 
+<a name="Account+deleteMethod"></a>
+
+### account.deleteMethod(options) ⇒ <code>Promise.&lt;void&gt;</code>
+Deletes a verification method if the method exists.
+
+**Kind**: instance method of [<code>Account</code>](#Account)  
+
+| Param | Type |
+| --- | --- |
+| options | <code>DeleteMethodOptions</code> | 
+
 <a name="Account+deleteService"></a>
 
 ### account.deleteService(options) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -508,17 +519,6 @@ Sets the `alsoKnownAs` property in the DID document.
 | Param | Type |
 | --- | --- |
 | options | <code>SetAlsoKnownAsOptions</code> | 
-
-<a name="Account+deleteMethod"></a>
-
-### account.deleteMethod(options) ⇒ <code>Promise.&lt;void&gt;</code>
-Deletes a verification method if the method exists.
-
-**Kind**: instance method of [<code>Account</code>](#Account)  
-
-| Param | Type |
-| --- | --- |
-| options | <code>DeleteMethodOptions</code> | 
 
 <a name="Account+setController"></a>
 
@@ -5061,13 +5061,13 @@ Return all errors that occur during validation.
 Return after the first error occurs.
 
 **Kind**: global variable  
-<a name="KeyType"></a>
-
-## KeyType
-**Kind**: global variable  
 <a name="MethodRelationship"></a>
 
 ## MethodRelationship
+**Kind**: global variable  
+<a name="KeyType"></a>
+
+## KeyType
 **Kind**: global variable  
 <a name="start"></a>
 

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -128,7 +128,8 @@ with a DID subject.</p>
 <p>See: <a href="https://www.w3.org/TR/did-core/#services">https://www.w3.org/TR/did-core/#services</a></p>
 </dd>
 <dt><a href="#Signature">Signature</a></dt>
-<dd></dd>
+<dd><p>A digital signature.</p>
+</dd>
 <dt><a href="#StorageTestSuite">StorageTestSuite</a></dt>
 <dd><p>A test suite for the <code>Storage</code> interface.</p>
 <p>This module contains a set of tests that a correct storage implementation
@@ -223,7 +224,9 @@ publishing to the Tangle.
 
 * [Account](#Account)
     * [.createService(options)](#Account+createService) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.attachMethodRelationships(options)](#Account+attachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.createMethod(options)](#Account+createMethod) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.detachMethodRelationships(options)](#Account+detachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.did()](#Account+did) ⇒ [<code>DID</code>](#DID)
     * [.autopublish()](#Account+autopublish) ⇒ <code>boolean</code>
     * [.autosave()](#Account+autosave) ⇒ [<code>AutoSave</code>](#AutoSave)
@@ -241,12 +244,10 @@ publishing to the Tangle.
     * [.unrevokeCredentials(fragment, indices)](#Account+unrevokeCredentials) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.encryptData(plaintext, associated_data, encryption_algorithm, cek_algorithm, public_key)](#Account+encryptData) ⇒ [<code>Promise.&lt;EncryptedData&gt;</code>](#EncryptedData)
     * [.decryptData(data, encryption_algorithm, cek_algorithm, fragment)](#Account+decryptData) ⇒ <code>Promise.&lt;Uint8Array&gt;</code>
-    * [.attachMethodRelationships(options)](#Account+attachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
-    * [.detachMethodRelationships(options)](#Account+detachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.deleteService(options)](#Account+deleteService) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.setAlsoKnownAs(options)](#Account+setAlsoKnownAs) ⇒ <code>Promise.&lt;void&gt;</code>
-    * [.setController(options)](#Account+setController) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.deleteMethod(options)](#Account+deleteMethod) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.setController(options)](#Account+setController) ⇒ <code>Promise.&lt;void&gt;</code>
 
 <a name="Account+createService"></a>
 
@@ -259,6 +260,20 @@ Adds a new Service to the DID Document.
 | --- | --- |
 | options | <code>CreateServiceOptions</code> | 
 
+<a name="Account+attachMethodRelationships"></a>
+
+### account.attachMethodRelationships(options) ⇒ <code>Promise.&lt;void&gt;</code>
+Attach one or more verification relationships to a method.
+
+Note: the method must exist and be in the set of verification methods;
+it cannot be an embedded method.
+
+**Kind**: instance method of [<code>Account</code>](#Account)  
+
+| Param | Type |
+| --- | --- |
+| options | <code>AttachMethodRelationshipOptions</code> | 
+
 <a name="Account+createMethod"></a>
 
 ### account.createMethod(options) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -269,6 +284,17 @@ Adds a new verification method to the DID document.
 | Param | Type |
 | --- | --- |
 | options | <code>CreateMethodOptions</code> | 
+
+<a name="Account+detachMethodRelationships"></a>
+
+### account.detachMethodRelationships(options) ⇒ <code>Promise.&lt;void&gt;</code>
+Detaches the given relationship from the given method, if the method exists.
+
+**Kind**: instance method of [<code>Account</code>](#Account)  
+
+| Param | Type |
+| --- | --- |
+| options | <code>DetachMethodRelationshipOptions</code> | 
 
 <a name="Account+did"></a>
 
@@ -461,31 +487,6 @@ Returns the decrypted text.
 | cek_algorithm | [<code>CekAlgorithm</code>](#CekAlgorithm) | 
 | fragment | <code>string</code> | 
 
-<a name="Account+attachMethodRelationships"></a>
-
-### account.attachMethodRelationships(options) ⇒ <code>Promise.&lt;void&gt;</code>
-Attach one or more verification relationships to a method.
-
-Note: the method must exist and be in the set of verification methods;
-it cannot be an embedded method.
-
-**Kind**: instance method of [<code>Account</code>](#Account)  
-
-| Param | Type |
-| --- | --- |
-| options | <code>AttachMethodRelationshipOptions</code> | 
-
-<a name="Account+detachMethodRelationships"></a>
-
-### account.detachMethodRelationships(options) ⇒ <code>Promise.&lt;void&gt;</code>
-Detaches the given relationship from the given method, if the method exists.
-
-**Kind**: instance method of [<code>Account</code>](#Account)  
-
-| Param | Type |
-| --- | --- |
-| options | <code>DetachMethodRelationshipOptions</code> | 
-
 <a name="Account+deleteService"></a>
 
 ### account.deleteService(options) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -508,17 +509,6 @@ Sets the `alsoKnownAs` property in the DID document.
 | --- | --- |
 | options | <code>SetAlsoKnownAsOptions</code> | 
 
-<a name="Account+setController"></a>
-
-### account.setController(options) ⇒ <code>Promise.&lt;void&gt;</code>
-Sets the controllers of the DID document.
-
-**Kind**: instance method of [<code>Account</code>](#Account)  
-
-| Param | Type |
-| --- | --- |
-| options | <code>SetControllerOptions</code> | 
-
 <a name="Account+deleteMethod"></a>
 
 ### account.deleteMethod(options) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -529,6 +519,17 @@ Deletes a verification method if the method exists.
 | Param | Type |
 | --- | --- |
 | options | <code>DeleteMethodOptions</code> | 
+
+<a name="Account+setController"></a>
+
+### account.setController(options) ⇒ <code>Promise.&lt;void&gt;</code>
+Sets the controllers of the DID document.
+
+**Kind**: instance method of [<code>Account</code>](#Account)  
+
+| Param | Type |
+| --- | --- |
+| options | <code>SetControllerOptions</code> | 
 
 <a name="AccountBuilder"></a>
 
@@ -602,7 +603,7 @@ Agreement information used as the input for the concat KDF.
         * [.privInfo()](#AgreementInfo+privInfo) ⇒ <code>Uint8Array</code>
         * [.toJSON()](#AgreementInfo+toJSON) ⇒ <code>any</code>
     * _static_
-        * [.fromJSON(json_value)](#AgreementInfo.fromJSON) ⇒ [<code>AgreementInfo</code>](#AgreementInfo)
+        * [.fromJSON(json)](#AgreementInfo.fromJSON) ⇒ [<code>AgreementInfo</code>](#AgreementInfo)
 
 <a name="new_AgreementInfo_new"></a>
 
@@ -644,19 +645,19 @@ Returns a copy of `privInfo'
 <a name="AgreementInfo+toJSON"></a>
 
 ### agreementInfo.toJSON() ⇒ <code>any</code>
-Serializes `AgreementInfo` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>AgreementInfo</code>](#AgreementInfo)  
 <a name="AgreementInfo.fromJSON"></a>
 
-### AgreementInfo.fromJSON(json_value) ⇒ [<code>AgreementInfo</code>](#AgreementInfo)
-Deserializes `AgreementInfo` from a JSON object.
+### AgreementInfo.fromJSON(json) ⇒ [<code>AgreementInfo</code>](#AgreementInfo)
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>AgreementInfo</code>](#AgreementInfo)  
 
 | Param | Type |
 | --- | --- |
-| json_value | <code>any</code> | 
+| json | <code>any</code> | 
 
 <a name="AutoSave"></a>
 
@@ -670,12 +671,12 @@ Deserializes `AgreementInfo` from a JSON object.
         * [.never()](#AutoSave.never) ⇒ [<code>AutoSave</code>](#AutoSave)
         * [.every()](#AutoSave.every) ⇒ [<code>AutoSave</code>](#AutoSave)
         * [.batch(number_of_actions)](#AutoSave.batch) ⇒ [<code>AutoSave</code>](#AutoSave)
-        * [.fromJSON(json_value)](#AutoSave.fromJSON) ⇒ [<code>AutoSave</code>](#AutoSave)
+        * [.fromJSON(json)](#AutoSave.fromJSON) ⇒ [<code>AutoSave</code>](#AutoSave)
 
 <a name="AutoSave+toJSON"></a>
 
 ### autoSave.toJSON() ⇒ <code>any</code>
-Serializes `AutoSave` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>AutoSave</code>](#AutoSave)  
 <a name="AutoSave.never"></a>
@@ -703,14 +704,14 @@ Save after every N actions.
 
 <a name="AutoSave.fromJSON"></a>
 
-### AutoSave.fromJSON(json_value) ⇒ [<code>AutoSave</code>](#AutoSave)
-Deserializes `AutoSave` from a JSON object.
+### AutoSave.fromJSON(json) ⇒ [<code>AutoSave</code>](#AutoSave)
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>AutoSave</code>](#AutoSave)  
 
 | Param | Type |
 | --- | --- |
-| json_value | <code>any</code> | 
+| json | <code>any</code> | 
 
 <a name="CekAlgorithm"></a>
 
@@ -725,12 +726,12 @@ Supported algorithms used to determine and potentially encrypt the content encry
     * _static_
         * [.EcdhEs(agreement)](#CekAlgorithm.EcdhEs) ⇒ [<code>CekAlgorithm</code>](#CekAlgorithm)
         * [.EcdhEsA256Kw(agreement)](#CekAlgorithm.EcdhEsA256Kw) ⇒ [<code>CekAlgorithm</code>](#CekAlgorithm)
-        * [.fromJSON(json_value)](#CekAlgorithm.fromJSON) ⇒ [<code>CekAlgorithm</code>](#CekAlgorithm)
+        * [.fromJSON(json)](#CekAlgorithm.fromJSON) ⇒ [<code>CekAlgorithm</code>](#CekAlgorithm)
 
 <a name="CekAlgorithm+toJSON"></a>
 
 ### cekAlgorithm.toJSON() ⇒ <code>any</code>
-Serializes `CekAlgorithm` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>CekAlgorithm</code>](#CekAlgorithm)  
 <a name="CekAlgorithm.EcdhEs"></a>
@@ -757,14 +758,14 @@ Elliptic Curve Diffie-Hellman Ephemeral Static key agreement using Concat KDF.
 
 <a name="CekAlgorithm.fromJSON"></a>
 
-### CekAlgorithm.fromJSON(json_value) ⇒ [<code>CekAlgorithm</code>](#CekAlgorithm)
-Deserializes `CekAlgorithm` from a JSON object.
+### CekAlgorithm.fromJSON(json) ⇒ [<code>CekAlgorithm</code>](#CekAlgorithm)
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>CekAlgorithm</code>](#CekAlgorithm)  
 
 | Param | Type |
 | --- | --- |
-| json_value | <code>any</code> | 
+| json | <code>any</code> | 
 
 <a name="ChainState"></a>
 
@@ -774,25 +775,32 @@ Deserializes `CekAlgorithm` from a JSON object.
 * [ChainState](#ChainState)
     * _instance_
         * [.toJSON()](#ChainState+toJSON) ⇒ <code>any</code>
+        * [.clone()](#ChainState+clone) ⇒ [<code>ChainState</code>](#ChainState)
     * _static_
-        * [.fromJSON(json_value)](#ChainState.fromJSON) ⇒ [<code>ChainState</code>](#ChainState)
+        * [.fromJSON(json)](#ChainState.fromJSON) ⇒ [<code>ChainState</code>](#ChainState)
 
 <a name="ChainState+toJSON"></a>
 
 ### chainState.toJSON() ⇒ <code>any</code>
-Serializes a `ChainState` object as a JSON object.
+Serializes this to a JSON object.
+
+**Kind**: instance method of [<code>ChainState</code>](#ChainState)  
+<a name="ChainState+clone"></a>
+
+### chainState.clone() ⇒ [<code>ChainState</code>](#ChainState)
+Deep clones the object.
 
 **Kind**: instance method of [<code>ChainState</code>](#ChainState)  
 <a name="ChainState.fromJSON"></a>
 
-### ChainState.fromJSON(json_value) ⇒ [<code>ChainState</code>](#ChainState)
-Deserializes a JSON object as `ChainState`.
+### ChainState.fromJSON(json) ⇒ [<code>ChainState</code>](#ChainState)
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>ChainState</code>](#ChainState)  
 
 | Param | Type |
 | --- | --- |
-| json_value | <code>any</code> | 
+| json | <code>any</code> | 
 
 <a name="Client"></a>
 
@@ -1073,7 +1081,7 @@ Returns a copy of the miscellaneous properties on the `Credential`.
 <a name="Credential+toJSON"></a>
 
 ### credential.toJSON() ⇒ <code>any</code>
-Serializes a `Credential` to a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>Credential</code>](#Credential)  
 <a name="Credential+clone"></a>
@@ -1097,7 +1105,7 @@ Returns the base type.
 <a name="Credential.fromJSON"></a>
 
 ### Credential.fromJSON(json) ⇒ [<code>Credential</code>](#Credential)
-Deserializes a `Credential` from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>Credential</code>](#Credential)  
 
@@ -1136,7 +1144,7 @@ Throws an error if any of the options are invalid.
 <a name="CredentialValidationOptions+toJSON"></a>
 
 ### credentialValidationOptions.toJSON() ⇒ <code>any</code>
-Serializes a `CredentialValidationOptions` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>CredentialValidationOptions</code>](#CredentialValidationOptions)  
 <a name="CredentialValidationOptions+clone"></a>
@@ -1154,7 +1162,7 @@ Creates a new `CredentialValidationOptions` with defaults.
 <a name="CredentialValidationOptions.fromJSON"></a>
 
 ### CredentialValidationOptions.fromJSON(json) ⇒ [<code>CredentialValidationOptions</code>](#CredentialValidationOptions)
-Deserializes a `CredentialValidationOptions` from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>CredentialValidationOptions</code>](#CredentialValidationOptions)  
 
@@ -1335,7 +1343,7 @@ Fails if the issuer field is not a valid DID.
         * [.clone()](#DID+clone) ⇒ [<code>DID</code>](#DID)
     * _static_
         * [.parse(input)](#DID.parse) ⇒ [<code>DID</code>](#DID)
-        * [.fromJSON(json_value)](#DID.fromJSON) ⇒ [<code>DID</code>](#DID)
+        * [.fromJSON(json)](#DID.fromJSON) ⇒ [<code>DID</code>](#DID)
 
 <a name="new_DID_new"></a>
 
@@ -1398,7 +1406,7 @@ Returns the `DID` as a string.
 <a name="DID+toJSON"></a>
 
 ### did.toJSON() ⇒ <code>any</code>
-Serializes a `DID` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>DID</code>](#DID)  
 <a name="DID+clone"></a>
@@ -1420,14 +1428,14 @@ Parses a `DID` from the input string.
 
 <a name="DID.fromJSON"></a>
 
-### DID.fromJSON(json_value) ⇒ [<code>DID</code>](#DID)
-Deserializes a JSON object as `DID`.
+### DID.fromJSON(json) ⇒ [<code>DID</code>](#DID)
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>DID</code>](#DID)  
 
 | Param | Type |
 | --- | --- |
-| json_value | <code>any</code> | 
+| json | <code>any</code> | 
 
 <a name="DIDUrl"></a>
 
@@ -1450,6 +1458,7 @@ Deserializes a JSON object as `DID`.
         * [.clone()](#DIDUrl+clone) ⇒ [<code>DIDUrl</code>](#DIDUrl)
     * _static_
         * [.parse(input)](#DIDUrl.parse) ⇒ [<code>DIDUrl</code>](#DIDUrl)
+        * [.fromJSON(json)](#DIDUrl.fromJSON) ⇒ [<code>DIDUrl</code>](#DIDUrl)
 
 <a name="DIDUrl+did"></a>
 
@@ -1542,7 +1551,7 @@ Returns the `DIDUrl` as a string.
 <a name="DIDUrl+toJSON"></a>
 
 ### didUrl.toJSON() ⇒ <code>any</code>
-Serializes a `DIDUrl` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>DIDUrl</code>](#DIDUrl)  
 <a name="DIDUrl+clone"></a>
@@ -1561,6 +1570,17 @@ Parses a `DIDUrl` from the input string.
 | Param | Type |
 | --- | --- |
 | input | <code>string</code> | 
+
+<a name="DIDUrl.fromJSON"></a>
+
+### DIDUrl.fromJSON(json) ⇒ [<code>DIDUrl</code>](#DIDUrl)
+Deserializes an instance from a JSON object.
+
+**Kind**: static method of [<code>DIDUrl</code>](#DIDUrl)  
+
+| Param | Type |
+| --- | --- |
+| json | <code>any</code> | 
 
 <a name="DiffChainHistory"></a>
 
@@ -1630,10 +1650,10 @@ Defines the difference between two DID `Document`s' JSON representations.
         * ~~[.setPreviousMessageId(message_id)](#DiffMessage+setPreviousMessageId)~~
         * ~~[.proof()](#DiffMessage+proof) ⇒ [<code>Proof</code>](#Proof) \| <code>undefined</code>~~
         * ~~[.merge(document)](#DiffMessage+merge) ⇒ [<code>Document</code>](#Document)~~
-        * ~~[.toJSON()](#DiffMessage+toJSON) ⇒ <code>any</code>~~
+        * [.toJSON()](#DiffMessage+toJSON) ⇒ <code>any</code>
         * [.clone()](#DiffMessage+clone) ⇒ [<code>DiffMessage</code>](#DiffMessage)
     * _static_
-        * ~~[.fromJSON(json)](#DiffMessage.fromJSON) ⇒ [<code>DiffMessage</code>](#DiffMessage)~~
+        * [.fromJSON(json)](#DiffMessage.fromJSON) ⇒ [<code>DiffMessage</code>](#DiffMessage)
 
 <a name="DiffMessage+id"></a>
 
@@ -1727,10 +1747,8 @@ with the given Document.
 
 <a name="DiffMessage+toJSON"></a>
 
-### ~~diffMessage.toJSON() ⇒ <code>any</code>~~
-***Deprecated***
-
-Serializes a `DiffMessage` as a JSON object.
+### diffMessage.toJSON() ⇒ <code>any</code>
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>DiffMessage</code>](#DiffMessage)  
 <a name="DiffMessage+clone"></a>
@@ -1741,10 +1759,8 @@ Deep clones the object.
 **Kind**: instance method of [<code>DiffMessage</code>](#DiffMessage)  
 <a name="DiffMessage.fromJSON"></a>
 
-### ~~DiffMessage.fromJSON(json) ⇒ [<code>DiffMessage</code>](#DiffMessage)~~
-***Deprecated***
-
-Deserializes a `DiffMessage` from a JSON object.
+### DiffMessage.fromJSON(json) ⇒ [<code>DiffMessage</code>](#DiffMessage)
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>DiffMessage</code>](#DiffMessage)  
 
@@ -2307,7 +2323,7 @@ unrevoke all specified `indices`.
 <a name="Document+toJSON"></a>
 
 ### document.toJSON() ⇒ <code>any</code>
-Serializes a `Document` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>Document</code>](#Document)  
 <a name="Document+clone"></a>
@@ -2374,7 +2390,7 @@ This is the Base58-btc encoded SHA-256 digest of the hex-encoded message id.
 <a name="Document.fromJSON"></a>
 
 ### Document.fromJSON(json) ⇒ [<code>Document</code>](#Document)
-Deserializes a `Document` from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>Document</code>](#Document)  
 
@@ -2441,7 +2457,7 @@ NOTE: clones the data.
 <a name="DocumentHistory+toJSON"></a>
 
 ### documentHistory.toJSON() ⇒ <code>any</code>
-Serializes `DocumentHistory` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>DocumentHistory</code>](#DocumentHistory)  
 <a name="DocumentHistory+clone"></a>
@@ -2453,7 +2469,7 @@ Deep clones the object.
 <a name="DocumentHistory.fromJSON"></a>
 
 ### DocumentHistory.fromJSON(json) ⇒ [<code>DocumentHistory</code>](#DocumentHistory)
-Deserializes `DocumentHistory` from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>DocumentHistory</code>](#DocumentHistory)  
 
@@ -2469,10 +2485,14 @@ Additional attributes related to an IOTA DID Document.
 **Kind**: global class  
 
 * [DocumentMetadata](#DocumentMetadata)
-    * [.previousMessageId](#DocumentMetadata+previousMessageId) ⇒ <code>string</code>
-    * [.created()](#DocumentMetadata+created) ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
-    * [.updated()](#DocumentMetadata+updated) ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
-    * [.clone()](#DocumentMetadata+clone) ⇒ [<code>DocumentMetadata</code>](#DocumentMetadata)
+    * _instance_
+        * [.previousMessageId](#DocumentMetadata+previousMessageId) ⇒ <code>string</code>
+        * [.created()](#DocumentMetadata+created) ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
+        * [.updated()](#DocumentMetadata+updated) ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
+        * [.toJSON()](#DocumentMetadata+toJSON) ⇒ <code>any</code>
+        * [.clone()](#DocumentMetadata+clone) ⇒ [<code>DocumentMetadata</code>](#DocumentMetadata)
+    * _static_
+        * [.fromJSON(json)](#DocumentMetadata.fromJSON) ⇒ [<code>DocumentMetadata</code>](#DocumentMetadata)
 
 <a name="DocumentMetadata+previousMessageId"></a>
 
@@ -2490,12 +2510,29 @@ Returns a copy of the timestamp of when the DID document was created.
 Returns a copy of the timestamp of the last DID document update.
 
 **Kind**: instance method of [<code>DocumentMetadata</code>](#DocumentMetadata)  
+<a name="DocumentMetadata+toJSON"></a>
+
+### documentMetadata.toJSON() ⇒ <code>any</code>
+Serializes this to a JSON object.
+
+**Kind**: instance method of [<code>DocumentMetadata</code>](#DocumentMetadata)  
 <a name="DocumentMetadata+clone"></a>
 
 ### documentMetadata.clone() ⇒ [<code>DocumentMetadata</code>](#DocumentMetadata)
 Deep clones the object.
 
 **Kind**: instance method of [<code>DocumentMetadata</code>](#DocumentMetadata)  
+<a name="DocumentMetadata.fromJSON"></a>
+
+### DocumentMetadata.fromJSON(json) ⇒ [<code>DocumentMetadata</code>](#DocumentMetadata)
+Deserializes an instance from a JSON object.
+
+**Kind**: static method of [<code>DocumentMetadata</code>](#DocumentMetadata)  
+
+| Param | Type |
+| --- | --- |
+| json | <code>any</code> | 
+
 <a name="Duration"></a>
 
 ## Duration
@@ -2517,7 +2554,7 @@ A span of time.
 <a name="Duration+toJSON"></a>
 
 ### duration.toJSON() ⇒ <code>any</code>
-Serializes a `Duration` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>Duration</code>](#Duration)  
 <a name="Duration.seconds"></a>
@@ -2578,7 +2615,7 @@ Create a new `Duration` with the given number of weeks.
 <a name="Duration.fromJSON"></a>
 
 ### Duration.fromJSON(json) ⇒ [<code>Duration</code>](#Duration)
-Deserializes a `Duration` from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>Duration</code>](#Duration)  
 
@@ -2665,7 +2702,7 @@ The structure returned after encrypting data
         * [.tag()](#EncryptedData+tag) ⇒ <code>Uint8Array</code>
         * [.toJSON()](#EncryptedData+toJSON) ⇒ <code>any</code>
     * _static_
-        * [.fromJSON(json_value)](#EncryptedData.fromJSON) ⇒ [<code>EncryptedData</code>](#EncryptedData)
+        * [.fromJSON(json)](#EncryptedData.fromJSON) ⇒ [<code>EncryptedData</code>](#EncryptedData)
 
 <a name="EncryptedData+nonce"></a>
 
@@ -2694,19 +2731,19 @@ Returns a copy of the tag
 <a name="EncryptedData+toJSON"></a>
 
 ### encryptedData.toJSON() ⇒ <code>any</code>
-Serializes `EncryptedData` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>EncryptedData</code>](#EncryptedData)  
 <a name="EncryptedData.fromJSON"></a>
 
-### EncryptedData.fromJSON(json_value) ⇒ [<code>EncryptedData</code>](#EncryptedData)
-Deserializes `EncryptedData` from a JSON object.
+### EncryptedData.fromJSON(json) ⇒ [<code>EncryptedData</code>](#EncryptedData)
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>EncryptedData</code>](#EncryptedData)  
 
 | Param | Type |
 | --- | --- |
-| json_value | <code>any</code> | 
+| json | <code>any</code> | 
 
 <a name="EncryptionAlgorithm"></a>
 
@@ -2721,7 +2758,7 @@ Supported content encryption algorithms.
         * [.toJSON()](#EncryptionAlgorithm+toJSON) ⇒ <code>any</code>
     * _static_
         * [.A256GCM()](#EncryptionAlgorithm.A256GCM) ⇒ [<code>EncryptionAlgorithm</code>](#EncryptionAlgorithm)
-        * [.fromJSON(json_value)](#EncryptionAlgorithm.fromJSON) ⇒ [<code>EncryptionAlgorithm</code>](#EncryptionAlgorithm)
+        * [.fromJSON(json)](#EncryptionAlgorithm.fromJSON) ⇒ [<code>EncryptionAlgorithm</code>](#EncryptionAlgorithm)
 
 <a name="EncryptionAlgorithm+keyLength"></a>
 
@@ -2732,7 +2769,7 @@ Returns the length of the cipher's key.
 <a name="EncryptionAlgorithm+toJSON"></a>
 
 ### encryptionAlgorithm.toJSON() ⇒ <code>any</code>
-Serializes `EncryptionAlgorithm` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>EncryptionAlgorithm</code>](#EncryptionAlgorithm)  
 <a name="EncryptionAlgorithm.A256GCM"></a>
@@ -2743,14 +2780,14 @@ AES GCM using 256-bit key.
 **Kind**: static method of [<code>EncryptionAlgorithm</code>](#EncryptionAlgorithm)  
 <a name="EncryptionAlgorithm.fromJSON"></a>
 
-### EncryptionAlgorithm.fromJSON(json_value) ⇒ [<code>EncryptionAlgorithm</code>](#EncryptionAlgorithm)
-Deserializes `EncryptionAlgorithm` from a JSON object.
+### EncryptionAlgorithm.fromJSON(json) ⇒ [<code>EncryptionAlgorithm</code>](#EncryptionAlgorithm)
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>EncryptionAlgorithm</code>](#EncryptionAlgorithm)  
 
 | Param | Type |
 | --- | --- |
-| json_value | <code>any</code> | 
+| json | <code>any</code> | 
 
 <a name="ExplorerUrl"></a>
 
@@ -2762,10 +2799,12 @@ Deserializes `EncryptionAlgorithm` from a JSON object.
         * [.messageUrl(message_id)](#ExplorerUrl+messageUrl) ⇒ <code>string</code>
         * [.resolverUrl(did)](#ExplorerUrl+resolverUrl) ⇒ <code>string</code>
         * [.toString()](#ExplorerUrl+toString) ⇒ <code>string</code>
+        * [.toJSON()](#ExplorerUrl+toJSON) ⇒ <code>any</code>
     * _static_
         * [.parse(url)](#ExplorerUrl.parse) ⇒ [<code>ExplorerUrl</code>](#ExplorerUrl)
         * [.mainnet()](#ExplorerUrl.mainnet) ⇒ [<code>ExplorerUrl</code>](#ExplorerUrl)
         * [.devnet()](#ExplorerUrl.devnet) ⇒ [<code>ExplorerUrl</code>](#ExplorerUrl)
+        * [.fromJSON(json)](#ExplorerUrl.fromJSON) ⇒ [<code>ExplorerUrl</code>](#ExplorerUrl)
 
 <a name="ExplorerUrl+messageUrl"></a>
 
@@ -2797,6 +2836,12 @@ E.g. https://explorer.iota.org/mainnet/identity-resolver/{did}
 
 ### explorerUrl.toString() ⇒ <code>string</code>
 **Kind**: instance method of [<code>ExplorerUrl</code>](#ExplorerUrl)  
+<a name="ExplorerUrl+toJSON"></a>
+
+### explorerUrl.toJSON() ⇒ <code>any</code>
+Serializes this to a JSON object.
+
+**Kind**: instance method of [<code>ExplorerUrl</code>](#ExplorerUrl)  
 <a name="ExplorerUrl.parse"></a>
 
 ### ExplorerUrl.parse(url) ⇒ [<code>ExplorerUrl</code>](#ExplorerUrl)
@@ -2823,6 +2868,17 @@ Returns the Tangle explorer URL for the mainnet.
 Returns the Tangle explorer URL for the devnet.
 
 **Kind**: static method of [<code>ExplorerUrl</code>](#ExplorerUrl)  
+<a name="ExplorerUrl.fromJSON"></a>
+
+### ExplorerUrl.fromJSON(json) ⇒ [<code>ExplorerUrl</code>](#ExplorerUrl)
+Deserializes an instance from a JSON object.
+
+**Kind**: static method of [<code>ExplorerUrl</code>](#ExplorerUrl)  
+
+| Param | Type |
+| --- | --- |
+| json | <code>any</code> | 
+
 <a name="IntegrationChainHistory"></a>
 
 ## IntegrationChainHistory
@@ -2889,11 +2945,11 @@ The string representation of that location can be obtained via `canonicalRepr`.
     * _instance_
         * [.canonical()](#KeyLocation+canonical) ⇒ <code>string</code>
         * [.keyType()](#KeyLocation+keyType) ⇒ <code>number</code>
-        * [.toJSON()](#KeyLocation+toJSON) ⇒ <code>any</code>
         * [.toString()](#KeyLocation+toString) ⇒ <code>string</code>
+        * [.toJSON()](#KeyLocation+toJSON) ⇒ <code>any</code>
     * _static_
         * [.fromVerificationMethod(method)](#KeyLocation.fromVerificationMethod) ⇒ [<code>KeyLocation</code>](#KeyLocation)
-        * [.fromJSON(json_value)](#KeyLocation.fromJSON) ⇒ [<code>KeyLocation</code>](#KeyLocation)
+        * [.fromJSON(json)](#KeyLocation.fromJSON) ⇒ [<code>KeyLocation</code>](#KeyLocation)
 
 <a name="new_KeyLocation_new"></a>
 
@@ -2922,15 +2978,15 @@ This should be used as the representation for storage keys.
 Returns a copy of the key type of the key location.
 
 **Kind**: instance method of [<code>KeyLocation</code>](#KeyLocation)  
-<a name="KeyLocation+toJSON"></a>
-
-### keyLocation.toJSON() ⇒ <code>any</code>
-Serializes `KeyLocation` as a JSON object.
-
-**Kind**: instance method of [<code>KeyLocation</code>](#KeyLocation)  
 <a name="KeyLocation+toString"></a>
 
 ### keyLocation.toString() ⇒ <code>string</code>
+**Kind**: instance method of [<code>KeyLocation</code>](#KeyLocation)  
+<a name="KeyLocation+toJSON"></a>
+
+### keyLocation.toJSON() ⇒ <code>any</code>
+Serializes this to a JSON object.
+
 **Kind**: instance method of [<code>KeyLocation</code>](#KeyLocation)  
 <a name="KeyLocation.fromVerificationMethod"></a>
 
@@ -2945,14 +3001,14 @@ Obtain the location of a verification method's key in storage.
 
 <a name="KeyLocation.fromJSON"></a>
 
-### KeyLocation.fromJSON(json_value) ⇒ [<code>KeyLocation</code>](#KeyLocation)
-Deserializes a JSON object into a `KeyLocation`.
+### KeyLocation.fromJSON(json) ⇒ [<code>KeyLocation</code>](#KeyLocation)
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>KeyLocation</code>](#KeyLocation)  
 
 | Param | Type |
 | --- | --- |
-| json_value | <code>any</code> | 
+| json | <code>any</code> | 
 
 <a name="KeyPair"></a>
 
@@ -3067,12 +3123,12 @@ Deserializes a `KeyPair` object from a JSON object.
         * [.GenerateX25519()](#MethodContent.GenerateX25519) ⇒ [<code>MethodContent</code>](#MethodContent)
         * [.PrivateX25519(privateKey)](#MethodContent.PrivateX25519) ⇒ [<code>MethodContent</code>](#MethodContent)
         * [.PublicX25519(publicKey)](#MethodContent.PublicX25519) ⇒ [<code>MethodContent</code>](#MethodContent)
-        * [.fromJSON(json_value)](#MethodContent.fromJSON) ⇒ [<code>MethodContent</code>](#MethodContent)
+        * [.fromJSON(json)](#MethodContent.fromJSON) ⇒ [<code>MethodContent</code>](#MethodContent)
 
 <a name="MethodContent+toJSON"></a>
 
 ### methodContent.toJSON() ⇒ <code>any</code>
-Serializes `MethodContent` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>MethodContent</code>](#MethodContent)  
 <a name="MethodContent.GenerateEd25519"></a>
@@ -3141,14 +3197,14 @@ NOTE: the method will be unable to be used for key exchange without a private ke
 
 <a name="MethodContent.fromJSON"></a>
 
-### MethodContent.fromJSON(json_value) ⇒ [<code>MethodContent</code>](#MethodContent)
-Deserializes `MethodContent` from a JSON object.
+### MethodContent.fromJSON(json) ⇒ [<code>MethodContent</code>](#MethodContent)
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>MethodContent</code>](#MethodContent)  
 
 | Param | Type |
 | --- | --- |
-| json_value | <code>any</code> | 
+| json | <code>any</code> | 
 
 <a name="MethodData"></a>
 
@@ -3182,7 +3238,7 @@ represented as a vector of bytes.
 <a name="MethodData+toJSON"></a>
 
 ### methodData.toJSON() ⇒ <code>any</code>
-Serializes a `MethodData` object as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>MethodData</code>](#MethodData)  
 <a name="MethodData+clone"></a>
@@ -3216,7 +3272,7 @@ Creates a new `MethodData` variant with Multibase-encoded content.
 <a name="MethodData.fromJSON"></a>
 
 ### MethodData.fromJSON(json) ⇒ [<code>MethodData</code>](#MethodData)
-Deserializes a `MethodData` object from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>MethodData</code>](#MethodData)  
 
@@ -3254,7 +3310,7 @@ Returns the `MethodScope` as a string.
 <a name="MethodScope+toJSON"></a>
 
 ### methodScope.toJSON() ⇒ <code>any</code>
-Serializes a `MethodScope` object as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>MethodScope</code>](#MethodScope)  
 <a name="MethodScope+clone"></a>
@@ -3290,7 +3346,7 @@ Deep clones the object.
 <a name="MethodScope.fromJSON"></a>
 
 ### MethodScope.fromJSON(json) ⇒ [<code>MethodScope</code>](#MethodScope)
-Deserializes a `MethodScope` object from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>MethodScope</code>](#MethodScope)  
 
@@ -3307,24 +3363,24 @@ Supported verification method types.
 
 * [MethodType](#MethodType)
     * _instance_
-        * [.toJSON()](#MethodType+toJSON) ⇒ <code>any</code>
         * [.toString()](#MethodType+toString) ⇒ <code>string</code>
+        * [.toJSON()](#MethodType+toJSON) ⇒ <code>any</code>
         * [.clone()](#MethodType+clone) ⇒ [<code>MethodType</code>](#MethodType)
     * _static_
         * [.Ed25519VerificationKey2018()](#MethodType.Ed25519VerificationKey2018) ⇒ [<code>MethodType</code>](#MethodType)
         * [.X25519KeyAgreementKey2019()](#MethodType.X25519KeyAgreementKey2019) ⇒ [<code>MethodType</code>](#MethodType)
         * [.fromJSON(json)](#MethodType.fromJSON) ⇒ [<code>MethodType</code>](#MethodType)
 
-<a name="MethodType+toJSON"></a>
-
-### methodType.toJSON() ⇒ <code>any</code>
-Serializes a `MethodType` object as a JSON object.
-
-**Kind**: instance method of [<code>MethodType</code>](#MethodType)  
 <a name="MethodType+toString"></a>
 
 ### methodType.toString() ⇒ <code>string</code>
 Returns the `MethodType` as a string.
+
+**Kind**: instance method of [<code>MethodType</code>](#MethodType)  
+<a name="MethodType+toJSON"></a>
+
+### methodType.toJSON() ⇒ <code>any</code>
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>MethodType</code>](#MethodType)  
 <a name="MethodType+clone"></a>
@@ -3344,7 +3400,7 @@ Deep clones the object.
 <a name="MethodType.fromJSON"></a>
 
 ### MethodType.fromJSON(json) ⇒ [<code>MethodType</code>](#MethodType)
-Deserializes a `MethodType` object from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>MethodType</code>](#MethodType)  
 
@@ -3389,7 +3445,7 @@ Returns a copy of the node URL of the Tangle network.
 <a name="Network+toJSON"></a>
 
 ### network.toJSON() ⇒ <code>any</code>
-Serializes a `Network` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>Network</code>](#Network)  
 <a name="Network+clone"></a>
@@ -3422,7 +3478,7 @@ Errors if the name is invalid.
 <a name="Network.fromJSON"></a>
 
 ### Network.fromJSON(json) ⇒ [<code>Network</code>](#Network)
-Deserializes a `Network` from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>Network</code>](#Network)  
 
@@ -3521,7 +3577,7 @@ Returns a copy of the miscellaneous properties on the `Presentation`.
 <a name="Presentation+toJSON"></a>
 
 ### presentation.toJSON() ⇒ <code>any</code>
-Serializes a `Presentation` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>Presentation</code>](#Presentation)  
 <a name="Presentation+clone"></a>
@@ -3545,7 +3601,7 @@ Returns the base type.
 <a name="Presentation.fromJSON"></a>
 
 ### Presentation.fromJSON(json) ⇒ [<code>Presentation</code>](#Presentation)
-Deserializes a `Presentation` from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>Presentation</code>](#Presentation)  
 
@@ -3584,7 +3640,7 @@ Throws an error if any of the options are invalid.
 <a name="PresentationValidationOptions+toJSON"></a>
 
 ### presentationValidationOptions.toJSON() ⇒ <code>any</code>
-Serializes a `PresentationValidationOptions` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>PresentationValidationOptions</code>](#PresentationValidationOptions)  
 <a name="PresentationValidationOptions+clone"></a>
@@ -3602,7 +3658,7 @@ Creates a new `PresentationValidationOptions` with defaults.
 <a name="PresentationValidationOptions.fromJSON"></a>
 
 ### PresentationValidationOptions.fromJSON(json) ⇒ [<code>PresentationValidationOptions</code>](#PresentationValidationOptions)
-Deserializes a `PresentationValidationOptions` from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>PresentationValidationOptions</code>](#PresentationValidationOptions)  
 
@@ -3782,7 +3838,7 @@ Purpose for which the proof was generated.
 <a name="Proof+toJSON"></a>
 
 ### proof.toJSON() ⇒ <code>any</code>
-Serializes a `Proof` to a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>Proof</code>](#Proof)  
 <a name="Proof+clone"></a>
@@ -3794,7 +3850,7 @@ Deep clones the object.
 <a name="Proof.fromJSON"></a>
 
 ### Proof.fromJSON(json) ⇒ [<code>Proof</code>](#Proof)
-Deserializes a `Proof` from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>Proof</code>](#Proof)  
 
@@ -3813,9 +3869,11 @@ See `IProofOptions`.
 * [ProofOptions](#ProofOptions)
     * [new ProofOptions(options)](#new_ProofOptions_new)
     * _instance_
+        * [.toJSON()](#ProofOptions+toJSON) ⇒ <code>any</code>
         * [.clone()](#ProofOptions+clone) ⇒ [<code>ProofOptions</code>](#ProofOptions)
     * _static_
         * [.default()](#ProofOptions.default) ⇒ [<code>ProofOptions</code>](#ProofOptions)
+        * [.fromJSON(json)](#ProofOptions.fromJSON) ⇒ [<code>ProofOptions</code>](#ProofOptions)
 
 <a name="new_ProofOptions_new"></a>
 
@@ -3829,6 +3887,12 @@ Throws an error if any of the options are invalid.
 | --- | --- |
 | options | <code>IProofOptions</code> | 
 
+<a name="ProofOptions+toJSON"></a>
+
+### proofOptions.toJSON() ⇒ <code>any</code>
+Serializes this to a JSON object.
+
+**Kind**: instance method of [<code>ProofOptions</code>](#ProofOptions)  
 <a name="ProofOptions+clone"></a>
 
 ### proofOptions.clone() ⇒ [<code>ProofOptions</code>](#ProofOptions)
@@ -3841,6 +3905,17 @@ Deep clones the object.
 Creates a new `ProofOptions` with default options.
 
 **Kind**: static method of [<code>ProofOptions</code>](#ProofOptions)  
+<a name="ProofOptions.fromJSON"></a>
+
+### ProofOptions.fromJSON(json) ⇒ [<code>ProofOptions</code>](#ProofOptions)
+Deserializes an instance from a JSON object.
+
+**Kind**: static method of [<code>ProofOptions</code>](#ProofOptions)  
+
+| Param | Type |
+| --- | --- |
+| json | <code>any</code> | 
+
 <a name="ProofPurpose"></a>
 
 ## ProofPurpose
@@ -3862,7 +3937,7 @@ See https://w3c-ccg.github.io/security-vocab/#proofPurpose
 <a name="ProofPurpose+toJSON"></a>
 
 ### proofPurpose.toJSON() ⇒ <code>any</code>
-Serializes a `ProofPurpose` to a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>ProofPurpose</code>](#ProofPurpose)  
 <a name="ProofPurpose+clone"></a>
@@ -3888,7 +3963,7 @@ See https://www.w3.org/TR/did-core/#authentication
 <a name="ProofPurpose.fromJSON"></a>
 
 ### ProofPurpose.fromJSON(json) ⇒ [<code>ProofPurpose</code>](#ProofPurpose)
-Deserializes a `ProofPurpose` from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>ProofPurpose</code>](#ProofPurpose)  
 
@@ -3939,7 +4014,7 @@ Returns a copy of the message `nonce`.
 <a name="Receipt+toJSON"></a>
 
 ### receipt.toJSON() ⇒ <code>any</code>
-Serializes a `Receipt` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>Receipt</code>](#Receipt)  
 <a name="Receipt+clone"></a>
@@ -3951,7 +4026,7 @@ Deep clones the object.
 <a name="Receipt.fromJSON"></a>
 
 ### Receipt.fromJSON(json) ⇒ [<code>Receipt</code>](#Receipt)
-Deserializes a `Receipt` from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>Receipt</code>](#Receipt)  
 
@@ -4062,7 +4137,7 @@ Sets the integration chain message id.
 <a name="ResolvedDocument+toJSON"></a>
 
 ### resolvedDocument.toJSON() ⇒ <code>any</code>
-Serializes a `Document` object as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>ResolvedDocument</code>](#ResolvedDocument)  
 <a name="ResolvedDocument+clone"></a>
@@ -4074,7 +4149,7 @@ Deep clones the object.
 <a name="ResolvedDocument.fromJSON"></a>
 
 ### ResolvedDocument.fromJSON(json) ⇒ [<code>ResolvedDocument</code>](#ResolvedDocument)
-Deserializes a `Document` object from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>ResolvedDocument</code>](#ResolvedDocument)  
 
@@ -4398,7 +4473,7 @@ See: https://www.w3.org/TR/did-core/#services
         * [.toJSON()](#Service+toJSON) ⇒ <code>any</code>
         * [.clone()](#Service+clone) ⇒ [<code>Service</code>](#Service)
     * _static_
-        * [.fromJSON(value)](#Service.fromJSON) ⇒ [<code>Service</code>](#Service)
+        * [.fromJSON(json)](#Service.fromJSON) ⇒ [<code>Service</code>](#Service)
 
 <a name="new_Service_new"></a>
 
@@ -4435,7 +4510,7 @@ Returns a copy of the custom properties on the `Service`.
 <a name="Service+toJSON"></a>
 
 ### service.toJSON() ⇒ <code>any</code>
-Serializes a `Service` object as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>Service</code>](#Service)  
 <a name="Service+clone"></a>
@@ -4446,18 +4521,20 @@ Deep clones the object.
 **Kind**: instance method of [<code>Service</code>](#Service)  
 <a name="Service.fromJSON"></a>
 
-### Service.fromJSON(value) ⇒ [<code>Service</code>](#Service)
-Deserializes a `Service` object from a JSON object.
+### Service.fromJSON(json) ⇒ [<code>Service</code>](#Service)
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>Service</code>](#Service)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> | 
+| json | <code>any</code> | 
 
 <a name="Signature"></a>
 
 ## Signature
+A digital signature.
+
 **Kind**: global class  
 
 * [Signature](#Signature)
@@ -4466,7 +4543,7 @@ Deserializes a `Service` object from a JSON object.
         * [.asBytes()](#Signature+asBytes) ⇒ <code>Uint8Array</code>
         * [.toJSON()](#Signature+toJSON) ⇒ <code>any</code>
     * _static_
-        * [.fromJSON(json_value)](#Signature.fromJSON) ⇒ [<code>Signature</code>](#Signature)
+        * [.fromJSON(json)](#Signature.fromJSON) ⇒ [<code>Signature</code>](#Signature)
 
 <a name="new_Signature_new"></a>
 
@@ -4487,19 +4564,19 @@ Returns a copy of the signature as a `UInt8Array`.
 <a name="Signature+toJSON"></a>
 
 ### signature.toJSON() ⇒ <code>any</code>
-Serializes a `Signature` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>Signature</code>](#Signature)  
 <a name="Signature.fromJSON"></a>
 
-### Signature.fromJSON(json_value) ⇒ [<code>Signature</code>](#Signature)
-Deserializes a JSON object as `Signature`.
+### Signature.fromJSON(json) ⇒ [<code>Signature</code>](#Signature)
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>Signature</code>](#Signature)  
 
 | Param | Type |
 | --- | --- |
-| json_value | <code>any</code> | 
+| json | <code>any</code> | 
 
 <a name="StorageTestSuite"></a>
 
@@ -4659,7 +4736,7 @@ Returns `null` if the operation leads to a timestamp not in the valid range for 
 <a name="Timestamp+toJSON"></a>
 
 ### timestamp.toJSON() ⇒ <code>any</code>
-Serializes a `Timestamp` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>Timestamp</code>](#Timestamp)  
 <a name="Timestamp.parse"></a>
@@ -4682,7 +4759,7 @@ Creates a new `Timestamp` with the current date and time.
 <a name="Timestamp.fromJSON"></a>
 
 ### Timestamp.fromJSON(json) ⇒ [<code>Timestamp</code>](#Timestamp)
-Deserializes a `Timestamp` from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>Timestamp</code>](#Timestamp)  
 
@@ -4706,7 +4783,7 @@ Deserializes a `Timestamp` from a JSON object.
         * [.toJSON()](#VerificationMethod+toJSON) ⇒ <code>any</code>
         * [.clone()](#VerificationMethod+clone) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
     * _static_
-        * [.fromJSON(value)](#VerificationMethod.fromJSON) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
+        * [.fromJSON(json)](#VerificationMethod.fromJSON) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
 
 <a name="new_VerificationMethod_new"></a>
 
@@ -4759,7 +4836,7 @@ Returns a copy of the `VerificationMethod` public key data.
 <a name="VerificationMethod+toJSON"></a>
 
 ### verificationMethod.toJSON() ⇒ <code>any</code>
-Serializes a `VerificationMethod` object as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)  
 <a name="VerificationMethod+clone"></a>
@@ -4770,14 +4847,14 @@ Deep clones the object.
 **Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)  
 <a name="VerificationMethod.fromJSON"></a>
 
-### VerificationMethod.fromJSON(value) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
-Deserializes a `VerificationMethod` object from a JSON object.
+### VerificationMethod.fromJSON(json) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>VerificationMethod</code>](#VerificationMethod)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>any</code> | 
+| json | <code>any</code> | 
 
 <a name="VerifierOptions"></a>
 
@@ -4811,7 +4888,7 @@ Throws an error if any of the options are invalid.
 <a name="VerifierOptions+toJSON"></a>
 
 ### verifierOptions.toJSON() ⇒ <code>any</code>
-Serializes a `VerifierOptions` as a JSON object.
+Serializes this to a JSON object.
 
 **Kind**: instance method of [<code>VerifierOptions</code>](#VerifierOptions)  
 <a name="VerifierOptions+clone"></a>
@@ -4829,7 +4906,7 @@ Creates a new `VerifierOptions` with default options.
 <a name="VerifierOptions.fromJSON"></a>
 
 ### VerifierOptions.fromJSON(json) ⇒ [<code>VerifierOptions</code>](#VerifierOptions)
-Deserializes a `VerifierOptions` from a JSON object.
+Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>VerifierOptions</code>](#VerifierOptions)  
 

--- a/bindings/wasm/src/account/identity/chain_state.rs
+++ b/bindings/wasm/src/account/identity/chain_state.rs
@@ -4,26 +4,11 @@
 use identity_iota::account_storage::ChainState;
 use wasm_bindgen::prelude::*;
 
-use crate::error::Result;
-use crate::error::WasmResult;
-
 #[wasm_bindgen(js_name = ChainState, inspectable)]
 pub struct WasmChainState(pub(crate) ChainState);
 
-#[wasm_bindgen(js_class = ChainState)]
-impl WasmChainState {
-  /// Serializes a `ChainState` object as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a JSON object as `ChainState`.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json_value: JsValue) -> Result<WasmChainState> {
-    json_value.into_serde().map(Self).wasm_result()
-  }
-}
+impl_wasm_json!(WasmChainState, ChainState);
+impl_wasm_clone!(WasmChainState, ChainState);
 
 impl From<ChainState> for WasmChainState {
   fn from(chain_state: ChainState) -> Self {

--- a/bindings/wasm/src/account/types/agreement_info.rs
+++ b/bindings/wasm/src/account/types/agreement_info.rs
@@ -2,16 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use identity_iota::account_storage::AgreementInfo;
-use serde::Deserialize;
-use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
-use crate::error::Result;
-use crate::error::WasmResult;
-
 /// Agreement information used as the input for the concat KDF.
-#[derive(Clone, Serialize, Deserialize)]
 #[wasm_bindgen(js_name = AgreementInfo, inspectable)]
+#[derive(Clone)]
 pub struct WasmAgreementInfo(AgreementInfo);
 
 #[wasm_bindgen(js_class = AgreementInfo)]
@@ -45,19 +40,9 @@ impl WasmAgreementInfo {
   pub fn priv_info(&self) -> Vec<u8> {
     self.0.priv_info.clone()
   }
-
-  /// Serializes `AgreementInfo` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes `AgreementInfo` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json_value: JsValue) -> Result<WasmAgreementInfo> {
-    json_value.into_serde().map(Self).wasm_result()
-  }
 }
+
+impl_wasm_json!(WasmAgreementInfo, AgreementInfo);
 
 impl From<WasmAgreementInfo> for AgreementInfo {
   fn from(wasm_agreement_info: WasmAgreementInfo) -> Self {

--- a/bindings/wasm/src/account/types/agreement_info.rs
+++ b/bindings/wasm/src/account/types/agreement_info.rs
@@ -6,8 +6,7 @@ use wasm_bindgen::prelude::*;
 
 /// Agreement information used as the input for the concat KDF.
 #[wasm_bindgen(js_name = AgreementInfo, inspectable)]
-#[derive(Clone)]
-pub struct WasmAgreementInfo(AgreementInfo);
+pub struct WasmAgreementInfo(pub(crate) AgreementInfo);
 
 #[wasm_bindgen(js_class = AgreementInfo)]
 impl WasmAgreementInfo {

--- a/bindings/wasm/src/account/types/auto_save.rs
+++ b/bindings/wasm/src/account/types/auto_save.rs
@@ -4,9 +4,6 @@
 use identity_iota::account::AutoSave;
 use wasm_bindgen::prelude::*;
 
-use crate::error::Result;
-use crate::error::WasmResult;
-
 #[wasm_bindgen]
 extern "C" {
   #[wasm_bindgen(typescript_type = "AutoSave | undefined")]
@@ -36,16 +33,6 @@ impl WasmAutoSave {
   pub fn batch(number_of_actions: usize) -> WasmAutoSave {
     Self(AutoSave::Batch(number_of_actions))
   }
-
-  /// Serializes `AutoSave` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes `AutoSave` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json_value: JsValue) -> Result<WasmAutoSave> {
-    json_value.into_serde().map(Self).wasm_result()
-  }
 }
+
+impl_wasm_json!(WasmAutoSave, AutoSave);

--- a/bindings/wasm/src/account/types/cek_algorithm.rs
+++ b/bindings/wasm/src/account/types/cek_algorithm.rs
@@ -8,21 +8,20 @@ use crate::account::types::WasmAgreementInfo;
 
 /// Supported algorithms used to determine and potentially encrypt the content encryption key (CEK).
 #[wasm_bindgen(js_name = CekAlgorithm, inspectable)]
-#[derive(Clone)]
-pub struct WasmCekAlgorithm(CekAlgorithm);
+pub struct WasmCekAlgorithm(pub(crate) CekAlgorithm);
 
 #[wasm_bindgen(js_class = CekAlgorithm)]
 impl WasmCekAlgorithm {
   /// Elliptic Curve Diffie-Hellman Ephemeral Static key agreement using Concat KDF.
   #[wasm_bindgen(js_name = EcdhEs)]
   pub fn ecdh_es(agreement: &WasmAgreementInfo) -> WasmCekAlgorithm {
-    Self(CekAlgorithm::ECDH_ES(agreement.clone().into()))
+    Self(CekAlgorithm::ECDH_ES(agreement.0.clone()))
   }
 
   /// Elliptic Curve Diffie-Hellman Ephemeral Static key agreement using Concat KDF.
   #[wasm_bindgen(js_name = EcdhEsA256Kw)]
   pub fn ecdh_es_a256kw(agreement: &WasmAgreementInfo) -> WasmCekAlgorithm {
-    Self(CekAlgorithm::ECDH_ES_A256KW(agreement.clone().into()))
+    Self(CekAlgorithm::ECDH_ES_A256KW(agreement.0.clone()))
   }
 }
 

--- a/bindings/wasm/src/account/types/cek_algorithm.rs
+++ b/bindings/wasm/src/account/types/cek_algorithm.rs
@@ -2,17 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use identity_iota::account_storage::CekAlgorithm;
-use serde::Deserialize;
-use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
 use crate::account::types::WasmAgreementInfo;
-use crate::error::Result;
-use crate::error::WasmResult;
 
 /// Supported algorithms used to determine and potentially encrypt the content encryption key (CEK).
-#[derive(Clone, Serialize, Deserialize)]
 #[wasm_bindgen(js_name = CekAlgorithm, inspectable)]
+#[derive(Clone)]
 pub struct WasmCekAlgorithm(CekAlgorithm);
 
 #[wasm_bindgen(js_class = CekAlgorithm)]
@@ -28,19 +24,9 @@ impl WasmCekAlgorithm {
   pub fn ecdh_es_a256kw(agreement: &WasmAgreementInfo) -> WasmCekAlgorithm {
     Self(CekAlgorithm::ECDH_ES_A256KW(agreement.clone().into()))
   }
-
-  /// Serializes `CekAlgorithm` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes `CekAlgorithm` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json_value: JsValue) -> Result<WasmCekAlgorithm> {
-    json_value.into_serde().map(Self).wasm_result()
-  }
 }
+
+impl_wasm_json!(WasmCekAlgorithm, CekAlgorithm);
 
 impl From<WasmCekAlgorithm> for CekAlgorithm {
   fn from(wasm_cek_algorithm: WasmCekAlgorithm) -> Self {

--- a/bindings/wasm/src/account/types/encrypted_data.rs
+++ b/bindings/wasm/src/account/types/encrypted_data.rs
@@ -4,9 +4,6 @@
 use identity_iota::account_storage::EncryptedData;
 use wasm_bindgen::prelude::*;
 
-use crate::error::Result;
-use crate::error::WasmResult;
-
 /// The structure returned after encrypting data
 #[wasm_bindgen(js_name = EncryptedData, inspectable)]
 pub struct WasmEncryptedData(pub(crate) EncryptedData);
@@ -36,19 +33,9 @@ impl WasmEncryptedData {
   pub fn tag(&self) -> Vec<u8> {
     self.0.tag.clone()
   }
-
-  /// Serializes `EncryptedData` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes `EncryptedData` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json_value: JsValue) -> Result<WasmEncryptedData> {
-    json_value.into_serde().map(Self).wasm_result()
-  }
 }
+
+impl_wasm_json!(WasmEncryptedData, EncryptedData);
 
 impl From<WasmEncryptedData> for EncryptedData {
   fn from(wasm_encrypted_data: WasmEncryptedData) -> Self {

--- a/bindings/wasm/src/account/types/encryption_algorithm.rs
+++ b/bindings/wasm/src/account/types/encryption_algorithm.rs
@@ -6,8 +6,7 @@ use wasm_bindgen::prelude::*;
 
 /// Supported content encryption algorithms.
 #[wasm_bindgen(js_name = EncryptionAlgorithm, inspectable)]
-#[derive(Clone)]
-pub struct WasmEncryptionAlgorithm(EncryptionAlgorithm);
+pub struct WasmEncryptionAlgorithm(pub(crate) EncryptionAlgorithm);
 
 #[wasm_bindgen(js_class = EncryptionAlgorithm)]
 impl WasmEncryptionAlgorithm {

--- a/bindings/wasm/src/account/types/encryption_algorithm.rs
+++ b/bindings/wasm/src/account/types/encryption_algorithm.rs
@@ -2,16 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use identity_iota::account_storage::EncryptionAlgorithm;
-use serde::Deserialize;
-use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
-use crate::error::Result;
-use crate::error::WasmResult;
-
 /// Supported content encryption algorithms.
-#[derive(Clone, Serialize, Deserialize)]
 #[wasm_bindgen(js_name = EncryptionAlgorithm, inspectable)]
+#[derive(Clone)]
 pub struct WasmEncryptionAlgorithm(EncryptionAlgorithm);
 
 #[wasm_bindgen(js_class = EncryptionAlgorithm)]
@@ -27,19 +22,9 @@ impl WasmEncryptionAlgorithm {
   pub fn key_length(&self) -> usize {
     self.0.key_length()
   }
-
-  /// Serializes `EncryptionAlgorithm` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes `EncryptionAlgorithm` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json_value: JsValue) -> Result<WasmEncryptionAlgorithm> {
-    json_value.into_serde().map(Self).wasm_result()
-  }
 }
+
+impl_wasm_json!(WasmEncryptionAlgorithm, EncryptionAlgorithm);
 
 impl From<WasmEncryptionAlgorithm> for EncryptionAlgorithm {
   fn from(wasm_encryption_algorithm: WasmEncryptionAlgorithm) -> Self {

--- a/bindings/wasm/src/account/types/key_location.rs
+++ b/bindings/wasm/src/account/types/key_location.rs
@@ -54,24 +54,14 @@ impl WasmKeyLocation {
     self.0.key_type.into()
   }
 
-  /// Serializes `KeyLocation` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a JSON object into a `KeyLocation`.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json_value: JsValue) -> Result<WasmKeyLocation> {
-    json_value.into_serde().map(Self).wasm_result()
-  }
-
   #[wasm_bindgen(js_name = toString)]
   #[allow(clippy::inherent_to_string)]
   pub fn to_string(&self) -> String {
     self.0.to_string()
   }
 }
+
+impl_wasm_json!(WasmKeyLocation, KeyLocation);
 
 impl From<WasmKeyLocation> for KeyLocation {
   fn from(wasm_key_location: WasmKeyLocation) -> Self {

--- a/bindings/wasm/src/account/types/key_location.rs
+++ b/bindings/wasm/src/account/types/key_location.rs
@@ -18,7 +18,6 @@ use crate::error::WasmResult;
 /// situations like these.
 ///
 /// The string representation of that location can be obtained via `canonicalRepr`.
-#[derive(Debug)]
 #[wasm_bindgen(js_name = KeyLocation, inspectable)]
 pub struct WasmKeyLocation(pub(crate) KeyLocation);
 

--- a/bindings/wasm/src/account/types/method_content.rs
+++ b/bindings/wasm/src/account/types/method_content.rs
@@ -8,9 +8,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
-use crate::error::Result;
-use crate::error::WasmResult;
-
 #[wasm_bindgen]
 extern "C" {
   #[wasm_bindgen(typescript_type = "MethodContent | undefined")]
@@ -82,22 +79,9 @@ impl WasmMethodContent {
   pub fn public_x25519(publicKey: Vec<u8>) -> WasmMethodContent {
     Self(WasmMethodContentInner::PublicX25519(publicKey))
   }
-
-  /// Serializes `MethodContent` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes `MethodContent` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json_value: JsValue) -> Result<WasmMethodContent> {
-    json_value
-      .into_serde::<WasmMethodContentInner>()
-      .map(Self)
-      .wasm_result()
-  }
 }
+
+impl_wasm_json!(WasmMethodContent, MethodContent);
 
 impl From<WasmMethodContent> for MethodContent {
   fn from(content: WasmMethodContent) -> Self {

--- a/bindings/wasm/src/account/types/signature.rs
+++ b/bindings/wasm/src/account/types/signature.rs
@@ -4,9 +4,7 @@
 use identity_iota::account_storage::Signature;
 use wasm_bindgen::prelude::*;
 
-use crate::error::Result;
-use crate::error::WasmResult;
-
+/// A digital signature.
 #[wasm_bindgen(js_name = Signature, inspectable)]
 pub struct WasmSignature(pub(crate) Signature);
 
@@ -23,19 +21,9 @@ impl WasmSignature {
   pub fn as_bytes(&self) -> Vec<u8> {
     self.0.as_bytes().to_vec()
   }
-
-  /// Serializes a `Signature` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a JSON object as `Signature`.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json_value: JsValue) -> Result<WasmSignature> {
-    json_value.into_serde().map(Self).wasm_result()
-  }
 }
+
+impl_wasm_json!(WasmSignature, Signature);
 
 impl From<WasmSignature> for Signature {
   fn from(wasm_signature: WasmSignature) -> Self {

--- a/bindings/wasm/src/account/wasm_account/account.rs
+++ b/bindings/wasm/src/account/wasm_account/account.rs
@@ -328,8 +328,8 @@ impl WasmAccount {
     public_key: Vec<u8>,
   ) -> PromiseEncryptedData {
     let account = self.0.clone();
-    let encryption_algorithm: EncryptionAlgorithm = encryption_algorithm.clone().into();
-    let cek_algorithm: CekAlgorithm = cek_algorithm.clone().into();
+    let encryption_algorithm: EncryptionAlgorithm = encryption_algorithm.0;
+    let cek_algorithm: CekAlgorithm = cek_algorithm.0.clone();
     let public_key: PublicKey = public_key.to_vec().into();
 
     future_to_promise(async move {
@@ -364,8 +364,8 @@ impl WasmAccount {
   ) -> PromiseData {
     let account = self.0.clone();
     let data: EncryptedData = data.0.clone();
-    let encryption_algorithm: EncryptionAlgorithm = encryption_algorithm.clone().into();
-    let cek_algorithm: CekAlgorithm = cek_algorithm.clone().into();
+    let encryption_algorithm: EncryptionAlgorithm = encryption_algorithm.0;
+    let cek_algorithm: CekAlgorithm = cek_algorithm.0.clone();
 
     future_to_promise(async move {
       let data: Vec<u8> = account

--- a/bindings/wasm/src/chain/document_history.rs
+++ b/bindings/wasm/src/chain/document_history.rs
@@ -17,7 +17,6 @@ use crate::error::WasmResult;
 
 /// A DID Document's history and current state.
 #[wasm_bindgen(js_name = DocumentHistory, inspectable)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WasmDocumentHistory(DocumentHistory);
 
 // Workaround for Typescript type annotations on async function returns and arrays.
@@ -107,20 +106,9 @@ impl WasmDocumentHistory {
       .collect::<js_sys::Array>()
       .unchecked_into::<ArrayString>()
   }
-
-  /// Serializes `DocumentHistory` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes `DocumentHistory` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmDocumentHistory> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
 
+impl_wasm_json!(WasmDocumentHistory, DocumentHistory);
 impl_wasm_clone!(WasmDocumentHistory, DocumentHistory);
 
 impl From<DocumentHistory> for WasmDocumentHistory {
@@ -130,12 +118,10 @@ impl From<DocumentHistory> for WasmDocumentHistory {
 }
 
 #[wasm_bindgen(inspectable)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IntegrationChainHistory(ChainHistory<ResolvedIotaDocument>);
 
 /// @deprecated since 0.5.0, diff chain features are slated for removal.
 #[wasm_bindgen(inspectable)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DiffChainHistory(ChainHistory<DiffMessage>);
 
 #[wasm_bindgen]

--- a/bindings/wasm/src/common/timestamp.rs
+++ b/bindings/wasm/src/common/timestamp.rs
@@ -47,19 +47,9 @@ impl WasmTimestamp {
   pub fn checked_sub(&self, duration: &WasmDuration) -> Option<WasmTimestamp> {
     self.0.checked_sub(duration.0).map(WasmTimestamp)
   }
-
-  /// Serializes a `Timestamp` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `Timestamp` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmTimestamp> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
+
+impl_wasm_json!(WasmTimestamp, Timestamp);
 
 impl From<Timestamp> for WasmTimestamp {
   fn from(timestamp: Timestamp) -> Self {
@@ -101,19 +91,9 @@ impl WasmDuration {
   pub fn weeks(weeks: u32) -> WasmDuration {
     Self(Duration::weeks(weeks))
   }
-
-  /// Serializes a `Duration` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `Duration` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmDuration> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
+
+impl_wasm_json!(WasmDuration, Duration);
 
 impl From<Duration> for WasmDuration {
   fn from(duration: Duration) -> Self {

--- a/bindings/wasm/src/credential/credential.rs
+++ b/bindings/wasm/src/credential/credential.rs
@@ -25,7 +25,6 @@ use crate::error::Result;
 use crate::error::WasmResult;
 
 #[wasm_bindgen(js_name = Credential, inspectable)]
-#[derive(Debug)]
 pub struct WasmCredential(pub(crate) Credential);
 
 #[wasm_bindgen(js_class = Credential)]

--- a/bindings/wasm/src/credential/credential.rs
+++ b/bindings/wasm/src/credential/credential.rs
@@ -25,7 +25,7 @@ use crate::error::Result;
 use crate::error::WasmResult;
 
 #[wasm_bindgen(js_name = Credential, inspectable)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct WasmCredential(pub(crate) Credential);
 
 #[wasm_bindgen(js_class = Credential)]
@@ -200,20 +200,9 @@ impl WasmCredential {
   pub fn properties(&self) -> Result<MapStringAny> {
     MapStringAny::try_from(&self.0.properties)
   }
-
-  /// Serializes a `Credential` to a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `Credential` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmCredential> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
 
+impl_wasm_json!(WasmCredential, Credential);
 impl_wasm_clone!(WasmCredential, Credential);
 
 impl From<Credential> for WasmCredential {

--- a/bindings/wasm/src/credential/presentation.rs
+++ b/bindings/wasm/src/credential/presentation.rs
@@ -20,7 +20,7 @@ use crate::error::Result;
 use crate::error::WasmResult;
 
 #[wasm_bindgen(js_name = Presentation, inspectable)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub struct WasmPresentation(pub(crate) Presentation);
 
 // Workaround for Typescript type annotations for returned arrays.
@@ -143,20 +143,9 @@ impl WasmPresentation {
   pub fn properties(&self) -> Result<MapStringAny> {
     MapStringAny::try_from(&self.0.properties)
   }
-
-  /// Serializes a `Presentation` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `Presentation` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmPresentation> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
 
+impl_wasm_json!(WasmPresentation, Presentation);
 impl_wasm_clone!(WasmPresentation, Presentation);
 
 impl From<Presentation> for WasmPresentation {

--- a/bindings/wasm/src/credential/presentation.rs
+++ b/bindings/wasm/src/credential/presentation.rs
@@ -20,7 +20,6 @@ use crate::error::Result;
 use crate::error::WasmResult;
 
 #[wasm_bindgen(js_name = Presentation, inspectable)]
-#[derive(Debug)]
 pub struct WasmPresentation(pub(crate) Presentation);
 
 // Workaround for Typescript type annotations for returned arrays.

--- a/bindings/wasm/src/credential/validation_options.rs
+++ b/bindings/wasm/src/credential/validation_options.rs
@@ -15,7 +15,6 @@ use crate::error::WasmResult;
 
 /// Options to declare validation criteria when validating credentials.
 #[wasm_bindgen(js_name = CredentialValidationOptions)]
-#[derive(Clone)]
 pub struct WasmCredentialValidationOptions(pub(crate) CredentialValidationOptions);
 
 #[wasm_bindgen(js_class = CredentialValidationOptions)]
@@ -34,20 +33,9 @@ impl WasmCredentialValidationOptions {
   pub fn default() -> WasmCredentialValidationOptions {
     WasmCredentialValidationOptions::from(CredentialValidationOptions::default())
   }
-
-  /// Serializes a `CredentialValidationOptions` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `CredentialValidationOptions` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmCredentialValidationOptions> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
 
+impl_wasm_json!(WasmCredentialValidationOptions, CredentialValidationOptions);
 impl_wasm_clone!(WasmCredentialValidationOptions, CredentialValidationOptions);
 
 impl From<CredentialValidationOptions> for WasmCredentialValidationOptions {
@@ -64,7 +52,6 @@ impl From<WasmCredentialValidationOptions> for CredentialValidationOptions {
 
 /// Options to declare validation criteria when validating presentation.
 #[wasm_bindgen(js_name = PresentationValidationOptions)]
-#[derive(Clone)]
 pub struct WasmPresentationValidationOptions(pub(crate) PresentationValidationOptions);
 
 #[wasm_bindgen(js_class = PresentationValidationOptions)]
@@ -83,20 +70,9 @@ impl WasmPresentationValidationOptions {
   pub fn default() -> WasmPresentationValidationOptions {
     WasmPresentationValidationOptions::from(PresentationValidationOptions::default())
   }
-
-  /// Serializes a `PresentationValidationOptions` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `PresentationValidationOptions` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmPresentationValidationOptions> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
 
+impl_wasm_json!(WasmPresentationValidationOptions, PresentationValidationOptions);
 impl_wasm_clone!(WasmPresentationValidationOptions, PresentationValidationOptions);
 
 impl From<PresentationValidationOptions> for WasmPresentationValidationOptions {
@@ -114,7 +90,7 @@ impl From<WasmPresentationValidationOptions> for PresentationValidationOptions {
 /// Controls validation behaviour when checking whether or not a credential has been revoked by its
 /// [`credentialStatus`](https://www.w3.org/TR/vc-data-model/#status).
 #[wasm_bindgen(js_name = StatusCheck)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize_repr, Deserialize_repr)]
+#[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr)]
 #[repr(u8)]
 pub enum WasmStatusCheck {
   /// Validate the status if supported, reject any unsupported

--- a/bindings/wasm/src/crypto/key_pair.rs
+++ b/bindings/wasm/src/crypto/key_pair.rs
@@ -21,7 +21,7 @@ struct JsonData {
 // =============================================================================
 
 #[wasm_bindgen(inspectable, js_name = KeyPair)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct WasmKeyPair(pub(crate) KeyPair);
 
 #[wasm_bindgen(js_class = KeyPair)]

--- a/bindings/wasm/src/crypto/key_pair.rs
+++ b/bindings/wasm/src/crypto/key_pair.rs
@@ -21,7 +21,6 @@ struct JsonData {
 // =============================================================================
 
 #[wasm_bindgen(inspectable, js_name = KeyPair)]
-#[derive(Debug)]
 pub struct WasmKeyPair(pub(crate) KeyPair);
 
 #[wasm_bindgen(js_class = KeyPair)]

--- a/bindings/wasm/src/crypto/wasm_proof.rs
+++ b/bindings/wasm/src/crypto/wasm_proof.rs
@@ -7,8 +7,6 @@ use wasm_bindgen::JsValue;
 
 use crate::common::WasmTimestamp;
 use crate::crypto::WasmProofPurpose;
-use crate::error::Result;
-use crate::error::WasmResult;
 
 /// A digital signature.
 ///
@@ -65,20 +63,9 @@ impl WasmProof {
   pub fn purpose(&self) -> Option<WasmProofPurpose> {
     self.0.purpose.map(WasmProofPurpose::from)
   }
-
-  /// Serializes a `Proof` to a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `Proof` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmProof> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
 
+impl_wasm_json!(WasmProof, Proof);
 impl_wasm_clone!(WasmProof, Proof);
 
 impl From<Proof> for WasmProof {

--- a/bindings/wasm/src/crypto/wasm_proof_options.rs
+++ b/bindings/wasm/src/crypto/wasm_proof_options.rs
@@ -30,6 +30,7 @@ impl WasmProofOptions {
   }
 }
 
+impl_wasm_json!(WasmProofOptions, ProofOptions);
 impl_wasm_clone!(WasmProofOptions, ProofOptions);
 
 impl From<ProofOptions> for WasmProofOptions {

--- a/bindings/wasm/src/crypto/wasm_proof_purpose.rs
+++ b/bindings/wasm/src/crypto/wasm_proof_purpose.rs
@@ -8,7 +8,6 @@ use wasm_bindgen::prelude::*;
 ///
 /// See https://w3c-ccg.github.io/security-vocab/#proofPurpose
 #[wasm_bindgen(js_name = ProofPurpose, inspectable)]
-#[derive(Debug)]
 pub struct WasmProofPurpose(pub(crate) ProofPurpose);
 
 #[wasm_bindgen(js_class = ProofPurpose)]

--- a/bindings/wasm/src/crypto/wasm_proof_purpose.rs
+++ b/bindings/wasm/src/crypto/wasm_proof_purpose.rs
@@ -4,14 +4,11 @@
 use identity_iota::crypto::ProofPurpose;
 use wasm_bindgen::prelude::*;
 
-use crate::error::Result;
-use crate::error::WasmResult;
-
 /// Associates a purpose with a {@link Proof}.
 ///
 /// See https://w3c-ccg.github.io/security-vocab/#proofPurpose
 #[wasm_bindgen(js_name = ProofPurpose, inspectable)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct WasmProofPurpose(pub(crate) ProofPurpose);
 
 #[wasm_bindgen(js_class = ProofPurpose)]
@@ -29,20 +26,9 @@ impl WasmProofPurpose {
   pub fn authentication() -> WasmProofPurpose {
     WasmProofPurpose(ProofPurpose::Authentication)
   }
-
-  /// Serializes a `ProofPurpose` to a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `ProofPurpose` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmProofPurpose> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
 
+impl_wasm_json!(WasmProofPurpose, ProofPurpose);
 impl_wasm_clone!(WasmProofPurpose, ProofPurpose);
 
 impl From<ProofPurpose> for WasmProofPurpose {

--- a/bindings/wasm/src/did/wasm_did.rs
+++ b/bindings/wasm/src/did/wasm_did.rs
@@ -12,7 +12,7 @@ use crate::tangle::WasmNetwork;
 
 /// @typicalname did
 #[wasm_bindgen(js_name = DID, inspectable)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub struct WasmDID(pub(crate) IotaDID);
 
 #[wasm_bindgen(js_class = DID)]
@@ -81,21 +81,9 @@ impl WasmDID {
   pub fn to_string(&self) -> String {
     self.0.to_string()
   }
-
-  /// Deserializes a JSON object as `DID`.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json_value: JsValue) -> Result<WasmDID> {
-    json_value.into_serde().map(Self).wasm_result()
-  }
-
-  /// Serializes a `DID` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> JsValue {
-    // This must match the serialization of IotaDID for UWasmDID to work.
-    JsValue::from_str(self.0.as_str())
-  }
 }
 
+impl_wasm_json!(WasmDID, DID);
 impl_wasm_clone!(WasmDID, DID);
 
 impl From<IotaDID> for WasmDID {

--- a/bindings/wasm/src/did/wasm_did.rs
+++ b/bindings/wasm/src/did/wasm_did.rs
@@ -12,7 +12,6 @@ use crate::tangle::WasmNetwork;
 
 /// @typicalname did
 #[wasm_bindgen(js_name = DID, inspectable)]
-#[derive(Debug)]
 pub struct WasmDID(pub(crate) IotaDID);
 
 #[wasm_bindgen(js_class = DID)]

--- a/bindings/wasm/src/did/wasm_did_url.rs
+++ b/bindings/wasm/src/did/wasm_did_url.rs
@@ -12,7 +12,6 @@ use crate::error::WasmResult;
 
 /// @typicalname didUrl
 #[wasm_bindgen(js_name = DIDUrl, inspectable)]
-#[derive(Debug)]
 pub struct WasmDIDUrl(pub(crate) IotaDIDUrl);
 
 #[wasm_bindgen(js_class = DIDUrl)]

--- a/bindings/wasm/src/did/wasm_did_url.rs
+++ b/bindings/wasm/src/did/wasm_did_url.rs
@@ -12,7 +12,7 @@ use crate::error::WasmResult;
 
 /// @typicalname didUrl
 #[wasm_bindgen(js_name = DIDUrl, inspectable)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub struct WasmDIDUrl(pub(crate) IotaDIDUrl);
 
 #[wasm_bindgen(js_class = DIDUrl)]
@@ -91,14 +91,9 @@ impl WasmDIDUrl {
   pub fn to_string(&self) -> String {
     self.0.to_string()
   }
-
-  /// Serializes a `DIDUrl` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
 }
 
+impl_wasm_json!(WasmDIDUrl, DIDUrl);
 impl_wasm_clone!(WasmDIDUrl, DIDUrl);
 
 impl From<IotaDIDUrl> for WasmDIDUrl {

--- a/bindings/wasm/src/did/wasm_diff_message.rs
+++ b/bindings/wasm/src/did/wasm_diff_message.rs
@@ -103,24 +103,9 @@ impl WasmDiffMessage {
   pub fn merge(&self, document: &WasmDocument) -> Result<WasmDocument> {
     self.0.merge(&document.0).map(WasmDocument).wasm_result()
   }
-
-  /// Serializes a `DiffMessage` as a JSON object.
-  ///
-  /// @deprecated since 0.5.0, diff chain features are slated for removal.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `DiffMessage` from a JSON object.
-  ///
-  /// @deprecated since 0.5.0, diff chain features are slated for removal.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmDiffMessage> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
 
+impl_wasm_json!(WasmDiffMessage, DiffMessage);
 impl_wasm_clone!(WasmDiffMessage, DiffMessage);
 
 impl From<DiffMessage> for WasmDiffMessage {

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -50,7 +50,6 @@ use crate::error::WasmResult;
 // =============================================================================
 
 #[wasm_bindgen(js_name = Document, inspectable)]
-#[derive(Debug)]
 pub struct WasmDocument(pub(crate) IotaDocument);
 
 #[wasm_bindgen(js_class = Document)]

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -50,7 +50,7 @@ use crate::error::WasmResult;
 // =============================================================================
 
 #[wasm_bindgen(js_name = Document, inspectable)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct WasmDocument(pub(crate) IotaDocument);
 
 #[wasm_bindgen(js_class = Document)]
@@ -660,24 +660,9 @@ impl WasmDocument {
 
     self.0.unrevoke_credentials(&query, indices.as_slice()).wasm_result()
   }
-
-  // ===========================================================================
-  // JSON
-  // ===========================================================================
-
-  /// Serializes a `Document` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `Document` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmDocument> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
 
+impl_wasm_json!(WasmDocument, Document);
 impl_wasm_clone!(WasmDocument, Document);
 
 impl From<IotaDocument> for WasmDocument {

--- a/bindings/wasm/src/did/wasm_document_metadata.rs
+++ b/bindings/wasm/src/did/wasm_document_metadata.rs
@@ -11,7 +11,7 @@ use crate::common::WasmTimestamp;
 
 /// Additional attributes related to an IOTA DID Document.
 #[wasm_bindgen(js_name = DocumentMetadata, inspectable)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub struct WasmDocumentMetadata(pub(crate) IotaDocumentMetadata);
 
 // NOTE: these properties are read-only (no setters) to prevent bugs where a clone of the metadata
@@ -36,6 +36,7 @@ impl WasmDocumentMetadata {
   }
 }
 
+impl_wasm_json!(WasmDocumentMetadata, DocumentMetadata);
 impl_wasm_clone!(WasmDocumentMetadata, DocumentMetadata);
 
 impl From<IotaDocumentMetadata> for WasmDocumentMetadata {

--- a/bindings/wasm/src/did/wasm_document_metadata.rs
+++ b/bindings/wasm/src/did/wasm_document_metadata.rs
@@ -11,7 +11,6 @@ use crate::common::WasmTimestamp;
 
 /// Additional attributes related to an IOTA DID Document.
 #[wasm_bindgen(js_name = DocumentMetadata, inspectable)]
-#[derive(Debug)]
 pub struct WasmDocumentMetadata(pub(crate) IotaDocumentMetadata);
 
 // NOTE: these properties are read-only (no setters) to prevent bugs where a clone of the metadata

--- a/bindings/wasm/src/did/wasm_method_data.rs
+++ b/bindings/wasm/src/did/wasm_method_data.rs
@@ -9,7 +9,7 @@ use crate::error::WasmResult;
 
 /// Supported verification method data formats.
 #[wasm_bindgen(js_name = MethodData, inspectable)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct WasmMethodData(pub(crate) MethodData);
 
 #[wasm_bindgen(js_class = MethodData)]
@@ -37,19 +37,10 @@ impl WasmMethodData {
   pub fn try_decode(&self) -> Result<Vec<u8>> {
     self.0.try_decode().wasm_result()
   }
-
-  /// Serializes a `MethodData` object as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `MethodData` object from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmMethodData> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
+
+impl_wasm_json!(WasmMethodData, MethodData);
+impl_wasm_clone!(WasmMethodData, MethodData);
 
 impl From<WasmMethodData> for MethodData {
   fn from(data: WasmMethodData) -> Self {
@@ -62,5 +53,3 @@ impl From<MethodData> for WasmMethodData {
     WasmMethodData(data)
   }
 }
-
-impl_wasm_clone!(WasmMethodData, MethodData);

--- a/bindings/wasm/src/did/wasm_method_data.rs
+++ b/bindings/wasm/src/did/wasm_method_data.rs
@@ -9,7 +9,6 @@ use crate::error::WasmResult;
 
 /// Supported verification method data formats.
 #[wasm_bindgen(js_name = MethodData, inspectable)]
-#[derive(Debug)]
 pub struct WasmMethodData(pub(crate) MethodData);
 
 #[wasm_bindgen(js_class = MethodData)]

--- a/bindings/wasm/src/did/wasm_method_scope.rs
+++ b/bindings/wasm/src/did/wasm_method_scope.rs
@@ -16,7 +16,6 @@ extern "C" {
 
 /// Supported verification method types.
 #[wasm_bindgen(js_name = MethodScope, inspectable)]
-#[derive(Debug)]
 pub struct WasmMethodScope(pub(crate) MethodScope);
 
 #[wasm_bindgen(js_class = MethodScope)]

--- a/bindings/wasm/src/did/wasm_method_scope.rs
+++ b/bindings/wasm/src/did/wasm_method_scope.rs
@@ -4,9 +4,6 @@
 use identity_iota::did::MethodScope;
 use wasm_bindgen::prelude::*;
 
-use crate::error::Result;
-use crate::error::WasmResult;
-
 #[wasm_bindgen]
 extern "C" {
   // Workaround for lack of Option<&Type>/&Option<Type> support.
@@ -19,7 +16,7 @@ extern "C" {
 
 /// Supported verification method types.
 #[wasm_bindgen(js_name = MethodScope, inspectable)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct WasmMethodScope(pub(crate) MethodScope);
 
 #[wasm_bindgen(js_class = MethodScope)]
@@ -60,18 +57,7 @@ impl WasmMethodScope {
   pub fn to_string(&self) -> String {
     self.0.to_string()
   }
-
-  /// Serializes a `MethodScope` object as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `MethodScope` object from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmMethodScope> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
 
+impl_wasm_json!(WasmMethodScope, MethodScope);
 impl_wasm_clone!(WasmMethodScope, MethodScope);

--- a/bindings/wasm/src/did/wasm_method_type.rs
+++ b/bindings/wasm/src/did/wasm_method_type.rs
@@ -6,7 +6,6 @@ use wasm_bindgen::prelude::*;
 
 /// Supported verification method types.
 #[wasm_bindgen(js_name = MethodType, inspectable)]
-#[derive(Debug)]
 pub struct WasmMethodType(pub(crate) MethodType);
 
 #[wasm_bindgen(js_class = MethodType)]

--- a/bindings/wasm/src/did/wasm_method_type.rs
+++ b/bindings/wasm/src/did/wasm_method_type.rs
@@ -4,12 +4,9 @@
 use identity_iota::did::MethodType;
 use wasm_bindgen::prelude::*;
 
-use crate::error::Result;
-use crate::error::WasmResult;
-
 /// Supported verification method types.
 #[wasm_bindgen(js_name = MethodType, inspectable)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct WasmMethodType(pub(crate) MethodType);
 
 #[wasm_bindgen(js_class = MethodType)]
@@ -24,18 +21,6 @@ impl WasmMethodType {
     WasmMethodType(MethodType::X25519KeyAgreementKey2019)
   }
 
-  /// Serializes a `MethodType` object as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `MethodType` object from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmMethodType> {
-    json.into_serde().map(Self).wasm_result()
-  }
-
   /// Returns the `MethodType` as a string.
   #[allow(clippy::inherent_to_string)]
   #[wasm_bindgen(js_name = toString)]
@@ -44,6 +29,9 @@ impl WasmMethodType {
     self.0.to_string()
   }
 }
+
+impl_wasm_json!(WasmMethodType, MethodType);
+impl_wasm_clone!(WasmMethodType, MethodType);
 
 impl From<WasmMethodType> for MethodType {
   fn from(wasm_method_type: WasmMethodType) -> Self {
@@ -56,5 +44,3 @@ impl From<MethodType> for WasmMethodType {
     WasmMethodType(method_type)
   }
 }
-
-impl_wasm_clone!(WasmMethodType, MethodType);

--- a/bindings/wasm/src/did/wasm_resolved_document.rs
+++ b/bindings/wasm/src/did/wasm_resolved_document.rs
@@ -15,7 +15,6 @@ use crate::error::WasmResult;
 /// An IOTA DID document resolved from the Tangle. Represents an integration chain message possibly
 /// merged with one or more `DiffMessages`.
 #[wasm_bindgen(js_name = ResolvedDocument, inspectable)]
-#[derive(Debug)]
 pub struct WasmResolvedDocument(pub(crate) ResolvedIotaDocument);
 
 #[wasm_bindgen]

--- a/bindings/wasm/src/did/wasm_resolved_document.rs
+++ b/bindings/wasm/src/did/wasm_resolved_document.rs
@@ -15,7 +15,7 @@ use crate::error::WasmResult;
 /// An IOTA DID document resolved from the Tangle. Represents an integration chain message possibly
 /// merged with one or more `DiffMessages`.
 #[wasm_bindgen(js_name = ResolvedDocument, inspectable)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct WasmResolvedDocument(pub(crate) ResolvedIotaDocument);
 
 #[wasm_bindgen]
@@ -116,24 +116,9 @@ impl WasmResolvedDocument {
     self.0.integration_message_id = message_id;
     Ok(())
   }
-
-  // ===========================================================================
-  // JSON
-  // ===========================================================================
-
-  /// Serializes a `Document` object as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `Document` object from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmResolvedDocument> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
 
+impl_wasm_json!(WasmResolvedDocument, ResolvedDocument);
 impl_wasm_clone!(WasmResolvedDocument, ResolvedDocument);
 
 impl From<ResolvedIotaDocument> for WasmResolvedDocument {

--- a/bindings/wasm/src/did/wasm_service.rs
+++ b/bindings/wasm/src/did/wasm_service.rs
@@ -70,20 +70,9 @@ impl WasmService {
   pub fn properties(&self) -> Result<MapStringAny> {
     MapStringAny::try_from(self.0.properties())
   }
-
-  /// Serializes a `Service` object as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `Service` object from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(value: &JsValue) -> Result<WasmService> {
-    value.into_serde().map(Self).wasm_result()
-  }
 }
 
+impl_wasm_json!(WasmService, Service);
 impl_wasm_clone!(WasmService, Service);
 
 impl From<IotaService> for WasmService {

--- a/bindings/wasm/src/did/wasm_verification_method.rs
+++ b/bindings/wasm/src/did/wasm_verification_method.rs
@@ -14,7 +14,6 @@ use crate::error::Result;
 use crate::error::WasmResult;
 
 #[wasm_bindgen(js_name = VerificationMethod, inspectable)]
-#[derive(Debug)]
 pub struct WasmVerificationMethod(pub(crate) IotaVerificationMethod);
 
 #[wasm_bindgen(js_class = VerificationMethod)]

--- a/bindings/wasm/src/did/wasm_verification_method.rs
+++ b/bindings/wasm/src/did/wasm_verification_method.rs
@@ -14,7 +14,7 @@ use crate::error::Result;
 use crate::error::WasmResult;
 
 #[wasm_bindgen(js_name = VerificationMethod, inspectable)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub struct WasmVerificationMethod(pub(crate) IotaVerificationMethod);
 
 #[wasm_bindgen(js_class = VerificationMethod)]
@@ -62,20 +62,9 @@ impl WasmVerificationMethod {
   pub fn data(&self) -> WasmMethodData {
     WasmMethodData::from(self.0.data().clone())
   }
-
-  /// Serializes a `VerificationMethod` object as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `VerificationMethod` object from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(value: &JsValue) -> Result<WasmVerificationMethod> {
-    value.into_serde().map(Self).wasm_result()
-  }
 }
 
+impl_wasm_json!(WasmVerificationMethod, VerificationMethod);
 impl_wasm_clone!(WasmVerificationMethod, VerificationMethod);
 
 impl From<IotaVerificationMethod> for WasmVerificationMethod {

--- a/bindings/wasm/src/did/wasm_verifier_options.rs
+++ b/bindings/wasm/src/did/wasm_verifier_options.rs
@@ -10,7 +10,7 @@ use crate::error::WasmResult;
 /// Holds additional proof verification options.
 /// See `IVerifierOptions`.
 #[wasm_bindgen(js_name = VerifierOptions, inspectable)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct WasmVerifierOptions(pub(crate) VerifierOptions);
 
 #[wasm_bindgen(js_class = VerifierOptions)]
@@ -29,19 +29,10 @@ impl WasmVerifierOptions {
   pub fn default() -> WasmVerifierOptions {
     WasmVerifierOptions(VerifierOptions::default())
   }
-
-  /// Serializes a `VerifierOptions` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `VerifierOptions` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmVerifierOptions> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
+
+impl_wasm_json!(WasmVerifierOptions, VerifierOptions);
+impl_wasm_clone!(WasmVerifierOptions, VerifierOptions);
 
 impl From<VerifierOptions> for WasmVerifierOptions {
   fn from(options: VerifierOptions) -> Self {
@@ -54,8 +45,6 @@ impl From<WasmVerifierOptions> for VerifierOptions {
     options.0
   }
 }
-
-impl_wasm_clone!(WasmVerifierOptions, VerifierOptions);
 
 /// Duck-typed interface to allow creating `VerifierOptions` easily.
 #[wasm_bindgen]

--- a/bindings/wasm/src/did/wasm_verifier_options.rs
+++ b/bindings/wasm/src/did/wasm_verifier_options.rs
@@ -10,7 +10,6 @@ use crate::error::WasmResult;
 /// Holds additional proof verification options.
 /// See `IVerifierOptions`.
 #[wasm_bindgen(js_name = VerifierOptions, inspectable)]
-#[derive(Debug)]
 pub struct WasmVerifierOptions(pub(crate) VerifierOptions);
 
 #[wasm_bindgen(js_class = VerifierOptions)]

--- a/bindings/wasm/src/macros.rs
+++ b/bindings/wasm/src/macros.rs
@@ -21,3 +21,25 @@ macro_rules! impl_wasm_clone {
     }
   };
 }
+
+#[macro_export]
+macro_rules! impl_wasm_json {
+  ($wasm_class:ident, $js_class:ident) => {
+    #[wasm_bindgen(js_class = $js_class)]
+    impl $wasm_class {
+      /// Serializes this to a JSON object.
+      #[wasm_bindgen(js_name = toJSON)]
+      pub fn to_json(&self) -> $crate::error::Result<JsValue> {
+        use $crate::error::WasmResult;
+        JsValue::from_serde(&self.0).wasm_result()
+      }
+
+      /// Deserializes an instance from a JSON object.
+      #[wasm_bindgen(js_name = fromJSON)]
+      pub fn from_json(json: &JsValue) -> $crate::error::Result<$wasm_class> {
+        use $crate::error::WasmResult;
+        json.into_serde().map(Self).wasm_result()
+      }
+    }
+  };
+}

--- a/bindings/wasm/src/tangle/client.rs
+++ b/bindings/wasm/src/tangle/client.rs
@@ -36,7 +36,6 @@ use crate::tangle::WasmNetwork;
 use crate::tangle::WasmReceipt;
 
 #[wasm_bindgen(js_name = Client)]
-#[derive(Debug)]
 pub struct WasmClient {
   pub(crate) client: Rc<Client>,
 }

--- a/bindings/wasm/src/tangle/explorer.rs
+++ b/bindings/wasm/src/tangle/explorer.rs
@@ -13,7 +13,7 @@ use crate::error::Result;
 use crate::error::WasmResult;
 
 #[wasm_bindgen(js_name = ExplorerUrl)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct WasmExplorerUrl(ExplorerUrl);
 
 #[wasm_bindgen(js_class = ExplorerUrl)]
@@ -65,6 +65,8 @@ impl WasmExplorerUrl {
     self.0.to_string()
   }
 }
+
+impl_wasm_json!(WasmExplorerUrl, ExplorerUrl);
 
 impl From<WasmExplorerUrl> for ExplorerUrl {
   fn from(other: WasmExplorerUrl) -> Self {

--- a/bindings/wasm/src/tangle/explorer.rs
+++ b/bindings/wasm/src/tangle/explorer.rs
@@ -13,7 +13,6 @@ use crate::error::Result;
 use crate::error::WasmResult;
 
 #[wasm_bindgen(js_name = ExplorerUrl)]
-#[derive(Debug)]
 pub struct WasmExplorerUrl(ExplorerUrl);
 
 #[wasm_bindgen(js_class = ExplorerUrl)]

--- a/bindings/wasm/src/tangle/network.rs
+++ b/bindings/wasm/src/tangle/network.rs
@@ -47,20 +47,9 @@ impl WasmNetwork {
   pub fn to_string(&self) -> String {
     self.0.name_str().to_owned()
   }
-
-  /// Serializes a `Network` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `Network` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmNetwork> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
 
+impl_wasm_json!(WasmNetwork, Network);
 impl_wasm_clone!(WasmNetwork, Network);
 
 impl From<WasmNetwork> for Network {

--- a/bindings/wasm/src/tangle/receipt.rs
+++ b/bindings/wasm/src/tangle/receipt.rs
@@ -4,12 +4,10 @@
 use identity_iota::client::Receipt;
 use wasm_bindgen::prelude::*;
 
-use crate::error::Result;
-use crate::error::WasmResult;
 use crate::tangle::WasmNetwork;
 
 #[wasm_bindgen(js_name = Receipt, inspectable)]
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug)]
 pub struct WasmReceipt(pub(crate) Receipt);
 
 // Workaround for Typescript type annotations on async function returns.
@@ -46,20 +44,9 @@ impl WasmReceipt {
     // NOTE: do not return u64 to avoid BigInt64Array/BigUint64Array compatibility issues.
     self.0.nonce().to_string()
   }
-
-  /// Serializes a `Receipt` as a JSON object.
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0).wasm_result()
-  }
-
-  /// Deserializes a `Receipt` from a JSON object.
-  #[wasm_bindgen(js_name = fromJSON)]
-  pub fn from_json(json: &JsValue) -> Result<WasmReceipt> {
-    json.into_serde().map(Self).wasm_result()
-  }
 }
 
+impl_wasm_json!(WasmReceipt, Receipt);
 impl_wasm_clone!(WasmReceipt, Receipt);
 
 impl From<Receipt> for WasmReceipt {

--- a/bindings/wasm/src/tangle/receipt.rs
+++ b/bindings/wasm/src/tangle/receipt.rs
@@ -7,7 +7,6 @@ use wasm_bindgen::prelude::*;
 use crate::tangle::WasmNetwork;
 
 #[wasm_bindgen(js_name = Receipt, inspectable)]
-#[derive(Debug)]
 pub struct WasmReceipt(pub(crate) Receipt);
 
 // Workaround for Typescript type annotations on async function returns.

--- a/bindings/wasm/src/tangle/resolver.rs
+++ b/bindings/wasm/src/tangle/resolver.rs
@@ -10,6 +10,8 @@ use identity_iota::client::ClientBuilder;
 use identity_iota::client::ResolvedIotaDocument;
 use identity_iota::client::Resolver;
 use identity_iota::client::ResolverBuilder;
+use identity_iota::credential::Presentation;
+use identity_iota::credential::PresentationValidationOptions;
 use identity_iota::credential::PresentationValidator;
 use identity_iota::credential::ValidatorDocument;
 use identity_iota::iota_core::IotaDID;
@@ -261,8 +263,8 @@ impl WasmResolver {
     let issuers: Option<Vec<IotaDocument>> = issuers.map(|js| js.into_serde().wasm_result()).transpose()?;
 
     let resolver: Rc<Resolver<Rc<Client>>> = Rc::clone(&self.0);
-    let presentation: WasmPresentation = presentation.clone();
-    let options: WasmPresentationValidationOptions = options.clone();
+    let presentation: Presentation = presentation.0.clone();
+    let options: PresentationValidationOptions = options.0.clone();
 
     let promise: Promise = future_to_promise(async move {
       let issuer_refs: Option<Vec<&dyn ValidatorDocument>> = issuers
@@ -270,8 +272,8 @@ impl WasmResolver {
         .map(|issuers| issuers.iter().map(ValidatorDocument::as_validator).collect());
       resolver
         .verify_presentation(
-          &presentation.0,
-          &options.0,
+          &presentation,
+          &options,
           fail_fast.into(),
           holder.as_ref().map(ValidatorDocument::as_validator),
           issuer_refs.as_deref(),

--- a/bindings/wasm/tests/wasm.rs
+++ b/bindings/wasm/tests/wasm.rs
@@ -273,7 +273,7 @@ fn test_did_serde() {
   // Check WasmDID deserialization.
   {
     let wasm_did: WasmDID = WasmDID::from(expected.clone());
-    let de: IotaDID = wasm_did.to_json().into_serde().unwrap();
+    let de: IotaDID = wasm_did.to_json().unwrap().into_serde().unwrap();
     assert_eq!(de, expected);
   }
 
@@ -305,7 +305,7 @@ fn test_sign_document() {
   let document1: WasmDocument = WasmDocument::new(&keypair1, None, None).unwrap();
 
   // Replace the default signing method.
-  let mut document2: WasmDocument = document1.clone();
+  let mut document2: WasmDocument = document1.deep_clone();
   let keypair2: WasmKeyPair = WasmKeyPair::new(WasmKeyType::Ed25519).unwrap();
   let method: WasmVerificationMethod = WasmVerificationMethod::new(
     &document2.id(),


### PR DESCRIPTION
# Description of change
Small change to implement `toJSON` and `fromJSON` functions using a declarative macro.

Also removes several (but not all) unnecessary derives from Wasm structs and executes `test:unit:node` in GitHub CI for the Wasm Node.js unit tests, which were previously omitted.

## Type of change

- [x] Chore/Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Works fine locally. No functional changes are expected.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
