### PR TITLE
Bump versions of legacy crates

### DIFF
--- a/.github/actions/release/bump-versions/action.yml
+++ b/.github/actions/release/bump-versions/action.yml
@@ -53,6 +53,32 @@ runs:
       run: |
         cargo set-version ${{ inputs.version }}
 
+    # cargo workspaces ignores the legacy crates because they are excluded from the workspace.
+    # Bump versions for consistency.
+    - name: Bump Rust legacy crates' version
+      shell: bash
+      if: ${{inputs.release-target == 'rust'}}
+      run: |
+        cargo set-version --manifest-path identity_account_storage/Cargo.toml ${{ inputs.version }}
+        cargo set-version --manifest-path identity_iota_client_legacy/Cargo.toml ${{ inputs.version }}
+        cargo set-version --manifest-path identity_iota_core_legacy/Cargo.toml ${{ inputs.version }}
+        cargo set-version --manifest-path identity_account/Cargo.toml ${{ inputs.version }}
+        cargo add --manifest-path identity_account_storage/Cargo.toml --path identity_core
+        cargo add --manifest-path identity_account_storage/Cargo.toml --path identity_did
+        cargo add --manifest-path identity_account_storage/Cargo.toml --path identity_iota_core_legacy
+        cargo add --manifest-path identity_account/Cargo.toml --path identity_account_storage
+        cargo add --manifest-path identity_account/Cargo.toml --path identity_core
+        cargo add --manifest-path identity_account/Cargo.toml --path identity_credential
+        cargo add --manifest-path identity_account/Cargo.toml --path identity_did
+        cargo add --manifest-path identity_account/Cargo.toml --path identity_iota_client_legacy
+        cargo add --manifest-path identity_account/Cargo.toml --path identity_iota_core_legacy
+        cargo add --manifest-path identity_iota_core_legacy/Cargo.toml --path identity_core
+        cargo add --manifest-path identity_iota_core_legacy/Cargo.toml --path identity_did
+        cargo add --manifest-path identity_iota_client_legacy/Cargo.toml --path identity_core
+        cargo add --manifest-path identity_iota_client_legacy/Cargo.toml --path identity_credential
+        cargo add --manifest-path identity_iota_client_legacy/Cargo.toml --path identity_did
+        cargo add --manifest-path identity_iota_client_legacy/Cargo.toml --path identity_iota_core_legacy
+
     # cargo workspaces ignores identity_agent because it is excluded from the workspace.
     # Bump versions for consistency.
     - name: Bump Rust agent version

--- a/bindings/stronghold-nodejs/Cargo.lock
+++ b/bindings/stronghold-nodejs/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "identity_account_storage"
-version = "0.6.0"
+version = "0.7.0-alpha.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "identity_iota_core_legacy"
-version = "0.6.0"
+version = "0.7.0-alpha.1"
 dependencies = [
  "bee-message",
  "identity_core",

--- a/bindings/stronghold-nodejs/Cargo.toml
+++ b/bindings/stronghold-nodejs/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-identity_account_storage = { version = "0.6.0", path = "../../identity_account_storage", default-features = false, features = ["stronghold", "send-sync-storage", "encryption"] }
+identity_account_storage = { version = "0.7.0-alpha.1", path = "../../identity_account_storage", default-features = false, features = ["stronghold", "send-sync-storage", "encryption"] }
 identity_core = { version = "0.7.0-alpha.1", path = "../../identity_core", default-features = false }
 identity_did = { version = "0.7.0-alpha.1", path = "../../identity_did", default-features = false }
-identity_iota_core_legacy = { version = "0.6.0", path = "../../identity_iota_core_legacy", default-features = false }
+identity_iota_core_legacy = { version = "0.7.0-alpha.1", path = "../../identity_iota_core_legacy", default-features = false }
 napi = { version = "2.4.3", default-features = false, features = ["napi4", "tokio_rt", "serde-json"] }
 napi-derive = { version = "2.4.1", default-features = false, features = ["compat-mode", "full"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/identity_account/Cargo.toml
+++ b/identity_account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity_account"
-version = "0.6.0"
+version = "0.7.0-alpha.1"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 homepage = "https://www.iota.org"
@@ -14,12 +14,12 @@ description = "High-level interface for managing IOTA DID Documents."
 [workspace]
 
 [dependencies]
-identity_account_storage = { version = "=0.6.0", path = "../identity_account_storage", default-features = false }
-identity_core = { version = "=0.6.0", path = "../identity_core", default-features = false }
-identity_credential = { version = "=0.6.0", path = "../identity_credential", default-features = false }
-identity_did = { version = "=0.6.0", path = "../identity_did", default-features = false }
-identity_iota_client_legacy = { version = "=0.6.0", path = "../identity_iota_client_legacy", default-features = false }
-identity_iota_core_legacy = { version = "=0.6.0", path = "../identity_iota_core_legacy", default-features = false }
+identity_account_storage = { version = "0.7.0-alpha.1", path = "../identity_account_storage", default-features = false }
+identity_core = { version = "0.7.0-alpha.1", path = "../identity_core", default-features = false }
+identity_credential = { version = "0.7.0-alpha.1", path = "../identity_credential", default-features = false }
+identity_did = { version = "0.7.0-alpha.1", path = "../identity_did", default-features = false }
+identity_iota_client_legacy = { version = "0.7.0-alpha.1", path = "../identity_iota_client_legacy", default-features = false }
+identity_iota_core_legacy = { version = "0.7.0-alpha.1", path = "../identity_iota_core_legacy", default-features = false }
 log = { version = "0.4", default-features = false }
 paste = { version = "1.0" }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }

--- a/identity_account_storage/Cargo.toml
+++ b/identity_account_storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity_account_storage"
-version = "0.6.0"
+version = "0.7.0-alpha.1"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 homepage = "https://www.iota.org"
@@ -21,7 +21,7 @@ futures = { version = "0.3", optional = true }
 hashbrown = { version = "0.11", features = ["serde"] }
 identity_core = { version = "0.7.0-alpha.1", path = "../identity_core", default-features = false }
 identity_did = { version = "0.7.0-alpha.1", path = "../identity_did", default-features = false }
-identity_iota_core_legacy = { version = "=0.6.0", path = "../identity_iota_core_legacy", default-features = false }
+identity_iota_core_legacy = { version = "0.7.0-alpha.1", path = "../identity_iota_core_legacy", default-features = false }
 iota-crypto = { version = "0.12.1", default-features = false, features = ["hmac", "pbkdf", "sha", "std", "aes-gcm", "aes-kw"] }
 iota_stronghold = { version = "0.6.4", default-features = false, features = ["std"], optional = true }
 once_cell = { version = "1.7", default-features = false, features = ["std"], optional = true }

--- a/identity_iota_client_legacy/Cargo.toml
+++ b/identity_iota_client_legacy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity_iota_client_legacy"
-version = "0.6.0"
+version = "0.7.0-alpha.1"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 homepage = "https://www.iota.org"
@@ -19,10 +19,10 @@ bee-rest-api = { version = "0.1.7", default-features = false }
 brotli = { version = "3.3", default-features = false, features = ["std"] }
 form_urlencoded = { version = "1.0" }
 futures = { version = "0.3" }
-identity_core = { version = "=0.6.0", path = "../identity_core", default-features = false }
-identity_credential = { version = "=0.6.0", path = "../identity_credential", default-features = false, features = ["validator"] }
-identity_did = { version = "=0.6.0", path = "../identity_did", default-features = false }
-identity_iota_core_legacy = { version = "=0.6.0", path = "../identity_iota_core_legacy", default-features = false }
+identity_core = { version = "0.7.0-alpha.1", path = "../identity_core", default-features = false }
+identity_credential = { version = "0.7.0-alpha.1", path = "../identity_credential", default-features = false, features = ["validator"] }
+identity_did = { version = "0.7.0-alpha.1", path = "../identity_did", default-features = false }
+identity_iota_core_legacy = { version = "0.7.0-alpha.1", path = "../identity_iota_core_legacy", default-features = false }
 itertools = { version = "0.10" }
 lazy_static = { version = "1.4", default-features = false }
 log = { version = "0.4", default-features = false }

--- a/identity_iota_core_legacy/Cargo.toml
+++ b/identity_iota_core_legacy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity_iota_core_legacy"
-version = "0.6.0"
+version = "0.7.0-alpha.1"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 homepage = "https://www.iota.org"
@@ -15,8 +15,8 @@ description = "Core data structures for the IOTA DID Method."
 
 [dependencies]
 bee-message = { version = "0.1.6", default-features = false, features = ["serde"] }
-identity_core = { version = "=0.7.0-alpha.1", path = "../identity_core", default-features = false }
-identity_did = { version = "=0.7.0-alpha.1", path = "../identity_did", default-features = false }
+identity_core = { version = "0.7.0-alpha.1", path = "../identity_core", default-features = false }
+identity_did = { version = "0.7.0-alpha.1", path = "../identity_did", default-features = false }
 lazy_static = { version = "1.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
 strum = { version = "0.24.0", default-features = false, features = ["std", "derive"] }


### PR DESCRIPTION
# Description of change

- Bump versions of legacy crates for consistency.
- Bump them in the next release as part of the workflow.
- Note that stronghold-nodejs crate versions were updated but not explicitly added to `action.yml`, because they are already bumped as part of that script, it just bumped to the same version in the last release because those crates weren't bumped earlier. Since they are bumped before that step now, that should work out on the next run.

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

`cargo check`

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
