### PR TITLE
Expose iteration over verification relationship fields

### DIFF
--- a/bindings/wasm/src/did/wasm_core_document.rs
+++ b/bindings/wasm/src/did/wasm_core_document.rs
@@ -10,6 +10,7 @@ use crate::crypto::WasmProofOptions;
 use crate::did::wasm_core_service::WasmCoreService;
 use crate::did::wasm_core_url::WasmCoreDIDUrl;
 use crate::did::wasm_core_verification_method::WasmCoreVerificationMethod;
+use crate::did::OptionMethodScope;
 use crate::did::RefMethodScope;
 use crate::did::WasmMethodRelationship;
 use crate::did::WasmMethodScope;
@@ -295,15 +296,18 @@ impl WasmCoreDocument {
 
   /// Returns a list of all {@link CoreVerificationMethod} in the DID Document.
   #[wasm_bindgen]
-  pub fn methods(&self) -> ArrayCoreVerificationMethod {
-    self
+  pub fn methods(&self, scope: &OptionMethodScope) -> Result<ArrayCoreVerificationMethod> {
+    let scope: Option<MethodScope> = scope.into_serde().wasm_result()?;
+    let methods = self
       .0
-      .methods()
+      .methods(scope)
+      .into_iter()
       .cloned()
       .map(WasmCoreVerificationMethod::from)
       .map(JsValue::from)
       .collect::<js_sys::Array>()
-      .unchecked_into::<ArrayCoreVerificationMethod>()
+      .unchecked_into::<ArrayCoreVerificationMethod>();
+    Ok(methods)
   }
 
   /// Returns an array of all verification relationships.

--- a/bindings/wasm/src/did/wasm_core_document.rs
+++ b/bindings/wasm/src/did/wasm_core_document.rs
@@ -10,7 +10,6 @@ use crate::crypto::WasmProofOptions;
 use crate::did::wasm_core_service::WasmCoreService;
 use crate::did::wasm_core_url::WasmCoreDIDUrl;
 use crate::did::wasm_core_verification_method::WasmCoreVerificationMethod;
-use crate::did::OptionMethodScope;
 use crate::did::RefMethodScope;
 use crate::did::WasmMethodRelationship;
 use crate::did::WasmMethodScope;
@@ -296,8 +295,8 @@ impl WasmCoreDocument {
 
   /// Returns a list of all {@link CoreVerificationMethod} in the DID Document.
   #[wasm_bindgen]
-  pub fn methods(&self, scope: &OptionMethodScope) -> Result<ArrayCoreVerificationMethod> {
-    let scope: Option<MethodScope> = scope.into_serde().wasm_result()?;
+  pub fn methods(&self, scope: Option<RefMethodScope>) -> Result<ArrayCoreVerificationMethod> {
+    let scope: Option<MethodScope> = scope.map(|js| js.into_serde().wasm_result()).transpose()?;
     let methods = self
       .0
       .methods(scope)

--- a/bindings/wasm/src/did/wasm_core_document.rs
+++ b/bindings/wasm/src/did/wasm_core_document.rs
@@ -293,7 +293,10 @@ impl WasmCoreDocument {
   // Verification Methods
   // ===========================================================================
 
-  /// Returns a list of all {@link CoreVerificationMethod} in the DID Document.
+  /// Returns a list of all {@link CoreVerificationMethod} in the DID Document,
+  /// whose verification relationship matches `scope`.
+  ///
+  /// If `scope` is not set, a list over the **embedded** methods is returned.
   #[wasm_bindgen]
   pub fn methods(&self, scope: Option<RefMethodScope>) -> Result<ArrayCoreVerificationMethod> {
     let scope: Option<MethodScope> = scope.map(|js| js.into_serde().wasm_result()).transpose()?;

--- a/bindings/wasm/src/iota/iota_document.rs
+++ b/bindings/wasm/src/iota/iota_document.rs
@@ -29,7 +29,6 @@ use crate::common::WasmTimestamp;
 use crate::credential::WasmCredential;
 use crate::credential::WasmPresentation;
 use crate::crypto::WasmProofOptions;
-use crate::did::OptionMethodScope;
 use crate::did::RefMethodScope;
 use crate::did::WasmMethodRelationship;
 use crate::did::WasmMethodScope;
@@ -202,8 +201,8 @@ impl WasmIotaDocument {
 
   /// Returns a list of all {@link IotaVerificationMethod} in the DID Document.
   #[wasm_bindgen]
-  pub fn methods(&self, scope: &OptionMethodScope) -> Result<ArrayIotaVerificationMethods> {
-    let scope: Option<MethodScope> = scope.into_serde().wasm_result()?;
+  pub fn methods(&self, scope: Option<RefMethodScope>) -> Result<ArrayIotaVerificationMethods> {
+    let scope: Option<MethodScope> = scope.map(|js| js.into_serde().wasm_result()).transpose()?;
     let methods = self
       .0
       .methods(scope)

--- a/bindings/wasm/src/iota/iota_document.rs
+++ b/bindings/wasm/src/iota/iota_document.rs
@@ -199,7 +199,10 @@ impl WasmIotaDocument {
   // Verification Methods
   // ===========================================================================
 
-  /// Returns a list of all {@link IotaVerificationMethod} in the DID Document.
+  /// Returns a list of all {@link IotaVerificationMethod} in the DID Document,
+  /// whose verification relationship matches `scope`.
+  ///
+  /// If `scope` is not set, a list over the **embedded** methods is returned.
   #[wasm_bindgen]
   pub fn methods(&self, scope: Option<RefMethodScope>) -> Result<ArrayIotaVerificationMethods> {
     let scope: Option<MethodScope> = scope.map(|js| js.into_serde().wasm_result()).transpose()?;

--- a/bindings/wasm/src/iota/iota_document.rs
+++ b/bindings/wasm/src/iota/iota_document.rs
@@ -29,6 +29,7 @@ use crate::common::WasmTimestamp;
 use crate::credential::WasmCredential;
 use crate::credential::WasmPresentation;
 use crate::crypto::WasmProofOptions;
+use crate::did::OptionMethodScope;
 use crate::did::RefMethodScope;
 use crate::did::WasmMethodRelationship;
 use crate::did::WasmMethodScope;
@@ -201,15 +202,18 @@ impl WasmIotaDocument {
 
   /// Returns a list of all {@link IotaVerificationMethod} in the DID Document.
   #[wasm_bindgen]
-  pub fn methods(&self) -> ArrayIotaVerificationMethods {
-    self
+  pub fn methods(&self, scope: &OptionMethodScope) -> Result<ArrayIotaVerificationMethods> {
+    let scope: Option<MethodScope> = scope.into_serde().wasm_result()?;
+    let methods = self
       .0
-      .methods()
+      .methods(scope)
+      .into_iter()
       .cloned()
       .map(WasmIotaVerificationMethod::from)
       .map(JsValue::from)
       .collect::<js_sys::Array>()
-      .unchecked_into::<ArrayIotaVerificationMethods>()
+      .unchecked_into::<ArrayIotaVerificationMethods>();
+    Ok(methods)
   }
 
   /// Adds a new `method` to the document in the given `scope`.

--- a/identity_account/src/tests/account.rs
+++ b/identity_account/src/tests/account.rs
@@ -159,7 +159,7 @@ async fn test_account_autopublish() {
 
   let doc = account.document();
 
-  assert_eq!(doc.methods().count(), 1);
+  assert_eq!(doc.methods().len(), 1);
   assert_eq!(doc.service().len(), 2);
 
   for service in ["my-service", "my-other-service"] {
@@ -213,7 +213,7 @@ async fn test_account_autopublish() {
   let doc = account.document();
 
   assert_eq!(doc.service().len(), 0);
-  assert_eq!(doc.methods().count(), 2);
+  assert_eq!(doc.methods().len(), 2);
 
   for method in ["sign-0", "new-method"] {
     assert!(doc.resolve_method(method, None).is_some());

--- a/identity_account/src/tests/updates.rs
+++ b/identity_account/src/tests/updates.rs
@@ -55,7 +55,7 @@ async fn test_create_identity() -> Result<()> {
     let method: &IotaVerificationMethod = document.resolve_method(expected_fragment, None).unwrap();
 
     assert_eq!(document.core_document().verification_relationships().count(), 1);
-    assert_eq!(document.core_document().methods().count(), 1);
+    assert_eq!(document.core_document().methods(None).len(), 1);
 
     let location: KeyLocation = KeyLocation::from_verification_method(method).unwrap();
 
@@ -204,7 +204,7 @@ async fn test_create_method_content_generate() -> Result<()> {
 
       // Still only the default relationship.
       assert_eq!(document.core_document().verification_relationships().count(), 1);
-      assert_eq!(document.core_document().methods().count(), 2);
+      assert_eq!(document.core_document().methods(None).len(), 2);
 
       let location: KeyLocation = KeyLocation::from_verification_method(method).unwrap();
 
@@ -291,7 +291,7 @@ async fn test_create_scoped_method() -> Result<()> {
 
     assert_eq!(document.core_document().verification_relationships().count(), 2);
 
-    assert_eq!(document.core_document().methods().count(), 2);
+    assert_eq!(document.core_document().methods(None).len(), 2);
 
     let core_doc = document.core_document();
 
@@ -601,7 +601,7 @@ async fn test_delete_method() -> Result<()> {
   // Still only the default relationship.
   assert_eq!(document.core_document().verification_relationships().count(), 1);
 
-  assert_eq!(document.core_document().methods().count(), 1);
+  assert_eq!(document.core_document().methods(None).len(), 1);
 
   // Ensure the key still exists in storage.
   assert!(account

--- a/identity_credential/src/validator/credential_validator.rs
+++ b/identity_credential/src/validator/credential_validator.rs
@@ -413,7 +413,7 @@ mod tests {
     issuer_doc
       .signer(issuer_key.private())
       .options(ProofOptions::default())
-      .method(issuer_doc.methods().next().unwrap().id())
+      .method(issuer_doc.methods(None).get(0).unwrap().id())
       .sign(&mut credential)
       .unwrap();
 
@@ -483,7 +483,7 @@ mod tests {
     issuer_doc
       .signer(issuer_key.private())
       .options(ProofOptions::default())
-      .method(issuer_doc.methods().next().unwrap().id())
+      .method(issuer_doc.methods(None).get(0).unwrap().id())
       .sign(&mut credential)
       .unwrap();
 
@@ -521,7 +521,7 @@ mod tests {
     issuer_doc
       .signer(issuer_key.private())
       .options(ProofOptions::default())
-      .method(issuer_doc.methods().next().unwrap().id())
+      .method(issuer_doc.methods(None).get(0).unwrap().id())
       .sign(&mut credential)
       .unwrap();
 
@@ -547,7 +547,7 @@ mod tests {
     issuer_doc
       .signer(issuer_key.private())
       .options(ProofOptions::default())
-      .method(issuer_doc.methods().next().unwrap().id())
+      .method(issuer_doc.methods(None).get(0).unwrap().id())
       .sign(&mut credential)
       .unwrap();
 
@@ -594,7 +594,7 @@ mod tests {
     issuer_doc
       .signer(other_keys.private())
       .options(ProofOptions::default())
-      .method(issuer_doc.methods().next().unwrap().id())
+      .method(issuer_doc.methods(None).get(0).unwrap().id())
       .sign(&mut credential)
       .unwrap();
 
@@ -820,7 +820,7 @@ mod tests {
     issuer_doc
       .signer(issuer_key.private())
       .options(ProofOptions::default())
-      .method(issuer_doc.methods().next().unwrap().id())
+      .method(issuer_doc.methods(None).get(0).unwrap().id())
       .sign(&mut credential)
       .unwrap();
     // the credential now has no credential subjects which is not semantically correct
@@ -860,7 +860,7 @@ mod tests {
     issuer_doc
       .signer(issuer_key.private())
       .options(ProofOptions::default())
-      .method(issuer_doc.methods().next().unwrap().id())
+      .method(issuer_doc.methods(None).get(0).unwrap().id())
       .sign(&mut credential)
       .unwrap();
     // the credential now has no credential subjects which is not semantically correct
@@ -899,7 +899,7 @@ mod tests {
     issuer_doc
       .signer(issuer_key.private())
       .options(ProofOptions::default())
-      .method(issuer_doc.methods().next().unwrap().id())
+      .method(issuer_doc.methods(None).get(0).unwrap().id())
       .sign(&mut credential)
       .unwrap();
     // the credential now has no credential subjects which is not semantically correct

--- a/identity_credential/src/validator/presentation_validator.rs
+++ b/identity_credential/src/validator/presentation_validator.rs
@@ -318,14 +318,14 @@ mod tests {
       issuer_foo_doc
         .signer(issuer_foo_key.private())
         .options(ProofOptions::default())
-        .method(issuer_foo_doc.methods().next().unwrap().id())
+        .method(issuer_foo_doc.methods(None).get(0).unwrap().id())
         .sign(credential_foo)
         .unwrap();
 
       issuer_bar_doc
         .signer(issuer_bar_key.private())
         .options(ProofOptions::default())
-        .method(issuer_bar_doc.methods().next().unwrap().id())
+        .method(issuer_bar_doc.methods(None).get(0).unwrap().id())
         .sign(credential_bar)
         .unwrap();
       setup
@@ -350,7 +350,7 @@ mod tests {
     subject_foo_doc
       .signer(subject_foo_key.private())
       .options(ProofOptions::new().challenge("475a7984-1bb5-4c4c-a56f-822bccd46440".to_owned()))
-      .method(subject_foo_doc.methods().next().unwrap().id())
+      .method(subject_foo_doc.methods(None).get(0).unwrap().id())
       .sign(&mut presentation)
       .unwrap();
 
@@ -396,7 +396,7 @@ mod tests {
     subject_foo_doc
       .signer(subject_foo_key.private())
       .options(ProofOptions::new().challenge("some challenge".to_owned()))
-      .method(subject_foo_doc.methods().next().unwrap().id())
+      .method(subject_foo_doc.methods(None).get(0).unwrap().id())
       .sign(&mut presentation)
       .unwrap();
 
@@ -461,7 +461,7 @@ mod tests {
     subject_foo_doc
       .signer(subject_foo_key.private())
       .options(ProofOptions::new().challenge("some challenge".to_owned()))
-      .method(subject_foo_doc.methods().next().unwrap().id())
+      .method(subject_foo_doc.methods(None).get(0).unwrap().id())
       .sign(&mut presentation)
       .unwrap();
 
@@ -513,7 +513,7 @@ mod tests {
     issuer_bar_doc
       .signer(issuer_bar_key.private())
       .options(ProofOptions::default())
-      .method(issuer_bar_doc.methods().next().unwrap().id())
+      .method(issuer_bar_doc.methods(None).get(0).unwrap().id())
       .sign(&mut credential_bar)
       .unwrap();
 
@@ -525,7 +525,7 @@ mod tests {
     subject_foo_doc
       .signer(subject_foo_key.private())
       .options(ProofOptions::new().challenge("some challenge".to_owned()))
-      .method(subject_foo_doc.methods().next().unwrap().id())
+      .method(subject_foo_doc.methods(None).get(0).unwrap().id())
       .sign(&mut presentation)
       .unwrap();
 
@@ -619,7 +619,7 @@ mod tests {
     subject_foo_doc
       .signer(subject_foo_key.private())
       .options(ProofOptions::new().challenge("some challenge".to_owned()))
-      .method(subject_foo_doc.methods().next().unwrap().id())
+      .method(subject_foo_doc.methods(None).get(0).unwrap().id())
       .sign(&mut presentation)
       .unwrap();
 
@@ -692,7 +692,7 @@ mod tests {
     subject_foo_doc
       .signer(subject_foo_key.private())
       .options(ProofOptions::new().challenge("some challenge".to_owned()))
-      .method(subject_foo_doc.methods().next().unwrap().id())
+      .method(subject_foo_doc.methods(None).get(0).unwrap().id())
       .sign(&mut presentation)
       .unwrap();
 

--- a/identity_did/src/document/core_document.rs
+++ b/identity_did/src/document/core_document.rs
@@ -483,6 +483,9 @@ where
     }
   }
 
+  /// Returns a `Vec` of verification methods references whose verification relationship matches `scope`.
+  ///
+  /// If `scope` is `None`, an iterator over all **embedded** methods is returned.
   pub fn methods(&self, scope: Option<MethodScope>) -> Vec<&VerificationMethod<D, U>>
   where
     D: DID,

--- a/identity_did/src/document/core_document.rs
+++ b/identity_did/src/document/core_document.rs
@@ -493,27 +493,27 @@ where
         MethodScope::VerificationRelationship(MethodRelationship::AssertionMethod) => self
           .assertion_method()
           .iter()
-          .filter_map(|mr| self.resolve_method_ref(mr))
+          .filter_map(|method_ref| self.resolve_method_ref(method_ref))
           .collect(),
         MethodScope::VerificationRelationship(MethodRelationship::Authentication) => self
           .authentication()
           .iter()
-          .filter_map(|mr| self.resolve_method_ref(mr))
+          .filter_map(|method_ref| self.resolve_method_ref(method_ref))
           .collect(),
         MethodScope::VerificationRelationship(MethodRelationship::CapabilityDelegation) => self
           .capability_delegation()
           .iter()
-          .filter_map(|mr| self.resolve_method_ref(mr))
+          .filter_map(|method_ref| self.resolve_method_ref(method_ref))
           .collect(),
         MethodScope::VerificationRelationship(MethodRelationship::CapabilityInvocation) => self
           .capability_invocation()
           .iter()
-          .filter_map(|mr| self.resolve_method_ref(mr))
+          .filter_map(|method_ref| self.resolve_method_ref(method_ref))
           .collect(),
         MethodScope::VerificationRelationship(MethodRelationship::KeyAgreement) => self
           .key_agreement()
           .iter()
-          .filter_map(|mr| self.resolve_method_ref(mr))
+          .filter_map(|method_ref| self.resolve_method_ref(method_ref))
           .collect(),
       }
     } else {
@@ -1100,66 +1100,32 @@ mod tests {
     let document: CoreDocument = document();
 
     // VerificationMethod
+    let verification_methods: Vec<&VerificationMethod> = document.methods(Some(MethodScope::VerificationMethod));
     assert_eq!(
-      document
-        .methods(Some(MethodScope::VerificationMethod))
-        .get(0)
-        .unwrap()
-        .id()
-        .to_string(),
+      verification_methods.get(0).unwrap().id().to_string(),
       "did:example:1234#key-1"
     );
     assert_eq!(
-      document
-        .methods(Some(MethodScope::VerificationMethod))
-        .get(1)
-        .unwrap()
-        .id()
-        .to_string(),
+      verification_methods.get(1).unwrap().id().to_string(),
       "did:example:1234#key-2"
     );
     assert_eq!(
-      document
-        .methods(Some(MethodScope::VerificationMethod))
-        .get(2)
-        .unwrap()
-        .id()
-        .to_string(),
+      verification_methods.get(2).unwrap().id().to_string(),
       "did:example:1234#key-3"
     );
-    assert_eq!(document.methods(Some(MethodScope::VerificationMethod)).len(), 3);
+    assert_eq!(verification_methods.len(), 3);
 
     // Authentication
+    let authentication: Vec<&VerificationMethod> = document.methods(Some(MethodScope::authentication()));
     assert_eq!(
-      document
-        .methods(Some(MethodScope::VerificationRelationship(
-          MethodRelationship::Authentication
-        )))
-        .get(0)
-        .unwrap()
-        .id()
-        .to_string(),
+      authentication.get(0).unwrap().id().to_string(),
       "did:example:1234#auth-key"
     );
     assert_eq!(
-      document
-        .methods(Some(MethodScope::VerificationRelationship(
-          MethodRelationship::Authentication
-        )))
-        .get(1)
-        .unwrap()
-        .id()
-        .to_string(),
+      authentication.get(1).unwrap().id().to_string(),
       "did:example:1234#key-3"
     );
-    assert_eq!(
-      document
-        .methods(Some(MethodScope::VerificationRelationship(
-          MethodRelationship::Authentication
-        )))
-        .len(),
-      2
-    );
+    assert_eq!(authentication.len(), 2);
   }
 
   #[test]

--- a/identity_did/src/document/core_document.rs
+++ b/identity_did/src/document/core_document.rs
@@ -483,10 +483,48 @@ where
     }
   }
 
+  pub fn methods(&self, scope: Option<MethodScope>) -> Vec<&VerificationMethod<D, U>>
+  where
+    D: DID,
+  {
+    if let Some(scope) = scope {
+      match scope {
+        MethodScope::VerificationMethod => self.verification_method().iter().collect(),
+        MethodScope::VerificationRelationship(MethodRelationship::AssertionMethod) => self
+          .assertion_method()
+          .iter()
+          .filter_map(|mr| self.resolve_method_ref(mr))
+          .collect(),
+        MethodScope::VerificationRelationship(MethodRelationship::Authentication) => self
+          .authentication()
+          .iter()
+          .filter_map(|mr| self.resolve_method_ref(mr))
+          .collect(),
+        MethodScope::VerificationRelationship(MethodRelationship::CapabilityDelegation) => self
+          .capability_delegation()
+          .iter()
+          .filter_map(|mr| self.resolve_method_ref(mr))
+          .collect(),
+        MethodScope::VerificationRelationship(MethodRelationship::CapabilityInvocation) => self
+          .capability_invocation()
+          .iter()
+          .filter_map(|mr| self.resolve_method_ref(mr))
+          .collect(),
+        MethodScope::VerificationRelationship(MethodRelationship::KeyAgreement) => self
+          .key_agreement()
+          .iter()
+          .filter_map(|mr| self.resolve_method_ref(mr))
+          .collect(),
+      }
+    } else {
+      self.all_methods().collect()
+    }
+  }
+
   /// Returns an iterator over all embedded verification methods in the DID Document.
   ///
   /// This excludes verification methods that are referenced by the DID Document.
-  pub fn methods(&self) -> impl Iterator<Item = &VerificationMethod<D, U>> {
+  fn all_methods(&self) -> impl Iterator<Item = &VerificationMethod<D, U>> {
     fn __filter_ref<D, T>(method: &MethodRef<D, T>) -> Option<&VerificationMethod<D, T>>
     where
       D: DID,
@@ -1053,8 +1091,8 @@ mod tests {
     let document: CoreDocument = document();
 
     // Access methods by index.
-    assert_eq!(document.methods().next().unwrap().id().to_string(), "did:example:1234#key-1");
-    assert_eq!(document.methods().nth(2).unwrap().id().to_string(), "did:example:1234#key-3");
+    assert_eq!(document.methods(None).get(0).unwrap().id().to_string(), "did:example:1234#key-1");
+    assert_eq!(document.methods(None).get(2).unwrap().id().to_string(), "did:example:1234#key-3");
   }
 
   #[test]

--- a/identity_did/src/document/core_document.rs
+++ b/identity_did/src/document/core_document.rs
@@ -1096,6 +1096,73 @@ mod tests {
   }
 
   #[test]
+  fn test_methods_scope() {
+    let document: CoreDocument = document();
+
+    // VerificationMethod
+    assert_eq!(
+      document
+        .methods(Some(MethodScope::VerificationMethod))
+        .get(0)
+        .unwrap()
+        .id()
+        .to_string(),
+      "did:example:1234#key-1"
+    );
+    assert_eq!(
+      document
+        .methods(Some(MethodScope::VerificationMethod))
+        .get(1)
+        .unwrap()
+        .id()
+        .to_string(),
+      "did:example:1234#key-2"
+    );
+    assert_eq!(
+      document
+        .methods(Some(MethodScope::VerificationMethod))
+        .get(2)
+        .unwrap()
+        .id()
+        .to_string(),
+      "did:example:1234#key-3"
+    );
+    assert_eq!(document.methods(Some(MethodScope::VerificationMethod)).len(), 3);
+
+    // Authentication
+    assert_eq!(
+      document
+        .methods(Some(MethodScope::VerificationRelationship(
+          MethodRelationship::Authentication
+        )))
+        .get(0)
+        .unwrap()
+        .id()
+        .to_string(),
+      "did:example:1234#auth-key"
+    );
+    assert_eq!(
+      document
+        .methods(Some(MethodScope::VerificationRelationship(
+          MethodRelationship::Authentication
+        )))
+        .get(1)
+        .unwrap()
+        .id()
+        .to_string(),
+      "did:example:1234#key-3"
+    );
+    assert_eq!(
+      document
+        .methods(Some(MethodScope::VerificationRelationship(
+          MethodRelationship::Authentication
+        )))
+        .len(),
+      2
+    );
+  }
+
+  #[test]
   fn test_attach_verification_relationships() {
     let mut document: CoreDocument = document();
 

--- a/identity_did/src/document/core_document.rs
+++ b/identity_did/src/document/core_document.rs
@@ -483,7 +483,7 @@ where
     }
   }
 
-  /// Returns a `Vec` of verification methods references whose verification relationship matches `scope`.
+  /// Returns a `Vec` of verification method references whose verification relationship matches `scope`.
   ///
   /// If `scope` is `None`, an iterator over all **embedded** methods is returned.
   pub fn methods(&self, scope: Option<MethodScope>) -> Vec<&VerificationMethod<D, U>>

--- a/identity_iota_client_legacy/src/tangle/resolver.rs
+++ b/identity_iota_client_legacy/src/tangle/resolver.rs
@@ -410,7 +410,7 @@ mod tests {
       issuer_core_doc
         .signer(issuer_core_key.private())
         .options(ProofOptions::default())
-        .method(issuer_core_doc.methods().next().unwrap().id())
+        .method(issuer_core_doc.methods(None).get(0).unwrap().id())
         .sign(credential_core)
         .unwrap();
       setup
@@ -436,7 +436,7 @@ mod tests {
     subject_doc
       .signer(subject_key.private())
       .options(ProofOptions::new().challenge(challenge.clone()))
-      .method(subject_doc.methods().next().unwrap().id())
+      .method(subject_doc.methods(None).get(0).unwrap().id())
       .sign(&mut presentation)
       .unwrap();
 
@@ -479,7 +479,7 @@ mod tests {
     subject_doc
       .signer(subject_key.private())
       .options(ProofOptions::new().challenge(challenge.clone()))
-      .method(subject_doc.methods().next().unwrap().id())
+      .method(subject_doc.methods(None).get(0).unwrap().id())
       .sign(&mut presentation)
       .unwrap();
 

--- a/identity_iota_core/src/document/iota_document.rs
+++ b/identity_iota_core/src/document/iota_document.rs
@@ -161,7 +161,7 @@ impl IotaDocument {
   // Verification Methods
   // ===========================================================================
 
-  /// Returns a `Vec` of verification methods references whose verification relationship matches `scope`.
+  /// Returns a `Vec` of verification method references whose verification relationship matches `scope`.
   ///
   /// If `scope` is `None`, an iterator over all **embedded** methods is returned.
   pub fn methods(&self, scope: Option<MethodScope>) -> Vec<&IotaVerificationMethod> {

--- a/identity_iota_core/src/document/iota_document.rs
+++ b/identity_iota_core/src/document/iota_document.rs
@@ -4,6 +4,7 @@
 use core::fmt;
 use core::fmt::Debug;
 use core::fmt::Display;
+use std::slice::Iter;
 
 use identity_core::common::Object;
 use identity_core::common::OneOrSet;
@@ -14,12 +15,15 @@ use identity_core::crypto::GetSignature;
 use identity_core::crypto::PrivateKey;
 use identity_core::crypto::ProofOptions;
 use identity_core::crypto::SetSignature;
+use identity_did::did::DID;
 use identity_did::document::CoreDocument;
 use identity_did::document::Document;
 use identity_did::service::Service;
 use identity_did::utils::DIDUrlQuery;
+use identity_did::utils::Queryable;
 use identity_did::verifiable::DocumentSigner;
 use identity_did::verifiable::VerifierOptions;
+use identity_did::verification::MethodRef;
 use identity_did::verification::MethodRelationship;
 use identity_did::verification::MethodScope;
 use identity_did::verification::MethodUriType;
@@ -162,8 +166,8 @@ impl IotaDocument {
   // ===========================================================================
 
   /// Returns an iterator over all [`IotaVerificationMethod`] in the DID Document.
-  pub fn methods(&self) -> impl Iterator<Item = &IotaVerificationMethod> {
-    self.document.methods()
+  pub fn methods(&self, scope: Option<MethodScope>) -> Vec<&IotaVerificationMethod> {
+    self.document.methods(scope)
   }
 
   /// Adds a new [`IotaVerificationMethod`] to the document in the given [`MethodScope`].
@@ -506,14 +510,14 @@ mod tests {
     assert_eq!(doc1.id().network_str(), network.as_ref());
     assert_eq!(doc1.id().tag(), placeholder.tag());
     assert_eq!(doc1.id(), &placeholder);
-    assert_eq!(doc1.methods().count(), 0);
+    assert_eq!(doc1.methods(None).len(), 0);
     assert!(doc1.service().is_empty());
 
     // VALID new_with_id().
     let did: IotaDID = valid_did();
     let doc2: IotaDocument = IotaDocument::new_with_id(did.clone());
     assert_eq!(doc2.id(), &did);
-    assert_eq!(doc2.methods().count(), 0);
+    assert_eq!(doc2.methods(None).len(), 0);
     assert!(doc2.service().is_empty());
   }
 
@@ -528,7 +532,7 @@ mod tests {
       generate_method(&controller, "#auth-key"),
     ];
 
-    let mut methods = document.methods();
+    let mut methods = document.methods(None).into_iter();
     assert_eq!(methods.next(), Some(&expected[0]));
     assert_eq!(methods.next(), Some(&expected[1]));
     assert_eq!(methods.next(), Some(&expected[2]));

--- a/identity_iota_core/src/document/iota_document.rs
+++ b/identity_iota_core/src/document/iota_document.rs
@@ -4,7 +4,6 @@
 use core::fmt;
 use core::fmt::Debug;
 use core::fmt::Display;
-use std::slice::Iter;
 
 use identity_core::common::Object;
 use identity_core::common::OneOrSet;
@@ -15,15 +14,12 @@ use identity_core::crypto::GetSignature;
 use identity_core::crypto::PrivateKey;
 use identity_core::crypto::ProofOptions;
 use identity_core::crypto::SetSignature;
-use identity_did::did::DID;
 use identity_did::document::CoreDocument;
 use identity_did::document::Document;
 use identity_did::service::Service;
 use identity_did::utils::DIDUrlQuery;
-use identity_did::utils::Queryable;
 use identity_did::verifiable::DocumentSigner;
 use identity_did::verifiable::VerifierOptions;
-use identity_did::verification::MethodRef;
 use identity_did::verification::MethodRelationship;
 use identity_did::verification::MethodScope;
 use identity_did::verification::MethodUriType;

--- a/identity_iota_core/src/document/iota_document.rs
+++ b/identity_iota_core/src/document/iota_document.rs
@@ -161,7 +161,9 @@ impl IotaDocument {
   // Verification Methods
   // ===========================================================================
 
-  /// Returns an iterator over all [`IotaVerificationMethod`] in the DID Document.
+  /// Returns a `Vec` of verification methods references whose verification relationship matches `scope`.
+  ///
+  /// If `scope` is `None`, an iterator over all **embedded** methods is returned.
   pub fn methods(&self, scope: Option<MethodScope>) -> Vec<&IotaVerificationMethod> {
     self.document.methods(scope)
   }

--- a/identity_iota_core_legacy/src/document/iota_document.rs
+++ b/identity_iota_core_legacy/src/document/iota_document.rs
@@ -273,8 +273,8 @@ impl IotaDocument {
   // ===========================================================================
 
   /// Returns an iterator over all [`IotaVerificationMethods`][IotaVerificationMethod] in the DID Document.
-  pub fn methods(&self) -> impl Iterator<Item = &IotaVerificationMethod> {
-    self.document.methods()
+  pub fn methods(&self) -> Vec<&IotaVerificationMethod> {
+    self.document.methods(None)
   }
 
   /// Adds a new [`IotaVerificationMethod`] to the document in the given [`MethodScope`].
@@ -950,7 +950,7 @@ mod tests {
       .build()
       .unwrap();
 
-    let mut methods = document.methods();
+    let mut methods = document.methods().into_iter();
 
     assert_eq!(methods.next(), Some(expected).as_ref());
     assert_eq!(methods.next(), None);
@@ -967,7 +967,7 @@ mod tests {
       valid_verification_method(&controller, "#auth-key"),
     ];
 
-    let mut methods = document.methods();
+    let mut methods = document.methods().into_iter();
     assert_eq!(methods.next(), Some(&expected[0]));
     assert_eq!(methods.next(), Some(&expected[1]));
     assert_eq!(methods.next(), Some(&expected[2]));
@@ -1640,7 +1640,7 @@ mod tests {
     }
 
     // `methods` returns all embedded verification methods, so only one is expected.
-    assert_eq!(document.methods().count(), 1);
+    assert_eq!(document.methods().len(), 1);
   }
 
   #[test]


### PR DESCRIPTION
# Description of change
Add an optional scope parameter to the method getter on DID Document implementations to allow iterating over particular verification relationship fields.

## Links to any relevant issues
`fixes issue #989`

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix