### PR TITLE
Add length prefix to DID Document payloads

### DIFF
--- a/documentation/docs/specs/did/iota_did_method_spec.md
+++ b/documentation/docs/specs/did/iota_did_method_spec.md
@@ -111,19 +111,14 @@ This tag identifies the Alias Output where the DID Document is stored, and it wi
 
 In the `State Metadata` of the Alias Output must be a byte packed payload with header fields as follows:
 
-| Name          | Type         | Description                                                                                                                                              |
-|---------------|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Document Type | ByteArray[3] | Set to value **DID** to denote a DID Document.                                                                                                           |
-| Version       | uint8        | Set value **1** to denote the version number of this method                                                                                              |
-| Encoding      | uint8        | Set to value to **0** to denote JSON encoding without compression.                                                                                       |
-| Payload       | ByteArray    | A DID Document and its metadata, where every occurrence of the DID in the document is replaced by `did:0:0`. It must be encoded according to `Encoding`. |
+| Name          | Type              | Description                                                                                                                                              |
+|---------------|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Document Type | ByteArray[3]      | Set to value **DID** to denote a DID Document.                                                                                                           |
+| Version       | uint8             | Set value **1** to denote the version number of this method                                                                                              |
+| Encoding      | uint8             | Set to value to **0** to denote JSON encoding without compression.                                                                                       |
+| Payload       | (uint16)ByteArray | A DID Document and its metadata, where every occurrence of the DID in the document is replaced by `did:0:0`. It must be encoded according to `Encoding`. |
 
-Next to [TIP-21](#data-types--subschema-notation), we use the following type definitions:
-
-| Name      | Description                                     |
-|-----------|-------------------------------------------------|
-| ByteArray | A dynamically sized, but unprefixed byte array. |
-
+The types are defined in [TIP-21](#data-types--subschema-notation).
 
 #### Payload
 

--- a/identity_iota_core/src/document/iota_document.rs
+++ b/identity_iota_core/src/document/iota_document.rs
@@ -267,7 +267,7 @@ impl IotaDocument {
   /// Serializes the document for inclusion in an Alias Output's state metadata
   /// with the default [`StateMetadataEncoding`].
   pub fn pack(self) -> Result<Vec<u8>> {
-    self.pack_with_encoding(StateMetadataEncoding::Json)
+    self.pack_with_encoding(StateMetadataEncoding::default())
   }
 
   /// Serializes the document for inclusion in an Alias Output's state metadata.

--- a/identity_iota_core/src/error.rs
+++ b/identity_iota_core/src/error.rs
@@ -7,7 +7,7 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 #[non_exhaustive]
 pub enum Error {
   #[error("serialization error")]
-  SerializationError(#[source] identity_core::Error),
+  SerializationError(&'static str, #[source] Option<identity_core::Error>),
   #[error("{0}")]
   DIDSyntaxError(#[from] identity_did::did::DIDError),
   #[error("{0}")]

--- a/identity_iota_core/src/state_metadata/encoding.rs
+++ b/identity_iota_core/src/state_metadata/encoding.rs
@@ -6,8 +6,9 @@ use num_traits::FromPrimitive;
 use crate::Error;
 
 /// Indicates the encoding of a DID document in state metadata.
-#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, num_derive::FromPrimitive)]
+#[derive(Copy, Clone, Debug, Default, Ord, PartialOrd, Eq, PartialEq, num_derive::FromPrimitive)]
 pub enum StateMetadataEncoding {
+  #[default]
   Json = 0,
 }
 


### PR DESCRIPTION
# Description of change
Changes the state metadata payload to include a length prefix for the encoded DID Document, and updates the IOTA DID Method specification on the wiki accordingly.

Little Endian is used per [TIP-21](https://github.com/iotaledger/tips/blob/main/tips/TIP-0021/tip-0021.md).

Alternatively, we could switch to [packable](https://crates.io/crates/packable) but that requires other changes.

## Links to any relevant issues
Fixes #1003.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested
Updated the unit tests and examples should pass.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
