### PR TITLE
Reexport `bee-block` from `iota-client`

### DIFF
--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -17,7 +17,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 async-trait = { version = "0.1", default-features = false }
-bee-block = { version = "1.0.0-beta.5", default-features = false, features = ["dto"] }
+# Ensure bee-block always matches the version used by iota-client.
+bee-block = { version = "1.0.0-beta.7", default-features = false, features = ["dto"] }
 console_error_panic_hook = { version = "0.1" }
 futures = { version = "0.3" }
 js-sys = { version = "0.3" }

--- a/examples/0_basic/0_create_did.rs
+++ b/examples/0_basic/0_create_did.rs
@@ -30,7 +30,7 @@ async fn main() -> anyhow::Result<()> {
   let mut secret_manager: SecretManager = SecretManager::Stronghold(
     StrongholdSecretManager::builder()
       .password("secure_password")
-      .try_build(random_stronghold_path())?,
+      .build(random_stronghold_path())?,
   );
 
   // Get an address and with funds for testing.

--- a/examples/0_basic/1_update_did.rs
+++ b/examples/0_basic/1_update_did.rs
@@ -33,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
   let mut secret_manager: SecretManager = SecretManager::Stronghold(
     StrongholdSecretManager::builder()
       .password("secure_password")
-      .try_build(random_stronghold_path())?,
+      .build(random_stronghold_path())?,
   );
 
   // Create a new DID in an Alias Output for us to modify.

--- a/examples/0_basic/2_resolve_did.rs
+++ b/examples/0_basic/2_resolve_did.rs
@@ -23,7 +23,7 @@ async fn main() -> anyhow::Result<()> {
   let mut secret_manager: SecretManager = SecretManager::Stronghold(
     StrongholdSecretManager::builder()
       .password("secure_password")
-      .try_build(random_stronghold_path())?,
+      .build(random_stronghold_path())?,
   );
 
   // Create a new DID in an Alias Output for us to modify.

--- a/examples/0_basic/3_deactivate_did.rs
+++ b/examples/0_basic/3_deactivate_did.rs
@@ -25,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
   let mut secret_manager: SecretManager = SecretManager::Stronghold(
     StrongholdSecretManager::builder()
       .password("secure_password")
-      .try_build(random_stronghold_path())?,
+      .build(random_stronghold_path())?,
   );
 
   // Create a new DID in an Alias Output for us to modify.

--- a/examples/0_basic/4_delete_did.rs
+++ b/examples/0_basic/4_delete_did.rs
@@ -23,7 +23,7 @@ async fn main() -> anyhow::Result<()> {
   let mut secret_manager: SecretManager = SecretManager::Stronghold(
     StrongholdSecretManager::builder()
       .password("secure_password")
-      .try_build(random_stronghold_path())?,
+      .build(random_stronghold_path())?,
   );
 
   // Create a new DID in an Alias Output for us to modify.

--- a/examples/1_advanced/0_did_controls_did.rs
+++ b/examples/1_advanced/0_did_controls_did.rs
@@ -43,7 +43,7 @@ async fn main() -> anyhow::Result<()> {
   let mut secret_manager: SecretManager = SecretManager::Stronghold(
     StrongholdSecretManager::builder()
       .password("secure_password")
-      .try_build(random_stronghold_path())?,
+      .build(random_stronghold_path())?,
   );
 
   // Create a new DID for the company.

--- a/examples/1_advanced/1_did_issues_nft.rs
+++ b/examples/1_advanced/1_did_issues_nft.rs
@@ -48,7 +48,7 @@ async fn main() -> anyhow::Result<()> {
   let mut secret_manager: SecretManager = SecretManager::Stronghold(
     StrongholdSecretManager::builder()
       .password("secure_password")
-      .try_build(random_stronghold_path())?,
+      .build(random_stronghold_path())?,
   );
 
   // Create a new DID for the manufacturer.

--- a/examples/1_advanced/2_nft_owns_did.rs
+++ b/examples/1_advanced/2_nft_owns_did.rs
@@ -46,7 +46,7 @@ async fn main() -> anyhow::Result<()> {
   let mut secret_manager: SecretManager = SecretManager::Stronghold(
     StrongholdSecretManager::builder()
       .password("secure_password")
-      .try_build(random_stronghold_path())?,
+      .build(random_stronghold_path())?,
   );
 
   // Get an address with funds for testing.

--- a/examples/1_advanced/3_did_issues_tokens.rs
+++ b/examples/1_advanced/3_did_issues_tokens.rs
@@ -59,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
   let mut secret_manager: SecretManager = SecretManager::Stronghold(
     StrongholdSecretManager::builder()
       .password("secure_password")
-      .try_build(random_stronghold_path())?,
+      .build(random_stronghold_path())?,
   );
 
   // Create a new DID for the authority.

--- a/examples/1_advanced/4_key_exchange.rs
+++ b/examples/1_advanced/4_key_exchange.rs
@@ -40,7 +40,7 @@ async fn main() -> anyhow::Result<()> {
   let mut secret_manager: SecretManager = SecretManager::Stronghold(
     StrongholdSecretManager::builder()
       .password("secure_password")
-      .try_build(random_stronghold_path())?,
+      .build(random_stronghold_path())?,
   );
 
   // Get an address and with funds for testing.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.62"
 identity_core = { path = "../identity_core" }
 identity_did = { path = "../identity_did" }
 identity_stardust = { path = "../identity_stardust" }
-iota-client = { version = "2.0.0-beta.2", default-features = false, features = ["tls", "stronghold"] }
+iota-client = { version = "2.0.0-beta.3", default-features = false, features = ["tls", "stronghold"] }
 primitive-types = "0.11.1"
 rand = "0.8.5"
 tokio = { version = "1.20.1", default-features = false, features = ["rt"] }

--- a/identity_stardust/Cargo.toml
+++ b/identity_stardust/Cargo.toml
@@ -12,6 +12,8 @@ rust-version = "1.62"
 description = "An IOTA Ledger integration for the identity.rs library."
 
 [dependencies]
+# Ensure bee-block always matches the version used by iota-client.
+bee-block = { version = "1.0.0-beta.7", default-features = false, features = ["std"], optional = true }
 identity_core = { version = "=0.6.0", path = "../identity_core", default-features = false }
 identity_credential = { version = "=0.6.0", path = "../identity_credential", default-features = false }
 identity_did = { version = "=0.6.0", path = "../identity_did", default-features = false }
@@ -41,7 +43,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = ["client", "iota-client", "revocation-bitmap"]
 # Exposes the `StardustIdentityClient` and `StardustIdentityClientExt` traits.
-client = ["dep:async-trait"]
+client = ["dep:async-trait", "dep:bee-block"]
 # Enables the iota-client dependency, the client trait implementations for it, and the `StardustClientExt` trait.
 iota-client = ["dep:iota-client", "client"]
 # Enables revocation with `RevocationBitmap2022`.

--- a/identity_stardust/Cargo.toml
+++ b/identity_stardust/Cargo.toml
@@ -12,14 +12,12 @@ rust-version = "1.62"
 description = "An IOTA Ledger integration for the identity.rs library."
 
 [dependencies]
-# Ensure bee-block always matches the version used by iota-client.
-bee-block = { version = "1.0.0-beta.6", default-features = false, features = ["std"], optional = true }
 identity_core = { version = "=0.6.0", path = "../identity_core", default-features = false }
 identity_credential = { version = "=0.6.0", path = "../identity_credential", default-features = false }
 identity_did = { version = "=0.6.0", path = "../identity_did", default-features = false }
 
 async-trait = { version = "0.1.56", default-features = false, optional = true }
-iota-client = { version = "2.0.0-beta.2", default-features = false, features = ["tls"], optional = true }
+iota-client = { version = "2.0.0-beta.3", default-features = false, features = ["tls"], optional = true }
 num-derive = { version = "0.3", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["std"] }
 once_cell = { version = "1", default-features = false, features = ["std"] }
@@ -43,7 +41,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = ["client", "iota-client", "revocation-bitmap"]
 # Exposes the `StardustIdentityClient` and `StardustIdentityClientExt` traits.
-client = ["dep:async-trait", "dep:bee-block"]
+client = ["dep:async-trait"]
 # Enables the iota-client dependency, the client trait implementations for it, and the `StardustClientExt` trait.
 iota-client = ["dep:iota-client", "client"]
 # Enables revocation with `RevocationBitmap2022`.

--- a/identity_stardust/src/error.rs
+++ b/identity_stardust/src/error.rs
@@ -31,7 +31,7 @@ pub enum Error {
   RevocationError(#[source] identity_did::Error),
   #[cfg(feature = "client")]
   #[error("alias output build error")]
-  AliasOutputBuildError(#[source] bee_block::Error),
+  AliasOutputBuildError(#[source] iota_client::block::Error),
   #[cfg(feature = "iota-client")]
   #[error("output with id `{0}` is not an alias output")]
   NotAnAliasOutput(iota_client::block::output::OutputId),

--- a/identity_stardust/src/error.rs
+++ b/identity_stardust/src/error.rs
@@ -31,7 +31,7 @@ pub enum Error {
   RevocationError(#[source] identity_did::Error),
   #[cfg(feature = "client")]
   #[error("alias output build error")]
-  AliasOutputBuildError(#[source] iota_client::block::Error),
+  AliasOutputBuildError(#[source] crate::block::Error),
   #[cfg(feature = "iota-client")]
   #[error("output with id `{0}` is not an alias output")]
   NotAnAliasOutput(iota_client::block::output::OutputId),

--- a/identity_stardust/src/lib.rs
+++ b/identity_stardust/src/lib.rs
@@ -6,7 +6,7 @@
 
 /// Re-export the `bee_block` crate for implementer convenience.
 #[cfg(feature = "client")]
-pub use bee_block as block;
+pub use iota_client::block;
 
 #[cfg(feature = "client")]
 pub use client::*;

--- a/identity_stardust/src/lib.rs
+++ b/identity_stardust/src/lib.rs
@@ -4,8 +4,10 @@
 #![forbid(unsafe_code)]
 #![allow(clippy::upper_case_acronyms)]
 
-/// Re-export the `bee_block` crate for implementer convenience.
-#[cfg(feature = "client")]
+// Re-export the `bee_block` crate for implementer convenience.
+#[cfg(all(feature = "client", not(feature = "iota-client")))]
+pub use bee_block as block;
+#[cfg(feature = "iota-client")]
 pub use iota_client::block;
 
 #[cfg(feature = "client")]


### PR DESCRIPTION
# Description of change

To avoid version clashes due to different versions of `bee-block` and `iota-client::block`, this PR changes the reexport of `bee-block` to use `iota_client::block` in general, and only fall back to `bee-block` for bindings.

Update to new `iota-client` version, since the older version prevented a successfull build due to a version clash.

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Local build succeeds.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
