### PR TITLE
Stardust Refactor (Part 3)

### DIFF
--- a/identity_agent/Cargo.toml
+++ b/identity_agent/Cargo.toml
@@ -15,8 +15,6 @@ async-trait = { version = "0.1", default-features = false }
 dashmap = { version = "5.3", default-features = false }
 futures = { version = "0.3", default-features = false }
 identity_core = { version = "=0.6.0", path = "../identity_core", default-features = false }
-identity_iota_client_legacy = { version = "=0.6.0", path = "../identity_iota_client_legacy", default-features = false }
-identity_iota_core_legacy = { version = "=0.6.0", path = "../identity_iota_core_legacy", default-features = false }
 libp2p = { version = "0.45", default-features = false, features = ["tcp-tokio", "dns-tokio", "websocket", "request-response", "noise", "yamux"] }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -28,6 +26,7 @@ uuid = { version = "0.8", default-features = false, features = ["v4", "serde"] }
 [dev-dependencies]
 criterion = { version = "0.3", default-features = false, features = ["stable"] }
 identity_account = { version = "=0.6.0", path = "../identity_account", default-features = false, features = ["send-sync-storage"] }
+identity_iota_core_legacy = { version = "=0.6.0", path = "../identity_iota_core_legacy", default-features = false }
 pretty_env_logger = { version = "0.4", default-features = false }
 
 [[bench]]

--- a/identity_agent/benches/didcomm.rs
+++ b/identity_agent/benches/didcomm.rs
@@ -13,18 +13,13 @@ use identity_agent::didcomm::DidCommPlaintextMessage;
 use identity_agent::didcomm::ThreadId;
 use identity_agent::Multiaddr;
 
-use identity_core::crypto::KeyPair;
-use identity_core::crypto::KeyType;
-use identity_iota_core_legacy::document::IotaDocument;
 use test_handler::PresentationOffer;
 use test_handler::PresentationRequest;
 use test_handler::TestHandler;
 
 async fn setup() -> (DidCommAgent, AgentId, DidCommAgent) {
   let addr: Multiaddr = "/ip4/0.0.0.0/tcp/0".parse().unwrap();
-  let mut builder = DidCommAgentBuilder::new().identity(DidCommAgentIdentity {
-    document: IotaDocument::new(&KeyPair::new(KeyType::Ed25519).unwrap()).unwrap(),
-  });
+  let mut builder = DidCommAgentBuilder::new().identity(DidCommAgentIdentity::new());
 
   builder.attach_didcomm(TestHandler);
 
@@ -34,9 +29,7 @@ async fn setup() -> (DidCommAgent, AgentId, DidCommAgent) {
   let receiver_agent_id = receiver.agent_id();
 
   let mut sender: DidCommAgent = DidCommAgentBuilder::new()
-    .identity(DidCommAgentIdentity {
-      document: IotaDocument::new(&KeyPair::new(KeyType::Ed25519).unwrap()).unwrap(),
-    })
+    .identity(DidCommAgentIdentity::new())
     .build()
     .await
     .unwrap();

--- a/identity_agent/src/didcomm/agent.rs
+++ b/identity_agent/src/didcomm/agent.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use dashmap::DashMap;
 use futures::channel::oneshot;
-use identity_iota_core_legacy::document::IotaDocument;
 use libp2p::Multiaddr;
 use serde::de::DeserializeOwned;
 
@@ -31,11 +30,15 @@ use crate::p2p::ThreadRequest;
 /// The identity of a [`DidCommAgent`].
 ///
 /// Note: Currently an incomplete implementation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct DidCommAgentIdentity {
   // TODO: This type is meant to be used in a future update.
-  #[allow(dead_code)]
-  pub document: IotaDocument,
+}
+
+impl DidCommAgentIdentity {
+  pub fn new() -> Self {
+    Self {}
+  }
 }
 
 /// The internal state of a [`DidCommAgent`].

--- a/identity_agent/src/tests/mod.rs
+++ b/identity_agent/src/tests/mod.rs
@@ -6,8 +6,6 @@ mod handler;
 mod presentation;
 mod remote_account;
 
-use identity_core::crypto::KeyPair;
-use identity_iota_core_legacy::document::IotaDocument;
 use libp2p::identity::Keypair;
 use libp2p::Multiaddr;
 
@@ -77,9 +75,5 @@ async fn default_listening_didcomm_agent(
 }
 
 fn default_identity() -> DidCommAgentIdentity {
-  let keypair: KeyPair = KeyPair::new(identity_core::crypto::KeyType::Ed25519).unwrap();
-
-  DidCommAgentIdentity {
-    document: IotaDocument::new(&keypair).unwrap(),
-  }
+  DidCommAgentIdentity::new()
 }


### PR DESCRIPTION
# Description of change

Remove direct dependency of the agent on legacy crates. These were only used for the proof-of-concept type `DidCommAgentIdentity` so removing them is rather straightforward.

Note that this was branched off of the currently broken `epic/stardust-refactor` branch, so I don't expect CI to pass and I will merge after reviewer approval.

## Links to any relevant issues

part of #908

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Ran agent tests successfully.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
