### PR TITLE
Fix broken wasm bindings compilation

### DIFF
--- a/identity_iota_client/Cargo.toml
+++ b/identity_iota_client/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0", default-features = false, features = ["std", "derive"
 strum = { version = "0.24.0", default-features = false, features = ["std", "derive"] }
 thiserror = { version = "1.0", default-features = false }
 
-[dependencies.iota-client]
+[target.'cfg(not(target_family = "wasm"))'.dependencies.iota-client]
 version = "1.2.0"
 features = ["async", "tls"]
 default-features = false


### PR DESCRIPTION
# Description of change
With the release of `tokio 1.21.0` the wasm bindings no longer compile. This PR fixes that. 

## More detailed description 
Until now the `identity_iota_client` crate depended on `iota-client` with the `async` feature which brings in `tokio` with the `rt-multi-thread` feature which now no longer compiles when targeting `wasm32-unknown-unknown`. 

With this PR the `iota-client` dependency will only be compiled with the `async` feature when the target family is NOT `wasm`. The `tokio` namespace is only present in `iota-client: 1.3.0` when the `wasm` feature is NOT or certain other features (which we do not use) such as `mqtt` is, hence this PR should not break any functionality from `iota-client: 1.3.0` that the identity.rs bindings currently relies on. 

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
