### PR TITLE
Add initial Wasm Stardust bindings

### DIFF
--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -24,7 +24,7 @@ proc_typescript = { version = "0.1.0", path = "./proc_typescript" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
 serde_repr = { version = "0.1", default-features = false }
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"] }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 
 [dependencies.identity_iota]
@@ -44,7 +44,6 @@ wasm-bindgen-test = { version = "0.3" }
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-parking_lot = { version = "0.11.2", features = ["wasm-bindgen"] }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = true

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -33,6 +33,12 @@ path = "../../identity_iota"
 default-features = false
 features = ["account", "storage-test-suite", "unstable-encryption", "revocation-bitmap"]
 
+[dependencies.identity_stardust]
+version = "=0.6.0"
+path = "../../identity_stardust"
+default-features = false
+features = ["revocation-bitmap"]
+
 [dev-dependencies]
 wasm-bindgen-test = { version = "0.3" }
 

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -43,7 +43,8 @@ features = ["revocation-bitmap"]
 wasm-bindgen-test = { version = "0.3" }
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.2", default-features = false, features = ["js"] }
+instant = { version = "0.1", default-features = false, features = ["wasm-bindgen"] }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = true

--- a/bindings/wasm/build/lints.js
+++ b/bindings/wasm/build/lints.js
@@ -42,11 +42,45 @@ See: https://github.com/rustwasm/wasm-bindgen/pull/2677`);
     }
 }
 
+/** Rejects any `imports['env']` occurrences, which cause failures at runtime.
+ *
+ *  This is typically due to Wasm compatibility features not being enabled on crate dependencies. **/
+function lintImportEnv(content) {
+    if (content.includes("imports['env']") || content.includes("require('env')") || content.includes("from 'env'")) {
+        throw(`ERROR: generated Javascript should not include any imports for 'env', e.g.:
+
+- imports['env'] = require('env'); 
+- imports['env'] = __wbg_star0;
+- import * as __wbg_star0 from 'env';
+
+It causes runtime errors such as "Module not found: Error: Can't resolve 'env'".
+This usually indicates a dependency trying to use or import non-Wasm-compatible code or libraries.
+
+Common problematic crates and the feature flag required to be compatible:
+- parking_lot <= 0.11.2, "wasm-bindgen" (0.12.0 deprecated the "wasm-bindgen" feature).
+- instant 0.1, "wasm-bindgen".
+- getrandom 0.2, "js".
+
+SUGGESTION: Identify the problematic crate by comparing recent changes to Cargo.toml in this project and any
+dependencies. Then, enable the relevant "js" or "wasm-bindgen" feature flag in Cargo.toml for that specific
+dependency and version.
+
+E.g. (only add this to Cargo.toml if they appear in Cargo.lock, and the version must match Cargo.lock).
+getrandom = { version = "0.2", default-features = false, features = ["js"] }
+instant = { version = "0.1", default-features = false, features = ["wasm-bindgen"] }
+ 
+See: 
+- https://github.com/rustwasm/wasm-bindgen/issues/2160
+- https://github.com/rustwasm/wasm-pack/issues/743`);
+    }
+}
+
 /** Runs all custom lints on the generated code. Exits the process immediately with code 1 if any fail. **/
 function lintAll(content) {
     try {
         lintBigInt(content);
         lintPtrNullWithoutFree(content);
+        lintImportEnv(content);
     } catch (err) {
         console.error("Custom lint failed!");
         console.error(err);

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -34,9 +34,11 @@ the configuration of previously built accounts.</p>
 <dt><a href="#CredentialValidator">CredentialValidator</a></dt>
 <dd></dd>
 <dt><a href="#DID">DID</a></dt>
-<dd></dd>
+<dd><p>A DID conforming to the IOTA DID method specification.</p>
+</dd>
 <dt><a href="#DIDUrl">DIDUrl</a></dt>
-<dd></dd>
+<dd><p>A DID URL conforming to the IOTA DID method specification.</p>
+</dd>
 <dt><del><a href="#DiffChainHistory">DiffChainHistory</a></del></dt>
 <dd></dd>
 <dt><del><a href="#DiffMessage">DiffMessage</a></del></dt>
@@ -130,6 +132,12 @@ with a DID subject.</p>
 <dt><a href="#Signature">Signature</a></dt>
 <dd><p>A digital signature.</p>
 </dd>
+<dt><a href="#StardustDID">StardustDID</a></dt>
+<dd><p>A DID conforming to the IOTA UTXO DID method specification.</p>
+</dd>
+<dt><a href="#StardustDIDUrl">StardustDIDUrl</a></dt>
+<dd><p>A DID URL conforming to the IOTA Stardust UTXO DID method specification.</p>
+</dd>
 <dt><a href="#StorageTestSuite">StorageTestSuite</a></dt>
 <dd><p>A test suite for the <code>Storage</code> interface.</p>
 <p>This module contains a set of tests that a correct storage implementation
@@ -198,9 +206,9 @@ This variant is the default used if no other variant is specified when construct
 <dt><a href="#FirstError">FirstError</a></dt>
 <dd><p>Return after the first error occurs.</p>
 </dd>
-<dt><a href="#MethodRelationship">MethodRelationship</a></dt>
-<dd></dd>
 <dt><a href="#KeyType">KeyType</a></dt>
+<dd></dd>
+<dt><a href="#MethodRelationship">MethodRelationship</a></dt>
 <dd></dd>
 </dl>
 
@@ -1327,6 +1335,8 @@ Fails if the issuer field is not a valid DID.
 <a name="DID"></a>
 
 ## DID
+A DID conforming to the IOTA DID method specification.
+
 **Kind**: global class  
 
 * [DID](#DID)
@@ -1342,6 +1352,8 @@ Fails if the issuer field is not a valid DID.
         * [.toJSON()](#DID+toJSON) ⇒ <code>any</code>
         * [.clone()](#DID+clone) ⇒ [<code>DID</code>](#DID)
     * _static_
+        * [.METHOD](#DID.METHOD) ⇒ <code>string</code>
+        * [.DEFAULT_NETWORK](#DID.DEFAULT_NETWORK) ⇒ <code>string</code>
         * [.parse(input)](#DID.parse) ⇒ [<code>DID</code>](#DID)
         * [.fromJSON(json)](#DID.fromJSON) ⇒ [<code>DID</code>](#DID)
 
@@ -1415,6 +1427,18 @@ Serializes this to a JSON object.
 Deep clones the object.
 
 **Kind**: instance method of [<code>DID</code>](#DID)  
+<a name="DID.METHOD"></a>
+
+### DID.METHOD ⇒ <code>string</code>
+The IOTA DID method name (`"iota"`).
+
+**Kind**: static property of [<code>DID</code>](#DID)  
+<a name="DID.DEFAULT_NETWORK"></a>
+
+### DID.DEFAULT\_NETWORK ⇒ <code>string</code>
+The default Tangle network (`"main"`).
+
+**Kind**: static property of [<code>DID</code>](#DID)  
 <a name="DID.parse"></a>
 
 ### DID.parse(input) ⇒ [<code>DID</code>](#DID)
@@ -1440,6 +1464,8 @@ Deserializes an instance from a JSON object.
 <a name="DIDUrl"></a>
 
 ## DIDUrl
+A DID URL conforming to the IOTA DID method specification.
+
 **Kind**: global class  
 
 * [DIDUrl](#DIDUrl)
@@ -4578,6 +4604,336 @@ Deserializes an instance from a JSON object.
 | --- | --- |
 | json | <code>any</code> | 
 
+<a name="StardustDID"></a>
+
+## StardustDID
+A DID conforming to the IOTA UTXO DID method specification.
+
+**Kind**: global class  
+
+* [StardustDID](#StardustDID)
+    * [new StardustDID(bytes, network)](#new_StardustDID_new)
+    * _instance_
+        * [.networkStr()](#StardustDID+networkStr) ⇒ <code>string</code>
+        * [.tag()](#StardustDID+tag) ⇒ <code>string</code>
+        * [.scheme()](#StardustDID+scheme) ⇒ <code>string</code>
+        * [.authority()](#StardustDID+authority) ⇒ <code>string</code>
+        * [.method()](#StardustDID+method) ⇒ <code>string</code>
+        * [.methodId()](#StardustDID+methodId) ⇒ <code>string</code>
+        * [.join(segment)](#StardustDID+join) ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+        * [.toUrl()](#StardustDID+toUrl) ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+        * [.intoUrl()](#StardustDID+intoUrl) ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+        * [.toString()](#StardustDID+toString) ⇒ <code>string</code>
+        * [.toJSON()](#StardustDID+toJSON) ⇒ <code>any</code>
+        * [.clone()](#StardustDID+clone) ⇒ [<code>StardustDID</code>](#StardustDID)
+    * _static_
+        * [.METHOD](#StardustDID.METHOD) ⇒ <code>string</code>
+        * [.DEFAULT_NETWORK](#StardustDID.DEFAULT_NETWORK) ⇒ <code>string</code>
+        * [.placeholder(network)](#StardustDID.placeholder) ⇒ [<code>StardustDID</code>](#StardustDID)
+        * [.parse(input)](#StardustDID.parse) ⇒ [<code>StardustDID</code>](#StardustDID)
+        * [.fromJSON(json)](#StardustDID.fromJSON) ⇒ [<code>StardustDID</code>](#StardustDID)
+
+<a name="new_StardustDID_new"></a>
+
+### new StardustDID(bytes, network)
+Constructs a new `StardustDID` from a byte representation of the tag and the given
+network name.
+
+See also [placeholder](#StardustDID.placeholder).
+
+
+| Param | Type |
+| --- | --- |
+| bytes | <code>Uint8Array</code> | 
+| network | <code>string</code> | 
+
+<a name="StardustDID+networkStr"></a>
+
+### did.networkStr() ⇒ <code>string</code>
+Returns the Tangle network name of the `StardustDID`.
+
+**Kind**: instance method of [<code>StardustDID</code>](#StardustDID)  
+<a name="StardustDID+tag"></a>
+
+### did.tag() ⇒ <code>string</code>
+Returns a copy of the unique tag of the `StardustDID`.
+
+**Kind**: instance method of [<code>StardustDID</code>](#StardustDID)  
+<a name="StardustDID+scheme"></a>
+
+### did.scheme() ⇒ <code>string</code>
+Returns the `DID` scheme.
+
+E.g.
+- `"did:example:12345678" -> "did"`
+- `"did:iota:main:12345678" -> "did"`
+
+**Kind**: instance method of [<code>StardustDID</code>](#StardustDID)  
+<a name="StardustDID+authority"></a>
+
+### did.authority() ⇒ <code>string</code>
+Returns the `DID` authority: the method name and method-id.
+
+E.g.
+- `"did:example:12345678" -> "example:12345678"`
+- `"did:iota:main:12345678" -> "iota:main:12345678"`
+
+**Kind**: instance method of [<code>StardustDID</code>](#StardustDID)  
+<a name="StardustDID+method"></a>
+
+### did.method() ⇒ <code>string</code>
+Returns the `DID` method name.
+
+E.g.
+- `"did:example:12345678" -> "example"`
+- `"did:iota:main:12345678" -> "iota"`
+
+**Kind**: instance method of [<code>StardustDID</code>](#StardustDID)  
+<a name="StardustDID+methodId"></a>
+
+### did.methodId() ⇒ <code>string</code>
+Returns the `DID` method-specific ID.
+
+E.g.
+- `"did:example:12345678" -> "12345678"`
+- `"did:iota:main:12345678" -> "main:12345678"`
+
+**Kind**: instance method of [<code>StardustDID</code>](#StardustDID)  
+<a name="StardustDID+join"></a>
+
+### did.join(segment) ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+Construct a new `DIDUrl` by joining with a relative DID Url string.
+
+**Kind**: instance method of [<code>StardustDID</code>](#StardustDID)  
+
+| Param | Type |
+| --- | --- |
+| segment | <code>string</code> | 
+
+<a name="StardustDID+toUrl"></a>
+
+### did.toUrl() ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+Clones the `DID` into a `DIDUrl`.
+
+**Kind**: instance method of [<code>StardustDID</code>](#StardustDID)  
+<a name="StardustDID+intoUrl"></a>
+
+### did.intoUrl() ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+Converts the `DID` into a `DIDUrl`.
+
+**Kind**: instance method of [<code>StardustDID</code>](#StardustDID)  
+<a name="StardustDID+toString"></a>
+
+### did.toString() ⇒ <code>string</code>
+Returns the `DID` as a string.
+
+**Kind**: instance method of [<code>StardustDID</code>](#StardustDID)  
+<a name="StardustDID+toJSON"></a>
+
+### did.toJSON() ⇒ <code>any</code>
+Serializes this to a JSON object.
+
+**Kind**: instance method of [<code>StardustDID</code>](#StardustDID)  
+<a name="StardustDID+clone"></a>
+
+### did.clone() ⇒ [<code>StardustDID</code>](#StardustDID)
+Deep clones the object.
+
+**Kind**: instance method of [<code>StardustDID</code>](#StardustDID)  
+<a name="StardustDID.METHOD"></a>
+
+### StardustDID.METHOD ⇒ <code>string</code>
+The IOTA UTXO DID method name (`"stardust"`).
+
+**Kind**: static property of [<code>StardustDID</code>](#StardustDID)  
+<a name="StardustDID.DEFAULT_NETWORK"></a>
+
+### StardustDID.DEFAULT\_NETWORK ⇒ <code>string</code>
+The default Tangle network (`"main"`).
+
+**Kind**: static property of [<code>StardustDID</code>](#StardustDID)  
+<a name="StardustDID.placeholder"></a>
+
+### StardustDID.placeholder(network) ⇒ [<code>StardustDID</code>](#StardustDID)
+Creates a new placeholder [`StardustDID`] with the given network name.
+
+E.g. `did:stardust:smr:0x0000000000000000000000000000000000000000000000000000000000000000`.
+
+**Kind**: static method of [<code>StardustDID</code>](#StardustDID)  
+
+| Param | Type |
+| --- | --- |
+| network | <code>string</code> | 
+
+<a name="StardustDID.parse"></a>
+
+### StardustDID.parse(input) ⇒ [<code>StardustDID</code>](#StardustDID)
+Parses a `StardustDID` from the input string.
+
+**Kind**: static method of [<code>StardustDID</code>](#StardustDID)  
+
+| Param | Type |
+| --- | --- |
+| input | <code>string</code> | 
+
+<a name="StardustDID.fromJSON"></a>
+
+### StardustDID.fromJSON(json) ⇒ [<code>StardustDID</code>](#StardustDID)
+Deserializes an instance from a JSON object.
+
+**Kind**: static method of [<code>StardustDID</code>](#StardustDID)  
+
+| Param | Type |
+| --- | --- |
+| json | <code>any</code> | 
+
+<a name="StardustDIDUrl"></a>
+
+## StardustDIDUrl
+A DID URL conforming to the IOTA Stardust UTXO DID method specification.
+
+**Kind**: global class  
+
+* [StardustDIDUrl](#StardustDIDUrl)
+    * _instance_
+        * [.did()](#StardustDIDUrl+did) ⇒ [<code>StardustDID</code>](#StardustDID)
+        * [.urlStr()](#StardustDIDUrl+urlStr) ⇒ <code>string</code>
+        * [.fragment()](#StardustDIDUrl+fragment) ⇒ <code>string</code> \| <code>undefined</code>
+        * [.setFragment(value)](#StardustDIDUrl+setFragment)
+        * [.path()](#StardustDIDUrl+path) ⇒ <code>string</code> \| <code>undefined</code>
+        * [.setPath(value)](#StardustDIDUrl+setPath)
+        * [.query()](#StardustDIDUrl+query) ⇒ <code>string</code> \| <code>undefined</code>
+        * [.setQuery(value)](#StardustDIDUrl+setQuery)
+        * [.join(segment)](#StardustDIDUrl+join) ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+        * [.toString()](#StardustDIDUrl+toString) ⇒ <code>string</code>
+        * [.toJSON()](#StardustDIDUrl+toJSON) ⇒ <code>any</code>
+        * [.clone()](#StardustDIDUrl+clone) ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+    * _static_
+        * [.parse(input)](#StardustDIDUrl.parse) ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+        * [.fromJSON(json)](#StardustDIDUrl.fromJSON) ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+
+<a name="StardustDIDUrl+did"></a>
+
+### stardustDIDUrl.did() ⇒ [<code>StardustDID</code>](#StardustDID)
+Return a copy of the `StardustDID` section of the `StardustDIDUrl`.
+
+**Kind**: instance method of [<code>StardustDIDUrl</code>](#StardustDIDUrl)  
+<a name="StardustDIDUrl+urlStr"></a>
+
+### stardustDIDUrl.urlStr() ⇒ <code>string</code>
+Return a copy of the relative DID Url as a string, including only the path, query, and fragment.
+
+**Kind**: instance method of [<code>StardustDIDUrl</code>](#StardustDIDUrl)  
+<a name="StardustDIDUrl+fragment"></a>
+
+### stardustDIDUrl.fragment() ⇒ <code>string</code> \| <code>undefined</code>
+Returns a copy of the `StardustDIDUrl` method fragment, if any. Excludes the leading '#'.
+
+**Kind**: instance method of [<code>StardustDIDUrl</code>](#StardustDIDUrl)  
+<a name="StardustDIDUrl+setFragment"></a>
+
+### stardustDIDUrl.setFragment(value)
+Sets the `fragment` component of the `StardustDIDUrl`.
+
+**Kind**: instance method of [<code>StardustDIDUrl</code>](#StardustDIDUrl)  
+
+| Param | Type |
+| --- | --- |
+| value | <code>string</code> \| <code>undefined</code> | 
+
+<a name="StardustDIDUrl+path"></a>
+
+### stardustDIDUrl.path() ⇒ <code>string</code> \| <code>undefined</code>
+Returns a copy of the `StardustDIDUrl` path.
+
+**Kind**: instance method of [<code>StardustDIDUrl</code>](#StardustDIDUrl)  
+<a name="StardustDIDUrl+setPath"></a>
+
+### stardustDIDUrl.setPath(value)
+Sets the `path` component of the `StardustDIDUrl`.
+
+**Kind**: instance method of [<code>StardustDIDUrl</code>](#StardustDIDUrl)  
+
+| Param | Type |
+| --- | --- |
+| value | <code>string</code> \| <code>undefined</code> | 
+
+<a name="StardustDIDUrl+query"></a>
+
+### stardustDIDUrl.query() ⇒ <code>string</code> \| <code>undefined</code>
+Returns a copy of the `StardustDIDUrl` method query, if any. Excludes the leading '?'.
+
+**Kind**: instance method of [<code>StardustDIDUrl</code>](#StardustDIDUrl)  
+<a name="StardustDIDUrl+setQuery"></a>
+
+### stardustDIDUrl.setQuery(value)
+Sets the `query` component of the `StardustDIDUrl`.
+
+**Kind**: instance method of [<code>StardustDIDUrl</code>](#StardustDIDUrl)  
+
+| Param | Type |
+| --- | --- |
+| value | <code>string</code> \| <code>undefined</code> | 
+
+<a name="StardustDIDUrl+join"></a>
+
+### stardustDIDUrl.join(segment) ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+Append a string representing a path, query, and/or fragment, returning a new `StardustDIDUrl`.
+
+Must begin with a valid delimiter character: '/', '?', '#'. Overwrites the existing URL
+segment and any following segments in order of path, query, then fragment.
+
+I.e.
+- joining a path will clear the query and fragment.
+- joining a query will clear the fragment.
+- joining a fragment will only overwrite the fragment.
+
+**Kind**: instance method of [<code>StardustDIDUrl</code>](#StardustDIDUrl)  
+
+| Param | Type |
+| --- | --- |
+| segment | <code>string</code> | 
+
+<a name="StardustDIDUrl+toString"></a>
+
+### stardustDIDUrl.toString() ⇒ <code>string</code>
+Returns the `StardustDIDUrl` as a string.
+
+**Kind**: instance method of [<code>StardustDIDUrl</code>](#StardustDIDUrl)  
+<a name="StardustDIDUrl+toJSON"></a>
+
+### stardustDIDUrl.toJSON() ⇒ <code>any</code>
+Serializes this to a JSON object.
+
+**Kind**: instance method of [<code>StardustDIDUrl</code>](#StardustDIDUrl)  
+<a name="StardustDIDUrl+clone"></a>
+
+### stardustDIDUrl.clone() ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+Deep clones the object.
+
+**Kind**: instance method of [<code>StardustDIDUrl</code>](#StardustDIDUrl)  
+<a name="StardustDIDUrl.parse"></a>
+
+### StardustDIDUrl.parse(input) ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+Parses a `StardustDIDUrl` from the input string.
+
+**Kind**: static method of [<code>StardustDIDUrl</code>](#StardustDIDUrl)  
+
+| Param | Type |
+| --- | --- |
+| input | <code>string</code> | 
+
+<a name="StardustDIDUrl.fromJSON"></a>
+
+### StardustDIDUrl.fromJSON(json) ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+Deserializes an instance from a JSON object.
+
+**Kind**: static method of [<code>StardustDIDUrl</code>](#StardustDIDUrl)  
+
+| Param | Type |
+| --- | --- |
+| json | <code>any</code> | 
+
 <a name="StorageTestSuite"></a>
 
 ## StorageTestSuite
@@ -5061,13 +5417,13 @@ Return all errors that occur during validation.
 Return after the first error occurs.
 
 **Kind**: global variable  
-<a name="MethodRelationship"></a>
-
-## MethodRelationship
-**Kind**: global variable  
 <a name="KeyType"></a>
 
 ## KeyType
+**Kind**: global variable  
+<a name="MethodRelationship"></a>
+
+## MethodRelationship
 **Kind**: global variable  
 <a name="start"></a>
 

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -174,6 +174,8 @@ See <code>IVerifierOptions</code>.</p>
 <dl>
 <dt><a href="#DIDMessageEncoding">DIDMessageEncoding</a></dt>
 <dd></dd>
+<dt><a href="#StateMetadataEncoding">StateMetadataEncoding</a></dt>
+<dd></dd>
 <dt><a href="#StatusCheck">StatusCheck</a></dt>
 <dd><p>Controls validation behaviour when checking whether or not a credential has been revoked by its
 <a href="https://www.w3.org/TR/vc-data-model/#status"><code>credentialStatus</code></a>.</p>
@@ -220,8 +222,6 @@ This variant is the default used if no other variant is specified when construct
 <dd></dd>
 <dt><a href="#MethodRelationship">MethodRelationship</a></dt>
 <dd></dd>
-<dt><a href="#StateMetadataEncoding">StateMetadataEncoding</a></dt>
-<dd></dd>
 </dl>
 
 ## Functions
@@ -244,8 +244,8 @@ publishing to the Tangle.
 
 * [Account](#Account)
     * [.createService(options)](#Account+createService) ⇒ <code>Promise.&lt;void&gt;</code>
-    * [.attachMethodRelationships(options)](#Account+attachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.createMethod(options)](#Account+createMethod) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.attachMethodRelationships(options)](#Account+attachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.detachMethodRelationships(options)](#Account+detachMethodRelationships) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.did()](#Account+did) ⇒ [<code>DID</code>](#DID)
     * [.autopublish()](#Account+autopublish) ⇒ <code>boolean</code>
@@ -280,6 +280,17 @@ Adds a new Service to the DID Document.
 | --- | --- |
 | options | <code>CreateServiceOptions</code> | 
 
+<a name="Account+createMethod"></a>
+
+### account.createMethod(options) ⇒ <code>Promise.&lt;void&gt;</code>
+Adds a new verification method to the DID document.
+
+**Kind**: instance method of [<code>Account</code>](#Account)  
+
+| Param | Type |
+| --- | --- |
+| options | <code>CreateMethodOptions</code> | 
+
 <a name="Account+attachMethodRelationships"></a>
 
 ### account.attachMethodRelationships(options) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -293,17 +304,6 @@ it cannot be an embedded method.
 | Param | Type |
 | --- | --- |
 | options | <code>AttachMethodRelationshipOptions</code> | 
-
-<a name="Account+createMethod"></a>
-
-### account.createMethod(options) ⇒ <code>Promise.&lt;void&gt;</code>
-Adds a new verification method to the DID document.
-
-**Kind**: instance method of [<code>Account</code>](#Account)  
-
-| Param | Type |
-| --- | --- |
-| options | <code>CreateMethodOptions</code> | 
 
 <a name="Account+detachMethodRelationships"></a>
 
@@ -1418,7 +1418,7 @@ Clones the `DID` into a `DIDUrl`.
 <a name="DID+intoUrl"></a>
 
 ### did.intoUrl() ⇒ [<code>DIDUrl</code>](#DIDUrl)
-Converts the `DID` into a `DIDUrl`.
+Converts the `DID` into a `DIDUrl`, consuming it.
 
 **Kind**: instance method of [<code>DID</code>](#DID)  
 <a name="DID+toString"></a>
@@ -1851,6 +1851,7 @@ Deserializes an instance from a JSON object.
         * [.setMetadataUpdated(timestamp)](#Document+setMetadataUpdated)
         * [.metadataPreviousMessageId()](#Document+metadataPreviousMessageId) ⇒ <code>string</code>
         * [.setMetadataPreviousMessageId(value)](#Document+setMetadataPreviousMessageId)
+        * [.setMetadataPropertyUnchecked(key, value)](#Document+setMetadataPropertyUnchecked)
         * [.proof()](#Document+proof) ⇒ [<code>Proof</code>](#Proof) \| <code>undefined</code>
         * [.revokeCredentials(serviceQuery, indices)](#Document+revokeCredentials)
         * [.unrevokeCredentials(serviceQuery, indices)](#Document+unrevokeCredentials)
@@ -2324,6 +2325,19 @@ Sets the previous integration chain message id.
 | Param | Type |
 | --- | --- |
 | value | <code>string</code> | 
+
+<a name="Document+setMetadataPropertyUnchecked"></a>
+
+### document.setMetadataPropertyUnchecked(key, value)
+Sets a custom property in the document metadata.
+If the value is set to `null`, the custom property will be removed.
+
+**Kind**: instance method of [<code>Document</code>](#Document)  
+
+| Param | Type |
+| --- | --- |
+| key | <code>string</code> | 
+| value | <code>any</code> | 
 
 <a name="Document+proof"></a>
 
@@ -4739,7 +4753,7 @@ Clones the `DID` into a `DIDUrl`.
 <a name="StardustDID+intoUrl"></a>
 
 ### did.intoUrl() ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
-Converts the `DID` into a `DIDUrl`.
+Converts the `DID` into a `DIDUrl`, consuming it.
 
 **Kind**: instance method of [<code>StardustDID</code>](#StardustDID)  
 <a name="StardustDID+toString"></a>
@@ -4989,6 +5003,7 @@ Deserializes an instance from a JSON object.
         * [.setMetadataCreated(timestamp)](#StardustDocument+setMetadataCreated)
         * [.metadataUpdated()](#StardustDocument+metadataUpdated) ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
         * [.setMetadataUpdated(timestamp)](#StardustDocument+setMetadataUpdated)
+        * [.setMetadataPropertyUnchecked(key, value)](#StardustDocument+setMetadataPropertyUnchecked)
         * [.revokeCredentials(serviceQuery, indices)](#StardustDocument+revokeCredentials)
         * [.unrevokeCredentials(serviceQuery, indices)](#StardustDocument+unrevokeCredentials)
         * [.toJSON()](#StardustDocument+toJSON) ⇒ <code>any</code>
@@ -5050,7 +5065,7 @@ Returns a copy of the custom DID Document properties.
 <a name="StardustDocument+setPropertyUnchecked"></a>
 
 ### stardustDocument.setPropertyUnchecked(key, value)
-Adds a custom property to the DID Document.
+Sets a custom property in the DID Document.
 If the value is set to `null`, the custom property will be removed.
 
 ### WARNING
@@ -5296,6 +5311,19 @@ Sets the timestamp of the last DID document update.
 | Param | Type |
 | --- | --- |
 | timestamp | [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code> | 
+
+<a name="StardustDocument+setMetadataPropertyUnchecked"></a>
+
+### stardustDocument.setMetadataPropertyUnchecked(key, value)
+Sets a custom property in the document metadata.
+If the value is set to `null`, the custom property will be removed.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| key | <code>string</code> | 
+| value | <code>any</code> | 
 
 <a name="StardustDocument+revokeCredentials"></a>
 
@@ -5999,6 +6027,10 @@ This is possible because Ed25519 is birationally equivalent to Curve25519 used b
 
 ## DIDMessageEncoding
 **Kind**: global variable  
+<a name="StateMetadataEncoding"></a>
+
+## StateMetadataEncoding
+**Kind**: global variable  
 <a name="StatusCheck"></a>
 
 ## StatusCheck
@@ -6084,10 +6116,6 @@ Return after the first error occurs.
 <a name="MethodRelationship"></a>
 
 ## MethodRelationship
-**Kind**: global variable  
-<a name="StateMetadataEncoding"></a>
-
-## StateMetadataEncoding
 **Kind**: global variable  
 <a name="start"></a>
 

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -146,6 +146,8 @@ with a DID subject.</p>
 <dt><a href="#StardustService">StardustService</a></dt>
 <dd><p>A <code>Service</code> adhering to the IOTA UTXO DID method specification.</p>
 </dd>
+<dt><a href="#StardustVerificationMethod">StardustVerificationMethod</a></dt>
+<dd></dd>
 <dt><a href="#StorageTestSuite">StorageTestSuite</a></dt>
 <dd><p>A test suite for the <code>Storage</code> interface.</p>
 <p>This module contains a set of tests that a correct storage implementation
@@ -214,11 +216,11 @@ This variant is the default used if no other variant is specified when construct
 <dt><a href="#FirstError">FirstError</a></dt>
 <dd><p>Return after the first error occurs.</p>
 </dd>
+<dt><a href="#KeyType">KeyType</a></dt>
+<dd></dd>
 <dt><a href="#MethodRelationship">MethodRelationship</a></dt>
 <dd></dd>
 <dt><a href="#StateMetadataEncoding">StateMetadataEncoding</a></dt>
-<dd></dd>
-<dt><a href="#KeyType">KeyType</a></dt>
 <dd></dd>
 </dl>
 
@@ -262,9 +264,9 @@ publishing to the Tangle.
     * [.unrevokeCredentials(fragment, indices)](#Account+unrevokeCredentials) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.encryptData(plaintext, associated_data, encryption_algorithm, cek_algorithm, public_key)](#Account+encryptData) ⇒ [<code>Promise.&lt;EncryptedData&gt;</code>](#EncryptedData)
     * [.decryptData(data, encryption_algorithm, cek_algorithm, fragment)](#Account+decryptData) ⇒ <code>Promise.&lt;Uint8Array&gt;</code>
+    * [.setAlsoKnownAs(options)](#Account+setAlsoKnownAs) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.deleteMethod(options)](#Account+deleteMethod) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.deleteService(options)](#Account+deleteService) ⇒ <code>Promise.&lt;void&gt;</code>
-    * [.setAlsoKnownAs(options)](#Account+setAlsoKnownAs) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.setController(options)](#Account+setController) ⇒ <code>Promise.&lt;void&gt;</code>
 
 <a name="Account+createService"></a>
@@ -505,6 +507,17 @@ Returns the decrypted text.
 | cek_algorithm | [<code>CekAlgorithm</code>](#CekAlgorithm) | 
 | fragment | <code>string</code> | 
 
+<a name="Account+setAlsoKnownAs"></a>
+
+### account.setAlsoKnownAs(options) ⇒ <code>Promise.&lt;void&gt;</code>
+Sets the `alsoKnownAs` property in the DID document.
+
+**Kind**: instance method of [<code>Account</code>](#Account)  
+
+| Param | Type |
+| --- | --- |
+| options | <code>SetAlsoKnownAsOptions</code> | 
+
 <a name="Account+deleteMethod"></a>
 
 ### account.deleteMethod(options) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -526,17 +539,6 @@ Deletes a Service if it exists.
 | Param | Type |
 | --- | --- |
 | options | <code>DeleteServiceOptions</code> | 
-
-<a name="Account+setAlsoKnownAs"></a>
-
-### account.setAlsoKnownAs(options) ⇒ <code>Promise.&lt;void&gt;</code>
-Sets the `alsoKnownAs` property in the DID document.
-
-**Kind**: instance method of [<code>Account</code>](#Account)  
-
-| Param | Type |
-| --- | --- |
-| options | <code>SetAlsoKnownAsOptions</code> | 
 
 <a name="Account+setController"></a>
 
@@ -1829,8 +1831,8 @@ Deserializes an instance from a JSON object.
         * [.defaultSigningMethod()](#Document+defaultSigningMethod) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
         * [.resolveMethod(query, scope)](#Document+resolveMethod) ⇒ [<code>VerificationMethod</code>](#VerificationMethod) \| <code>undefined</code>
         * [.resolveSigningMethod(query)](#Document+resolveSigningMethod) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
-        * [.attachMethodRelationship(did_url, relationship)](#Document+attachMethodRelationship) ⇒ <code>boolean</code>
-        * [.detachMethodRelationship(did_url, relationship)](#Document+detachMethodRelationship) ⇒ <code>boolean</code>
+        * [.attachMethodRelationship(didUrl, relationship)](#Document+attachMethodRelationship) ⇒ <code>boolean</code>
+        * [.detachMethodRelationship(didUrl, relationship)](#Document+detachMethodRelationship) ⇒ <code>boolean</code>
         * [.signSelf(key_pair, method_query)](#Document+signSelf)
         * [.signDocument(document, key_pair, method_query)](#Document+signDocument)
         * [.signCredential(credential, privateKey, methodQuery, options)](#Document+signCredential) ⇒ [<code>Credential</code>](#Credential)
@@ -2005,7 +2007,7 @@ Returns a list of all [VerificationMethod](#VerificationMethod) in the DID Docum
 <a name="Document+insertMethod"></a>
 
 ### document.insertMethod(method, scope)
-Adds a new Verification Method to the DID Document.
+Adds a new `method` to the document in the given `scope`.
 
 **Kind**: instance method of [<code>Document</code>](#Document)  
 
@@ -2037,10 +2039,9 @@ Throws an error if no signing method is present.
 <a name="Document+resolveMethod"></a>
 
 ### document.resolveMethod(query, scope) ⇒ [<code>VerificationMethod</code>](#VerificationMethod) \| <code>undefined</code>
-Returns a copy of the first `VerificationMethod` with an `id` property
-matching the provided `query`.
-
-Throws an error if the method is not found.
+Returns a copy of the first verification method with an `id` property
+matching the provided `query` and the verification relationship
+specified by `scope`, if present.
 
 **Kind**: instance method of [<code>Document</code>](#Document)  
 
@@ -2062,7 +2063,7 @@ Attempts to resolve the given method query into a method capable of signing a do
 
 <a name="Document+attachMethodRelationship"></a>
 
-### document.attachMethodRelationship(did_url, relationship) ⇒ <code>boolean</code>
+### document.attachMethodRelationship(didUrl, relationship) ⇒ <code>boolean</code>
 Attaches the relationship to the given method, if the method exists.
 
 Note: The method needs to be in the set of verification methods,
@@ -2072,19 +2073,19 @@ so it cannot be an embedded one.
 
 | Param | Type |
 | --- | --- |
-| did_url | [<code>DIDUrl</code>](#DIDUrl) | 
+| didUrl | [<code>DIDUrl</code>](#DIDUrl) | 
 | relationship | <code>number</code> | 
 
 <a name="Document+detachMethodRelationship"></a>
 
-### document.detachMethodRelationship(did_url, relationship) ⇒ <code>boolean</code>
+### document.detachMethodRelationship(didUrl, relationship) ⇒ <code>boolean</code>
 Detaches the given relationship from the given method, if the method exists.
 
 **Kind**: instance method of [<code>Document</code>](#Document)  
 
 | Param | Type |
 | --- | --- |
-| did_url | [<code>DIDUrl</code>](#DIDUrl) | 
+| didUrl | [<code>DIDUrl</code>](#DIDUrl) | 
 | relationship | <code>number</code> | 
 
 <a name="Document+signSelf"></a>
@@ -4971,9 +4972,12 @@ Deserializes an instance from a JSON object.
         * [.insertService(service)](#StardustDocument+insertService) ⇒ <code>boolean</code>
         * [.removeService(did)](#StardustDocument+removeService) ⇒ <code>boolean</code>
         * [.resolveService(query)](#StardustDocument+resolveService) ⇒ [<code>StardustService</code>](#StardustService) \| <code>undefined</code>
+        * [.methods()](#StardustDocument+methods) ⇒ [<code>Array.&lt;StardustVerificationMethod&gt;</code>](#StardustVerificationMethod)
+        * [.insertMethod(method, scope)](#StardustDocument+insertMethod)
         * [.removeMethod(did)](#StardustDocument+removeMethod)
-        * [.attachMethodRelationship(did_url, relationship)](#StardustDocument+attachMethodRelationship) ⇒ <code>boolean</code>
-        * [.detachMethodRelationship(did_url, relationship)](#StardustDocument+detachMethodRelationship) ⇒ <code>boolean</code>
+        * [.resolveMethod(query, scope)](#StardustDocument+resolveMethod) ⇒ [<code>StardustVerificationMethod</code>](#StardustVerificationMethod) \| <code>undefined</code>
+        * [.attachMethodRelationship(didUrl, relationship)](#StardustDocument+attachMethodRelationship) ⇒ <code>boolean</code>
+        * [.detachMethodRelationship(didUrl, relationship)](#StardustDocument+detachMethodRelationship) ⇒ <code>boolean</code>
         * [.signCredential(credential, privateKey, methodQuery, options)](#StardustDocument+signCredential) ⇒ [<code>Credential</code>](#Credential)
         * [.signPresentation(presentation, privateKey, methodQuery, options)](#StardustDocument+signPresentation) ⇒ [<code>Presentation</code>](#Presentation)
         * [.signData(data, privateKey, methodQuery, options)](#StardustDocument+signData) ⇒ <code>any</code>
@@ -5062,7 +5066,7 @@ This method can overwrite existing properties like `id` and result in an invalid
 <a name="StardustDocument+service"></a>
 
 ### stardustDocument.service() ⇒ [<code>Array.&lt;StardustService&gt;</code>](#StardustService)
-Return a set of all [StardustServices](#StardustService) in the document.
+Return a set of all [StardustService](#StardustService) in the document.
 
 **Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
 <a name="StardustDocument+insertService"></a>
@@ -5103,6 +5107,24 @@ if present.
 | --- | --- |
 | query | [<code>StardustDIDUrl</code>](#StardustDIDUrl) \| <code>string</code> | 
 
+<a name="StardustDocument+methods"></a>
+
+### stardustDocument.methods() ⇒ [<code>Array.&lt;StardustVerificationMethod&gt;</code>](#StardustVerificationMethod)
+Returns a list of all [StardustVerificationMethod](#StardustVerificationMethod) in the DID Document.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+<a name="StardustDocument+insertMethod"></a>
+
+### stardustDocument.insertMethod(method, scope)
+Adds a new `method` to the document in the given `scope`.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| method | [<code>StardustVerificationMethod</code>](#StardustVerificationMethod) | 
+| scope | [<code>MethodScope</code>](#MethodScope) | 
+
 <a name="StardustDocument+removeMethod"></a>
 
 ### stardustDocument.removeMethod(did)
@@ -5114,9 +5136,23 @@ Removes all references to the specified Verification Method.
 | --- | --- |
 | did | [<code>StardustDIDUrl</code>](#StardustDIDUrl) | 
 
+<a name="StardustDocument+resolveMethod"></a>
+
+### stardustDocument.resolveMethod(query, scope) ⇒ [<code>StardustVerificationMethod</code>](#StardustVerificationMethod) \| <code>undefined</code>
+Returns a copy of the first verification method with an `id` property
+matching the provided `query` and the verification relationship
+specified by `scope`, if present.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| query | [<code>StardustDIDUrl</code>](#StardustDIDUrl) \| <code>string</code> | 
+| scope | [<code>MethodScope</code>](#MethodScope) \| <code>undefined</code> | 
+
 <a name="StardustDocument+attachMethodRelationship"></a>
 
-### stardustDocument.attachMethodRelationship(did_url, relationship) ⇒ <code>boolean</code>
+### stardustDocument.attachMethodRelationship(didUrl, relationship) ⇒ <code>boolean</code>
 Attaches the relationship to the given method, if the method exists.
 
 Note: The method needs to be in the set of verification methods,
@@ -5126,19 +5162,19 @@ so it cannot be an embedded one.
 
 | Param | Type |
 | --- | --- |
-| did_url | [<code>StardustDIDUrl</code>](#StardustDIDUrl) | 
+| didUrl | [<code>StardustDIDUrl</code>](#StardustDIDUrl) | 
 | relationship | <code>number</code> | 
 
 <a name="StardustDocument+detachMethodRelationship"></a>
 
-### stardustDocument.detachMethodRelationship(did_url, relationship) ⇒ <code>boolean</code>
+### stardustDocument.detachMethodRelationship(didUrl, relationship) ⇒ <code>boolean</code>
 Detaches the given relationship from the given method, if the method exists.
 
 **Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
 
 | Param | Type |
 | --- | --- |
-| did_url | [<code>StardustDIDUrl</code>](#StardustDIDUrl) | 
+| didUrl | [<code>StardustDIDUrl</code>](#StardustDIDUrl) | 
 | relationship | <code>number</code> | 
 
 <a name="StardustDocument+signCredential"></a>
@@ -5469,6 +5505,95 @@ Deserializes an instance from a JSON object.
 | --- | --- |
 | json | <code>any</code> | 
 
+<a name="StardustVerificationMethod"></a>
+
+## StardustVerificationMethod
+**Kind**: global class  
+
+* [StardustVerificationMethod](#StardustVerificationMethod)
+    * [new StardustVerificationMethod(did, keyType, publicKey, fragment)](#new_StardustVerificationMethod_new)
+    * _instance_
+        * [.id()](#StardustVerificationMethod+id) ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+        * [.controller()](#StardustVerificationMethod+controller) ⇒ [<code>StardustDID</code>](#StardustDID)
+        * [.setController(did)](#StardustVerificationMethod+setController)
+        * [.type()](#StardustVerificationMethod+type) ⇒ [<code>MethodType</code>](#MethodType)
+        * [.data()](#StardustVerificationMethod+data) ⇒ [<code>MethodData</code>](#MethodData)
+        * [.toJSON()](#StardustVerificationMethod+toJSON) ⇒ <code>any</code>
+        * [.clone()](#StardustVerificationMethod+clone) ⇒ [<code>StardustVerificationMethod</code>](#StardustVerificationMethod)
+    * _static_
+        * [.fromJSON(json)](#StardustVerificationMethod.fromJSON) ⇒ [<code>StardustVerificationMethod</code>](#StardustVerificationMethod)
+
+<a name="new_StardustVerificationMethod_new"></a>
+
+### new StardustVerificationMethod(did, keyType, publicKey, fragment)
+Creates a new `StardustVerificationMethod` from the given `did` and public key.
+
+
+| Param | Type |
+| --- | --- |
+| did | [<code>StardustDID</code>](#StardustDID) | 
+| keyType | <code>number</code> | 
+| publicKey | <code>Uint8Array</code> | 
+| fragment | <code>string</code> | 
+
+<a name="StardustVerificationMethod+id"></a>
+
+### stardustVerificationMethod.id() ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+Returns a reference to the `StardustVerificationMethod` id.
+
+**Kind**: instance method of [<code>StardustVerificationMethod</code>](#StardustVerificationMethod)  
+<a name="StardustVerificationMethod+controller"></a>
+
+### stardustVerificationMethod.controller() ⇒ [<code>StardustDID</code>](#StardustDID)
+Returns a copy of the `controller` `DID` of the `StardustVerificationMethod`.
+
+**Kind**: instance method of [<code>StardustVerificationMethod</code>](#StardustVerificationMethod)  
+<a name="StardustVerificationMethod+setController"></a>
+
+### stardustVerificationMethod.setController(did)
+Sets the `controller` `DID` of the `StardustVerificationMethod`.
+
+**Kind**: instance method of [<code>StardustVerificationMethod</code>](#StardustVerificationMethod)  
+
+| Param | Type |
+| --- | --- |
+| did | [<code>StardustDID</code>](#StardustDID) | 
+
+<a name="StardustVerificationMethod+type"></a>
+
+### stardustVerificationMethod.type() ⇒ [<code>MethodType</code>](#MethodType)
+Returns a copy of the `StardustVerificationMethod` type.
+
+**Kind**: instance method of [<code>StardustVerificationMethod</code>](#StardustVerificationMethod)  
+<a name="StardustVerificationMethod+data"></a>
+
+### stardustVerificationMethod.data() ⇒ [<code>MethodData</code>](#MethodData)
+Returns a copy of the `StardustVerificationMethod` public key data.
+
+**Kind**: instance method of [<code>StardustVerificationMethod</code>](#StardustVerificationMethod)  
+<a name="StardustVerificationMethod+toJSON"></a>
+
+### stardustVerificationMethod.toJSON() ⇒ <code>any</code>
+Serializes this to a JSON object.
+
+**Kind**: instance method of [<code>StardustVerificationMethod</code>](#StardustVerificationMethod)  
+<a name="StardustVerificationMethod+clone"></a>
+
+### stardustVerificationMethod.clone() ⇒ [<code>StardustVerificationMethod</code>](#StardustVerificationMethod)
+Deep clones the object.
+
+**Kind**: instance method of [<code>StardustVerificationMethod</code>](#StardustVerificationMethod)  
+<a name="StardustVerificationMethod.fromJSON"></a>
+
+### StardustVerificationMethod.fromJSON(json) ⇒ [<code>StardustVerificationMethod</code>](#StardustVerificationMethod)
+Deserializes an instance from a JSON object.
+
+**Kind**: static method of [<code>StardustVerificationMethod</code>](#StardustVerificationMethod)  
+
+| Param | Type |
+| --- | --- |
+| json | <code>any</code> | 
+
 <a name="StorageTestSuite"></a>
 
 ## StorageTestSuite
@@ -5664,11 +5789,11 @@ Deserializes an instance from a JSON object.
 **Kind**: global class  
 
 * [VerificationMethod](#VerificationMethod)
-    * [new VerificationMethod(did, key_type, public_key, fragment)](#new_VerificationMethod_new)
+    * [new VerificationMethod(did, keyType, publicKey, fragment)](#new_VerificationMethod_new)
     * _instance_
         * [.id()](#VerificationMethod+id) ⇒ [<code>DIDUrl</code>](#DIDUrl)
         * [.controller()](#VerificationMethod+controller) ⇒ [<code>DID</code>](#DID)
-        * [.SetController(did)](#VerificationMethod+SetController)
+        * [.setController(did)](#VerificationMethod+setController)
         * [.type()](#VerificationMethod+type) ⇒ [<code>MethodType</code>](#MethodType)
         * [.data()](#VerificationMethod+data) ⇒ [<code>MethodData</code>](#MethodData)
         * [.toJSON()](#VerificationMethod+toJSON) ⇒ <code>any</code>
@@ -5678,33 +5803,33 @@ Deserializes an instance from a JSON object.
 
 <a name="new_VerificationMethod_new"></a>
 
-### new VerificationMethod(did, key_type, public_key, fragment)
-Creates a new `VerificationMethod` object from the given `did` and public key.
+### new VerificationMethod(did, keyType, publicKey, fragment)
+Creates a new `VerificationMethod` from the given `did` and public key.
 
 
 | Param | Type |
 | --- | --- |
 | did | [<code>DID</code>](#DID) | 
-| key_type | <code>number</code> | 
-| public_key | <code>Uint8Array</code> | 
+| keyType | <code>number</code> | 
+| publicKey | <code>Uint8Array</code> | 
 | fragment | <code>string</code> | 
 
 <a name="VerificationMethod+id"></a>
 
 ### verificationMethod.id() ⇒ [<code>DIDUrl</code>](#DIDUrl)
-Returns a copy of the `id` `DIDUrl` of the `VerificationMethod` object.
+Returns a copy of the `id` `DIDUrl` of the `VerificationMethod`.
 
 **Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)  
 <a name="VerificationMethod+controller"></a>
 
 ### verificationMethod.controller() ⇒ [<code>DID</code>](#DID)
-Returns a copy of the `controller` `DID` of the `VerificationMethod` object.
+Returns a copy of the `controller` `DID` of the `VerificationMethod`.
 
 **Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)  
-<a name="VerificationMethod+SetController"></a>
+<a name="VerificationMethod+setController"></a>
 
-### verificationMethod.SetController(did)
-Sets the `controller` `DID` of the `VerificationMethod` object.
+### verificationMethod.setController(did)
+Sets the `controller` `DID` of the `VerificationMethod`.
 
 **Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)  
 
@@ -5952,6 +6077,10 @@ Return all errors that occur during validation.
 Return after the first error occurs.
 
 **Kind**: global variable  
+<a name="KeyType"></a>
+
+## KeyType
+**Kind**: global variable  
 <a name="MethodRelationship"></a>
 
 ## MethodRelationship
@@ -5959,10 +6088,6 @@ Return after the first error occurs.
 <a name="StateMetadataEncoding"></a>
 
 ## StateMetadataEncoding
-**Kind**: global variable  
-<a name="KeyType"></a>
-
-## KeyType
 **Kind**: global variable  
 <a name="start"></a>
 

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -143,6 +143,9 @@ with a DID subject.</p>
 <dt><a href="#StardustDocumentMetadata">StardustDocumentMetadata</a></dt>
 <dd><p>Additional attributes related to an IOTA DID Document.</p>
 </dd>
+<dt><a href="#StardustService">StardustService</a></dt>
+<dd><p>A <code>Service</code> adhering to the IOTA UTXO DID method specification.</p>
+</dd>
 <dt><a href="#StorageTestSuite">StorageTestSuite</a></dt>
 <dd><p>A test suite for the <code>Storage</code> interface.</p>
 <p>This module contains a set of tests that a correct storage implementation
@@ -211,11 +214,11 @@ This variant is the default used if no other variant is specified when construct
 <dt><a href="#FirstError">FirstError</a></dt>
 <dd><p>Return after the first error occurs.</p>
 </dd>
-<dt><a href="#KeyType">KeyType</a></dt>
-<dd></dd>
 <dt><a href="#MethodRelationship">MethodRelationship</a></dt>
 <dd></dd>
 <dt><a href="#StateMetadataEncoding">StateMetadataEncoding</a></dt>
+<dd></dd>
+<dt><a href="#KeyType">KeyType</a></dt>
 <dd></dd>
 </dl>
 
@@ -4964,7 +4967,10 @@ Deserializes an instance from a JSON object.
         * [.setAlsoKnownAs(urls)](#StardustDocument+setAlsoKnownAs)
         * [.properties()](#StardustDocument+properties) ⇒ <code>Map.&lt;string, any&gt;</code>
         * [.setPropertyUnchecked(key, value)](#StardustDocument+setPropertyUnchecked)
+        * [.service()](#StardustDocument+service) ⇒ [<code>Array.&lt;StardustService&gt;</code>](#StardustService)
+        * [.insertService(service)](#StardustDocument+insertService) ⇒ <code>boolean</code>
         * [.removeService(did)](#StardustDocument+removeService) ⇒ <code>boolean</code>
+        * [.resolveService(query)](#StardustDocument+resolveService) ⇒ [<code>StardustService</code>](#StardustService) \| <code>undefined</code>
         * [.removeMethod(did)](#StardustDocument+removeMethod)
         * [.attachMethodRelationship(did_url, relationship)](#StardustDocument+attachMethodRelationship) ⇒ <code>boolean</code>
         * [.detachMethodRelationship(did_url, relationship)](#StardustDocument+detachMethodRelationship) ⇒ <code>boolean</code>
@@ -4973,7 +4979,7 @@ Deserializes an instance from a JSON object.
         * [.signData(data, privateKey, methodQuery, options)](#StardustDocument+signData) ⇒ <code>any</code>
         * [.verifyData(data, options)](#StardustDocument+verifyData) ⇒ <code>boolean</code>
         * [.pack()](#StardustDocument+pack) ⇒ <code>Uint8Array</code>
-        * [.pack_with_encoding(encoding)](#StardustDocument+pack_with_encoding) ⇒ <code>Uint8Array</code>
+        * [.packWithEncoding(encoding)](#StardustDocument+packWithEncoding) ⇒ <code>Uint8Array</code>
         * [.metadata()](#StardustDocument+metadata) ⇒ [<code>StardustDocumentMetadata</code>](#StardustDocumentMetadata)
         * [.metadataCreated()](#StardustDocument+metadataCreated) ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
         * [.setMetadataCreated(timestamp)](#StardustDocument+setMetadataCreated)
@@ -5053,10 +5059,29 @@ This method can overwrite existing properties like `id` and result in an invalid
 | key | <code>string</code> | 
 | value | <code>any</code> | 
 
+<a name="StardustDocument+service"></a>
+
+### stardustDocument.service() ⇒ [<code>Array.&lt;StardustService&gt;</code>](#StardustService)
+Return a set of all [StardustServices](#StardustService) in the document.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+<a name="StardustDocument+insertService"></a>
+
+### stardustDocument.insertService(service) ⇒ <code>boolean</code>
+Add a new [StardustService](#StardustService) to the document.
+
+Returns `true` if the service was added.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| service | [<code>StardustService</code>](#StardustService) | 
+
 <a name="StardustDocument+removeService"></a>
 
 ### stardustDocument.removeService(did) ⇒ <code>boolean</code>
-Remove a [Service](#Service) identified by the given [DIDUrl](#DIDUrl) from the document.
+Remove a [StardustService](#StardustService) identified by the given [DIDUrl](#DIDUrl) from the document.
 
 Returns `true` if a service was removed.
 
@@ -5065,6 +5090,18 @@ Returns `true` if a service was removed.
 | Param | Type |
 | --- | --- |
 | did | [<code>StardustDIDUrl</code>](#StardustDIDUrl) | 
+
+<a name="StardustDocument+resolveService"></a>
+
+### stardustDocument.resolveService(query) ⇒ [<code>StardustService</code>](#StardustService) \| <code>undefined</code>
+Returns the first [StardustService](#StardustService) with an `id` property matching the provided `query`,
+if present.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| query | [<code>StardustDIDUrl</code>](#StardustDIDUrl) \| <code>string</code> | 
 
 <a name="StardustDocument+removeMethod"></a>
 
@@ -5167,12 +5204,12 @@ Verifies the authenticity of `data` using the target verification method.
 
 ### stardustDocument.pack() ⇒ <code>Uint8Array</code>
 Serializes the document for inclusion in an Alias Output's state metadata
-with the default [`StateMetadataEncoding`].
+with the default [StateMetadataEncoding](#StateMetadataEncoding).
 
 **Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
-<a name="StardustDocument+pack_with_encoding"></a>
+<a name="StardustDocument+packWithEncoding"></a>
 
-### stardustDocument.pack\_with\_encoding(encoding) ⇒ <code>Uint8Array</code>
+### stardustDocument.packWithEncoding(encoding) ⇒ <code>Uint8Array</code>
 Serializes the document for inclusion in an Alias Output's state metadata.
 
 **Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
@@ -5353,6 +5390,80 @@ Deep clones the object.
 Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>StardustDocumentMetadata</code>](#StardustDocumentMetadata)  
+
+| Param | Type |
+| --- | --- |
+| json | <code>any</code> | 
+
+<a name="StardustService"></a>
+
+## StardustService
+A `Service` adhering to the IOTA UTXO DID method specification.
+
+**Kind**: global class  
+
+* [StardustService](#StardustService)
+    * [new StardustService(service)](#new_StardustService_new)
+    * _instance_
+        * [.id()](#StardustService+id) ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+        * [.type()](#StardustService+type) ⇒ <code>Array.&lt;string&gt;</code>
+        * [.serviceEndpoint()](#StardustService+serviceEndpoint) ⇒ <code>string</code> \| <code>Array.&lt;string&gt;</code> \| <code>Map.&lt;string, Array.&lt;string&gt;&gt;</code>
+        * [.properties()](#StardustService+properties) ⇒ <code>Map.&lt;string, any&gt;</code>
+        * [.toJSON()](#StardustService+toJSON) ⇒ <code>any</code>
+        * [.clone()](#StardustService+clone) ⇒ [<code>StardustService</code>](#StardustService)
+    * _static_
+        * [.fromJSON(json)](#StardustService.fromJSON) ⇒ [<code>StardustService</code>](#StardustService)
+
+<a name="new_StardustService_new"></a>
+
+### new StardustService(service)
+
+| Param | Type |
+| --- | --- |
+| service | <code>IStardustService</code> | 
+
+<a name="StardustService+id"></a>
+
+### stardustService.id() ⇒ [<code>StardustDIDUrl</code>](#StardustDIDUrl)
+Returns a copy of the `Service` id.
+
+**Kind**: instance method of [<code>StardustService</code>](#StardustService)  
+<a name="StardustService+type"></a>
+
+### stardustService.type() ⇒ <code>Array.&lt;string&gt;</code>
+Returns a copy of the `Service` type.
+
+**Kind**: instance method of [<code>StardustService</code>](#StardustService)  
+<a name="StardustService+serviceEndpoint"></a>
+
+### stardustService.serviceEndpoint() ⇒ <code>string</code> \| <code>Array.&lt;string&gt;</code> \| <code>Map.&lt;string, Array.&lt;string&gt;&gt;</code>
+Returns a copy of the `Service` endpoint.
+
+**Kind**: instance method of [<code>StardustService</code>](#StardustService)  
+<a name="StardustService+properties"></a>
+
+### stardustService.properties() ⇒ <code>Map.&lt;string, any&gt;</code>
+Returns a copy of the custom properties on the `Service`.
+
+**Kind**: instance method of [<code>StardustService</code>](#StardustService)  
+<a name="StardustService+toJSON"></a>
+
+### stardustService.toJSON() ⇒ <code>any</code>
+Serializes this to a JSON object.
+
+**Kind**: instance method of [<code>StardustService</code>](#StardustService)  
+<a name="StardustService+clone"></a>
+
+### stardustService.clone() ⇒ [<code>StardustService</code>](#StardustService)
+Deep clones the object.
+
+**Kind**: instance method of [<code>StardustService</code>](#StardustService)  
+<a name="StardustService.fromJSON"></a>
+
+### StardustService.fromJSON(json) ⇒ [<code>StardustService</code>](#StardustService)
+Deserializes an instance from a JSON object.
+
+**Kind**: static method of [<code>StardustService</code>](#StardustService)  
 
 | Param | Type |
 | --- | --- |
@@ -5841,10 +5952,6 @@ Return all errors that occur during validation.
 Return after the first error occurs.
 
 **Kind**: global variable  
-<a name="KeyType"></a>
-
-## KeyType
-**Kind**: global variable  
 <a name="MethodRelationship"></a>
 
 ## MethodRelationship
@@ -5852,6 +5959,10 @@ Return after the first error occurs.
 <a name="StateMetadataEncoding"></a>
 
 ## StateMetadataEncoding
+**Kind**: global variable  
+<a name="KeyType"></a>
+
+## KeyType
 **Kind**: global variable  
 <a name="start"></a>
 

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -1354,9 +1354,13 @@ A DID conforming to the IOTA DID method specification.
 * [DID](#DID)
     * [new DID(public_key, network)](#new_DID_new)
     * _instance_
-        * [.networkName](#DID+networkName) ⇒ <code>string</code>
         * [.network()](#DID+network) ⇒ [<code>Network</code>](#Network)
+        * [.networkStr()](#DID+networkStr) ⇒ <code>string</code>
         * [.tag()](#DID+tag) ⇒ <code>string</code>
+        * [.scheme()](#DID+scheme) ⇒ <code>string</code>
+        * [.authority()](#DID+authority) ⇒ <code>string</code>
+        * [.method()](#DID+method) ⇒ <code>string</code>
+        * [.methodId()](#DID+methodId) ⇒ <code>string</code>
         * [.join(segment)](#DID+join) ⇒ [<code>DIDUrl</code>](#DIDUrl)
         * [.toUrl()](#DID+toUrl) ⇒ [<code>DIDUrl</code>](#DIDUrl)
         * [.intoUrl()](#DID+intoUrl) ⇒ [<code>DIDUrl</code>](#DIDUrl)
@@ -1380,22 +1384,62 @@ Creates a new `DID` from a public key.
 | public_key | <code>Uint8Array</code> | 
 | network | <code>string</code> \| <code>undefined</code> | 
 
-<a name="DID+networkName"></a>
-
-### did.networkName ⇒ <code>string</code>
-Returns the IOTA tangle network of the `DID`.
-
-**Kind**: instance property of [<code>DID</code>](#DID)  
 <a name="DID+network"></a>
 
 ### did.network() ⇒ [<code>Network</code>](#Network)
-Returns the IOTA tangle network of the `DID`.
+Returns the Tangle network of the `DID`.
+
+**Kind**: instance method of [<code>DID</code>](#DID)  
+<a name="DID+networkStr"></a>
+
+### did.networkStr() ⇒ <code>string</code>
+Returns the Tangle network name of the `DID`.
 
 **Kind**: instance method of [<code>DID</code>](#DID)  
 <a name="DID+tag"></a>
 
 ### did.tag() ⇒ <code>string</code>
 Returns a copy of the unique tag of the `DID`.
+
+**Kind**: instance method of [<code>DID</code>](#DID)  
+<a name="DID+scheme"></a>
+
+### did.scheme() ⇒ <code>string</code>
+Returns the `DID` scheme.
+
+E.g.
+- `"did:example:12345678" -> "did"`
+- `"did:iota:main:12345678" -> "did"`
+
+**Kind**: instance method of [<code>DID</code>](#DID)  
+<a name="DID+authority"></a>
+
+### did.authority() ⇒ <code>string</code>
+Returns the `DID` authority: the method name and method-id.
+
+E.g.
+- `"did:example:12345678" -> "example:12345678"`
+- `"did:iota:main:12345678" -> "iota:main:12345678"`
+
+**Kind**: instance method of [<code>DID</code>](#DID)  
+<a name="DID+method"></a>
+
+### did.method() ⇒ <code>string</code>
+Returns the `DID` method name.
+
+E.g.
+- `"did:example:12345678" -> "example"`
+- `"did:iota:main:12345678" -> "iota"`
+
+**Kind**: instance method of [<code>DID</code>](#DID)  
+<a name="DID+methodId"></a>
+
+### did.methodId() ⇒ <code>string</code>
+Returns the `DID` method-specific ID.
+
+E.g.
+- `"did:example:12345678" -> "12345678"`
+- `"did:iota:main:12345678" -> "main:12345678"`
 
 **Kind**: instance method of [<code>DID</code>](#DID)  
 <a name="DID+join"></a>

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -138,6 +138,11 @@ with a DID subject.</p>
 <dt><a href="#StardustDIDUrl">StardustDIDUrl</a></dt>
 <dd><p>A DID URL conforming to the IOTA Stardust UTXO DID method specification.</p>
 </dd>
+<dt><a href="#StardustDocument">StardustDocument</a></dt>
+<dd></dd>
+<dt><a href="#StardustDocumentMetadata">StardustDocumentMetadata</a></dt>
+<dd><p>Additional attributes related to an IOTA DID Document.</p>
+</dd>
 <dt><a href="#StorageTestSuite">StorageTestSuite</a></dt>
 <dd><p>A test suite for the <code>Storage</code> interface.</p>
 <p>This module contains a set of tests that a correct storage implementation
@@ -209,6 +214,8 @@ This variant is the default used if no other variant is specified when construct
 <dt><a href="#KeyType">KeyType</a></dt>
 <dd></dd>
 <dt><a href="#MethodRelationship">MethodRelationship</a></dt>
+<dd></dd>
+<dt><a href="#StateMetadataEncoding">StateMetadataEncoding</a></dt>
 <dd></dd>
 </dl>
 
@@ -1900,7 +1907,7 @@ Use `null` to remove all controllers.
 <a name="Document+controller"></a>
 
 ### document.controller() ⇒ [<code>Array.&lt;DID&gt;</code>](#DID)
-Returns a list of document controllers.
+Returns a copy of the list of document controllers.
 
 **Kind**: instance method of [<code>Document</code>](#Document)  
 <a name="Document+setAlsoKnownAs"></a>
@@ -1917,7 +1924,7 @@ Sets the `alsoKnownAs` property in the DID document.
 <a name="Document+alsoKnownAs"></a>
 
 ### document.alsoKnownAs() ⇒ <code>Array.&lt;string&gt;</code>
-Returns a set of the document's `alsoKnownAs`.
+Returns a copy of the document's `alsoKnownAs` set.
 
 **Kind**: instance method of [<code>Document</code>](#Document)  
 <a name="Document+setPropertyUnchecked"></a>
@@ -2512,18 +2519,15 @@ Additional attributes related to an IOTA DID Document.
 
 * [DocumentMetadata](#DocumentMetadata)
     * _instance_
-        * [.previousMessageId](#DocumentMetadata+previousMessageId) ⇒ <code>string</code>
         * [.created()](#DocumentMetadata+created) ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
         * [.updated()](#DocumentMetadata+updated) ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
+        * [.previousMessageId()](#DocumentMetadata+previousMessageId) ⇒ <code>string</code>
+        * [.properties()](#DocumentMetadata+properties) ⇒ <code>Map.&lt;string, any&gt;</code>
         * [.toJSON()](#DocumentMetadata+toJSON) ⇒ <code>any</code>
         * [.clone()](#DocumentMetadata+clone) ⇒ [<code>DocumentMetadata</code>](#DocumentMetadata)
     * _static_
         * [.fromJSON(json)](#DocumentMetadata.fromJSON) ⇒ [<code>DocumentMetadata</code>](#DocumentMetadata)
 
-<a name="DocumentMetadata+previousMessageId"></a>
-
-### documentMetadata.previousMessageId ⇒ <code>string</code>
-**Kind**: instance property of [<code>DocumentMetadata</code>](#DocumentMetadata)  
 <a name="DocumentMetadata+created"></a>
 
 ### documentMetadata.created() ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
@@ -2534,6 +2538,18 @@ Returns a copy of the timestamp of when the DID document was created.
 
 ### documentMetadata.updated() ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
 Returns a copy of the timestamp of the last DID document update.
+
+**Kind**: instance method of [<code>DocumentMetadata</code>](#DocumentMetadata)  
+<a name="DocumentMetadata+previousMessageId"></a>
+
+### documentMetadata.previousMessageId() ⇒ <code>string</code>
+Returns a copy of the previous message identifier.
+
+**Kind**: instance method of [<code>DocumentMetadata</code>](#DocumentMetadata)  
+<a name="DocumentMetadata+properties"></a>
+
+### documentMetadata.properties() ⇒ <code>Map.&lt;string, any&gt;</code>
+Returns a copy of the custom metadata properties.
 
 **Kind**: instance method of [<code>DocumentMetadata</code>](#DocumentMetadata)  
 <a name="DocumentMetadata+toJSON"></a>
@@ -4507,7 +4523,7 @@ See: https://www.w3.org/TR/did-core/#services
 
 | Param | Type |
 | --- | --- |
-| service | <code>IService</code> | 
+| service | <code>IIotaService</code> | 
 
 <a name="Service+id"></a>
 
@@ -4929,6 +4945,414 @@ Parses a `StardustDIDUrl` from the input string.
 Deserializes an instance from a JSON object.
 
 **Kind**: static method of [<code>StardustDIDUrl</code>](#StardustDIDUrl)  
+
+| Param | Type |
+| --- | --- |
+| json | <code>any</code> | 
+
+<a name="StardustDocument"></a>
+
+## StardustDocument
+**Kind**: global class  
+
+* [StardustDocument](#StardustDocument)
+    * [new StardustDocument(network)](#new_StardustDocument_new)
+    * _instance_
+        * [.id()](#StardustDocument+id) ⇒ [<code>StardustDID</code>](#StardustDID)
+        * [.controller()](#StardustDocument+controller) ⇒ [<code>Array.&lt;StardustDID&gt;</code>](#StardustDID)
+        * [.alsoKnownAs()](#StardustDocument+alsoKnownAs) ⇒ <code>Array.&lt;string&gt;</code>
+        * [.setAlsoKnownAs(urls)](#StardustDocument+setAlsoKnownAs)
+        * [.properties()](#StardustDocument+properties) ⇒ <code>Map.&lt;string, any&gt;</code>
+        * [.setPropertyUnchecked(key, value)](#StardustDocument+setPropertyUnchecked)
+        * [.removeService(did)](#StardustDocument+removeService) ⇒ <code>boolean</code>
+        * [.removeMethod(did)](#StardustDocument+removeMethod)
+        * [.attachMethodRelationship(did_url, relationship)](#StardustDocument+attachMethodRelationship) ⇒ <code>boolean</code>
+        * [.detachMethodRelationship(did_url, relationship)](#StardustDocument+detachMethodRelationship) ⇒ <code>boolean</code>
+        * [.signCredential(credential, privateKey, methodQuery, options)](#StardustDocument+signCredential) ⇒ [<code>Credential</code>](#Credential)
+        * [.signPresentation(presentation, privateKey, methodQuery, options)](#StardustDocument+signPresentation) ⇒ [<code>Presentation</code>](#Presentation)
+        * [.signData(data, privateKey, methodQuery, options)](#StardustDocument+signData) ⇒ <code>any</code>
+        * [.verifyData(data, options)](#StardustDocument+verifyData) ⇒ <code>boolean</code>
+        * [.pack()](#StardustDocument+pack) ⇒ <code>Uint8Array</code>
+        * [.pack_with_encoding(encoding)](#StardustDocument+pack_with_encoding) ⇒ <code>Uint8Array</code>
+        * [.metadata()](#StardustDocument+metadata) ⇒ [<code>StardustDocumentMetadata</code>](#StardustDocumentMetadata)
+        * [.metadataCreated()](#StardustDocument+metadataCreated) ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
+        * [.setMetadataCreated(timestamp)](#StardustDocument+setMetadataCreated)
+        * [.metadataUpdated()](#StardustDocument+metadataUpdated) ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
+        * [.setMetadataUpdated(timestamp)](#StardustDocument+setMetadataUpdated)
+        * [.revokeCredentials(serviceQuery, indices)](#StardustDocument+revokeCredentials)
+        * [.unrevokeCredentials(serviceQuery, indices)](#StardustDocument+unrevokeCredentials)
+        * [.toJSON()](#StardustDocument+toJSON) ⇒ <code>any</code>
+        * [.clone()](#StardustDocument+clone) ⇒ [<code>StardustDocument</code>](#StardustDocument)
+    * _static_
+        * [.newWithId(id)](#StardustDocument.newWithId) ⇒ [<code>StardustDocument</code>](#StardustDocument)
+        * [.unpack(did, stateMetadata)](#StardustDocument.unpack) ⇒ [<code>StardustDocument</code>](#StardustDocument)
+        * [.fromJSON(json)](#StardustDocument.fromJSON) ⇒ [<code>StardustDocument</code>](#StardustDocument)
+
+<a name="new_StardustDocument_new"></a>
+
+### new StardustDocument(network)
+Constructs an empty DID Document with a [placeholder](#StardustDID.placeholder) identifier
+for the given `network`.
+
+
+| Param | Type |
+| --- | --- |
+| network | <code>string</code> | 
+
+<a name="StardustDocument+id"></a>
+
+### stardustDocument.id() ⇒ [<code>StardustDID</code>](#StardustDID)
+Returns a copy of the DID Document `id`.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+<a name="StardustDocument+controller"></a>
+
+### stardustDocument.controller() ⇒ [<code>Array.&lt;StardustDID&gt;</code>](#StardustDID)
+Returns a copy of the list of document controllers.
+
+NOTE: controllers are determined by the `state_controller` unlock condition of the output
+during resolution and are omitted when publishing.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+<a name="StardustDocument+alsoKnownAs"></a>
+
+### stardustDocument.alsoKnownAs() ⇒ <code>Array.&lt;string&gt;</code>
+Returns a copy of the document's `alsoKnownAs` set.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+<a name="StardustDocument+setAlsoKnownAs"></a>
+
+### stardustDocument.setAlsoKnownAs(urls)
+Sets the `alsoKnownAs` property in the DID document.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| urls | <code>string</code> \| <code>Array.&lt;string&gt;</code> \| <code>null</code> | 
+
+<a name="StardustDocument+properties"></a>
+
+### stardustDocument.properties() ⇒ <code>Map.&lt;string, any&gt;</code>
+Returns a copy of the custom DID Document properties.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+<a name="StardustDocument+setPropertyUnchecked"></a>
+
+### stardustDocument.setPropertyUnchecked(key, value)
+Adds a custom property to the DID Document.
+If the value is set to `null`, the custom property will be removed.
+
+### WARNING
+This method can overwrite existing properties like `id` and result in an invalid document.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| key | <code>string</code> | 
+| value | <code>any</code> | 
+
+<a name="StardustDocument+removeService"></a>
+
+### stardustDocument.removeService(did) ⇒ <code>boolean</code>
+Remove a [Service](#Service) identified by the given [DIDUrl](#DIDUrl) from the document.
+
+Returns `true` if a service was removed.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| did | [<code>StardustDIDUrl</code>](#StardustDIDUrl) | 
+
+<a name="StardustDocument+removeMethod"></a>
+
+### stardustDocument.removeMethod(did)
+Removes all references to the specified Verification Method.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| did | [<code>StardustDIDUrl</code>](#StardustDIDUrl) | 
+
+<a name="StardustDocument+attachMethodRelationship"></a>
+
+### stardustDocument.attachMethodRelationship(did_url, relationship) ⇒ <code>boolean</code>
+Attaches the relationship to the given method, if the method exists.
+
+Note: The method needs to be in the set of verification methods,
+so it cannot be an embedded one.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| did_url | [<code>StardustDIDUrl</code>](#StardustDIDUrl) | 
+| relationship | <code>number</code> | 
+
+<a name="StardustDocument+detachMethodRelationship"></a>
+
+### stardustDocument.detachMethodRelationship(did_url, relationship) ⇒ <code>boolean</code>
+Detaches the given relationship from the given method, if the method exists.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| did_url | [<code>StardustDIDUrl</code>](#StardustDIDUrl) | 
+| relationship | <code>number</code> | 
+
+<a name="StardustDocument+signCredential"></a>
+
+### stardustDocument.signCredential(credential, privateKey, methodQuery, options) ⇒ [<code>Credential</code>](#Credential)
+Creates a signature for the given `Credential` with the specified DID Document
+Verification Method.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| credential | [<code>Credential</code>](#Credential) | 
+| privateKey | <code>Uint8Array</code> | 
+| methodQuery | [<code>StardustDIDUrl</code>](#StardustDIDUrl) \| <code>string</code> | 
+| options | [<code>ProofOptions</code>](#ProofOptions) | 
+
+<a name="StardustDocument+signPresentation"></a>
+
+### stardustDocument.signPresentation(presentation, privateKey, methodQuery, options) ⇒ [<code>Presentation</code>](#Presentation)
+Creates a signature for the given `Presentation` with the specified DID Document
+Verification Method.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| presentation | [<code>Presentation</code>](#Presentation) | 
+| privateKey | <code>Uint8Array</code> | 
+| methodQuery | [<code>StardustDIDUrl</code>](#StardustDIDUrl) \| <code>string</code> | 
+| options | [<code>ProofOptions</code>](#ProofOptions) | 
+
+<a name="StardustDocument+signData"></a>
+
+### stardustDocument.signData(data, privateKey, methodQuery, options) ⇒ <code>any</code>
+Creates a signature for the given `data` with the specified DID Document
+Verification Method.
+
+NOTE: use `signSelf` or `signDocument` for DID Documents.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| data | <code>any</code> | 
+| privateKey | <code>Uint8Array</code> | 
+| methodQuery | [<code>StardustDIDUrl</code>](#StardustDIDUrl) \| <code>string</code> | 
+| options | [<code>ProofOptions</code>](#ProofOptions) | 
+
+<a name="StardustDocument+verifyData"></a>
+
+### stardustDocument.verifyData(data, options) ⇒ <code>boolean</code>
+Verifies the authenticity of `data` using the target verification method.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| data | <code>any</code> | 
+| options | [<code>VerifierOptions</code>](#VerifierOptions) | 
+
+<a name="StardustDocument+pack"></a>
+
+### stardustDocument.pack() ⇒ <code>Uint8Array</code>
+Serializes the document for inclusion in an Alias Output's state metadata
+with the default [`StateMetadataEncoding`].
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+<a name="StardustDocument+pack_with_encoding"></a>
+
+### stardustDocument.pack\_with\_encoding(encoding) ⇒ <code>Uint8Array</code>
+Serializes the document for inclusion in an Alias Output's state metadata.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| encoding | <code>number</code> | 
+
+<a name="StardustDocument+metadata"></a>
+
+### stardustDocument.metadata() ⇒ [<code>StardustDocumentMetadata</code>](#StardustDocumentMetadata)
+Returns a copy of the metadata associated with this document.
+
+NOTE: Copies all the metadata. See also `metadataCreated`, `metadataUpdated`,
+`metadataPreviousMessageId`, `metadataProof` if only a subset of the metadata required.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+<a name="StardustDocument+metadataCreated"></a>
+
+### stardustDocument.metadataCreated() ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
+Returns a copy of the timestamp of when the DID document was created.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+<a name="StardustDocument+setMetadataCreated"></a>
+
+### stardustDocument.setMetadataCreated(timestamp)
+Sets the timestamp of when the DID document was created.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| timestamp | [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code> | 
+
+<a name="StardustDocument+metadataUpdated"></a>
+
+### stardustDocument.metadataUpdated() ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
+Returns a copy of the timestamp of the last DID document update.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+<a name="StardustDocument+setMetadataUpdated"></a>
+
+### stardustDocument.setMetadataUpdated(timestamp)
+Sets the timestamp of the last DID document update.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| timestamp | [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code> | 
+
+<a name="StardustDocument+revokeCredentials"></a>
+
+### stardustDocument.revokeCredentials(serviceQuery, indices)
+If the document has a `RevocationBitmap` service identified by `serviceQuery`,
+revoke all specified `indices`.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| serviceQuery | [<code>StardustDIDUrl</code>](#StardustDIDUrl) \| <code>string</code> | 
+| indices | <code>number</code> \| <code>Array.&lt;number&gt;</code> | 
+
+<a name="StardustDocument+unrevokeCredentials"></a>
+
+### stardustDocument.unrevokeCredentials(serviceQuery, indices)
+If the document has a `RevocationBitmap` service identified by `serviceQuery`,
+unrevoke all specified `indices`.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| serviceQuery | [<code>StardustDIDUrl</code>](#StardustDIDUrl) \| <code>string</code> | 
+| indices | <code>number</code> \| <code>Array.&lt;number&gt;</code> | 
+
+<a name="StardustDocument+toJSON"></a>
+
+### stardustDocument.toJSON() ⇒ <code>any</code>
+Serializes this to a JSON object.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+<a name="StardustDocument+clone"></a>
+
+### stardustDocument.clone() ⇒ [<code>StardustDocument</code>](#StardustDocument)
+Deep clones the object.
+
+**Kind**: instance method of [<code>StardustDocument</code>](#StardustDocument)  
+<a name="StardustDocument.newWithId"></a>
+
+### StardustDocument.newWithId(id) ⇒ [<code>StardustDocument</code>](#StardustDocument)
+Constructs an empty DID Document with the given identifier.
+
+**Kind**: static method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| id | [<code>StardustDID</code>](#StardustDID) | 
+
+<a name="StardustDocument.unpack"></a>
+
+### StardustDocument.unpack(did, stateMetadata) ⇒ [<code>StardustDocument</code>](#StardustDocument)
+Deserializes the document from the state metadata bytes of an Alias Output.
+
+NOTE: `did` is required since it is omitted from the serialized DID Document and
+cannot be inferred from the state metadata. It also indicates the network, which is not
+encoded in the `AliasId` alone.
+
+**Kind**: static method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| did | [<code>StardustDID</code>](#StardustDID) | 
+| stateMetadata | <code>Uint8Array</code> | 
+
+<a name="StardustDocument.fromJSON"></a>
+
+### StardustDocument.fromJSON(json) ⇒ [<code>StardustDocument</code>](#StardustDocument)
+Deserializes an instance from a JSON object.
+
+**Kind**: static method of [<code>StardustDocument</code>](#StardustDocument)  
+
+| Param | Type |
+| --- | --- |
+| json | <code>any</code> | 
+
+<a name="StardustDocumentMetadata"></a>
+
+## StardustDocumentMetadata
+Additional attributes related to an IOTA DID Document.
+
+**Kind**: global class  
+
+* [StardustDocumentMetadata](#StardustDocumentMetadata)
+    * _instance_
+        * [.created()](#StardustDocumentMetadata+created) ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
+        * [.updated()](#StardustDocumentMetadata+updated) ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
+        * [.properties()](#StardustDocumentMetadata+properties) ⇒ <code>Map.&lt;string, any&gt;</code>
+        * [.toJSON()](#StardustDocumentMetadata+toJSON) ⇒ <code>any</code>
+        * [.clone()](#StardustDocumentMetadata+clone) ⇒ [<code>StardustDocumentMetadata</code>](#StardustDocumentMetadata)
+    * _static_
+        * [.fromJSON(json)](#StardustDocumentMetadata.fromJSON) ⇒ [<code>StardustDocumentMetadata</code>](#StardustDocumentMetadata)
+
+<a name="StardustDocumentMetadata+created"></a>
+
+### stardustDocumentMetadata.created() ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
+Returns a copy of the timestamp of when the DID document was created.
+
+**Kind**: instance method of [<code>StardustDocumentMetadata</code>](#StardustDocumentMetadata)  
+<a name="StardustDocumentMetadata+updated"></a>
+
+### stardustDocumentMetadata.updated() ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
+Returns a copy of the timestamp of the last DID document update.
+
+**Kind**: instance method of [<code>StardustDocumentMetadata</code>](#StardustDocumentMetadata)  
+<a name="StardustDocumentMetadata+properties"></a>
+
+### stardustDocumentMetadata.properties() ⇒ <code>Map.&lt;string, any&gt;</code>
+Returns a copy of the custom metadata properties.
+
+**Kind**: instance method of [<code>StardustDocumentMetadata</code>](#StardustDocumentMetadata)  
+<a name="StardustDocumentMetadata+toJSON"></a>
+
+### stardustDocumentMetadata.toJSON() ⇒ <code>any</code>
+Serializes this to a JSON object.
+
+**Kind**: instance method of [<code>StardustDocumentMetadata</code>](#StardustDocumentMetadata)  
+<a name="StardustDocumentMetadata+clone"></a>
+
+### stardustDocumentMetadata.clone() ⇒ [<code>StardustDocumentMetadata</code>](#StardustDocumentMetadata)
+Deep clones the object.
+
+**Kind**: instance method of [<code>StardustDocumentMetadata</code>](#StardustDocumentMetadata)  
+<a name="StardustDocumentMetadata.fromJSON"></a>
+
+### StardustDocumentMetadata.fromJSON(json) ⇒ [<code>StardustDocumentMetadata</code>](#StardustDocumentMetadata)
+Deserializes an instance from a JSON object.
+
+**Kind**: static method of [<code>StardustDocumentMetadata</code>](#StardustDocumentMetadata)  
 
 | Param | Type |
 | --- | --- |
@@ -5424,6 +5848,10 @@ Return after the first error occurs.
 <a name="MethodRelationship"></a>
 
 ## MethodRelationship
+**Kind**: global variable  
+<a name="StateMetadataEncoding"></a>
+
+## StateMetadataEncoding
 **Kind**: global variable  
 <a name="start"></a>
 

--- a/bindings/wasm/src/account/wasm_account/account.rs
+++ b/bindings/wasm/src/account/wasm_account/account.rs
@@ -31,6 +31,7 @@ use crate::account::types::WasmCekAlgorithm;
 use crate::account::types::WasmEncryptedData;
 use crate::account::types::WasmEncryptionAlgorithm;
 use crate::common::PromiseVoid;
+use crate::common::UOneOrManyNumber;
 use crate::credential::WasmCredential;
 use crate::credential::WasmPresentation;
 use crate::crypto::WasmProofOptions;
@@ -466,10 +467,4 @@ impl From<WasmPublishOptions> for PublishOptions {
 extern "C" {
   #[wasm_bindgen(typescript_type = "Promise<Account>")]
   pub type PromiseAccount;
-}
-
-#[wasm_bindgen]
-extern "C" {
-  #[wasm_bindgen(typescript_type = "number | number[]")]
-  pub type UOneOrManyNumber;
 }

--- a/bindings/wasm/src/account/wasm_account/mod.rs
+++ b/bindings/wasm/src/account/wasm_account/mod.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use self::account::PromiseAccount;
-pub use self::account::UOneOrManyNumber;
 pub use self::account::WasmAccount;
 pub use self::account_builder::WasmAccountBuilder;
 

--- a/bindings/wasm/src/common/timestamp.rs
+++ b/bindings/wasm/src/common/timestamp.rs
@@ -8,6 +8,12 @@ use wasm_bindgen::prelude::*;
 use crate::error::Result;
 use crate::error::WasmResult;
 
+#[wasm_bindgen]
+extern "C" {
+  #[wasm_bindgen(typescript_type = "Timestamp | undefined")]
+  pub type OptionTimestamp;
+}
+
 #[wasm_bindgen(js_name = Timestamp, inspectable)]
 pub struct WasmTimestamp(pub(crate) Timestamp);
 

--- a/bindings/wasm/src/common/types.rs
+++ b/bindings/wasm/src/common/types.rs
@@ -20,6 +20,12 @@ extern "C" {
 
   #[wasm_bindgen(typescript_type = "Map<string, any>")]
   pub type MapStringAny;
+
+  #[wasm_bindgen(typescript_type = "number | number[]")]
+  pub type UOneOrManyNumber;
+
+  #[wasm_bindgen(typescript_type = "string | string[] | null")]
+  pub type OptionOneOrManyString;
 }
 
 impl TryFrom<Object> for MapStringAny {

--- a/bindings/wasm/src/did/mod.rs
+++ b/bindings/wasm/src/did/mod.rs
@@ -19,7 +19,7 @@ pub use self::wasm_resolved_document::DocumentOrResolvedDocument;
 pub use self::wasm_resolved_document::PromiseArrayResolvedDocument;
 pub use self::wasm_resolved_document::PromiseResolvedDocument;
 pub use self::wasm_resolved_document::WasmResolvedDocument;
-pub(crate) use self::wasm_service::service_endpoint_to_js_value;
+pub use self::wasm_service::IService;
 pub use self::wasm_service::UServiceEndpoint;
 pub use self::wasm_service::WasmService;
 pub use self::wasm_verification_method::WasmVerificationMethod;

--- a/bindings/wasm/src/did/wasm_did.rs
+++ b/bindings/wasm/src/did/wasm_did.rs
@@ -10,12 +10,26 @@ use crate::error::Result;
 use crate::error::WasmResult;
 use crate::tangle::WasmNetwork;
 
+/// A DID conforming to the IOTA DID method specification.
+///
 /// @typicalname did
 #[wasm_bindgen(js_name = DID, inspectable)]
 pub struct WasmDID(pub(crate) IotaDID);
 
 #[wasm_bindgen(js_class = DID)]
 impl WasmDID {
+  /// The IOTA DID method name (`"iota"`).
+  #[wasm_bindgen(getter = METHOD)]
+  pub fn static_method() -> String {
+    IotaDID::METHOD.to_owned()
+  }
+
+  /// The default Tangle network (`"main"`).
+  #[wasm_bindgen(getter = DEFAULT_NETWORK)]
+  pub fn static_default_network() -> String {
+    IotaDID::DEFAULT_NETWORK.to_owned()
+  }
+
   /// Creates a new `DID` from a public key.
   #[wasm_bindgen(constructor)]
   pub fn new(public_key: &[u8], network: Option<String>) -> Result<WasmDID> {

--- a/bindings/wasm/src/did/wasm_did.rs
+++ b/bindings/wasm/src/did/wasm_did.rs
@@ -72,8 +72,8 @@ impl WasmDID {
 
   /// Construct a new `DIDUrl` by joining with a relative DID Url string.
   #[wasm_bindgen]
-  pub fn join(self, segment: &str) -> Result<WasmDIDUrl> {
-    self.0.join(segment).wasm_result().map(WasmDIDUrl)
+  pub fn join(&self, segment: &str) -> Result<WasmDIDUrl> {
+    self.0.clone().join(segment).wasm_result().map(WasmDIDUrl)
   }
 
   /// Clones the `DID` into a `DIDUrl`.
@@ -82,7 +82,7 @@ impl WasmDID {
     WasmDIDUrl::from(self.0.to_url())
   }
 
-  /// Converts the `DID` into a `DIDUrl`.
+  /// Converts the `DID` into a `DIDUrl`, consuming it.
   #[wasm_bindgen(js_name = intoUrl)]
   pub fn into_url(self) -> WasmDIDUrl {
     WasmDIDUrl::from(self.0.into_url())

--- a/bindings/wasm/src/did/wasm_did.rs
+++ b/bindings/wasm/src/did/wasm_did.rs
@@ -30,6 +30,10 @@ impl WasmDID {
     IotaDID::DEFAULT_NETWORK.to_owned()
   }
 
+  // ===========================================================================
+  // Constructors
+  // ===========================================================================
+
   /// Creates a new `DID` from a public key.
   #[wasm_bindgen(constructor)]
   pub fn new(public_key: &[u8], network: Option<String>) -> Result<WasmDID> {
@@ -52,22 +56,70 @@ impl WasmDID {
     IotaDID::parse(input).wasm_result().map(Self)
   }
 
-  /// Returns the IOTA tangle network of the `DID`.
+  // ===========================================================================
+  // Properties
+  // ===========================================================================
+
+  /// Returns the Tangle network of the `DID`.
   #[wasm_bindgen]
   pub fn network(&self) -> Result<WasmNetwork> {
     self.0.network().map(Into::into).wasm_result()
   }
 
-  /// Returns the IOTA tangle network of the `DID`.
-  #[wasm_bindgen(getter = networkName)]
-  pub fn network_name(&self) -> String {
-    self.0.network_str().into()
+  /// Returns the Tangle network name of the `DID`.
+  #[wasm_bindgen(js_name = networkStr)]
+  pub fn network_str(&self) -> String {
+    self.0.network_str().to_owned()
   }
 
   /// Returns a copy of the unique tag of the `DID`.
   #[wasm_bindgen]
   pub fn tag(&self) -> String {
-    self.0.tag().into()
+    self.0.tag().to_owned()
+  }
+
+  // ===========================================================================
+  // DID trait
+  // ===========================================================================
+
+  /// Returns the `DID` scheme.
+  ///
+  /// E.g.
+  /// - `"did:example:12345678" -> "did"`
+  /// - `"did:iota:main:12345678" -> "did"`
+  #[wasm_bindgen]
+  pub fn scheme(&self) -> String {
+    self.0.scheme().to_owned()
+  }
+
+  /// Returns the `DID` authority: the method name and method-id.
+  ///
+  /// E.g.
+  /// - `"did:example:12345678" -> "example:12345678"`
+  /// - `"did:iota:main:12345678" -> "iota:main:12345678"`
+  #[wasm_bindgen]
+  pub fn authority(&self) -> String {
+    self.0.authority().to_owned()
+  }
+
+  /// Returns the `DID` method name.
+  ///
+  /// E.g.
+  /// - `"did:example:12345678" -> "example"`
+  /// - `"did:iota:main:12345678" -> "iota"`
+  #[wasm_bindgen]
+  pub fn method(&self) -> String {
+    self.0.method().to_owned()
+  }
+
+  /// Returns the `DID` method-specific ID.
+  ///
+  /// E.g.
+  /// - `"did:example:12345678" -> "12345678"`
+  /// - `"did:iota:main:12345678" -> "main:12345678"`
+  #[wasm_bindgen(js_name = methodId)]
+  pub fn method_id(&self) -> String {
+    self.0.method_id().to_owned()
   }
 
   /// Construct a new `DIDUrl` by joining with a relative DID Url string.

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -624,6 +624,22 @@ impl WasmDocument {
     Ok(())
   }
 
+  /// Sets a custom property in the document metadata.
+  /// If the value is set to `null`, the custom property will be removed.
+  #[wasm_bindgen(js_name = setMetadataPropertyUnchecked)]
+  pub fn set_metadata_property_unchecked(&mut self, key: String, value: &JsValue) -> Result<()> {
+    let value: Option<serde_json::Value> = value.into_serde().wasm_result()?;
+    match value {
+      Some(value) => {
+        self.0.metadata.properties.insert(key, value);
+      }
+      None => {
+        self.0.metadata.properties.remove(&key);
+      }
+    }
+    Ok(())
+  }
+
   /// Returns a copy of the proof.
   #[wasm_bindgen]
   pub fn proof(&self) -> Option<WasmProof> {

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -23,21 +23,23 @@ use identity_iota::iota_core::NetworkName;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
-use crate::account::wasm_account::UOneOrManyNumber;
 use crate::common::ArrayString;
 use crate::common::MapStringAny;
+use crate::common::OptionOneOrManyString;
+use crate::common::OptionTimestamp;
+use crate::common::UOneOrManyNumber;
 use crate::common::WasmTimestamp;
 use crate::credential::WasmCredential;
 use crate::credential::WasmPresentation;
 use crate::crypto::WasmKeyPair;
 use crate::crypto::WasmProof;
 use crate::crypto::WasmProofOptions;
-use crate::did::wasm_method_relationship::WasmMethodRelationship;
 use crate::did::RefMethodScope;
 use crate::did::WasmDID;
 use crate::did::WasmDIDUrl;
 use crate::did::WasmDiffMessage;
 use crate::did::WasmDocumentMetadata;
+use crate::did::WasmMethodRelationship;
 use crate::did::WasmMethodScope;
 use crate::did::WasmMethodType;
 use crate::did::WasmService;
@@ -108,7 +110,7 @@ impl WasmDocument {
   /// Note: Duplicates will be ignored.
   /// Use `null` to remove all controllers.
   #[wasm_bindgen(js_name = setController)]
-  pub fn set_controller(&mut self, controllers: &UOneOrManyDID) -> Result<()> {
+  pub fn set_controller(&mut self, controllers: &OptionOneOrManyDID) -> Result<()> {
     let controllers: Option<OneOrMany<IotaDID>> = controllers.into_serde().wasm_result()?;
     let controller_set: Option<OneOrSet<IotaDID>> = if let Some(controllers) = controllers.map(OneOrMany::into_vec) {
       if controllers.is_empty() {
@@ -123,7 +125,7 @@ impl WasmDocument {
     Ok(())
   }
 
-  /// Returns a list of document controllers.
+  /// Returns a copy of the list of document controllers.
   #[wasm_bindgen]
   pub fn controller(&self) -> ArrayDID {
     match self.0.controller() {
@@ -140,7 +142,7 @@ impl WasmDocument {
 
   /// Sets the `alsoKnownAs` property in the DID document.
   #[wasm_bindgen(js_name = setAlsoKnownAs)]
-  pub fn set_also_known_as(&mut self, urls: &UOneOrManyUrl) -> Result<()> {
+  pub fn set_also_known_as(&mut self, urls: &OptionOneOrManyString) -> Result<()> {
     let urls: Option<OneOrMany<String>> = urls.into_serde().wasm_result()?;
     let mut urls_set: OrderedSet<Url> = OrderedSet::new();
     if let Some(urls) = urls {
@@ -152,7 +154,7 @@ impl WasmDocument {
     Ok(())
   }
 
-  /// Returns a set of the document's `alsoKnownAs`.
+  /// Returns a copy of the document's `alsoKnownAs` set.
   #[wasm_bindgen(js_name = alsoKnownAs)]
   pub fn also_known_as(&self) -> ArrayString {
     self
@@ -187,11 +189,7 @@ impl WasmDocument {
   /// Returns a copy of the custom DID Document properties.
   #[wasm_bindgen]
   pub fn properties(&mut self) -> Result<MapStringAny> {
-    let properties_map = js_sys::Map::new();
-    for (key, value) in self.0.properties().iter() {
-      properties_map.set(&JsValue::from(key), &JsValue::from_serde(&value).wasm_result()?);
-    }
-    Ok(properties_map.unchecked_into::<MapStringAny>())
+    MapStringAny::try_from(self.0.properties())
   }
 
   // ===========================================================================
@@ -681,11 +679,8 @@ extern "C" {
   #[wasm_bindgen(typescript_type = "DIDUrl | string")]
   pub type UDIDUrlQuery;
 
-  #[wasm_bindgen(typescript_type = "string | string[] | null")]
-  pub type UOneOrManyUrl;
-
   #[wasm_bindgen(typescript_type = "DID | DID[] | null")]
-  pub type UOneOrManyDID;
+  pub type OptionOneOrManyDID;
 
   #[wasm_bindgen(typescript_type = "DID[]")]
   pub type ArrayDID;
@@ -695,7 +690,4 @@ extern "C" {
 
   #[wasm_bindgen(typescript_type = "VerificationMethod[]")]
   pub type ArrayVerificationMethods;
-
-  #[wasm_bindgen(typescript_type = "Timestamp | undefined")]
-  pub type OptionTimestamp;
 }

--- a/bindings/wasm/src/did/wasm_document.rs
+++ b/bindings/wasm/src/did/wasm_document.rs
@@ -188,7 +188,7 @@ impl WasmDocument {
 
   /// Returns a copy of the custom DID Document properties.
   #[wasm_bindgen]
-  pub fn properties(&mut self) -> Result<MapStringAny> {
+  pub fn properties(&self) -> Result<MapStringAny> {
     MapStringAny::try_from(self.0.properties())
   }
 

--- a/bindings/wasm/src/did/wasm_document_metadata.rs
+++ b/bindings/wasm/src/did/wasm_document_metadata.rs
@@ -39,7 +39,7 @@ impl WasmDocumentMetadata {
 
   /// Returns a copy of the custom metadata properties.
   #[wasm_bindgen]
-  pub fn properties(&mut self) -> Result<MapStringAny> {
+  pub fn properties(&self) -> Result<MapStringAny> {
     MapStringAny::try_from(&self.0.properties)
   }
 }

--- a/bindings/wasm/src/did/wasm_service.rs
+++ b/bindings/wasm/src/did/wasm_service.rs
@@ -25,11 +25,13 @@ pub struct WasmService(pub(crate) IotaService);
 #[wasm_bindgen(js_class = Service)]
 impl WasmService {
   #[wasm_bindgen(constructor)]
-  pub fn new(service: IService) -> Result<WasmService> {
+  pub fn new(service: IIotaService) -> Result<WasmService> {
     let id: IotaDIDUrl = service.id().into_serde().wasm_result()?;
+
+    let i_service: &IService = service.as_ref();
     let types: OneOrMany<String> = service.type_().into_serde().wasm_result()?;
-    let service_endpoint: ServiceEndpoint = deserialize_map_or_any(&service.service_endpoint())?;
-    let properties: Option<identity_iota::core::Object> = deserialize_map_or_any(&service.properties())?;
+    let service_endpoint: ServiceEndpoint = deserialize_map_or_any(&i_service.service_endpoint())?;
+    let properties: Option<identity_iota::core::Object> = deserialize_map_or_any(&i_service.properties())?;
 
     IotaService::builder(properties.unwrap_or_default())
       .id(id)
@@ -62,7 +64,7 @@ impl WasmService {
   /// Returns a copy of the `Service` endpoint.
   #[wasm_bindgen(js_name = serviceEndpoint)]
   pub fn service_endpoint(&self) -> UServiceEndpoint {
-    service_endpoint_to_js_value(self.0.service_endpoint())
+    UServiceEndpoint::from(self.0.service_endpoint())
   }
 
   /// Returns a copy of the custom properties on the `Service`.
@@ -81,29 +83,37 @@ impl From<IotaService> for WasmService {
   }
 }
 
-pub(crate) fn service_endpoint_to_js_value(endpoint: &ServiceEndpoint) -> UServiceEndpoint {
-  match endpoint {
-    // string
-    ServiceEndpoint::One(url) => JsValue::from_str(url.as_str()).unchecked_into::<UServiceEndpoint>(),
-    // string[]
-    ServiceEndpoint::Set(set) => set
-      .iter()
-      .map(|url| JsValue::from_str(url.as_str()))
-      .collect::<js_sys::Array>()
-      .unchecked_into::<UServiceEndpoint>(),
-    // Map<string, string[]>
-    ServiceEndpoint::Map(map) => {
-      let js_map: js_sys::Map = js_sys::Map::new();
-      for (key, urls) in map.into_iter() {
-        js_map.set(
-          &JsValue::from_str(key.as_str()),
-          &urls
-            .iter()
-            .map(|url| JsValue::from_str(url.as_str()))
-            .collect::<js_sys::Array>(),
-        );
+impl From<ServiceEndpoint> for UServiceEndpoint {
+  fn from(endpoint: ServiceEndpoint) -> Self {
+    UServiceEndpoint::from(&endpoint)
+  }
+}
+
+impl From<&ServiceEndpoint> for UServiceEndpoint {
+  fn from(endpoint: &ServiceEndpoint) -> Self {
+    match endpoint {
+      // string
+      ServiceEndpoint::One(url) => JsValue::from_str(url.as_str()).unchecked_into::<UServiceEndpoint>(),
+      // string[]
+      ServiceEndpoint::Set(set) => set
+        .iter()
+        .map(|url| JsValue::from_str(url.as_str()))
+        .collect::<js_sys::Array>()
+        .unchecked_into::<UServiceEndpoint>(),
+      // Map<string, string[]>
+      ServiceEndpoint::Map(map) => {
+        let js_map: js_sys::Map = js_sys::Map::new();
+        for (key, urls) in map.into_iter() {
+          js_map.set(
+            &JsValue::from_str(key.as_str()),
+            &urls
+              .iter()
+              .map(|url| JsValue::from_str(url.as_str()))
+              .collect::<js_sys::Array>(),
+          );
+        }
+        js_map.unchecked_into::<UServiceEndpoint>()
       }
-      js_map.unchecked_into::<UServiceEndpoint>()
     }
   }
 }
@@ -116,11 +126,31 @@ extern "C" {
 
 #[wasm_bindgen]
 extern "C" {
-  #[wasm_bindgen(typescript_type = "IService")]
-  pub type IService;
+  #[wasm_bindgen(typescript_type = "IIotaService", extends = IService)]
+  pub type IIotaService;
 
   #[wasm_bindgen(method, getter)]
-  pub fn id(this: &IService) -> JsValue;
+  pub fn id(this: &IIotaService) -> JsValue;
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const I_IOTA_SERVICE: &'static str = r#"
+/**
+ * Holds options to create a new `IotaService`.
+ */
+interface IIotaService extends IService {
+    /**
+     * Identifier of the service.
+     *
+     * Must be a valid DIDUrl with a fragment.
+     */
+    readonly id: DIDUrl | string;
+}"#;
+
+#[wasm_bindgen]
+extern "C" {
+  #[wasm_bindgen(typescript_type = "IService")]
+  pub type IService;
 
   #[wasm_bindgen(method, getter, js_name = type)]
   pub fn type_(this: &IService) -> JsValue;
@@ -135,16 +165,9 @@ extern "C" {
 #[wasm_bindgen(typescript_custom_section)]
 const I_SERVICE: &'static str = r#"
 /**
- * Holds options to create a new `Service`.
+ * Base `Service` properties.
  */
 interface IService {
-    /**
-     * Identifier of the service.
-     *
-     * Must be a valid DIDUrl with a fragment.
-     */
-    readonly id: DIDUrl | string;
-
     /**
      * Type of service.
      *

--- a/bindings/wasm/src/did/wasm_service.rs
+++ b/bindings/wasm/src/did/wasm_service.rs
@@ -28,10 +28,10 @@ impl WasmService {
   pub fn new(service: IIotaService) -> Result<WasmService> {
     let id: IotaDIDUrl = service.id().into_serde().wasm_result()?;
 
-    let i_service: &IService = service.as_ref();
+    let base_service: &IService = service.as_ref();
     let types: OneOrMany<String> = service.type_().into_serde().wasm_result()?;
-    let service_endpoint: ServiceEndpoint = deserialize_map_or_any(&i_service.service_endpoint())?;
-    let properties: Option<identity_iota::core::Object> = deserialize_map_or_any(&i_service.properties())?;
+    let service_endpoint: ServiceEndpoint = deserialize_map_or_any(&base_service.service_endpoint())?;
+    let properties: Option<identity_iota::core::Object> = deserialize_map_or_any(&base_service.properties())?;
 
     IotaService::builder(properties.unwrap_or_default())
       .id(id)

--- a/bindings/wasm/src/did/wasm_verification_method.rs
+++ b/bindings/wasm/src/did/wasm_verification_method.rs
@@ -18,34 +18,35 @@ pub struct WasmVerificationMethod(pub(crate) IotaVerificationMethod);
 
 #[wasm_bindgen(js_class = VerificationMethod)]
 impl WasmVerificationMethod {
-  /// Creates a new `VerificationMethod` object from the given `did` and public key.
+  /// Creates a new `VerificationMethod` from the given `did` and public key.
+  #[allow(non_snake_case)]
   #[wasm_bindgen(constructor)]
   pub fn new(
     did: &WasmDID,
-    key_type: WasmKeyType,
-    public_key: Vec<u8>,
+    keyType: WasmKeyType,
+    publicKey: Vec<u8>,
     fragment: String,
   ) -> Result<WasmVerificationMethod> {
-    let public_key: PublicKey = PublicKey::from(public_key);
-    IotaVerificationMethod::new(did.0.clone(), key_type.into(), &public_key, &fragment)
+    let public_key: PublicKey = PublicKey::from(publicKey);
+    IotaVerificationMethod::new(did.0.clone(), keyType.into(), &public_key, &fragment)
       .map(Self)
       .wasm_result()
   }
 
-  /// Returns a copy of the `id` `DIDUrl` of the `VerificationMethod` object.
+  /// Returns a copy of the `id` `DIDUrl` of the `VerificationMethod`.
   #[wasm_bindgen]
   pub fn id(&self) -> WasmDIDUrl {
     WasmDIDUrl::from(self.0.id().clone())
   }
 
-  /// Returns a copy of the `controller` `DID` of the `VerificationMethod` object.
+  /// Returns a copy of the `controller` `DID` of the `VerificationMethod`.
   #[wasm_bindgen]
   pub fn controller(&self) -> WasmDID {
     WasmDID::from(self.0.controller().clone())
   }
 
-  /// Sets the `controller` `DID` of the `VerificationMethod` object.
-  #[wasm_bindgen(js_name = SetController)]
+  /// Sets the `controller` `DID` of the `VerificationMethod`.
+  #[wasm_bindgen(js_name = setController)]
   pub fn set_controller(&mut self, did: &WasmDID) {
     *self.0.controller_mut() = did.0.clone();
   }

--- a/bindings/wasm/src/error.rs
+++ b/bindings/wasm/src/error.rs
@@ -97,7 +97,8 @@ impl_wasm_error_from!(
   identity_iota::did::Error,
   identity_iota::did::DIDError,
   identity_iota::iota_core::Error,
-  identity_iota::credential::ValidationError
+  identity_iota::credential::ValidationError,
+  identity_stardust::Error
 );
 
 // Similar to `impl_wasm_error_from`, but uses the types name instead of requiring/calling Into &'static str

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -17,16 +17,15 @@ use wasm_bindgen::prelude::*;
 #[macro_use]
 mod macros;
 
-#[macro_use]
-pub mod error;
-
 pub mod account;
 pub mod chain;
 pub mod common;
 pub mod credential;
 pub mod crypto;
 pub mod did;
+pub mod error;
 pub mod revocation;
+pub mod stardust;
 pub mod tangle;
 
 /// Initializes the console error panic hook for better error messages

--- a/bindings/wasm/src/revocation/bitmap.rs
+++ b/bindings/wasm/src/revocation/bitmap.rs
@@ -7,7 +7,6 @@ use identity_iota::did::RevocationBitmap;
 use identity_iota::did::ServiceEndpoint;
 use wasm_bindgen::prelude::*;
 
-use crate::did::service_endpoint_to_js_value;
 use crate::did::UServiceEndpoint;
 use crate::error::Result;
 use crate::error::WasmError;
@@ -65,7 +64,7 @@ impl WasmRevocationBitmap {
   /// Return the bitmap as a data url embedded in a service endpoint.
   #[wasm_bindgen(js_name = toEndpoint)]
   pub fn to_enpdoint(&self) -> Result<UServiceEndpoint> {
-    Ok(service_endpoint_to_js_value(&self.0.to_endpoint().wasm_result()?))
+    self.0.to_endpoint().map(UServiceEndpoint::from).wasm_result()
   }
 
   /// Construct a `RevocationBitmap` from a data `url`.

--- a/bindings/wasm/src/stardust/mod.rs
+++ b/bindings/wasm/src/stardust/mod.rs
@@ -1,0 +1,8 @@
+// Copyright 2020-2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+pub use stardust_did::WasmStardustDID;
+pub use stardust_did_url::WasmStardustDIDUrl;
+
+mod stardust_did;
+mod stardust_did_url;

--- a/bindings/wasm/src/stardust/mod.rs
+++ b/bindings/wasm/src/stardust/mod.rs
@@ -3,6 +3,12 @@
 
 pub use stardust_did::WasmStardustDID;
 pub use stardust_did_url::WasmStardustDIDUrl;
+pub use stardust_document::WasmStardustDocument;
+pub use stardust_document_metadata::WasmStardustDocumentMetadata;
+pub use state_metadata_encoding::WasmStateMetadataEncoding;
 
 mod stardust_did;
 mod stardust_did_url;
+mod stardust_document;
+mod stardust_document_metadata;
+mod state_metadata_encoding;

--- a/bindings/wasm/src/stardust/mod.rs
+++ b/bindings/wasm/src/stardust/mod.rs
@@ -6,6 +6,7 @@ pub use stardust_did_url::WasmStardustDIDUrl;
 pub use stardust_document::WasmStardustDocument;
 pub use stardust_document_metadata::WasmStardustDocumentMetadata;
 pub use stardust_service::WasmStardustService;
+pub use stardust_verification_method::WasmStardustVerificationMethod;
 pub use state_metadata_encoding::WasmStateMetadataEncoding;
 
 mod stardust_did;
@@ -13,4 +14,5 @@ mod stardust_did_url;
 mod stardust_document;
 mod stardust_document_metadata;
 mod stardust_service;
+mod stardust_verification_method;
 mod state_metadata_encoding;

--- a/bindings/wasm/src/stardust/mod.rs
+++ b/bindings/wasm/src/stardust/mod.rs
@@ -5,10 +5,12 @@ pub use stardust_did::WasmStardustDID;
 pub use stardust_did_url::WasmStardustDIDUrl;
 pub use stardust_document::WasmStardustDocument;
 pub use stardust_document_metadata::WasmStardustDocumentMetadata;
+pub use stardust_service::WasmStardustService;
 pub use state_metadata_encoding::WasmStateMetadataEncoding;
 
 mod stardust_did;
 mod stardust_did_url;
 mod stardust_document;
 mod stardust_document_metadata;
+mod stardust_service;
 mod state_metadata_encoding;

--- a/bindings/wasm/src/stardust/stardust_did.rs
+++ b/bindings/wasm/src/stardust/stardust_did.rs
@@ -127,8 +127,8 @@ impl WasmStardustDID {
 
   /// Construct a new `DIDUrl` by joining with a relative DID Url string.
   #[wasm_bindgen]
-  pub fn join(self, segment: &str) -> Result<WasmStardustDIDUrl> {
-    self.0.join(segment).wasm_result().map(WasmStardustDIDUrl)
+  pub fn join(&self, segment: &str) -> Result<WasmStardustDIDUrl> {
+    self.0.clone().join(segment).wasm_result().map(WasmStardustDIDUrl)
   }
 
   /// Clones the `DID` into a `DIDUrl`.
@@ -137,7 +137,7 @@ impl WasmStardustDID {
     WasmStardustDIDUrl::from(self.0.to_url())
   }
 
-  /// Converts the `DID` into a `DIDUrl`.
+  /// Converts the `DID` into a `DIDUrl`, consuming it.
   #[wasm_bindgen(js_name = intoUrl)]
   pub fn into_url(self) -> WasmStardustDIDUrl {
     WasmStardustDIDUrl::from(self.0.into_url())

--- a/bindings/wasm/src/stardust/stardust_did.rs
+++ b/bindings/wasm/src/stardust/stardust_did.rs
@@ -1,0 +1,161 @@
+// Copyright 2020-2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use identity_iota::did::DIDError;
+use identity_iota::did::DID;
+use identity_stardust::NetworkName;
+use identity_stardust::StardustDID;
+use wasm_bindgen::prelude::*;
+
+use crate::error::Result;
+use crate::error::WasmResult;
+use crate::stardust::WasmStardustDIDUrl;
+
+/// A DID conforming to the IOTA UTXO DID method specification.
+///
+/// @typicalname did
+#[wasm_bindgen(js_name = StardustDID, inspectable)]
+pub struct WasmStardustDID(pub(crate) StardustDID);
+
+#[wasm_bindgen(js_class = StardustDID)]
+impl WasmStardustDID {
+  /// The IOTA UTXO DID method name (`"stardust"`).
+  // TODO: This will be changed to `iota` in the future.
+  #[wasm_bindgen(getter = METHOD)]
+  pub fn static_method() -> String {
+    StardustDID::METHOD.to_owned()
+  }
+
+  /// The default Tangle network (`"main"`).
+  #[wasm_bindgen(getter = DEFAULT_NETWORK)]
+  pub fn static_default_network() -> String {
+    StardustDID::DEFAULT_NETWORK.to_owned()
+  }
+
+  // ===========================================================================
+  // Constructors
+  // ===========================================================================
+
+  /// Constructs a new `StardustDID` from a byte representation of the tag and the given
+  /// network name.
+  ///
+  /// See also {@link StardustDID.placeholder}.
+  #[wasm_bindgen(constructor)]
+  pub fn new(bytes: &[u8], network: String) -> Result<WasmStardustDID> {
+    let network_name: NetworkName = NetworkName::try_from(network).wasm_result()?;
+    let tag_bytes: &[u8; 32] = bytes
+      .try_into()
+      .map_err(|_| DIDError::Other("invalid bytes length for StardustDID tag, expected 32"))
+      .wasm_result()?;
+    Ok(Self::from(StardustDID::new(tag_bytes, &network_name)))
+  }
+
+  /// Creates a new placeholder [`StardustDID`] with the given network name.
+  ///
+  /// E.g. `did:stardust:smr:0x0000000000000000000000000000000000000000000000000000000000000000`.
+  #[wasm_bindgen]
+  pub fn placeholder(network: String) -> Result<WasmStardustDID> {
+    let network_name: NetworkName = NetworkName::try_from(network).wasm_result()?;
+    Ok(Self::from(StardustDID::placeholder(&network_name)))
+  }
+
+  /// Parses a `StardustDID` from the input string.
+  #[wasm_bindgen]
+  pub fn parse(input: &str) -> Result<WasmStardustDID> {
+    StardustDID::parse(input).map(Self).wasm_result()
+  }
+
+  // ===========================================================================
+  // Properties
+  // ===========================================================================
+
+  /// Returns the Tangle network name of the `StardustDID`.
+  #[wasm_bindgen(js_name = networkStr)]
+  pub fn network_str(&self) -> String {
+    self.0.network_str().to_owned()
+  }
+
+  /// Returns a copy of the unique tag of the `StardustDID`.
+  #[wasm_bindgen]
+  pub fn tag(&self) -> String {
+    self.0.tag().to_owned()
+  }
+
+  // ===========================================================================
+  // DID trait
+  // ===========================================================================
+
+  /// Returns the `DID` scheme.
+  ///
+  /// E.g.
+  /// - `"did:example:12345678" -> "did"`
+  /// - `"did:iota:main:12345678" -> "did"`
+  #[wasm_bindgen]
+  pub fn scheme(&self) -> String {
+    self.0.scheme().to_owned()
+  }
+
+  /// Returns the `DID` authority: the method name and method-id.
+  ///
+  /// E.g.
+  /// - `"did:example:12345678" -> "example:12345678"`
+  /// - `"did:iota:main:12345678" -> "iota:main:12345678"`
+  #[wasm_bindgen]
+  pub fn authority(&self) -> String {
+    self.0.authority().to_owned()
+  }
+
+  /// Returns the `DID` method name.
+  ///
+  /// E.g.
+  /// - `"did:example:12345678" -> "example"`
+  /// - `"did:iota:main:12345678" -> "iota"`
+  #[wasm_bindgen]
+  pub fn method(&self) -> String {
+    self.0.method().to_owned()
+  }
+
+  /// Returns the `DID` method-specific ID.
+  ///
+  /// E.g.
+  /// - `"did:example:12345678" -> "12345678"`
+  /// - `"did:iota:main:12345678" -> "main:12345678"`
+  #[wasm_bindgen(js_name = methodId)]
+  pub fn method_id(&self) -> String {
+    self.0.method_id().to_owned()
+  }
+
+  /// Construct a new `DIDUrl` by joining with a relative DID Url string.
+  #[wasm_bindgen]
+  pub fn join(self, segment: &str) -> Result<WasmStardustDIDUrl> {
+    self.0.join(segment).wasm_result().map(WasmStardustDIDUrl)
+  }
+
+  /// Clones the `DID` into a `DIDUrl`.
+  #[wasm_bindgen(js_name = toUrl)]
+  pub fn to_url(&self) -> WasmStardustDIDUrl {
+    WasmStardustDIDUrl::from(self.0.to_url())
+  }
+
+  /// Converts the `DID` into a `DIDUrl`.
+  #[wasm_bindgen(js_name = intoUrl)]
+  pub fn into_url(self) -> WasmStardustDIDUrl {
+    WasmStardustDIDUrl::from(self.0.into_url())
+  }
+
+  /// Returns the `DID` as a string.
+  #[allow(clippy::inherent_to_string)]
+  #[wasm_bindgen(js_name = toString)]
+  pub fn to_string(&self) -> String {
+    self.0.to_string()
+  }
+}
+
+impl_wasm_json!(WasmStardustDID, StardustDID);
+impl_wasm_clone!(WasmStardustDID, StardustDID);
+
+impl From<StardustDID> for WasmStardustDID {
+  fn from(did: StardustDID) -> Self {
+    Self(did)
+  }
+}

--- a/bindings/wasm/src/stardust/stardust_did_url.rs
+++ b/bindings/wasm/src/stardust/stardust_did_url.rs
@@ -1,31 +1,29 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use identity_iota::iota_core::IotaDIDUrl;
+use identity_stardust::StardustDIDUrl;
 use wasm_bindgen::prelude::*;
 
-use crate::did::WasmDID;
 use crate::error::Result;
 use crate::error::WasmResult;
+use crate::stardust::WasmStardustDID;
 
-/// A DID URL conforming to the IOTA DID method specification.
-///
-/// @typicalname didUrl
-#[wasm_bindgen(js_name = DIDUrl, inspectable)]
-pub struct WasmDIDUrl(pub(crate) IotaDIDUrl);
+/// A DID URL conforming to the IOTA Stardust UTXO DID method specification.
+#[wasm_bindgen(js_name = StardustDIDUrl, inspectable)]
+pub struct WasmStardustDIDUrl(pub(crate) StardustDIDUrl);
 
-#[wasm_bindgen(js_class = DIDUrl)]
-impl WasmDIDUrl {
-  /// Parses a `DIDUrl` from the input string.
+#[wasm_bindgen(js_class = StardustDIDUrl)]
+impl WasmStardustDIDUrl {
+  /// Parses a `StardustDIDUrl` from the input string.
   #[wasm_bindgen]
-  pub fn parse(input: &str) -> Result<WasmDIDUrl> {
-    IotaDIDUrl::parse(input).map(WasmDIDUrl).wasm_result()
+  pub fn parse(input: &str) -> Result<WasmStardustDIDUrl> {
+    StardustDIDUrl::parse(input).map(WasmStardustDIDUrl).wasm_result()
   }
 
-  /// Return a copy of the `DID` section of the `DIDUrl`.
+  /// Return a copy of the `StardustDID` section of the `StardustDIDUrl`.
   #[wasm_bindgen]
-  pub fn did(&self) -> WasmDID {
-    WasmDID::from(self.0.did().clone())
+  pub fn did(&self) -> WasmStardustDID {
+    WasmStardustDID::from(self.0.did().clone())
   }
 
   /// Return a copy of the relative DID Url as a string, including only the path, query, and fragment.
@@ -34,43 +32,43 @@ impl WasmDIDUrl {
     self.0.url().to_string()
   }
 
-  /// Returns a copy of the `DIDUrl` method fragment, if any. Excludes the leading '#'.
+  /// Returns a copy of the `StardustDIDUrl` method fragment, if any. Excludes the leading '#'.
   #[wasm_bindgen]
   pub fn fragment(&self) -> Option<String> {
     self.0.fragment().map(str::to_owned)
   }
 
-  /// Sets the `fragment` component of the `DIDUrl`.
+  /// Sets the `fragment` component of the `StardustDIDUrl`.
   #[wasm_bindgen(js_name = setFragment)]
   pub fn set_fragment(&mut self, value: Option<String>) -> Result<()> {
     self.0.set_fragment(value.as_deref()).wasm_result()
   }
 
-  /// Returns a copy of the `DIDUrl` path.
+  /// Returns a copy of the `StardustDIDUrl` path.
   #[wasm_bindgen]
   pub fn path(&self) -> Option<String> {
     self.0.path().map(str::to_owned)
   }
 
-  /// Sets the `path` component of the `DIDUrl`.
+  /// Sets the `path` component of the `StardustDIDUrl`.
   #[wasm_bindgen(js_name = setPath)]
   pub fn set_path(&mut self, value: Option<String>) -> Result<()> {
     self.0.set_path(value.as_deref()).wasm_result()
   }
 
-  /// Returns a copy of the `DIDUrl` method query, if any. Excludes the leading '?'.
+  /// Returns a copy of the `StardustDIDUrl` method query, if any. Excludes the leading '?'.
   #[wasm_bindgen]
   pub fn query(&self) -> Option<String> {
     self.0.query().map(str::to_owned)
   }
 
-  /// Sets the `query` component of the `DIDUrl`.
+  /// Sets the `query` component of the `StardustDIDUrl`.
   #[wasm_bindgen(js_name = setQuery)]
   pub fn set_query(&mut self, value: Option<String>) -> Result<()> {
     self.0.set_query(value.as_deref()).wasm_result()
   }
 
-  /// Append a string representing a path, query, and/or fragment, returning a new `DIDUrl`.
+  /// Append a string representing a path, query, and/or fragment, returning a new `StardustDIDUrl`.
   ///
   /// Must begin with a valid delimiter character: '/', '?', '#'. Overwrites the existing URL
   /// segment and any following segments in order of path, query, then fragment.
@@ -80,11 +78,11 @@ impl WasmDIDUrl {
   /// - joining a query will clear the fragment.
   /// - joining a fragment will only overwrite the fragment.
   #[wasm_bindgen]
-  pub fn join(&self, segment: &str) -> Result<WasmDIDUrl> {
-    self.0.join(segment).map(WasmDIDUrl::from).wasm_result()
+  pub fn join(&self, segment: &str) -> Result<WasmStardustDIDUrl> {
+    self.0.join(segment).map(WasmStardustDIDUrl::from).wasm_result()
   }
 
-  /// Returns the `DIDUrl` as a string.
+  /// Returns the `StardustDIDUrl` as a string.
   #[allow(clippy::inherent_to_string)]
   #[wasm_bindgen(js_name = toString)]
   pub fn to_string(&self) -> String {
@@ -92,17 +90,17 @@ impl WasmDIDUrl {
   }
 }
 
-impl_wasm_json!(WasmDIDUrl, DIDUrl);
-impl_wasm_clone!(WasmDIDUrl, DIDUrl);
+impl_wasm_json!(WasmStardustDIDUrl, StardustDIDUrl);
+impl_wasm_clone!(WasmStardustDIDUrl, StardustDIDUrl);
 
-impl From<IotaDIDUrl> for WasmDIDUrl {
-  fn from(did_url: IotaDIDUrl) -> Self {
+impl From<StardustDIDUrl> for WasmStardustDIDUrl {
+  fn from(did_url: StardustDIDUrl) -> Self {
     Self(did_url)
   }
 }
 
-impl From<WasmDIDUrl> for IotaDIDUrl {
-  fn from(wasm_did_url: WasmDIDUrl) -> Self {
+impl From<WasmStardustDIDUrl> for StardustDIDUrl {
+  fn from(wasm_did_url: WasmStardustDIDUrl) -> Self {
     wasm_did_url.0
   }
 }

--- a/bindings/wasm/src/stardust/stardust_document.rs
+++ b/bindings/wasm/src/stardust/stardust_document.rs
@@ -130,7 +130,7 @@ impl WasmStardustDocument {
     MapStringAny::try_from(self.0.properties())
   }
 
-  /// Adds a custom property to the DID Document.
+  /// Sets a custom property in the DID Document.
   /// If the value is set to `null`, the custom property will be removed.
   ///
   /// ### WARNING
@@ -433,6 +433,22 @@ impl WasmStardustDocument {
   pub fn set_metadata_updated(&mut self, timestamp: OptionTimestamp) -> Result<()> {
     let timestamp: Option<Timestamp> = timestamp.into_serde().wasm_result()?;
     self.0.metadata.updated = timestamp;
+    Ok(())
+  }
+
+  /// Sets a custom property in the document metadata.
+  /// If the value is set to `null`, the custom property will be removed.
+  #[wasm_bindgen(js_name = setMetadataPropertyUnchecked)]
+  pub fn set_metadata_property_unchecked(&mut self, key: String, value: &JsValue) -> Result<()> {
+    let value: Option<serde_json::Value> = value.into_serde().wasm_result()?;
+    match value {
+      Some(value) => {
+        self.0.metadata.properties.insert(key, value);
+      }
+      None => {
+        self.0.metadata.properties.remove(&key);
+      }
+    }
     Ok(())
   }
 

--- a/bindings/wasm/src/stardust/stardust_document.rs
+++ b/bindings/wasm/src/stardust/stardust_document.rs
@@ -1,0 +1,494 @@
+// Copyright 2020-2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use identity_iota::core::OneOrMany;
+use identity_iota::core::OrderedSet;
+use identity_iota::core::Timestamp;
+use identity_iota::core::Url;
+use identity_iota::credential::Credential;
+use identity_iota::credential::Presentation;
+use identity_iota::crypto::PrivateKey;
+use identity_iota::crypto::ProofOptions;
+use identity_iota::did::verifiable::VerifiableProperties;
+use identity_iota::did::Document;
+use identity_stardust::NetworkName;
+use identity_stardust::StardustDID;
+use identity_stardust::StardustDocument;
+use identity_stardust::StateMetadataEncoding;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+
+use crate::common::ArrayString;
+use crate::common::MapStringAny;
+use crate::common::OptionOneOrManyString;
+use crate::common::OptionTimestamp;
+use crate::common::UOneOrManyNumber;
+use crate::common::WasmTimestamp;
+use crate::credential::WasmCredential;
+use crate::credential::WasmPresentation;
+use crate::crypto::WasmProofOptions;
+use crate::did::WasmMethodRelationship;
+use crate::did::WasmVerifierOptions;
+use crate::error::Result;
+use crate::error::WasmResult;
+use crate::stardust::WasmStardustDID;
+use crate::stardust::WasmStardustDIDUrl;
+use crate::stardust::WasmStardustDocumentMetadata;
+use crate::stardust::WasmStateMetadataEncoding;
+
+// =============================================================================
+// =============================================================================
+
+#[wasm_bindgen(js_name = StardustDocument, inspectable)]
+pub struct WasmStardustDocument(pub(crate) StardustDocument);
+
+#[wasm_bindgen(js_class = StardustDocument)]
+impl WasmStardustDocument {
+  // ===========================================================================
+  // Constructors
+  // ===========================================================================
+
+  /// Constructs an empty DID Document with a {@link StardustDID.placeholder} identifier
+  /// for the given `network`.
+  #[wasm_bindgen(constructor)]
+  pub fn new(network: String) -> Result<WasmStardustDocument> {
+    let network_name: NetworkName = NetworkName::try_from(network).wasm_result()?;
+    Ok(WasmStardustDocument::from(StardustDocument::new(&network_name)))
+  }
+
+  /// Constructs an empty DID Document with the given identifier.
+  #[wasm_bindgen(js_name = newWithId)]
+  pub fn new_with_id(id: &WasmStardustDID) -> WasmStardustDocument {
+    let did: StardustDID = id.0.clone();
+    WasmStardustDocument::from(StardustDocument::new_with_id(did))
+  }
+
+  // ===========================================================================
+  // Properties
+  // ===========================================================================
+
+  /// Returns a copy of the DID Document `id`.
+  #[wasm_bindgen]
+  pub fn id(&self) -> WasmStardustDID {
+    WasmStardustDID::from(self.0.id().clone())
+  }
+
+  /// Returns a copy of the list of document controllers.
+  ///
+  /// NOTE: controllers are determined by the `state_controller` unlock condition of the output
+  /// during resolution and are omitted when publishing.
+  #[wasm_bindgen]
+  pub fn controller(&self) -> ArrayStardustDID {
+    match self.0.controller() {
+      Some(controllers) => controllers
+        .iter()
+        .cloned()
+        .map(WasmStardustDID::from)
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<ArrayStardustDID>(),
+      None => js_sys::Array::new().unchecked_into::<ArrayStardustDID>(),
+    }
+  }
+
+  /// Returns a copy of the document's `alsoKnownAs` set.
+  #[wasm_bindgen(js_name = alsoKnownAs)]
+  pub fn also_known_as(&self) -> ArrayString {
+    self
+      .0
+      .also_known_as()
+      .iter()
+      .map(|url| url.to_string())
+      .map(JsValue::from)
+      .collect::<js_sys::Array>()
+      .unchecked_into::<ArrayString>()
+  }
+
+  /// Sets the `alsoKnownAs` property in the DID document.
+  #[wasm_bindgen(js_name = setAlsoKnownAs)]
+  pub fn set_also_known_as(&mut self, urls: &OptionOneOrManyString) -> Result<()> {
+    let urls: Option<OneOrMany<String>> = urls.into_serde().wasm_result()?;
+    let mut urls_set: OrderedSet<Url> = OrderedSet::new();
+    if let Some(urls) = urls {
+      for url in urls.into_vec() {
+        urls_set.append(Url::parse(url).wasm_result()?);
+      }
+    }
+    *self.0.also_known_as_mut() = urls_set;
+    Ok(())
+  }
+
+  /// Returns a copy of the custom DID Document properties.
+  #[wasm_bindgen]
+  pub fn properties(&mut self) -> Result<MapStringAny> {
+    MapStringAny::try_from(self.0.properties())
+  }
+
+  /// Adds a custom property to the DID Document.
+  /// If the value is set to `null`, the custom property will be removed.
+  ///
+  /// ### WARNING
+  /// This method can overwrite existing properties like `id` and result in an invalid document.
+  #[wasm_bindgen(js_name = setPropertyUnchecked)]
+  pub fn set_property_unchecked(&mut self, key: String, value: &JsValue) -> Result<()> {
+    let value: Option<serde_json::Value> = value.into_serde().wasm_result()?;
+    match value {
+      Some(value) => {
+        self.0.properties_mut().insert(key, value);
+      }
+      None => {
+        self.0.properties_mut().remove(&key);
+      }
+    }
+    Ok(())
+  }
+
+  // ===========================================================================
+  // Services
+  // ===========================================================================
+
+  // /// Return a set of all {@link Service Services} in the document.
+  // #[wasm_bindgen]
+  // pub fn service(&self) -> ArrayService {
+  //   self
+  //     .0
+  //     .service()
+  //     .iter()
+  //     .cloned()
+  //     .map(WasmService)
+  //     .map(JsValue::from)
+  //     .collect::<js_sys::Array>()
+  //     .unchecked_into::<ArrayService>()
+  // }
+  //
+  // /// Add a new {@link Service} to the document.
+  // ///
+  // /// Returns `true` if the service was added.
+  // #[wasm_bindgen(js_name = insertService)]
+  // pub fn insert_service(&mut self, service: &WasmService) -> bool {
+  //   self.0.insert_service(service.0.clone())
+  // }
+
+  /// Remove a {@link Service} identified by the given {@link DIDUrl} from the document.
+  ///
+  /// Returns `true` if a service was removed.
+  #[wasm_bindgen(js_name = removeService)]
+  pub fn remove_service(&mut self, did: &WasmStardustDIDUrl) -> bool {
+    self.0.remove_service(&did.0)
+  }
+
+  // /// Returns the first {@link Service} with an `id` property matching the provided `query`,
+  // /// if present.
+  // #[wasm_bindgen(js_name = resolveService)]
+  // pub fn resolve_service(&self, query: &UDIDUrlQuery) -> Option<WasmService> {
+  //   let service_query: String = query.into_serde().ok()?;
+  //   self.0.resolve_service(&service_query).cloned().map(WasmService::from)
+  // }
+
+  // ===========================================================================
+  // Verification Methods
+  // ===========================================================================
+
+  // /// Returns a list of all {@link VerificationMethod} in the DID Document.
+  // #[wasm_bindgen]
+  // pub fn methods(&self) -> ArrayVerificationMethods {
+  //   self
+  //     .0
+  //     .methods()
+  //     .cloned()
+  //     .map(WasmVerificationMethod::from)
+  //     .map(JsValue::from)
+  //     .collect::<js_sys::Array>()
+  //     .unchecked_into::<ArrayVerificationMethods>()
+  // }
+  //
+  // /// Adds a new Verification Method to the DID Document.
+  // #[wasm_bindgen(js_name = insertMethod)]
+  // pub fn insert_method(&mut self, method: &WasmVerificationMethod, scope: &WasmMethodScope) -> Result<()> {
+  //   self.0.insert_method(method.0.clone(), scope.0).wasm_result()?;
+  //   Ok(())
+  // }
+  //
+
+  /// Removes all references to the specified Verification Method.
+  #[wasm_bindgen(js_name = removeMethod)]
+  pub fn remove_method(&mut self, did: &WasmStardustDIDUrl) -> Result<()> {
+    self.0.remove_method(&did.0).wasm_result()
+  }
+
+  // /// Returns a copy of the first `VerificationMethod` with an `id` property
+  // /// matching the provided `query`.
+  // ///
+  // /// Throws an error if the method is not found.
+  // #[wasm_bindgen(js_name = resolveMethod)]
+  // pub fn resolve_method(
+  //   &self,
+  //   query: &UDIDUrlQuery,
+  //   scope: Option<RefMethodScope>,
+  // ) -> Result<Option<WasmVerificationMethod>> {
+  //   let method_query: String = query.into_serde().wasm_result()?;
+  //   let method_scope: Option<MethodScope> = scope.map(|js| js.into_serde().wasm_result()).transpose()?;
+  //
+  //   let method: Option<&IotaVerificationMethod> = if let Some(scope) = method_scope {
+  //     self.0.resolve_method(&method_query, Some(scope))
+  //   } else {
+  //     self.0.resolve_method(&method_query, None)
+  //   };
+  //   match method {
+  //     None => Ok(None),
+  //     Some(method) => Ok(Some(WasmVerificationMethod(method.clone()))),
+  //   }
+  // }
+
+  /// Attaches the relationship to the given method, if the method exists.
+  ///
+  /// Note: The method needs to be in the set of verification methods,
+  /// so it cannot be an embedded one.
+  #[wasm_bindgen(js_name = attachMethodRelationship)]
+  pub fn attach_method_relationship(
+    &mut self,
+    did_url: &WasmStardustDIDUrl,
+    relationship: WasmMethodRelationship,
+  ) -> Result<bool> {
+    self
+      .0
+      .attach_method_relationship(&did_url.0, relationship.into())
+      .wasm_result()
+  }
+
+  /// Detaches the given relationship from the given method, if the method exists.
+  #[wasm_bindgen(js_name = detachMethodRelationship)]
+  pub fn detach_method_relationship(
+    &mut self,
+    did_url: &WasmStardustDIDUrl,
+    relationship: WasmMethodRelationship,
+  ) -> Result<bool> {
+    self
+      .0
+      .detach_method_relationship(&did_url.0, relationship.into())
+      .wasm_result()
+  }
+
+  // ===========================================================================
+  // Signatures
+  // ===========================================================================
+
+  /// Creates a signature for the given `Credential` with the specified DID Document
+  /// Verification Method.
+  #[allow(non_snake_case)]
+  #[wasm_bindgen(js_name = signCredential)]
+  pub fn sign_credential(
+    &self,
+    credential: &WasmCredential,
+    privateKey: Vec<u8>,
+    methodQuery: &UStardustDIDUrlQuery,
+    options: &WasmProofOptions,
+  ) -> Result<WasmCredential> {
+    let mut data: Credential = credential.0.clone();
+    let private_key: PrivateKey = privateKey.into();
+    let method_query: String = methodQuery.into_serde().wasm_result()?;
+    let options: ProofOptions = options.0.clone();
+
+    self
+      .0
+      .sign_data(&mut data, &private_key, &method_query, options)
+      .wasm_result()?;
+    Ok(WasmCredential::from(data))
+  }
+
+  /// Creates a signature for the given `Presentation` with the specified DID Document
+  /// Verification Method.
+  #[allow(non_snake_case)]
+  #[wasm_bindgen(js_name = signPresentation)]
+  pub fn sign_presentation(
+    &self,
+    presentation: &WasmPresentation,
+    privateKey: Vec<u8>,
+    methodQuery: &UStardustDIDUrlQuery,
+    options: &WasmProofOptions,
+  ) -> Result<WasmPresentation> {
+    let mut data: Presentation = presentation.0.clone();
+    let private_key: PrivateKey = privateKey.into();
+    let method_query: String = methodQuery.into_serde().wasm_result()?;
+    let options: ProofOptions = options.0.clone();
+
+    self
+      .0
+      .sign_data(&mut data, &private_key, &method_query, options)
+      .wasm_result()?;
+    Ok(WasmPresentation::from(data))
+  }
+
+  /// Creates a signature for the given `data` with the specified DID Document
+  /// Verification Method.
+  ///
+  /// NOTE: use `signSelf` or `signDocument` for DID Documents.
+  #[allow(non_snake_case)]
+  #[wasm_bindgen(js_name = signData)]
+  pub fn sign_data(
+    &self,
+    data: &JsValue,
+    privateKey: Vec<u8>,
+    methodQuery: &UStardustDIDUrlQuery,
+    options: &WasmProofOptions,
+  ) -> Result<JsValue> {
+    let mut data: VerifiableProperties = data.into_serde().wasm_result()?;
+    let private_key: PrivateKey = privateKey.into();
+    let method_query: String = methodQuery.into_serde().wasm_result()?;
+    let options: ProofOptions = options.0.clone();
+
+    self
+      .0
+      .sign_data(&mut data, &private_key, &method_query, options)
+      .wasm_result()?;
+
+    JsValue::from_serde(&data).wasm_result()
+  }
+
+  // ===========================================================================
+  // Verification
+  // ===========================================================================
+
+  /// Verifies the authenticity of `data` using the target verification method.
+  #[wasm_bindgen(js_name = verifyData)]
+  pub fn verify_data(&self, data: &JsValue, options: &WasmVerifierOptions) -> Result<bool> {
+    let data: VerifiableProperties = data.into_serde().wasm_result()?;
+    Ok(self.0.verify_data(&data, &options.0).is_ok())
+  }
+
+  // ===========================================================================
+  // Publishing
+  // ===========================================================================
+
+  /// Serializes the document for inclusion in an Alias Output's state metadata
+  /// with the default {@link StateMetadataEncoding}.
+  #[wasm_bindgen]
+  pub fn pack(&self) -> Result<Vec<u8>> {
+    self.0.clone().pack().wasm_result()
+  }
+
+  /// Serializes the document for inclusion in an Alias Output's state metadata.
+  #[wasm_bindgen(js_name = packWithEncoding)]
+  pub fn pack_with_encoding(&self, encoding: WasmStateMetadataEncoding) -> Result<Vec<u8>> {
+    self
+      .0
+      .clone()
+      .pack_with_encoding(StateMetadataEncoding::from(encoding))
+      .wasm_result()
+  }
+
+  /// Deserializes the document from the state metadata bytes of an Alias Output.
+  ///
+  /// NOTE: `did` is required since it is omitted from the serialized DID Document and
+  /// cannot be inferred from the state metadata. It also indicates the network, which is not
+  /// encoded in the `AliasId` alone.
+  #[allow(non_snake_case)]
+  #[wasm_bindgen]
+  pub fn unpack(did: &WasmStardustDID, stateMetadata: &[u8]) -> Result<WasmStardustDocument> {
+    StardustDocument::unpack(&did.0, stateMetadata)
+      .map(WasmStardustDocument)
+      .wasm_result()
+  }
+
+  // TODO: unpack_from_output/unpackFromOutput ? Feature-gated method, do we need an equivalent?
+
+  // ===========================================================================
+  // Metadata
+  // ===========================================================================
+
+  /// Returns a copy of the metadata associated with this document.
+  ///
+  /// NOTE: Copies all the metadata. See also `metadataCreated`, `metadataUpdated`,
+  /// `metadataPreviousMessageId`, `metadataProof` if only a subset of the metadata required.
+  #[wasm_bindgen]
+  pub fn metadata(&self) -> WasmStardustDocumentMetadata {
+    WasmStardustDocumentMetadata::from(self.0.metadata.clone())
+  }
+
+  /// Returns a copy of the timestamp of when the DID document was created.
+  #[wasm_bindgen(js_name = metadataCreated)]
+  pub fn metadata_created(&self) -> Option<WasmTimestamp> {
+    self.0.metadata.created.map(WasmTimestamp::from)
+  }
+
+  /// Sets the timestamp of when the DID document was created.
+  #[wasm_bindgen(js_name = setMetadataCreated)]
+  pub fn set_metadata_created(&mut self, timestamp: OptionTimestamp) -> Result<()> {
+    let timestamp: Option<Timestamp> = timestamp.into_serde().wasm_result()?;
+    self.0.metadata.created = timestamp;
+    Ok(())
+  }
+
+  /// Returns a copy of the timestamp of the last DID document update.
+  #[wasm_bindgen(js_name = metadataUpdated)]
+  pub fn metadata_updated(&self) -> Option<WasmTimestamp> {
+    self.0.metadata.updated.map(WasmTimestamp::from)
+  }
+
+  /// Sets the timestamp of the last DID document update.
+  #[wasm_bindgen(js_name = setMetadataUpdated)]
+  pub fn set_metadata_updated(&mut self, timestamp: OptionTimestamp) -> Result<()> {
+    let timestamp: Option<Timestamp> = timestamp.into_serde().wasm_result()?;
+    self.0.metadata.updated = timestamp;
+    Ok(())
+  }
+
+  // ===========================================================================
+  // Revocation
+  // ===========================================================================
+
+  /// If the document has a `RevocationBitmap` service identified by `serviceQuery`,
+  /// revoke all specified `indices`.
+  #[wasm_bindgen(js_name = revokeCredentials)]
+  #[allow(non_snake_case)]
+  pub fn revoke_credentials(&mut self, serviceQuery: &UStardustDIDUrlQuery, indices: UOneOrManyNumber) -> Result<()> {
+    let query: String = serviceQuery.into_serde().wasm_result()?;
+    let indices: OneOrMany<u32> = indices.into_serde().wasm_result()?;
+
+    self.0.revoke_credentials(&query, indices.as_slice()).wasm_result()
+  }
+
+  /// If the document has a `RevocationBitmap` service identified by `serviceQuery`,
+  /// unrevoke all specified `indices`.
+  #[wasm_bindgen(js_name = unrevokeCredentials)]
+  #[allow(non_snake_case)]
+  pub fn unrevoke_credentials(&mut self, serviceQuery: &UStardustDIDUrlQuery, indices: UOneOrManyNumber) -> Result<()> {
+    let query: String = serviceQuery.into_serde().wasm_result()?;
+    let indices: OneOrMany<u32> = indices.into_serde().wasm_result()?;
+
+    self.0.unrevoke_credentials(&query, indices.as_slice()).wasm_result()
+  }
+}
+
+impl_wasm_json!(WasmStardustDocument, StardustDocument);
+impl_wasm_clone!(WasmStardustDocument, StardustDocument);
+
+impl From<StardustDocument> for WasmStardustDocument {
+  fn from(document: StardustDocument) -> Self {
+    Self(document)
+  }
+}
+
+impl From<WasmStardustDocument> for StardustDocument {
+  fn from(wasm_document: WasmStardustDocument) -> Self {
+    wasm_document.0
+  }
+}
+
+#[wasm_bindgen]
+extern "C" {
+  #[wasm_bindgen(typescript_type = "StardustDIDUrl | string")]
+  pub type UStardustDIDUrlQuery;
+
+  // #[wasm_bindgen(typescript_type = "StardustDID | StardustDID[] | null")]
+  // pub type OptionOneOrManyStardustDID;
+
+  #[wasm_bindgen(typescript_type = "StardustDID[]")]
+  pub type ArrayStardustDID;
+
+  // #[wasm_bindgen(typescript_type = "Service[]")]
+  // pub type ArrayService;
+  //
+  // #[wasm_bindgen(typescript_type = "VerificationMethod[]")]
+  // pub type ArrayVerificationMethods;
+}

--- a/bindings/wasm/src/stardust/stardust_document.rs
+++ b/bindings/wasm/src/stardust/stardust_document.rs
@@ -34,6 +34,7 @@ use crate::error::WasmResult;
 use crate::stardust::WasmStardustDID;
 use crate::stardust::WasmStardustDIDUrl;
 use crate::stardust::WasmStardustDocumentMetadata;
+use crate::stardust::WasmStardustService;
 use crate::stardust::WasmStateMetadataEncoding;
 
 // =============================================================================
@@ -147,29 +148,29 @@ impl WasmStardustDocument {
   // Services
   // ===========================================================================
 
-  // /// Return a set of all {@link Service Services} in the document.
-  // #[wasm_bindgen]
-  // pub fn service(&self) -> ArrayService {
-  //   self
-  //     .0
-  //     .service()
-  //     .iter()
-  //     .cloned()
-  //     .map(WasmService)
-  //     .map(JsValue::from)
-  //     .collect::<js_sys::Array>()
-  //     .unchecked_into::<ArrayService>()
-  // }
-  //
-  // /// Add a new {@link Service} to the document.
-  // ///
-  // /// Returns `true` if the service was added.
-  // #[wasm_bindgen(js_name = insertService)]
-  // pub fn insert_service(&mut self, service: &WasmService) -> bool {
-  //   self.0.insert_service(service.0.clone())
-  // }
+  /// Return a set of all {@link StardustService StardustServices} in the document.
+  #[wasm_bindgen]
+  pub fn service(&self) -> ArrayStardustService {
+    self
+      .0
+      .service()
+      .iter()
+      .cloned()
+      .map(WasmStardustService)
+      .map(JsValue::from)
+      .collect::<js_sys::Array>()
+      .unchecked_into::<ArrayStardustService>()
+  }
 
-  /// Remove a {@link Service} identified by the given {@link DIDUrl} from the document.
+  /// Add a new {@link StardustService} to the document.
+  ///
+  /// Returns `true` if the service was added.
+  #[wasm_bindgen(js_name = insertService)]
+  pub fn insert_service(&mut self, service: &WasmStardustService) -> bool {
+    self.0.insert_service(service.0.clone())
+  }
+
+  /// Remove a {@link StardustService} identified by the given {@link DIDUrl} from the document.
   ///
   /// Returns `true` if a service was removed.
   #[wasm_bindgen(js_name = removeService)]
@@ -177,13 +178,17 @@ impl WasmStardustDocument {
     self.0.remove_service(&did.0)
   }
 
-  // /// Returns the first {@link Service} with an `id` property matching the provided `query`,
-  // /// if present.
-  // #[wasm_bindgen(js_name = resolveService)]
-  // pub fn resolve_service(&self, query: &UDIDUrlQuery) -> Option<WasmService> {
-  //   let service_query: String = query.into_serde().ok()?;
-  //   self.0.resolve_service(&service_query).cloned().map(WasmService::from)
-  // }
+  /// Returns the first {@link StardustService} with an `id` property matching the provided `query`,
+  /// if present.
+  #[wasm_bindgen(js_name = resolveService)]
+  pub fn resolve_service(&self, query: &UStardustDIDUrlQuery) -> Option<WasmStardustService> {
+    let service_query: String = query.into_serde().ok()?;
+    self
+      .0
+      .resolve_service(&service_query)
+      .cloned()
+      .map(WasmStardustService::from)
+  }
 
   // ===========================================================================
   // Verification Methods
@@ -486,8 +491,8 @@ extern "C" {
   #[wasm_bindgen(typescript_type = "StardustDID[]")]
   pub type ArrayStardustDID;
 
-  // #[wasm_bindgen(typescript_type = "Service[]")]
-  // pub type ArrayService;
+  #[wasm_bindgen(typescript_type = "StardustService[]")]
+  pub type ArrayStardustService;
   //
   // #[wasm_bindgen(typescript_type = "VerificationMethod[]")]
   // pub type ArrayVerificationMethods;

--- a/bindings/wasm/src/stardust/stardust_document.rs
+++ b/bindings/wasm/src/stardust/stardust_document.rs
@@ -126,7 +126,7 @@ impl WasmStardustDocument {
 
   /// Returns a copy of the custom DID Document properties.
   #[wasm_bindgen]
-  pub fn properties(&mut self) -> Result<MapStringAny> {
+  pub fn properties(&self) -> Result<MapStringAny> {
     MapStringAny::try_from(self.0.properties())
   }
 

--- a/bindings/wasm/src/stardust/stardust_document_metadata.rs
+++ b/bindings/wasm/src/stardust/stardust_document_metadata.rs
@@ -30,7 +30,7 @@ impl WasmStardustDocumentMetadata {
 
   /// Returns a copy of the custom metadata properties.
   #[wasm_bindgen]
-  pub fn properties(&mut self) -> Result<MapStringAny> {
+  pub fn properties(&self) -> Result<MapStringAny> {
     MapStringAny::try_from(&self.0.properties)
   }
 }

--- a/bindings/wasm/src/stardust/stardust_document_metadata.rs
+++ b/bindings/wasm/src/stardust/stardust_document_metadata.rs
@@ -1,24 +1,21 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use identity_iota::iota_core::IotaDocumentMetadata;
+use identity_stardust::StardustDocumentMetadata;
 use wasm_bindgen::prelude::*;
 
 use crate::common::MapStringAny;
 use crate::common::WasmTimestamp;
 use crate::error::Result;
 
-// =============================================================================
-// =============================================================================
-
 /// Additional attributes related to an IOTA DID Document.
-#[wasm_bindgen(js_name = DocumentMetadata, inspectable)]
-pub struct WasmDocumentMetadata(pub(crate) IotaDocumentMetadata);
+#[wasm_bindgen(js_name = StardustDocumentMetadata, inspectable)]
+pub struct WasmStardustDocumentMetadata(pub(crate) StardustDocumentMetadata);
 
 // NOTE: these properties are read-only (no setters) to prevent bugs where a clone of the metadata
 //       is updated instead of the actual instance in the document.
-#[wasm_bindgen(js_class = DocumentMetadata)]
-impl WasmDocumentMetadata {
+#[wasm_bindgen(js_class = StardustDocumentMetadata)]
+impl WasmStardustDocumentMetadata {
   /// Returns a copy of the timestamp of when the DID document was created.
   #[wasm_bindgen]
   pub fn created(&self) -> Option<WasmTimestamp> {
@@ -31,12 +28,6 @@ impl WasmDocumentMetadata {
     self.0.updated.map(WasmTimestamp::from)
   }
 
-  /// Returns a copy of the previous message identifier.
-  #[wasm_bindgen(js_name = previousMessageId)]
-  pub fn previous_message_id(&self) -> String {
-    self.0.previous_message_id.to_string()
-  }
-
   /// Returns a copy of the custom metadata properties.
   #[wasm_bindgen]
   pub fn properties(&mut self) -> Result<MapStringAny> {
@@ -44,11 +35,11 @@ impl WasmDocumentMetadata {
   }
 }
 
-impl_wasm_json!(WasmDocumentMetadata, DocumentMetadata);
-impl_wasm_clone!(WasmDocumentMetadata, DocumentMetadata);
+impl_wasm_json!(WasmStardustDocumentMetadata, StardustDocumentMetadata);
+impl_wasm_clone!(WasmStardustDocumentMetadata, StardustDocumentMetadata);
 
-impl From<IotaDocumentMetadata> for WasmDocumentMetadata {
-  fn from(metadata: IotaDocumentMetadata) -> Self {
+impl From<StardustDocumentMetadata> for WasmStardustDocumentMetadata {
+  fn from(metadata: StardustDocumentMetadata) -> Self {
     Self(metadata)
   }
 }

--- a/bindings/wasm/src/stardust/stardust_service.rs
+++ b/bindings/wasm/src/stardust/stardust_service.rs
@@ -1,0 +1,106 @@
+// Copyright 2020-2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use identity_iota::core::OneOrMany;
+use identity_iota::did::ServiceEndpoint;
+use identity_stardust::StardustDIDUrl;
+use identity_stardust::StardustService;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+
+use crate::common::deserialize_map_or_any;
+use crate::common::ArrayString;
+use crate::common::MapStringAny;
+use crate::did::IService;
+use crate::did::UServiceEndpoint;
+use crate::error::Result;
+use crate::error::WasmResult;
+use crate::stardust::WasmStardustDIDUrl;
+
+/// A `Service` adhering to the IOTA UTXO DID method specification.
+#[wasm_bindgen(js_name = StardustService, inspectable)]
+pub struct WasmStardustService(pub(crate) StardustService);
+
+#[wasm_bindgen(js_class = StardustService)]
+impl WasmStardustService {
+  #[wasm_bindgen(constructor)]
+  pub fn new(service: IStardustService) -> Result<WasmStardustService> {
+    let id: StardustDIDUrl = service.id().into_serde().wasm_result()?;
+
+    let i_service: &IService = service.as_ref();
+    let types: OneOrMany<String> = service.type_().into_serde().wasm_result()?;
+    let service_endpoint: ServiceEndpoint = deserialize_map_or_any(&i_service.service_endpoint())?;
+    let properties: Option<identity_iota::core::Object> = deserialize_map_or_any(&i_service.properties())?;
+
+    StardustService::builder(properties.unwrap_or_default())
+      .id(id)
+      .types(types)
+      .service_endpoint(service_endpoint)
+      .build()
+      .map(WasmStardustService)
+      .wasm_result()
+  }
+
+  /// Returns a copy of the `Service` id.
+  #[wasm_bindgen]
+  pub fn id(&self) -> WasmStardustDIDUrl {
+    WasmStardustDIDUrl::from(self.0.id().clone())
+  }
+
+  /// Returns a copy of the `Service` type.
+  #[wasm_bindgen(js_name = type)]
+  pub fn type_(&self) -> ArrayString {
+    self
+      .0
+      .type_()
+      .iter()
+      .cloned()
+      .map(JsValue::from)
+      .collect::<js_sys::Array>()
+      .unchecked_into::<ArrayString>()
+  }
+
+  /// Returns a copy of the `Service` endpoint.
+  #[wasm_bindgen(js_name = serviceEndpoint)]
+  pub fn service_endpoint(&self) -> UServiceEndpoint {
+    UServiceEndpoint::from(self.0.service_endpoint())
+  }
+
+  /// Returns a copy of the custom properties on the `Service`.
+  #[wasm_bindgen]
+  pub fn properties(&self) -> Result<MapStringAny> {
+    MapStringAny::try_from(self.0.properties())
+  }
+}
+
+impl_wasm_json!(WasmStardustService, StardustService);
+impl_wasm_clone!(WasmStardustService, StardustService);
+
+impl From<StardustService> for WasmStardustService {
+  fn from(service: StardustService) -> Self {
+    Self(service)
+  }
+}
+
+#[wasm_bindgen]
+extern "C" {
+  #[wasm_bindgen(typescript_type = "IStardustService", extends = IService)]
+  pub type IStardustService;
+
+  #[wasm_bindgen(method, getter)]
+  pub fn id(this: &IStardustService) -> JsValue;
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const I_STARDUST_SERVICE: &'static str = r#"
+/**
+ * Holds options to create a new `StardustService`.
+ */
+interface IStardustService extends IService {
+    /**
+     * Identifier of the service.
+     *
+     * Must be a valid DIDUrl with a fragment.
+     */
+    readonly id: StardustDIDUrl | string;
+}"#;

--- a/bindings/wasm/src/stardust/stardust_service.rs
+++ b/bindings/wasm/src/stardust/stardust_service.rs
@@ -27,10 +27,10 @@ impl WasmStardustService {
   pub fn new(service: IStardustService) -> Result<WasmStardustService> {
     let id: StardustDIDUrl = service.id().into_serde().wasm_result()?;
 
-    let i_service: &IService = service.as_ref();
+    let base_service: &IService = service.as_ref();
     let types: OneOrMany<String> = service.type_().into_serde().wasm_result()?;
-    let service_endpoint: ServiceEndpoint = deserialize_map_or_any(&i_service.service_endpoint())?;
-    let properties: Option<identity_iota::core::Object> = deserialize_map_or_any(&i_service.properties())?;
+    let service_endpoint: ServiceEndpoint = deserialize_map_or_any(&base_service.service_endpoint())?;
+    let properties: Option<identity_iota::core::Object> = deserialize_map_or_any(&base_service.properties())?;
 
     StardustService::builder(properties.unwrap_or_default())
       .id(id)

--- a/bindings/wasm/src/stardust/stardust_verification_method.rs
+++ b/bindings/wasm/src/stardust/stardust_verification_method.rs
@@ -1,0 +1,74 @@
+// Copyright 2020-2022  Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use identity_iota::crypto::PublicKey;
+use identity_stardust::StardustVerificationMethod;
+use wasm_bindgen::prelude::*;
+
+use crate::crypto::WasmKeyType;
+use crate::did::WasmMethodData;
+use crate::did::WasmMethodType;
+use crate::error::Result;
+use crate::error::WasmResult;
+use crate::stardust::WasmStardustDID;
+use crate::stardust::WasmStardustDIDUrl;
+
+#[wasm_bindgen(js_name = StardustVerificationMethod, inspectable)]
+pub struct WasmStardustVerificationMethod(pub(crate) StardustVerificationMethod);
+
+#[wasm_bindgen(js_class = StardustVerificationMethod)]
+impl WasmStardustVerificationMethod {
+  /// Creates a new `StardustVerificationMethod` from the given `did` and public key.
+  #[allow(non_snake_case)]
+  #[wasm_bindgen(constructor)]
+  pub fn new(
+    did: &WasmStardustDID,
+    keyType: WasmKeyType,
+    publicKey: Vec<u8>,
+    fragment: String,
+  ) -> Result<WasmStardustVerificationMethod> {
+    let public_key: PublicKey = PublicKey::from(publicKey);
+    StardustVerificationMethod::new(did.0.clone(), keyType.into(), &public_key, &fragment)
+      .map(Self)
+      .wasm_result()
+  }
+
+  /// Returns a reference to the `StardustVerificationMethod` id.
+  #[wasm_bindgen]
+  pub fn id(&self) -> WasmStardustDIDUrl {
+    WasmStardustDIDUrl::from(self.0.id().clone())
+  }
+
+  /// Returns a copy of the `controller` `DID` of the `StardustVerificationMethod`.
+  #[wasm_bindgen]
+  pub fn controller(&self) -> WasmStardustDID {
+    WasmStardustDID::from(self.0.controller().clone())
+  }
+
+  /// Sets the `controller` `DID` of the `StardustVerificationMethod`.
+  #[wasm_bindgen(js_name = setController)]
+  pub fn set_controller(&mut self, did: &WasmStardustDID) {
+    *self.0.controller_mut() = did.0.clone();
+  }
+
+  /// Returns a copy of the `StardustVerificationMethod` type.
+  #[wasm_bindgen(js_name = type)]
+  pub fn type_(&self) -> WasmMethodType {
+    WasmMethodType::from(self.0.type_())
+  }
+
+  /// Returns a copy of the `StardustVerificationMethod` public key data.
+  #[wasm_bindgen]
+  pub fn data(&self) -> WasmMethodData {
+    WasmMethodData::from(self.0.data().clone())
+  }
+}
+
+impl_wasm_json!(WasmStardustVerificationMethod, StardustVerificationMethod);
+impl_wasm_clone!(WasmStardustVerificationMethod, StardustVerificationMethod);
+
+impl From<StardustVerificationMethod> for WasmStardustVerificationMethod {
+  fn from(method: StardustVerificationMethod) -> Self {
+    Self(method)
+  }
+}

--- a/bindings/wasm/src/stardust/state_metadata_encoding.rs
+++ b/bindings/wasm/src/stardust/state_metadata_encoding.rs
@@ -1,0 +1,30 @@
+// Copyright 2020-2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use identity_stardust::StateMetadataEncoding;
+use serde_repr::Deserialize_repr;
+use serde_repr::Serialize_repr;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(js_name = StateMetadataEncoding)]
+#[derive(Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
+pub enum WasmStateMetadataEncoding {
+  Json = 0,
+}
+
+impl From<StateMetadataEncoding> for WasmStateMetadataEncoding {
+  fn from(encoding: StateMetadataEncoding) -> Self {
+    match encoding {
+      StateMetadataEncoding::Json => Self::Json,
+    }
+  }
+}
+
+impl From<WasmStateMetadataEncoding> for StateMetadataEncoding {
+  fn from(encoding: WasmStateMetadataEncoding) -> Self {
+    match encoding {
+      WasmStateMetadataEncoding::Json => Self::Json,
+    }
+  }
+}

--- a/bindings/wasm/tests/credentials.ts
+++ b/bindings/wasm/tests/credentials.ts
@@ -181,7 +181,6 @@ describe('CredentialValidator, PresentationValidator', function () {
                 degreeType: "BachelorDegree",
                 GPA: "4.0"
             };
-            console.log(issuerDID.toString());
             const credential = new Credential({
                 id: "https://example.edu/credentials/3732",
                 type: "UniversityDegreeCredential",

--- a/bindings/wasm/tests/stardust.ts
+++ b/bindings/wasm/tests/stardust.ts
@@ -1,0 +1,189 @@
+export {};
+
+const assert = require('assert');
+const {
+    Duration,
+    KeyType,
+    MethodScope,
+    MethodType,
+    MethodRelationship,
+    StardustDID,
+    StardustDocument,
+    StardustService,
+    StardustVerificationMethod,
+    Timestamp,
+} = require("../node");
+
+const aliasIdBytes = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]);
+const aliasIdHex = "0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+const networkName = "smr";
+
+describe('StardustDID', function () {
+    describe('#constructor', function () {
+        it('should work', () => {
+            const did = new StardustDID(aliasIdBytes, networkName);
+            assert.deepStrictEqual(did.toString(), "did:" + StardustDID.METHOD + ":" + networkName + ":" + aliasIdHex);
+            assert.deepStrictEqual(did.tag(), aliasIdHex);
+            assert.deepStrictEqual(did.method(), StardustDID.METHOD);
+            assert.deepStrictEqual(did.networkStr(), networkName);
+            assert.deepStrictEqual(did.authority(), StardustDID.METHOD + ":" + networkName + ":" + aliasIdHex);
+            assert.deepStrictEqual(did.methodId(), networkName + ":" + aliasIdHex);
+            assert.deepStrictEqual(did.scheme(), "did");
+        });
+    });
+    describe('#placeholder()', function () {
+        it('should be zeroes', () => {
+            const expectedTag = "0x0000000000000000000000000000000000000000000000000000000000000000";
+            const did = StardustDID.placeholder(networkName);
+            assert.deepStrictEqual(did.toString(), "did:" + StardustDID.METHOD + ":" + networkName + ":" + expectedTag);
+            assert.deepStrictEqual(did.tag(), expectedTag);
+            assert.deepStrictEqual(did.method(), StardustDID.METHOD);
+            assert.deepStrictEqual(did.networkStr(), networkName);
+            assert.deepStrictEqual(did.authority(), StardustDID.METHOD + ":" + networkName + ":" + expectedTag);
+            assert.deepStrictEqual(did.methodId(), networkName + ":" + expectedTag);
+            assert.deepStrictEqual(did.scheme(), "did");
+        });
+    });
+});
+
+describe('StardustDocument', function () {
+    describe('#constructors', function () {
+        it('new should generate a placeholder', () => {
+            const doc = new StardustDocument(networkName);
+            assert.deepStrictEqual(doc.id().toString(), StardustDID.placeholder(networkName).toString());
+        });
+        it('newWithId should work', () => {
+            const did = new StardustDID(aliasIdBytes, networkName);
+            const doc = StardustDocument.newWithId(did);
+            assert.deepStrictEqual(doc.id().toString(), did.toString());
+        });
+    });
+    describe('#insert/resolve/removeMethod', function () {
+        it('should work', async () => {
+            const doc = new StardustDocument(networkName);
+            const fragment = "new-method-1";
+            const scope = MethodScope.AssertionMethod();
+            const method = new StardustVerificationMethod(doc.id(), KeyType.Ed25519, aliasIdBytes, fragment);
+
+            // Add.
+            doc.insertMethod(method, scope);
+            // Resolve.
+            const resolved = doc.resolveMethod(fragment, scope);
+            assert.deepStrictEqual(resolved.id().fragment(), fragment);
+            assert.deepStrictEqual(resolved.type().toString(), MethodType.Ed25519VerificationKey2018().toString());
+            assert.deepStrictEqual(resolved.controller().toString(), doc.id().toString());
+            assert.deepStrictEqual(resolved.data().tryDecode(), aliasIdBytes);
+            assert.deepStrictEqual(resolved.toJSON(), method.toJSON());
+            assert.deepStrictEqual(doc.resolveMethod(fragment, MethodScope.VerificationMethod()), undefined);
+            // List.
+            const list = doc.methods();
+            assert.deepStrictEqual(list.length, 1);
+            assert.deepStrictEqual(list[0].toJSON(), resolved.toJSON());
+            // Remove.
+            doc.removeMethod(resolved.id());
+            assert.deepStrictEqual(doc.resolveMethod(fragment), undefined);
+            assert.deepStrictEqual(doc.resolveMethod(fragment, scope), undefined);
+            assert.deepStrictEqual(doc.resolveMethod(fragment, MethodScope.VerificationMethod()), undefined);
+            assert.deepStrictEqual(doc.methods().length, 0);
+        });
+    });
+    describe('#attach/detachMethodRelationship', function () {
+        it('should work', async () => {
+            const doc = new StardustDocument(networkName);
+            const fragment = "new-method-1";
+            const method = new StardustVerificationMethod(doc.id(), KeyType.Ed25519, aliasIdBytes, fragment);
+            doc.insertMethod(method, MethodScope.VerificationMethod());
+            assert.deepStrictEqual(doc.resolveMethod(fragment, MethodScope.VerificationMethod()).toJSON(), method.toJSON());
+
+            // Attach.
+            doc.attachMethodRelationship(method.id(), MethodRelationship.Authentication);
+            assert.deepStrictEqual(doc.resolveMethod(fragment, MethodScope.VerificationMethod()).toJSON(), method.toJSON());
+            assert.deepStrictEqual(doc.resolveMethod(fragment, MethodScope.Authentication()).toJSON(), method.toJSON());
+            assert.deepStrictEqual(doc.resolveMethod(fragment, MethodScope.AssertionMethod()), undefined);
+            assert.deepStrictEqual(doc.resolveMethod(fragment, MethodScope.CapabilityInvocation()), undefined);
+            assert.deepStrictEqual(doc.resolveMethod(fragment, MethodScope.CapabilityDelegation()), undefined);
+            assert.deepStrictEqual(doc.resolveMethod(fragment, MethodScope.KeyAgreement()), undefined);
+
+            // Detach.
+            doc.detachMethodRelationship(method.id(), MethodRelationship.Authentication);
+            assert.deepStrictEqual(doc.resolveMethod(fragment, MethodScope.VerificationMethod()).toJSON(), method.toJSON());
+            assert.deepStrictEqual(doc.resolveMethod(fragment, MethodScope.Authentication()), undefined);
+            assert.deepStrictEqual(doc.resolveMethod(fragment, MethodScope.AssertionMethod()), undefined);
+            assert.deepStrictEqual(doc.resolveMethod(fragment, MethodScope.CapabilityInvocation()), undefined);
+            assert.deepStrictEqual(doc.resolveMethod(fragment, MethodScope.CapabilityDelegation()), undefined);
+            assert.deepStrictEqual(doc.resolveMethod(fragment, MethodScope.KeyAgreement()), undefined);
+        });
+    });
+    describe('#insert/resolve/removeService', function () {
+        it('should work', async () => {
+            const doc = new StardustDocument(networkName);
+
+            // Add.
+            const fragment1 = "new-service-1";
+            const service = new StardustService({
+                id: doc.id().toUrl().join('#' + fragment1),
+                type: ["LinkedDomains", "ExampleType"],
+                serviceEndpoint: ["https://example.com/", "https://iota.org/"],
+            });
+            doc.insertService(service);
+            // Resolve.
+            const resolved = doc.resolveService(fragment1);
+            assert.deepStrictEqual(resolved.id().fragment(), fragment1);
+            assert.deepStrictEqual(resolved.type(), ["LinkedDomains", "ExampleType"]);
+            assert.deepStrictEqual(resolved.serviceEndpoint(), ["https://example.com/", "https://iota.org/"]);
+            assert.deepStrictEqual(resolved.toJSON(), service.toJSON());
+            // List.
+            const list = doc.service();
+            assert.deepStrictEqual(list.length, 1);
+            assert.deepStrictEqual(list[0].toJSON(), resolved.toJSON());
+            // Remove
+            const remove = doc.removeService(resolved.id());
+            assert.deepStrictEqual(remove, true);
+            assert.deepStrictEqual(doc.resolveService(fragment1), undefined);
+            assert.deepStrictEqual(doc.service().length, 0);
+        });
+    });
+    describe('#metadata', function () {
+        it('should work', () => {
+            const doc = new StardustDocument(networkName);
+            const previousCreated = doc.metadataCreated();
+            const previousUpdated = doc.metadataUpdated();
+
+            // Created.
+            const created = Timestamp.nowUTC().checkedAdd(Duration.seconds(1));
+            doc.setMetadataCreated(created);
+            assert.deepStrictEqual(doc.metadataCreated().toRFC3339(), created.toRFC3339());
+            assert.deepStrictEqual(doc.metadata().created().toRFC3339(), created.toRFC3339());
+            assert.notDeepStrictEqual(doc.metadataCreated().toRFC3339(), previousCreated.toRFC3339());
+            assert.deepStrictEqual(doc.metadataUpdated().toRFC3339(), previousUpdated.toRFC3339());
+            // Updated.
+            const updated = Timestamp.nowUTC().checkedAdd(Duration.seconds(42));
+            doc.setMetadataUpdated(updated);
+            assert.deepStrictEqual(doc.metadataUpdated().toRFC3339(), updated.toRFC3339());
+            assert.deepStrictEqual(doc.metadata().updated().toRFC3339(), updated.toRFC3339());
+            assert.notDeepStrictEqual(doc.metadataUpdated().toRFC3339(), previousUpdated.toRFC3339());
+            assert.deepStrictEqual(doc.metadataCreated().toRFC3339(), created.toRFC3339());
+            // Properties.
+            assert.deepStrictEqual(doc.metadata().properties(), new Map());
+            const properties = new Map()
+            properties.set("custom1", "asdf");
+            properties.set("custom2", 1234);
+            doc.setMetadataPropertyUnchecked("custom1", "asdf");
+            doc.setMetadataPropertyUnchecked("custom2", 1234);
+            assert.deepStrictEqual(doc.metadata().properties(), properties);
+        });
+    });
+    describe('#properties', function () {
+        it('should work', () => {
+            const doc = new StardustDocument(networkName);
+            assert.deepStrictEqual(doc.properties(), new Map());
+
+            const properties = new Map()
+            properties.set("custom1", "asdf");
+            properties.set("custom2", 1234);
+            doc.setPropertyUnchecked("custom1", "asdf");
+            doc.setPropertyUnchecked("custom2", 1234);
+            assert.deepStrictEqual(doc.properties(), properties);
+        });
+    });
+});

--- a/bindings/wasm/tests/wasm.rs
+++ b/bindings/wasm/tests/wasm.rs
@@ -51,16 +51,30 @@ fn test_did() {
   let key = WasmKeyPair::new(WasmKeyType::Ed25519).unwrap();
   let did = WasmDID::new(&key.public(), None).unwrap();
 
-  assert_eq!(did.network_name(), "main");
+  assert_eq!(did.network_str(), "main");
 
   let parsed = WasmDID::parse(&did.to_string()).unwrap();
-
   assert_eq!(did.to_string(), parsed.to_string());
 
   let base58 = WasmDID::new(&key.public(), Some("dev".to_owned())).unwrap();
 
   assert_eq!(base58.tag(), did.tag());
-  assert_eq!(base58.network_name(), "dev");
+  assert_eq!(base58.network_str(), "dev");
+}
+
+#[wasm_bindgen_test]
+fn test_did_methods() {
+  let tag = "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV";
+  let did_str = format!("did:iota:dev:{tag}");
+  let did = WasmDID::parse(&did_str).unwrap();
+
+  assert_eq!(did.to_string(), did_str);
+  assert_eq!(did.tag(), tag);
+  assert_eq!(did.network_str(), "dev");
+  assert_eq!(did.scheme(), "did");
+  assert_eq!(did.method(), "iota");
+  assert_eq!(did.method_id(), format!("dev:{tag}"));
+  assert_eq!(did.authority(), format!("iota:dev:{tag}"));
 }
 
 #[wasm_bindgen_test]
@@ -93,7 +107,7 @@ fn test_did_url() {
 fn test_document_new() {
   let keypair: WasmKeyPair = WasmKeyPair::new(WasmKeyType::Ed25519).unwrap();
   let document: WasmDocument = WasmDocument::new(&keypair, None, None).unwrap();
-  assert_eq!(document.id().network_name(), "main");
+  assert_eq!(document.id().network_str(), "main");
   assert!(document.default_signing_method().is_ok());
 }
 
@@ -261,7 +275,7 @@ fn test_document_network() {
   let keypair: WasmKeyPair = WasmKeyPair::new(WasmKeyType::Ed25519).unwrap();
   let document: WasmDocument = WasmDocument::new(&keypair, Some("dev".to_owned()), None).unwrap();
 
-  assert_eq!(document.id().network_name(), "dev");
+  assert_eq!(document.id().network_str(), "dev");
 }
 
 #[wasm_bindgen_test]

--- a/identity_account_storage/Cargo.toml
+++ b/identity_account_storage/Cargo.toml
@@ -22,7 +22,6 @@ identity_iota_core = { version = "=0.6.0", path = "../identity_iota_core", defau
 iota-crypto = { version = "0.12.1", default-features = false, features = ["hmac", "pbkdf", "sha", "std", "aes-gcm", "aes-kw"] }
 iota_stronghold = { version = "0.6.4", default-features = false, features = ["std"], optional = true }
 once_cell = { version = "1.7", default-features = false, features = ["std"], optional = true }
-parking_lot = { version = "0.12" }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
 seahash = { version = "4.1.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }

--- a/identity_did/src/document/traits.rs
+++ b/identity_did/src/document/traits.rs
@@ -32,7 +32,7 @@ pub trait Document {
     Q: Into<DIDUrlQuery<'query>>;
 
   /// Returns the first [`VerificationMethod`] with an `id` property matching the
-  /// provided `query` and the verification relationship specified by `scope` if present.
+  /// provided `query` and the verification relationship specified by `scope`, if present.
   fn resolve_method<'query, 'me, Q>(
     &'me self,
     query: Q,

--- a/identity_did/src/verification/verification_method.rs
+++ b/identity_did/src/verification/verification_method.rs
@@ -108,42 +108,42 @@ where
     Ok(())
   }
 
-  /// Returns a reference to the verification `Method` controller.
+  /// Returns a reference to the `VerificationMethod` controller.
   pub fn controller(&self) -> &D {
     &self.controller
   }
 
-  /// Returns a mutable reference to the verification `Method` controller.
+  /// Returns a mutable reference to the `VerificationMethod` controller.
   pub fn controller_mut(&mut self) -> &mut D {
     &mut self.controller
   }
 
-  /// Returns a reference to the verification `Method` type.
+  /// Returns a reference to the `VerificationMethod` type.
   pub fn type_(&self) -> MethodType {
     self.type_
   }
 
-  /// Returns a mutable reference to the verification `Method` type.
+  /// Returns a mutable reference to the `VerificationMethod` type.
   pub fn type_mut(&mut self) -> &mut MethodType {
     &mut self.type_
   }
 
-  /// Returns a reference to the verification `Method` data.
+  /// Returns a reference to the `VerificationMethod` data.
   pub fn data(&self) -> &MethodData {
     &self.data
   }
 
-  /// Returns a mutable reference to the verification `Method` data.
+  /// Returns a mutable reference to the `VerificationMethod` data.
   pub fn data_mut(&mut self) -> &mut MethodData {
     &mut self.data
   }
 
-  /// Returns a reference to the custom verification `Method` properties.
+  /// Returns a reference to the custom `VerificationMethod` properties.
   pub fn properties(&self) -> &T {
     &self.properties
   }
 
-  /// Returns a mutable reference to the custom verification `Method` properties.
+  /// Returns a mutable reference to the custom `VerificationMethod` properties.
   pub fn properties_mut(&mut self) -> &mut T {
     &mut self.properties
   }

--- a/identity_stardust/src/document/stardust_document.rs
+++ b/identity_stardust/src/document/stardust_document.rs
@@ -271,7 +271,6 @@ impl StardustDocument {
   // ===========================================================================
   // Publishing
   // ===========================================================================
-  // TODO: clean up and feature-gate certain methods to avoid hard dependency on iota-client?
 
   /// Serializes the document for inclusion in an Alias Output's state metadata
   /// with the default [`StateMetadataEncoding`].

--- a/identity_stardust/src/document/stardust_document.rs
+++ b/identity_stardust/src/document/stardust_document.rs
@@ -36,16 +36,16 @@ use crate::StardustDocumentMetadata;
 use crate::StateMetadataDocument;
 use crate::StateMetadataEncoding;
 
-/// A [`VerificationMethod`] adhering to the IOTA DID method specification.
+/// A [`VerificationMethod`] adhering to the IOTA UTXO DID method specification.
 pub type StardustVerificationMethod = VerificationMethod<StardustDID, Object>;
 
-/// A [`Service`] adhering to the IOTA DID method specification.
+/// A [`Service`] adhering to the IOTA UTXO DID method specification.
 pub type StardustService = Service<StardustDID, Object>;
 
-/// A [`CoreDocument`] whose fields adhere to the IOTA DID method specification.
+/// A [`CoreDocument`] whose fields adhere to the IOTA UTXO DID method specification.
 pub type StardustCoreDocument = CoreDocument<StardustDID>;
 
-/// A DID Document adhering to the IOTA DID method specification.
+/// A DID Document adhering to the IOTA UTXO DID method specification.
 ///
 /// This extends [`CoreDocument`].
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]


### PR DESCRIPTION
# Description of change

Add initial Wasm bindings for the IOTA UTXO/Stardust DID Method.

### Added

- Add `WasmStardustDID`.
- Add `WasmStardustDIDUrl`.
- Add `WasmStardustDocument`.
- Add `WasmStardustDocumentMetadata`.
- Add `WasmStardustService`.
- Add `WasmStardustVerificationMethod`.
- Add `WasmDocumentMetadata.properties()`.
- Add `WasmDocument.setMetadataPropertyUnchecked()`.
- Add `WasmDID.METHOD`.
- Add `WasmDID.DEFAULT_NETWORK`.
- Add `IIotaService` interface which extends `IService`.

### Changed

- Change `WasmDocumentMetadata.previousMessageId` to not be a getter, for consistency.
- Change `WasmDID.join()` to borrow and clone internally.
- Change `IService` TypeScript interface to exclude `id`.
- Change several Wasm function parameter names to camelCase.

### Removed
- Remove unnecessary `parking_lot` dependency and `wasm-bindgen` feature, [which was deprecated](https://github.com/Amanieu/parking_lot/pull/302); enable the "wasm-bindgen" feature for `instant` directly instead. Added a custom lint to `lints.js` to catch future breakages.

## Links to any relevant issues
Sub-task of #908.

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Added `stardust.ts` unit tests. The new lint can be tested by commenting out the `instant` dependency in `Cargo.toml` and executing `npm run build`, which will fail with the lint error.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
