### PR TITLE
Pin agent dev-dependencies to crates versions

### DIFF
--- a/identity_agent/Cargo.toml
+++ b/identity_agent/Cargo.toml
@@ -25,8 +25,8 @@ uuid = { version = "0.8", default-features = false, features = ["v4", "serde"] }
 
 [dev-dependencies]
 criterion = { version = "0.3", default-features = false, features = ["stable"] }
-identity_account = { version = "=0.6.0", path = "../identity_account", default-features = false, features = ["send-sync-storage"] }
-identity_iota_core_legacy = { version = "=0.6.0", path = "../identity_iota_core_legacy", default-features = false }
+identity_account = { version = "=0.6.1", default-features = false, features = ["send-sync-storage", "encryption", "async", "revocation-bitmap"] }
+identity_iota_core = { version = "=0.6.1", default-features = false }
 pretty_env_logger = { version = "0.4", default-features = false }
 
 [[bench]]

--- a/identity_agent/benches/agent.rs
+++ b/identity_agent/benches/agent.rs
@@ -76,8 +76,8 @@ mod remote_account {
   use identity_agent::agent::Handler;
   use identity_agent::agent::HandlerRequest;
   use identity_agent::agent::RequestContext;
-  use identity_iota_core_legacy::did::IotaDID;
-  use identity_iota_core_legacy::document::IotaDocument;
+  use identity_iota_core::did::IotaDID;
+  use identity_iota_core::document::IotaDocument;
   use serde::Deserialize;
   use serde::Serialize;
   use std::sync::Arc;

--- a/identity_agent/src/tests/handler.rs
+++ b/identity_agent/src/tests/handler.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::task::Poll;
 
 use futures::pin_mut;
-use identity_iota_core_legacy::did::IotaDID;
+use identity_iota_core::did::IotaDID;
 use libp2p::request_response::OutboundFailure;
 use libp2p::Multiaddr;
 

--- a/identity_agent/src/tests/remote_account/handler.rs
+++ b/identity_agent/src/tests/remote_account/handler.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use dashmap::DashMap;
 use identity_account::account::Account;
 use identity_account::account::AccountBuilder;
-use identity_iota_core_legacy::did::IotaDID;
-use identity_iota_core_legacy::document::IotaDocument;
+use identity_iota_core::did::IotaDID;
+use identity_iota_core::document::IotaDocument;
 use tokio::sync::Mutex;
 
 use crate::agent::Handler;

--- a/identity_agent/src/tests/remote_account/requests.rs
+++ b/identity_agent/src/tests/remote_account/requests.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use identity_account::types::IdentitySetup;
-use identity_iota_core_legacy::did::IotaDID;
-use identity_iota_core_legacy::document::IotaDocument;
+use identity_iota_core::did::IotaDID;
+use identity_iota_core::document::IotaDocument;
 use serde::Deserialize;
 use serde::Serialize;
 

--- a/identity_agent/src/tests/remote_account/tests.rs
+++ b/identity_agent/src/tests/remote_account/tests.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use identity_iota_core_legacy::document::IotaDocument;
+use identity_iota_core::document::IotaDocument;
 
 use crate::agent::Result as AgentResult;
 use crate::tests::default_listening_agent;


### PR DESCRIPTION
# Description of change

Pin the `identity_account` and `identity_iota_core_legacy` dev-dependencies of the agent to the crates versions rather than paths.

This is in attempt to fix publishing of the agent crate with cargo-release, which apparently verifies that the dev-dependencies are on crates.io.

```
[2022-09-16T16:41:48Z INFO  cargo_release::release] Publishing identity_agent
    Updating crates.io index
   Packaging identity_agent v0.7.0-alpha.1 (/home/runner/work/identity.rs/identity.rs/identity_agent)
   Verifying identity_agent v0.7.0-alpha.1 (/home/runner/work/identity.rs/identity.rs/identity_agent)
error: failed to verify package tarball
Error: failed to verify package tarball
Caused by:
  no matching package named `identity_iota_core_legacy` found
  location searched: registry `crates-io`
  required by package `identity_agent v0.7.0-alpha.1 (/home/runner/work/identity.rs/identity.rs/target/package/identity_agent-0.7.0-alpha.1)`
Error: Process completed with exit code 103.
```

Additional features for the account were required because it would not compile otherwise. Somehow the path dependencies had features implicitly activated that the crates versions did not have.

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

`cargo test -p identity_agent`

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
