### PR TITLE
Change CI params to use all-features consistently

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -102,13 +102,13 @@ jobs:
         with:
           # Build the library, tests, and examples without running them to avoid recompilation in the run tests step
           command: build
-          args: --workspace --tests --examples --release
+          args: --workspace --tests --examples --all-features --release
 
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --all-features --release
+          args: --workspace --all-features --release
 
       - name: Run Rust examples
         # run examples only on ubuntu for now
@@ -116,7 +116,7 @@ jobs:
         run: |
           cargo read-manifest --manifest-path ./examples/Cargo.toml | \
           jq -r '.targets[].name' | \
-          parallel -k -j 4 --retries 3 cargo run --example {} --release
+          parallel -k -j 4 --retries 3 cargo run --example {} --all-features --release
 
       - name: Stop sccache
         uses: './.github/actions/rust/sccache/stop-sccache'
@@ -159,13 +159,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --manifest-path ./identity_stardust/Cargo.toml --workspace --tests --examples --release
+          args: --manifest-path ./identity_stardust/Cargo.toml --workspace --tests --examples --all-features --release
 
       - name: Run Stardust tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path ./identity_stardust/Cargo.toml --all --all-features --release
+          args: --manifest-path ./identity_stardust/Cargo.toml --workspace --all-features --release
 
       - name: Stop sccache
         uses: './.github/actions/rust/sccache/stop-sccache'


### PR DESCRIPTION
# Description of change
Changes the `cargo` parameters in CI workflows to use `all-features` consistently. This prevents recompilations when running the tests and examples.

#### BEFORE, notice the tests recompile.

Build:

> Compiling examples v0.6.0 (D:\a\[identity.rs](http://identity.rs/)\[identity.rs](http://identity.rs/)\examples)
>     Finished release [optimized] target(s) in 28m 12s

Run tests:

> Compiling examples v0.6.0 (D:\a\[identity.rs](http://identity.rs/)\[identity.rs](http://identity.rs/)\examples)
>     Finished release [optimized] target(s) in 23m 23s
>      Running unittests src\[lib.rs](http://lib.rs/) (target\release\deps\identity_diff-f13010726bc18707.exe)

https://github.com/iotaledger/identity.rs/runs/7516322686?check_suite_focus=true

#### AFTER, no recompilation.

Build:

>    Compiling examples v0.6.0 (D:\a\identity.rs\identity.rs\examples)
>     Finished release [optimized] target(s) in 24m 13s

Run:

> Finished release [optimized] target(s) in 0.67s
> Running unittests src\lib.rs (target\release\deps\identity_diff-f13010726bc18707.exe)

## Type of change

- [x] Chore/Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Build with: `cargo build --workspace --tests --examples --all-features --release`

Then, the tests and examples should run without recompilation:

- `cargo test --workspace --all-features --release`
- `cargo run --example create_did --all-features --release`

You can see the `Run tests` and `Run Rust examples` steps of the following CI run do _not_ recompile with this change, as intended.

https://github.com/iotaledger/identity.rs/runs/7517790776?check_suite_focus=true

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
