### PR TITLE
Support case insensitive serialization of `RentStructure`

### DIFF
--- a/bindings/wasm/src/iota/identity_client_ext.rs
+++ b/bindings/wasm/src/iota/identity_client_ext.rs
@@ -1,6 +1,7 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use bee_block::output::RentStructureBuilder;
 use identity_iota::iota::block::address::dto::AddressDto;
 use identity_iota::iota::block::address::Address;
 use identity_iota::iota::block::output::dto::AliasOutputDto;
@@ -71,8 +72,14 @@ impl WasmIotaIdentityClientExt {
     let doc: IotaDocument = document.0.clone();
 
     let promise: Promise = future_to_promise(async move {
-      let rent_structure: Option<RentStructure> =
-        rentStructure.map(|rent| rent.into_serde()).transpose().wasm_result()?;
+      let rent_structure: Option<RentStructure> = rentStructure
+        .map(|rent| {
+          rent
+            .into_serde::<RentStructureBuilder>()
+            .map(RentStructureBuilder::finish)
+        })
+        .transpose()
+        .wasm_result()?;
 
       let output: AliasOutput = IotaIdentityClientExt::new_did_output(&client, address, doc, rent_structure)
         .await


### PR DESCRIPTION
# Description of change

The `IRent` structure in JS uses camelCase while the Rust code in `new_did_output` expects snake_case. This fixes it by deserializing to `RentStructureBuilder` which supports both casings. Thanks to @cycraig for finding the culprit.

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Running an example that uses `newDidOutput` and passes an `IRent` object.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
