### PR TITLE
Feature-gate `iota-client` dependency, integrate `StardustDID`

### DIFF
--- a/identity_stardust/Cargo.toml
+++ b/identity_stardust/Cargo.toml
@@ -30,12 +30,13 @@ git = "https://github.com/iotaledger/iota.rs"
 rev = "2a35c7affe15034fd1b82884966269882bffb23b" # develop branch, 2022-07-18
 features = ["tls"]
 default-features = false
+optional = true
 
 [dev-dependencies]
 anyhow = { version = "1.0.57" }
 iota-crypto = { version = "0.12.1", default-features = false, features = ["bip39", "bip39-en"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
-tokio = { version = "1.17.0", default-features = false, features = ["macros"] }
+tokio = { version = "1.17.0", default-features = false, features = ["rt-multi-thread", "macros"] }
 
 [package.metadata.docs.rs]
 # To build locally:
@@ -44,6 +45,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["revocation-bitmap"]
+default = ["iota-client", "revocation-bitmap"]
+# Enables the iota-client dependency and associated helper functions.
+iota-client = ["dep:iota-client"]
 # Enables revocation with `RevocationBitmap2022`.
 revocation-bitmap = ["identity_did/revocation-bitmap"]

--- a/identity_stardust/examples/create_did.rs
+++ b/identity_stardust/examples/create_did.rs
@@ -6,23 +6,23 @@ use std::str::FromStr;
 use identity_core::crypto::KeyPair;
 use identity_core::crypto::KeyType;
 use identity_did::verification::MethodScope;
+use iota_client::block::output::feature::IssuerFeature;
+use iota_client::block::output::feature::MetadataFeature;
+use iota_client::block::output::feature::SenderFeature;
+use iota_client::block::output::unlock_condition::AddressUnlockCondition;
+use iota_client::block::output::unlock_condition::GovernorAddressUnlockCondition;
+use iota_client::block::output::unlock_condition::StateControllerAddressUnlockCondition;
+use iota_client::block::output::unlock_condition::UnlockCondition;
 use iota_client::block::output::AliasId;
 use iota_client::block::output::AliasOutputBuilder;
 use iota_client::block::output::BasicOutputBuilder;
 use iota_client::block::output::ByteCostConfig;
 use iota_client::block::output::Feature;
-use iota_client::block::output::feature::IssuerFeature;
-use iota_client::block::output::feature::MetadataFeature;
-use iota_client::block::output::feature::SenderFeature;
 use iota_client::block::output::Output;
-use iota_client::block::output::unlock_condition::AddressUnlockCondition;
-use iota_client::block::output::unlock_condition::GovernorAddressUnlockCondition;
-use iota_client::block::output::unlock_condition::StateControllerAddressUnlockCondition;
-use iota_client::block::output::unlock_condition::UnlockCondition;
-use iota_client::Client;
 use iota_client::constants::SHIMMER_TESTNET_BECH32_HRP;
 use iota_client::secret::mnemonic::MnemonicSecretManager;
 use iota_client::secret::SecretManager;
+use iota_client::Client;
 
 use identity_stardust::NetworkName;
 use identity_stardust::StardustDID;
@@ -126,7 +126,7 @@ async fn main() -> anyhow::Result<()> {
   let _ = client.retry_until_included(&block1.id(), None, None).await?;
 
   // Infer DID from the Alias Output block.
-  let did: StardustDID = StardustDocument::did_from_block(&block1, &network_hrp)?;
+  let did: StardustDID = StardustDID::from_block(&block1, &network_hrp)?;
   println!("DID: {did}");
 
   // ===========================================================================

--- a/identity_stardust/examples/create_did.rs
+++ b/identity_stardust/examples/create_did.rs
@@ -1,25 +1,31 @@
+// Copyright 2020-2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+
 use identity_core::crypto::KeyPair;
 use identity_core::crypto::KeyType;
 use identity_did::verification::MethodScope;
-use iota_client::block::output::feature::IssuerFeature;
-use iota_client::block::output::feature::MetadataFeature;
-use iota_client::block::output::feature::SenderFeature;
-use iota_client::block::output::unlock_condition::AddressUnlockCondition;
-use iota_client::block::output::unlock_condition::GovernorAddressUnlockCondition;
-use iota_client::block::output::unlock_condition::StateControllerAddressUnlockCondition;
-use iota_client::block::output::unlock_condition::UnlockCondition;
 use iota_client::block::output::AliasId;
 use iota_client::block::output::AliasOutputBuilder;
 use iota_client::block::output::BasicOutputBuilder;
 use iota_client::block::output::ByteCostConfig;
 use iota_client::block::output::Feature;
+use iota_client::block::output::feature::IssuerFeature;
+use iota_client::block::output::feature::MetadataFeature;
+use iota_client::block::output::feature::SenderFeature;
 use iota_client::block::output::Output;
+use iota_client::block::output::unlock_condition::AddressUnlockCondition;
+use iota_client::block::output::unlock_condition::GovernorAddressUnlockCondition;
+use iota_client::block::output::unlock_condition::StateControllerAddressUnlockCondition;
+use iota_client::block::output::unlock_condition::UnlockCondition;
+use iota_client::Client;
 use iota_client::constants::SHIMMER_TESTNET_BECH32_HRP;
 use iota_client::secret::mnemonic::MnemonicSecretManager;
 use iota_client::secret::SecretManager;
-use iota_client::Client;
 
 use identity_stardust::NetworkName;
+use identity_stardust::StardustDID;
 use identity_stardust::StardustDocument;
 use identity_stardust::StardustVerificationMethod;
 
@@ -120,7 +126,7 @@ async fn main() -> anyhow::Result<()> {
   let _ = client.retry_until_included(&block1.id(), None, None).await?;
 
   // Infer DID from the Alias Output block.
-  let did = StardustDocument::did_from_block(&block1, &network_hrp)?;
+  let did: StardustDID = StardustDocument::did_from_block(&block1, &network_hrp)?;
   println!("DID: {did}");
 
   // ===========================================================================
@@ -129,8 +135,8 @@ async fn main() -> anyhow::Result<()> {
   // iota.rs indexer example:
   // https://github.com/iotaledger/iota.rs/blob/f945ccf326829a418334942ae9cf53b8fab3dbe5/examples/indexer.rs
 
-  // Extract Alias ID from DID.
-  let alias_id: AliasId = StardustDocument::did_to_alias_id(&did)?;
+  // Extract Alias ID from the DID tag.
+  let alias_id: AliasId = AliasId::from_str(did.tag())?;
   println!("Alias ID: {alias_id}");
 
   // Query Indexer INX Plugin for the Output of the Alias ID.

--- a/identity_stardust/examples/create_did.rs
+++ b/identity_stardust/examples/create_did.rs
@@ -147,7 +147,7 @@ async fn main() -> anyhow::Result<()> {
   println!("Output: {output:?}");
 
   // The resolved DID Document replaces the placeholder DID with the correct one.
-  let resolved_document = StardustDocument::deserialize_from_output(&did, &output)?;
+  let resolved_document = StardustDocument::unpack_from_output(&did, &output)?;
   println!("Resolved Document: {resolved_document:#}");
 
   let alias_output = match output {

--- a/identity_stardust/src/did/mod.rs
+++ b/identity_stardust/src/did/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-mod stardust_did;
 pub use stardust_did::StardustDID;
-// TODO: Uncomment once the `document` module gets refactored to use the types from this module.
-//pub use stardust_did::StardustDIDUrl;
+pub use stardust_did::StardustDIDUrl;
+
+mod stardust_did;

--- a/identity_stardust/src/did/stardust_did.rs
+++ b/identity_stardust/src/did/stardust_did.rs
@@ -6,21 +6,26 @@ use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
 use core::str::FromStr;
-use identity_core::common::KeyComparable;
-use serde::Deserialize;
-use serde::Serialize;
 
+use identity_core::common::KeyComparable;
 use identity_did::did::BaseDIDUrl;
 use identity_did::did::CoreDID;
 use identity_did::did::DIDError;
 use identity_did::did::DIDUrl;
 use identity_did::did::DID;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::NetworkName;
 
 pub type Result<T> = std::result::Result<T, DIDError>;
 
-// The length of an AliasID, which is a BLAKE2b-256 hash (32-bytes).
+/// A DID URL conforming to the IOTA Stardust UTXO DID method specification.
+///
+/// See [`DIDUrl`].
+pub type StardustDIDUrl = DIDUrl<StardustDID>;
+
+// The length of an Alias ID, which is a BLAKE2b-256 hash (32-bytes).
 const TAG_BYTES_LEN: usize = 32;
 
 /// A DID conforming to the IOTA UTXO DID method specification.
@@ -43,18 +48,12 @@ impl StardustDID {
   /// The default Tangle network (`"main"`).
   pub const DEFAULT_NETWORK: &'static str = "main";
 
-  /// Converts an owned [`CoreDID`] to a [`StardustDID`].
-  ///
-  /// # Errors
-  ///
-  /// Returns `Err` if the input does not conform to the [`StardustDID`] specification.
-  pub fn try_from_core(did: CoreDID) -> Result<Self> {
-    Self::check_validity(&did)?;
+  // ===========================================================================
+  // Constructors
+  // ===========================================================================
 
-    Ok(Self(Self::normalize(did)))
-  }
-
-  /// Constructs a new [`StardustDID`] from a byte representation of the tag and the given network name.
+  /// Constructs a new [`StardustDID`] from a byte representation of the tag and the given
+  /// network name.
   ///
   /// See also [`StardustDID::placeholder`].
   ///
@@ -74,15 +73,6 @@ impl StardustDID {
     Self::parse(did).expect("DIDs constructed with new should be valid")
   }
 
-  /// Parses an [`StardustDID`] from the given `input`.
-  ///
-  /// # Errors
-  ///
-  /// Returns `Err` if the input does not conform to the [`StardustDID`] specification.
-  pub fn parse(input: impl AsRef<str>) -> Result<Self> {
-    CoreDID::parse(input).and_then(Self::try_from_core)
-  }
-
   /// Creates a new placeholder [`StardustDID`] with the given network name.
   ///
   /// # Example
@@ -98,18 +88,108 @@ impl StardustDID {
     Self::new(&[0; 32], network_name)
   }
 
-  // Check if the tag matches a potential alias_id
-  fn check_tag_str(tag: &str) -> Result<()> {
+  /// Parses an [`StardustDID`] from the given `input`.
+  ///
+  /// # Errors
+  ///
+  /// Returns `Err` if the input does not conform to the [`StardustDID`] specification.
+  pub fn parse(input: impl AsRef<str>) -> Result<Self> {
+    CoreDID::parse(input).and_then(Self::try_from_core)
+  }
+
+  /// Converts a [`CoreDID`] to a [`StardustDID`].
+  ///
+  /// # Errors
+  ///
+  /// Returns `Err` if the input does not conform to the [`StardustDID`] specification.
+  pub fn try_from_core(did: CoreDID) -> Result<Self> {
+    Self::check_validity(&did)?;
+
+    Ok(Self(Self::normalize(did)))
+  }
+
+  // ===========================================================================
+  // Properties
+  // ===========================================================================
+
+  /// Returns the IOTA `network` name of the `DID`.
+  pub fn network_str(&self) -> &str {
+    Self::denormalized_components(self.method_id()).0
+  }
+
+  /// Returns the tag of the `DID`, which is a hex-encoded Alias ID.
+  pub fn tag(&self) -> &str {
+    Self::denormalized_components(self.method_id()).1
+  }
+
+  // ===========================================================================
+  // Validation
+  // ===========================================================================
+
+  /// Checks if the given `DID` is syntactically valid according to the [`StardustDID`] method specification.
+  ///
+  /// # Errors
+  ///
+  /// Returns `Err` if the input is not a syntactically valid [`StardustDID`].
+  pub fn check_validity<D: DID>(did: &D) -> Result<()> {
+    Self::check_method(did)
+      .and_then(|_| Self::check_tag(did))
+      .and_then(|_| Self::check_network(did))
+  }
+
+  /// Returns a `bool` indicating if the given `DID` is valid according to the
+  /// [`StardustDID`] method specification.
+  ///
+  /// Equivalent to `StardustDID::check_validity(did).is_ok()`.
+  pub fn is_valid(did: &CoreDID) -> bool {
+    Self::check_validity(did).is_ok()
+  }
+
+  // ===========================================================================
+  // Helpers
+  // ===========================================================================
+
+  /// Checks if the given `DID` has a valid [`StardustDID`] `method` (i.e. `"stardust"`).
+  ///
+  /// # Errors
+  ///
+  /// Returns `Err` if the input represents another method.
+  // TODO: Change the naming in the docs once we remove the code for the current IOTA method.
+  fn check_method<D: DID>(did: &D) -> Result<()> {
+    (did.method() == Self::METHOD)
+      .then_some(())
+      .ok_or(DIDError::InvalidMethodName)
+  }
+
+  /// Checks if the given `DID` has a valid [`StardustDID`] `method_id`.
+  ///
+  /// # Errors
+  ///
+  /// Returns `Err` if the input does not have a [`StardustDID`] compliant method id.
+  fn check_tag<D: DID>(did: &D) -> Result<()> {
+    let (_, tag) = Self::denormalized_components(did.method_id());
+
+    // Implicitly catches if there are too many segments (:) in the DID too.
     prefix_hex::decode::<[u8; TAG_BYTES_LEN]>(tag)
       .map_err(|_| DIDError::InvalidMethodId)
       .map(|_| ())
   }
 
-  // Normalizes the DID `method_id` by removing the default network segment if present.
-  //
-  // E.g.
-  // - `"did:stardust:main:123" -> "did:stardust:123"` is normalized
-  // - `"did:stardust:dev:123" -> "did:stardust:dev:123"` is unchanged
+  /// Checks if the given `DID` has a valid [`StardustDID`] network name.
+  ///
+  /// # Errors
+  ///
+  /// Returns `Err` if the input is not a valid network name according to the [`StardustDID`] method specification.
+  fn check_network<D: DID>(did: &D) -> Result<()> {
+    let (network_name, _) = Self::denormalized_components(did.method_id());
+    NetworkName::validate_network_name(network_name).map_err(|_| DIDError::Other("invalid network name"))
+  }
+
+  /// Normalizes the DID `method_id` by removing the default network segment if present.
+  ///
+  /// E.g.
+  /// - `"did:stardust:main:123" -> "did:stardust:123"` is normalized
+  /// - `"did:stardust:dev:123" -> "did:stardust:dev:123"` is unchanged
   // TODO: Remove the lint once this bug in clippy has been fixed. Without to_owned a mutable reference will be aliased.
   #[allow(clippy::unnecessary_to_owned)]
   fn normalize(mut did: CoreDID) -> CoreDID {
@@ -125,62 +205,6 @@ impl StardustDID {
     }
   }
 
-  /// Checks if the given `DID` has a valid [`StardustDID`] network name.
-  ///
-  /// # Errors
-  ///
-  /// Returns `Err` if the input is not a valid network name according to the [`StardustDID`] method specification.
-  pub fn check_network<D: DID>(did: &D) -> Result<()> {
-    let network_name = Self::denormalized_components(did.method_id()).0;
-    NetworkName::validate_network_name(network_name).map_err(|_| DIDError::Other("invalid network name"))
-  }
-
-  /// Checks if the given `DID` is syntactically valid according to the [`StardustDID`] method specification.
-  ///
-  /// # Errors
-  ///
-  /// Returns `Err` if the input is not a syntactically valid [`StardustDID`].
-  pub fn check_validity<D: DID>(did: &D) -> Result<()> {
-    Self::check_method(did).and_then(|_| Self::check_method_id(did))
-  }
-
-  /// Checks if the given `DID` has a valid [`StardustDID`] `method` (i.e. `"stardust"`).
-  ///
-  /// # Errors
-  ///
-  /// Returns `Err` if the input represents another method.
-  // TODO: Change the naming in the docs once we remove the code for the current IOTA method.
-  pub fn check_method<D: DID>(did: &D) -> Result<()> {
-    (did.method() == Self::METHOD)
-      .then_some(())
-      .ok_or(DIDError::InvalidMethodName)
-  }
-
-  /// Checks if the given `DID` has a valid [`StardustDID`] `method_id`.
-  ///
-  /// # Errors
-  ///
-  /// Returns `Err` if the input does not have a [`StardustDID`] compliant method id.
-  pub fn check_method_id<D: DID>(did: &D) -> Result<()> {
-    let (network, tag) = Self::denormalized_components(did.method_id());
-    NetworkName::validate_network_name(network)
-      .map_err(|_| DIDError::InvalidMethodId)
-      .and_then(|_| Self::check_tag_str(tag))
-  }
-
-  /// Returns a `bool` indicating if the given `DID` is valid according to the
-  /// [`StardustDID`] method specification.
-  ///
-  /// Equivalent to `Self::check_validity(did).is_ok()`.
-  pub fn is_valid(did: &CoreDID) -> bool {
-    Self::check_validity(did).is_ok()
-  }
-
-  /// Returns the IOTA `network` name of the `DID`.
-  pub fn network_str(&self) -> &str {
-    Self::denormalized_components(self.method_id()).0
-  }
-
   /// foo:bar -> (foo,bar)
   /// foo:bar:baz -> (foo, bar:baz)
   /// foo -> (StardustDID::DEFAULT_NETWORK.as_ref(), foo)
@@ -192,19 +216,6 @@ impl StardustDID {
       .map(|(network, tail)| (network, &tail[1..]))
       // Self::DEFAULT_NETWORK is built from a static reference so unwrapping is fine
       .unwrap_or((Self::DEFAULT_NETWORK, input))
-  }
-
-  /// Returns the unique tag of the `DID`.
-  pub fn tag(&self) -> &str {
-    Self::denormalized_components(self.method_id()).1
-  }
-
-  /// Replace the network name of this [`StardustDID`] leaving all other segments (did, method, tag) intact.  
-  pub fn with_network_name(mut self, name: NetworkName) -> Self {
-    let new_method_id: String = format!("{}:{}", name, self.tag());
-    // unwrap is fine as we are only replacing the network
-    self.0.set_method_id(new_method_id).unwrap();
-    self
   }
 }
 
@@ -335,7 +346,6 @@ impl KeyComparable for StardustDID {
 
 #[cfg(test)]
 mod tests {
-
   use iota_client::block::output::AliasId;
   use iota_client::block::output::OutputId;
   use iota_client::block::output::OUTPUT_INDEX_RANGE;
@@ -378,10 +388,6 @@ mod tests {
     "foo42",
     "bar123",
     "42foo",
-  ];
-
-  const INVALID_NETWORK_NAMES: [&str; 10] = [
-    "Main", "fOo", "deV", "féta", "", "  ", "foo ", " foo", "1234567", "foobar0",
   ];
 
   static VALID_STARDUST_DID_STRINGS: Lazy<Vec<String>> = Lazy::new(|| {
@@ -456,6 +462,9 @@ mod tests {
 
     let mut check_network_executed: bool = false;
 
+    const INVALID_NETWORK_NAMES: [&str; 10] = [
+      "Main", "fOo", "deV", "féta", "", "  ", "foo ", " foo", "1234567", "foobar0",
+    ];
     for network_name in INVALID_NETWORK_NAMES {
       let did_string: String = format!(
         "did:method:{}:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
@@ -478,11 +487,11 @@ mod tests {
   }
 
   #[test]
-  fn valid_check_method_id() {
+  fn valid_check_tag() {
     for input in VALID_STARDUST_DID_STRINGS.iter() {
       let did_core: CoreDID = CoreDID::parse(input).unwrap();
       assert!(
-        StardustDID::check_method_id(&did_core).is_ok(),
+        StardustDID::check_tag(&did_core).is_ok(),
         "test: valid_check_method_id failed on input {}",
         input
       );
@@ -495,15 +504,13 @@ mod tests {
     let did_other_core: CoreDID = CoreDID::parse(&did_other_string).unwrap();
     let did_other_with_network_core: CoreDID = CoreDID::parse(&did_other_with_network).unwrap();
 
-    assert!(StardustDID::check_method_id(&did_other_core).is_ok());
-    assert!(StardustDID::check_method_id(&did_other_with_network_core).is_ok());
+    assert!(StardustDID::check_tag(&did_other_core).is_ok());
+    assert!(StardustDID::check_tag(&did_other_with_network_core).is_ok());
   }
 
   #[test]
-  fn invalid_check_method_id() {
+  fn invalid_check_tag() {
     let invalid_method_id_strings = [
-      // Invalid network name
-      format!("did:method:1234567:{}", VALID_ALIAS_ID_STR),
       // Too many segments
       format!("did:method:main:test:{}", VALID_ALIAS_ID_STR),
       // Tag is not prefixed
@@ -519,10 +526,11 @@ mod tests {
 
     for input in invalid_method_id_strings {
       let did_core: CoreDID = CoreDID::parse(input).unwrap();
-      assert!(matches!(
-        StardustDID::check_method_id(&did_core),
-        Err(DIDError::InvalidMethodId)
-      ));
+      assert!(
+        matches!(StardustDID::check_tag(&did_core), Err(DIDError::InvalidMethodId)),
+        "{}",
+        did_core
+      );
     }
   }
 
@@ -590,7 +598,7 @@ mod tests {
       // invalid network name (exceeded six characters)
       assert!(matches!(
         StardustDID::parse(format!("did:{}:1234567:{}", StardustDID::METHOD, valid_alias_id)),
-        Err(DIDError::InvalidMethodId)
+        Err(DIDError::Other(_))
       ));
 
       // invalid network name (contains non ascii character é)
@@ -790,33 +798,9 @@ mod tests {
   }
 
   // ===========================================================================================================================
-  // Test setters
-  // ===========================================================================================================================
-
-  #[test]
-  fn replace_network_name() {
-    for did in VALID_STARDUST_DID_STRINGS.iter() {
-      let stardust_did: StardustDID = StardustDID::parse(did).unwrap();
-      for name in VALID_NETWORK_NAMES {
-        let old_tag: String = stardust_did.tag().to_string();
-        let network_name: NetworkName = NetworkName::try_from(name).unwrap();
-        let transfromed: StardustDID = stardust_did.clone().with_network_name(network_name.clone());
-        assert_eq!(old_tag, transfromed.tag());
-        assert_eq!(transfromed.network_str(), name);
-      }
-    }
-  }
-
-  // ===========================================================================================================================
   // Test DIDUrl
   // ===========================================================================================================================
 
-  // TODO: Move `StardustDIDUrl` out of this test module once the `document` module gets refactored to use the types
-  // from this module.
-  /// A DID URL conforming to the IOTA Stardust UTXO DID method specification.
-  ///
-  /// See [`DIDUrl`].
-  type StardustDIDUrl = DIDUrl<StardustDID>;
   #[test]
   fn test_parse_did_url_valid() {
     let execute_assertions = |valid_alias_id: &str| {

--- a/identity_stardust/src/document/mod.rs
+++ b/identity_stardust/src/document/mod.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use stardust_document::StardustCoreDocument;
-pub use stardust_document::StardustDIDUrl;
 pub use stardust_document::StardustDocument;
 pub use stardust_document::StardustService;
 pub use stardust_document::StardustVerificationMethod;

--- a/identity_stardust/src/document/stardust_document.rs
+++ b/identity_stardust/src/document/stardust_document.rs
@@ -28,13 +28,13 @@ use identity_did::verification::VerificationMethod;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::did::StardustDIDUrl;
-use crate::document::stardust_document_metadata::StardustDocumentMetadata;
 use crate::error::Result;
-use crate::state_metadata::StateMetadataEncoding;
 use crate::NetworkName;
 use crate::StardustDID;
+use crate::StardustDIDUrl;
+use crate::StardustDocumentMetadata;
 use crate::StateMetadataDocument;
+use crate::StateMetadataEncoding;
 
 /// A [`VerificationMethod`] adhering to the IOTA DID method specification.
 pub type StardustVerificationMethod = VerificationMethod<StardustDID, Object>;
@@ -296,8 +296,9 @@ impl StardustDocument {
 
 #[cfg(feature = "iota-client")]
 mod stardust_document_iota_client {
-  use crate::Error;
   use iota_client::block::output::Output;
+
+  use crate::Error;
 
   use super::*;
 

--- a/identity_stardust/src/document/stardust_document.rs
+++ b/identity_stardust/src/document/stardust_document.rs
@@ -308,7 +308,7 @@ mod stardust_document_iota_client {
     /// cannot be inferred from the [`Output`]. It also indicates the network, which is not
     /// encoded in the `AliasId` alone.
     // TODO: remove? Is `unpack` sufficient?
-    pub fn deserialize_from_output(did: &StardustDID, output: &Output) -> Result<StardustDocument> {
+    pub fn unpack_from_output(did: &StardustDID, output: &Output) -> Result<StardustDocument> {
       let document: &[u8] = match output {
         Output::Alias(alias_output) => alias_output.state_metadata(),
         _ => return Err(Error::InvalidStateMetadata("not an alias output")),

--- a/identity_stardust/src/error.rs
+++ b/identity_stardust/src/error.rs
@@ -5,6 +5,7 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 // TODO: replace all variants with specific errors?
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[non_exhaustive]
 pub enum Error {
   #[error("{0}")]
   CoreError(#[from] identity_core::Error),
@@ -14,10 +15,12 @@ pub enum Error {
   InvalidDID(#[from] identity_did::did::DIDError),
   #[error("{0}")]
   InvalidDoc(#[from] identity_did::Error),
+  #[cfg(feature = "iota-client")]
   #[error("{0}")]
   ClientError(#[from] iota_client::error::Error),
+  #[cfg(feature = "iota-client")]
   #[error("{0}")]
-  BeeError(#[from] iota_client::block::Error),
+  BlockError(#[from] iota_client::block::Error),
 
   #[error("invalid network name")]
   InvalidNetworkName,

--- a/identity_stardust/src/error.rs
+++ b/identity_stardust/src/error.rs
@@ -12,8 +12,6 @@ pub enum Error {
   CredError(#[from] identity_credential::Error),
   #[error("{0}")]
   InvalidDID(#[from] identity_did::did::DIDError),
-  #[error("invalid network name")]
-  InvalidNetworkName,
   #[error("{0}")]
   InvalidDoc(#[from] identity_did::Error),
   #[error("{0}")]
@@ -21,6 +19,8 @@ pub enum Error {
   #[error("{0}")]
   BeeError(#[from] iota_client::block::Error),
 
+  #[error("invalid network name")]
+  InvalidNetworkName,
   #[error("invalid state metadata {0}")]
   InvalidStateMetadata(&'static str),
   #[error("credential revocation error")]

--- a/identity_stardust/src/lib.rs
+++ b/identity_stardust/src/lib.rs
@@ -4,16 +4,15 @@
 #![forbid(unsafe_code)]
 #![allow(clippy::upper_case_acronyms)]
 
+pub use did::StardustDID;
+pub use did::StardustDIDUrl;
+pub use document::*;
+pub use network::NetworkName;
+pub use state_metadata::*;
+
 pub use self::error::Error;
 pub use self::error::Result;
 
-pub use document::*;
-pub use state_metadata::*;
-
-pub use did::StardustDID;
-// TODO: Uncomment once `document` has been refactored to use the types from the `did` module in this crate.
-// pub use did::StardustDIDUrl;
-pub use network::NetworkName;
 mod did;
 mod document;
 mod error;

--- a/identity_stardust/src/state_metadata/document.rs
+++ b/identity_stardust/src/state_metadata/document.rs
@@ -44,6 +44,7 @@ impl StateMetadataDocument {
         if did == PLACEHOLDER_DID.as_ref() {
           Ok(original_did.clone())
         } else {
+          // TODO: wrap error?
           StardustDID::try_from_core(did)
         }
       },

--- a/identity_stardust/src/state_metadata/document.rs
+++ b/identity_stardust/src/state_metadata/document.rs
@@ -12,6 +12,7 @@ use serde::Serialize;
 use crate::error::Result;
 use crate::Error;
 use crate::StardustCoreDocument;
+use crate::StardustDID;
 use crate::StardustDocument;
 use crate::StardustDocumentMetadata;
 
@@ -35,21 +36,21 @@ pub(crate) struct StateMetadataDocument {
 
 impl StateMetadataDocument {
   /// Transforms the document into a [`StardustDocument`] by replacing all placeholders with `original_did`.
-  pub fn into_stardust_document(self, original_did: &CoreDID) -> StardustDocument {
+  pub fn into_stardust_document(self, original_did: &StardustDID) -> Result<StardustDocument> {
     let Self { document, metadata } = self;
-    let core_document: StardustCoreDocument = document.map(
+    let core_document: StardustCoreDocument = document.try_map(
       // Replace placeholder identifiers.
       |did| {
         if did == PLACEHOLDER_DID.as_ref() {
-          original_did.clone()
+          Ok(original_did.clone())
         } else {
-          did
+          StardustDID::try_from_core(did)
         }
       },
       // Do not modify properties.
-      |o| o,
-    );
-    StardustDocument::from((core_document, metadata))
+      Ok,
+    )?;
+    Ok(StardustDocument::from((core_document, metadata)))
   }
 
   /// Pack a [`StateMetadataDocument`] into bytes, suitable for inclusion in
@@ -116,14 +117,14 @@ impl From<StardustDocument> for StateMetadataDocument {
   /// occurrences of its did with a placeholder.
   fn from(document: StardustDocument) -> Self {
     let StardustDocument { document, metadata } = document;
-    let id: CoreDID = document.id().clone();
+    let id: StardustDID = document.id().clone();
     let core_document: CoreDocument = document.map(
       // Replace self-referential identifiers with a placeholder, but not others.
       |did| {
         if did == id {
           PLACEHOLDER_DID.clone()
         } else {
-          did
+          CoreDID::from(did)
         }
       },
       // Do not modify properties.
@@ -143,11 +144,11 @@ mod tests {
   use identity_core::common::Url;
   use identity_core::crypto::KeyPair;
   use identity_core::crypto::KeyType;
-  use identity_did::did::CoreDID;
   use identity_did::did::DID;
   use identity_did::verification::MethodScope;
 
   use crate::state_metadata::PLACEHOLDER_DID;
+  use crate::StardustDID;
   use crate::StardustDocument;
   use crate::StardustService;
   use crate::StardustVerificationMethod;
@@ -156,15 +157,15 @@ mod tests {
 
   struct TestSetup {
     document: StardustDocument,
-    did_self: CoreDID,
-    did_foreign: CoreDID,
+    did_self: StardustDID,
+    did_foreign: StardustDID,
   }
 
   fn test_document() -> TestSetup {
     let did_self =
-      CoreDID::parse("did:stardust:8036235b6b5939435a45d68bcea7890eef399209a669c8c263fac7f5089b2ec6").unwrap();
+      StardustDID::parse("did:stardust:0x8036235b6b5939435a45d68bcea7890eef399209a669c8c263fac7f5089b2ec6").unwrap();
     let did_foreign =
-      CoreDID::parse("did:stardust:71b709dff439f1ac9dd2b9c2e28db0807156b378e13bfa3605ce665aa0d0fdca").unwrap();
+      StardustDID::parse("did:stardust:0x71b709dff439f1ac9dd2b9c2e28db0807156b378e13bfa3605ce665aa0d0fdca").unwrap();
 
     let mut document: StardustDocument = StardustDocument::new_with_id(did_self.clone());
     let keypair: KeyPair = KeyPair::new(KeyType::Ed25519).unwrap();
@@ -251,7 +252,7 @@ mod tests {
         .unwrap()
         .id()
         .did(),
-      &did_foreign
+      did_foreign.as_ref()
     );
 
     assert_eq!(
@@ -263,7 +264,7 @@ mod tests {
         .unwrap()
         .id()
         .did(),
-      &did_foreign
+      did_foreign.as_ref()
     );
 
     assert_eq!(
@@ -279,11 +280,10 @@ mod tests {
     );
 
     let controllers = state_metadata_doc.document.controller().unwrap();
-    assert_eq!(controllers.get(0).unwrap(), &did_foreign);
+    assert_eq!(controllers.get(0).unwrap(), did_foreign.as_ref());
     assert_eq!(controllers.get(1).unwrap(), PLACEHOLDER_DID.as_ref());
 
-    let stardust_document = state_metadata_doc.into_stardust_document(&did_self);
-
+    let stardust_document = state_metadata_doc.into_stardust_document(&did_self).unwrap();
     assert_eq!(stardust_document, document);
   }
 


### PR DESCRIPTION
# Description of change
Integrates `StardustDocument` with `StardustDID` introduced in #949. Also simplifies the public API of `StardustDID` somewhat to reduce the work needed for the future Wasm bindings. The `"iota-client"` feature-gate is to prevent potential compilation errors in the future, and would be good to have in general.

### Added

- Add `"iota-client"` feature to `identity_stardust`.

### Changed

- Change `StardustDocument::new` to take `NetworkName`.
- Make `StardustDID` functions `check_method`, `check_method_id`, and `check_network` private.
- Move `StardustDocument::did_from_block` to `StardustDID::from_block`.
- Rename and feature-gate `StardustDocument::deserialize_from_output` to `unpack_from_output`.

### Removed

- Remove `StardustDocument::placeholder_did`.
- Remove `StardustDID::with_network_name` - it had a bug where setting the default network "main" would not be normalised.

## Links to any relevant issues
Part of #908.

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Unit tests pass with default features, `cargo test --no-default-features` (when example is removed, otherwise fails to compile), and `cargo test --all-features` (same as default).

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
