### PR TITLE
Remove `identity_agent` reexport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 resolver = "2"
 members = [
   # "identity_comm",
-  "identity_agent",
   "identity_core",
   "identity_credential",
   "identity_did",
@@ -16,6 +15,7 @@ members = [
 exclude = [
   "identity_account",
   "identity_account_storage",
+  "identity_agent",
   "examples_legacy",
   "identity_iota_core_legacy",
   "bindings/stronghold-nodejs",

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -12,7 +12,6 @@ rust-version = "1.62"
 description = "Framework for Self-Sovereign Identity with IOTA DID."
 
 [dependencies]
-identity_agent = { version = "=0.7.0-alpha.1", path = "../identity_agent", default-features = false, optional = true }
 identity_core = { version = "=0.7.0-alpha.1", path = "../identity_core", default-features = false }
 identity_credential = { version = "=0.7.0-alpha.1", path = "../identity_credential", features = ["validator"], default-features = false }
 identity_did = { version = "=0.7.0-alpha.1", path = "../identity_did", default-features = false }
@@ -42,10 +41,6 @@ revocation-bitmap = [
 
 # Enables support for the `Resolver`.
 resolver = ["dep:identity_resolver"]
-
-# Enables support for the unstable identity agent.
-# Breaking changes to types and functions behind this flag are not covered by semver.
-unstable-agent = ["dep:identity_agent"]
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/identity_iota/src/lib.rs
+++ b/identity_iota/src/lib.rs
@@ -118,14 +118,3 @@ pub mod resolver {
 
   pub use identity_resolver::*;
 }
-
-#[cfg(feature = "unstable-agent")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable-agent")))]
-pub mod agent {
-  //! Identity agent types
-
-  pub use identity_agent::agent::*;
-  pub use identity_agent::didcomm::*;
-  pub use identity_agent::IdentityKeypair;
-  pub use identity_agent::Multiaddr;
-}


### PR DESCRIPTION
# Description of change

Remove the reexport of the agent from `identity_iota` due to causing issues during publishing. The issues are caused by the agent's dev-dependency on `identity_account` and `identity_iota_core_legacy`, the latter of which does not exist on crates.io, which appears to be a requirement for publishing.

We'll address theses issues and include the agent in `identity_iota` again, eventually.

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

`cargo check`

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
