### PR TITLE
Remove deprecated `cargo read-manifest`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -114,18 +114,18 @@ jobs:
         # run examples only on ubuntu for now
         if: matrix.os == 'ubuntu-latest'
         run: |
-          cargo read-manifest --manifest-path ./examples_legacy/Cargo.toml | \
-          jq -r '.targets[].name' | \
-          parallel -k -j 4 --retries 3 cargo run --example {} --all-features --release
+          cargo metadata --format-version 1 --manifest-path ./examples_legacy/Cargo.toml | \
+          jq -r '.packages[] | select(.name == "examples_legacy") | .targets[].name'
+          parallel -k -j 4 --retries 3 ./target/release/examples/{}
 
       - name: Run Stardust Rust examples
         # run examples only on ubuntu for now
         if: matrix.os == 'ubuntu-latest'
         run: |
-          cargo read-manifest --manifest-path ./examples/Cargo.toml | \
-          jq -r '.targets[].name' | \
+          cargo metadata --format-version 1 --manifest-path ./examples/Cargo.toml | \
+          jq -r '.packages[] | select(.name == "examples") | .targets[].name'
           awk '$1 ~ /[0-9].*/' | \
-          parallel -k -j 4 --retries 3 cargo run --manifest-path ./examples/Cargo.toml --example {} --all-features --release
+          parallel -k -j 4 --retries 3 ./target/release/examples/{}
 
       - name: Stop sccache
         uses: './.github/actions/rust/sccache/stop-sccache'


### PR DESCRIPTION
# Description of change

- Use `cargo metadata` instead of `cargo read-manifest` for CI, since the former is deprecated.
- Improve performance slightly by invoking compiled examples directly rather than through cargo, which needs to acquire the build lock, which might be a problem when used with `parallel`.

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

n/a

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
