### PR TITLE
Add missing DID trait methods to Wasm

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -198,9 +198,9 @@ This variant is the default used if no other variant is specified when construct
 <dt><a href="#FirstError">FirstError</a></dt>
 <dd><p>Return after the first error occurs.</p>
 </dd>
-<dt><a href="#MethodRelationship">MethodRelationship</a></dt>
-<dd></dd>
 <dt><a href="#KeyType">KeyType</a></dt>
+<dd></dd>
+<dt><a href="#MethodRelationship">MethodRelationship</a></dt>
 <dd></dd>
 </dl>
 
@@ -223,7 +223,6 @@ publishing to the Tangle.
 **Kind**: global class  
 
 * [Account](#Account)
-    * [.createService(options)](#Account+createService) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.attachMethodRelationships(options)](#Account+attachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.createMethod(options)](#Account+createMethod) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.detachMethodRelationships(options)](#Account+detachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -248,17 +247,7 @@ publishing to the Tangle.
     * [.deleteService(options)](#Account+deleteService) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.setAlsoKnownAs(options)](#Account+setAlsoKnownAs) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.setController(options)](#Account+setController) ⇒ <code>Promise.&lt;void&gt;</code>
-
-<a name="Account+createService"></a>
-
-### account.createService(options) ⇒ <code>Promise.&lt;void&gt;</code>
-Adds a new Service to the DID Document.
-
-**Kind**: instance method of [<code>Account</code>](#Account)  
-
-| Param | Type |
-| --- | --- |
-| options | <code>CreateServiceOptions</code> | 
+    * [.createService(options)](#Account+createService) ⇒ <code>Promise.&lt;void&gt;</code>
 
 <a name="Account+attachMethodRelationships"></a>
 
@@ -530,6 +519,17 @@ Sets the controllers of the DID document.
 | Param | Type |
 | --- | --- |
 | options | <code>SetControllerOptions</code> | 
+
+<a name="Account+createService"></a>
+
+### account.createService(options) ⇒ <code>Promise.&lt;void&gt;</code>
+Adds a new Service to the DID Document.
+
+**Kind**: instance method of [<code>Account</code>](#Account)  
+
+| Param | Type |
+| --- | --- |
+| options | <code>CreateServiceOptions</code> | 
 
 <a name="AccountBuilder"></a>
 
@@ -1332,9 +1332,13 @@ Fails if the issuer field is not a valid DID.
 * [DID](#DID)
     * [new DID(public_key, network)](#new_DID_new)
     * _instance_
-        * [.networkName](#DID+networkName) ⇒ <code>string</code>
         * [.network()](#DID+network) ⇒ [<code>Network</code>](#Network)
+        * [.networkStr()](#DID+networkStr) ⇒ <code>string</code>
         * [.tag()](#DID+tag) ⇒ <code>string</code>
+        * [.scheme()](#DID+scheme) ⇒ <code>string</code>
+        * [.authority()](#DID+authority) ⇒ <code>string</code>
+        * [.method()](#DID+method) ⇒ <code>string</code>
+        * [.methodId()](#DID+methodId) ⇒ <code>string</code>
         * [.join(segment)](#DID+join) ⇒ [<code>DIDUrl</code>](#DIDUrl)
         * [.toUrl()](#DID+toUrl) ⇒ [<code>DIDUrl</code>](#DIDUrl)
         * [.intoUrl()](#DID+intoUrl) ⇒ [<code>DIDUrl</code>](#DIDUrl)
@@ -1356,22 +1360,62 @@ Creates a new `DID` from a public key.
 | public_key | <code>Uint8Array</code> | 
 | network | <code>string</code> \| <code>undefined</code> | 
 
-<a name="DID+networkName"></a>
-
-### did.networkName ⇒ <code>string</code>
-Returns the IOTA tangle network of the `DID`.
-
-**Kind**: instance property of [<code>DID</code>](#DID)  
 <a name="DID+network"></a>
 
 ### did.network() ⇒ [<code>Network</code>](#Network)
-Returns the IOTA tangle network of the `DID`.
+Returns the Tangle network of the `DID`.
+
+**Kind**: instance method of [<code>DID</code>](#DID)  
+<a name="DID+networkStr"></a>
+
+### did.networkStr() ⇒ <code>string</code>
+Returns the Tangle network name of the `DID`.
 
 **Kind**: instance method of [<code>DID</code>](#DID)  
 <a name="DID+tag"></a>
 
 ### did.tag() ⇒ <code>string</code>
 Returns a copy of the unique tag of the `DID`.
+
+**Kind**: instance method of [<code>DID</code>](#DID)  
+<a name="DID+scheme"></a>
+
+### did.scheme() ⇒ <code>string</code>
+Returns the `DID` scheme.
+
+E.g.
+- `"did:example:12345678" -> "did"`
+- `"did:iota:main:12345678" -> "did"`
+
+**Kind**: instance method of [<code>DID</code>](#DID)  
+<a name="DID+authority"></a>
+
+### did.authority() ⇒ <code>string</code>
+Returns the `DID` authority: the method name and method-id.
+
+E.g.
+- `"did:example:12345678" -> "example:12345678"`
+- `"did:iota:main:12345678" -> "iota:main:12345678"`
+
+**Kind**: instance method of [<code>DID</code>](#DID)  
+<a name="DID+method"></a>
+
+### did.method() ⇒ <code>string</code>
+Returns the `DID` method name.
+
+E.g.
+- `"did:example:12345678" -> "example"`
+- `"did:iota:main:12345678" -> "iota"`
+
+**Kind**: instance method of [<code>DID</code>](#DID)  
+<a name="DID+methodId"></a>
+
+### did.methodId() ⇒ <code>string</code>
+Returns the `DID` method-specific ID.
+
+E.g.
+- `"did:example:12345678" -> "12345678"`
+- `"did:iota:main:12345678" -> "main:12345678"`
 
 **Kind**: instance method of [<code>DID</code>](#DID)  
 <a name="DID+join"></a>
@@ -5061,13 +5105,13 @@ Return all errors that occur during validation.
 Return after the first error occurs.
 
 **Kind**: global variable  
-<a name="MethodRelationship"></a>
-
-## MethodRelationship
-**Kind**: global variable  
 <a name="KeyType"></a>
 
 ## KeyType
+**Kind**: global variable  
+<a name="MethodRelationship"></a>
+
+## MethodRelationship
 **Kind**: global variable  
 <a name="start"></a>
 

--- a/bindings/wasm/src/did/wasm_did.rs
+++ b/bindings/wasm/src/did/wasm_did.rs
@@ -38,22 +38,66 @@ impl WasmDID {
     IotaDID::parse(input).wasm_result().map(Self)
   }
 
-  /// Returns the IOTA tangle network of the `DID`.
+  /// Returns the Tangle network of the `DID`.
   #[wasm_bindgen]
   pub fn network(&self) -> Result<WasmNetwork> {
     self.0.network().map(Into::into).wasm_result()
   }
 
-  /// Returns the IOTA tangle network of the `DID`.
-  #[wasm_bindgen(getter = networkName)]
-  pub fn network_name(&self) -> String {
-    self.0.network_str().into()
+  /// Returns the Tangle network name of the `DID`.
+  #[wasm_bindgen(js_name = networkStr)]
+  pub fn network_str(&self) -> String {
+    self.0.network_str().to_owned()
   }
 
   /// Returns a copy of the unique tag of the `DID`.
   #[wasm_bindgen]
   pub fn tag(&self) -> String {
-    self.0.tag().into()
+    self.0.tag().to_owned()
+  }
+
+  // ===========================================================================
+  // DID trait
+  // ===========================================================================
+
+  /// Returns the `DID` scheme.
+  ///
+  /// E.g.
+  /// - `"did:example:12345678" -> "did"`
+  /// - `"did:iota:main:12345678" -> "did"`
+  #[wasm_bindgen]
+  pub fn scheme(&self) -> String {
+    self.0.scheme().to_owned()
+  }
+
+  /// Returns the `DID` authority: the method name and method-id.
+  ///
+  /// E.g.
+  /// - `"did:example:12345678" -> "example:12345678"`
+  /// - `"did:iota:main:12345678" -> "iota:main:12345678"`
+  #[wasm_bindgen]
+  pub fn authority(&self) -> String {
+    self.0.authority().to_owned()
+  }
+
+  /// Returns the `DID` method name.
+  ///
+  /// E.g.
+  /// - `"did:example:12345678" -> "example"`
+  /// - `"did:iota:main:12345678" -> "iota"`
+  #[wasm_bindgen]
+  pub fn method(&self) -> String {
+    self.0.method().to_owned()
+  }
+
+  /// Returns the `DID` method-specific ID.
+  ///
+  /// E.g.
+  /// - `"did:example:12345678" -> "12345678"`
+  /// - `"did:iota:main:12345678" -> "main:12345678"`
+  #[wasm_bindgen(js_name = methodId)]
+  pub fn method_id(&self) -> String {
+    self.0.method_id().to_owned()
   }
 
   /// Construct a new `DIDUrl` by joining with a relative DID Url string.

--- a/bindings/wasm/tests/wasm.rs
+++ b/bindings/wasm/tests/wasm.rs
@@ -54,13 +54,27 @@ fn test_did() {
   assert_eq!(did.network_str(), "main");
 
   let parsed = WasmDID::parse(&did.to_string()).unwrap();
-
   assert_eq!(did.to_string(), parsed.to_string());
 
   let base58 = WasmDID::new(&key.public(), Some("dev".to_owned())).unwrap();
 
   assert_eq!(base58.tag(), did.tag());
   assert_eq!(base58.network_str(), "dev");
+}
+
+#[wasm_bindgen_test]
+fn test_did_methods() {
+  let tag = "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV";
+  let did_str = format!("did:iota:dev:{tag}");
+  let did = WasmDID::parse(&did_str).unwrap();
+
+  assert_eq!(did.to_string(), did_str);
+  assert_eq!(did.tag(), tag);
+  assert_eq!(did.network_str(), "dev");
+  assert_eq!(did.scheme(), "did");
+  assert_eq!(did.method(), "iota");
+  assert_eq!(did.method_id(), format!("dev:{tag}"));
+  assert_eq!(did.authority(), format!("iota:dev:{tag}"));
 }
 
 #[wasm_bindgen_test]

--- a/bindings/wasm/tests/wasm.rs
+++ b/bindings/wasm/tests/wasm.rs
@@ -51,7 +51,7 @@ fn test_did() {
   let key = WasmKeyPair::new(WasmKeyType::Ed25519).unwrap();
   let did = WasmDID::new(&key.public(), None).unwrap();
 
-  assert_eq!(did.network_name(), "main");
+  assert_eq!(did.network_str(), "main");
 
   let parsed = WasmDID::parse(&did.to_string()).unwrap();
 
@@ -60,7 +60,7 @@ fn test_did() {
   let base58 = WasmDID::new(&key.public(), Some("dev".to_owned())).unwrap();
 
   assert_eq!(base58.tag(), did.tag());
-  assert_eq!(base58.network_name(), "dev");
+  assert_eq!(base58.network_str(), "dev");
 }
 
 #[wasm_bindgen_test]
@@ -93,7 +93,7 @@ fn test_did_url() {
 fn test_document_new() {
   let keypair: WasmKeyPair = WasmKeyPair::new(WasmKeyType::Ed25519).unwrap();
   let document: WasmDocument = WasmDocument::new(&keypair, None, None).unwrap();
-  assert_eq!(document.id().network_name(), "main");
+  assert_eq!(document.id().network_str(), "main");
   assert!(document.default_signing_method().is_ok());
 }
 
@@ -261,7 +261,7 @@ fn test_document_network() {
   let keypair: WasmKeyPair = WasmKeyPair::new(WasmKeyType::Ed25519).unwrap();
   let document: WasmDocument = WasmDocument::new(&keypair, Some("dev".to_owned()), None).unwrap();
 
-  assert_eq!(document.id().network_name(), "dev");
+  assert_eq!(document.id().network_str(), "dev");
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
# Description of change
Add missing DID trait methods to `WasmDID`.

### Added

- Add `WasmDID.scheme()`.
- Add `WasmDID.authority()`.
- Add `WasmDID.method()`.
- Add `WasmDID.methodId()`.

### Changed

- Rename `WasmDID.networkName` to `networkStr` for consistency.

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Added Wasm unit test.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
