### PR TITLE
Use cargo-license-template

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -72,7 +72,4 @@ jobs:
           dprint check
 
       - name: cargo-license-template check
-        uses: actions-rs/cargo@v1
-        with:
-          command: cargo-license-template
-          args: --template .license_template --ignore .license_template_ignore --verbose
+        run: cargo license-template --template .license_template --ignore .license_template_ignore --verbose

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -31,6 +31,12 @@ jobs:
           override: true
           components: rustfmt
 
+      - name: Install cargo-license-template
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-license-template
+
       - name: Install dprint
         run: npm install -g dprint
         #run: cargo install dprint # installing from source is slow, ~5 minutes
@@ -64,3 +70,9 @@ jobs:
       - name: Cargo.toml fmt check
         run:
           dprint check
+
+      - name: cargo-license-template check
+        uses: actions-rs/cargo@v1
+        with:
+          command: cargo-license-template
+          args: --template .license_template --ignore .license_template_ignore --verbose

--- a/.license_template_ignore
+++ b/.license_template_ignore
@@ -1,0 +1,1 @@
+libjose/tests/fixtures/*.rs

--- a/bindings/wasm/src/iota/iota_verification_method.rs
+++ b/bindings/wasm/src/iota/iota_verification_method.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2022  Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use identity_iota::crypto::PublicKey;

--- a/examples/utils/utils.rs
+++ b/examples/utils/utils.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::PathBuf;
 
 use anyhow::Context;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,5 @@
 comment_width = 120
 format_code_in_doc_comments = true
-license_template_path = ".license_template"
 max_width = 120
 normalize_comments = false
 normalize_doc_attributes = false


### PR DESCRIPTION
# Description of change
Use [cargo-license-template](https://crates.io/crates/cargo-license-template) as a replacement for the removed `license_template_path` feature of `rustfmt`.

Note that running `cargo-license-template` in the root of the workspace checks all sub-directories, including the Wasm and Stronghold bindings.

## Links to any relevant issues
Fixes #921.

## Type of change

- [x] Chore (a non-breaking change which fixes an issue)

## How the change has been tested
```
cargo install -f cargo-license-template
cargo license-template --template .license_template --ignore .license_template_ignore --verbose
```

Passes in CI too: https://github.com/iotaledger/identity.rs/actions/runs/3060562925/jobs/4939227569

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
