### PR TITLE
Update RevocationBitmap spec

### DIFF
--- a/documentation/docs/specs/revocation_bitmap_2022.md
+++ b/documentation/docs/specs/revocation_bitmap_2022.md
@@ -33,7 +33,7 @@ For an issuer to enable verifiers to check the status of a verifiable credential
 
 | Property | Description |
 | :--- | :--- |
-| `id` | The constraints on the `id` property are listed in the [Verifiable Credentials Data Model specification](https://www.w3.org/TR/vc-data-model/). The `id` MUST be a [DID URL](https://www.w3.org/TR/did-core/#did-url-syntax) that is the URL to a [Revocation Bitmap Service](#revocation-bitmap-service) in the DID Document of the issuer, with an `index` query set to the same value as `revocationBitmapIndex`. |
+| `id` | The constraints on the `id` property are listed in the [Verifiable Credentials Data Model specification](https://www.w3.org/TR/vc-data-model/). The `id` MUST be a [DID URL](https://www.w3.org/TR/did-core/#did-url-syntax) that is the URL to a [Revocation Bitmap Service](#revocation-bitmap-service) in the DID Document of the issuer. It SHOULD include an `index` query set to the same value as `revocationBitmapIndex`, to uniquely identify the `credentialStatus`. If the `index` query is present, implementations SHOULD reject statuses where the `index` query's value does not match `revocationBitmapIndex`. |
 | `type` | The `type` property MUST be `"RevocationBitmap2022"`. |
 | `revocationBitmapIndex` | The `revocationBitmapIndex` property MUST be an unsigned, 32-bit integer expressed as a string. This is the index of the credential in the issuer's revocation bitmap. Each index SHOULD be unique among all credentials linking to the same [Revocation Bitmap Service](#revocation-bitmap-service). |
 

--- a/documentation/docs/specs/revocation_bitmap_2022.md
+++ b/documentation/docs/specs/revocation_bitmap_2022.md
@@ -15,7 +15,7 @@ keywords:
 
 ## Abstract
 
-This specification describes an on-Tangle mechanism for publishing the revocation status of [Verifiable Credentials](../concepts/verifiable_credentials/overview) embedded in an issuer's DID document.
+This specification describes an on-ledger mechanism for publishing the revocation status of [Verifiable Credentials](../concepts/verifiable_credentials/overview) embedded in an issuer's DID document.
 
 ## Introduction
 
@@ -33,7 +33,7 @@ For an issuer to enable verifiers to check the status of a verifiable credential
 
 | Property | Description |
 | :--- | :--- |
-| `id` | The constraints on the `id` property are listed in the [Verifiable Credentials Data Model specification](https://www.w3.org/TR/vc-data-model/). The `id` MUST be a [DID URL](https://www.w3.org/TR/did-core/#did-url-syntax) that resolves to a [Revocation Bitmap Service](#revocation-bitmap-service) in the DID Document of the issuer. |
+| `id` | The constraints on the `id` property are listed in the [Verifiable Credentials Data Model specification](https://www.w3.org/TR/vc-data-model/). The `id` MUST be a [DID URL](https://www.w3.org/TR/did-core/#did-url-syntax) that is the URL to a [Revocation Bitmap Service](#revocation-bitmap-service) in the DID Document of the issuer, with an `index` query set to the same value as `revocationBitmapIndex`. |
 | `type` | The `type` property MUST be `"RevocationBitmap2022"`. |
 | `revocationBitmapIndex` | The `revocationBitmapIndex` property MUST be an unsigned, 32-bit integer expressed as a string. This is the index of the credential in the issuer's revocation bitmap. Each index SHOULD be unique among all credentials linking to the same [Revocation Bitmap Service](#revocation-bitmap-service). |
 
@@ -55,7 +55,7 @@ An example of a verifiable credential with a `credentialStatus` of type `Revocat
   "issuer": "did:iota:EvaQhPXXsJsGgxSXGhZGMCvTt63KuAFtaGThx6a5nSpw",
   "issuanceDate": "2022-06-13T08:04:36Z",
   "credentialStatus": {
-    "id": "did:iota:EvaQhPXXsJsGgxSXGhZGMCvTt63KuAFtaGThx6a5nSpw#revocation",
+    "id": "did:iota:EvaQhPXXsJsGgxSXGhZGMCvTt63KuAFtaGThx6a5nSpw?index=5#revocation",
     "type": "RevocationBitmap2022",
     "revocationBitmapIndex": "5"
   },

--- a/identity_credential/src/credential/revocation_bitmap_status.rs
+++ b/identity_credential/src/credential/revocation_bitmap_status.rs
@@ -201,7 +201,7 @@ mod tests {
 
   #[test]
   fn test_revocation_bitmap_status_index_requirements() {
-    // index mismatch in id and property.
+    // INVALID: index mismatch in id and property.
     let status: Status = Status::from_json_value(serde_json::json!({
       "id": "did:method:0xffff?index=10#rev-0",
       "type": RevocationBitmapStatus::TYPE,
@@ -214,25 +214,22 @@ mod tests {
       Error::InvalidStatus(_)
     ));
 
-    // index matches in id and property.
+    // VALID: index matches in id and property.
     let status: Status = Status::from_json_value(serde_json::json!({
       "id": "did:method:0xffff?index=5#rev-0",
       "type": RevocationBitmapStatus::TYPE,
       RevocationBitmapStatus::REVOCATION_BITMAP_INDEX_PROPERTY: "5",
     }))
     .unwrap();
-
-    // matching index is fine.
     assert!(RevocationBitmapStatus::try_from(status).is_ok());
 
+    // VALID: missing index in id is allowed to be backwards-compatible.
     let status: Status = Status::from_json_value(serde_json::json!({
       "id": "did:method:0xffff#rev-0",
       "type": RevocationBitmapStatus::TYPE,
       RevocationBitmapStatus::REVOCATION_BITMAP_INDEX_PROPERTY: "5",
     }))
     .unwrap();
-
-    // missing index in id is allowed to be backwards-compatible.
     assert!(RevocationBitmapStatus::try_from(status).is_ok());
   }
 }

--- a/identity_credential/src/credential/revocation_bitmap_status.rs
+++ b/identity_credential/src/credential/revocation_bitmap_status.rs
@@ -19,14 +19,37 @@ use crate::error::Result;
 pub struct RevocationBitmapStatus(Status);
 
 impl RevocationBitmapStatus {
-  const INDEX_PROPERTY_NAME: &'static str = "revocationBitmapIndex";
+  const REVOCATION_BITMAP_INDEX_PROPERTY: &'static str = "revocationBitmapIndex";
   /// Type name of the revocation bitmap.
   pub const TYPE: &'static str = "RevocationBitmap2022";
 
   /// Creates a new `RevocationBitmapStatus`.
-  pub fn new<D: DID>(id: DIDUrl<D>, index: u32) -> Self {
+  ///
+  /// The query of the `id` url is overwritten where "index" is set to `index`.
+  ///
+  /// # Example
+  ///
+  /// ```
+  /// # use identity_credential::credential::RevocationBitmapStatus;
+  /// # use identity_did::did::DIDUrl;
+  /// # use identity_did::did::CoreDID;
+  /// let did_url: DIDUrl<CoreDID> = DIDUrl::parse("did:method:0xffff#revocation-1").unwrap();
+  /// let status: RevocationBitmapStatus = RevocationBitmapStatus::new(did_url, 5);
+  /// assert_eq!(
+  ///   status.id::<CoreDID>().unwrap().to_string(),
+  ///   "did:method:0xffff?index=5#revocation-1"
+  /// );
+  /// assert_eq!(status.index().unwrap(), 5);
+  /// ```
+  pub fn new<D: DID>(mut id: DIDUrl<D>, index: u32) -> Self {
+    id.set_query(Some(&format!("index={index}")))
+      .expect("the string should be non-empty and a valid URL query");
+
     let mut object = Object::new();
-    object.insert(Self::INDEX_PROPERTY_NAME.to_owned(), Value::String(index.to_string()));
+    object.insert(
+      Self::REVOCATION_BITMAP_INDEX_PROPERTY.to_owned(),
+      Value::String(index.to_string()),
+    );
     RevocationBitmapStatus(Status::new_with_properties(
       Url::from(id),
       Self::TYPE.to_owned(),
@@ -43,18 +66,18 @@ impl RevocationBitmapStatus {
 
   /// Returns the index of the credential in the issuer's revocation bitmap if it can be decoded.
   pub fn index(&self) -> Result<u32> {
-    if let Some(Value::String(index)) = self.0.properties.get(Self::INDEX_PROPERTY_NAME) {
+    if let Some(Value::String(index)) = self.0.properties.get(Self::REVOCATION_BITMAP_INDEX_PROPERTY) {
       u32::from_str(index).map_err(|err| {
         Error::InvalidStatus(format!(
           "expected {} to be an unsigned 32-bit integer: {}",
-          Self::INDEX_PROPERTY_NAME,
+          Self::REVOCATION_BITMAP_INDEX_PROPERTY,
           err
         ))
       })
     } else {
       Err(Error::InvalidStatus(format!(
         "expected {} to be an unsigned 32-bit integer expressed as a string",
-        Self::INDEX_PROPERTY_NAME
+        Self::REVOCATION_BITMAP_INDEX_PROPERTY
       )))
     }
   }
@@ -65,19 +88,57 @@ impl TryFrom<Status> for RevocationBitmapStatus {
 
   fn try_from(status: Status) -> Result<Self> {
     if status.type_ != Self::TYPE {
-      Err(Error::InvalidStatus(format!(
+      return Err(Error::InvalidStatus(format!(
         "expected type '{}', got '{}'",
         Self::TYPE,
         status.type_
-      )))
-    } else if !status.properties.contains_key(Self::INDEX_PROPERTY_NAME) {
-      Err(Error::InvalidStatus(format!(
-        "missing required property '{}'",
-        Self::INDEX_PROPERTY_NAME
-      )))
-    } else {
-      Ok(Self(status))
+      )));
     }
+
+    let revocation_bitmap_index: &Value =
+      if let Some(revocation_bitmap_index) = status.properties.get(Self::REVOCATION_BITMAP_INDEX_PROPERTY) {
+        revocation_bitmap_index
+      } else {
+        return Err(Error::InvalidStatus(format!(
+          "missing required property '{}'",
+          Self::REVOCATION_BITMAP_INDEX_PROPERTY
+        )));
+      };
+
+    let revocation_bitmap_index: u32 = if let Value::String(index) = revocation_bitmap_index {
+      index.parse::<u32>().map_err(|err| {
+        Error::InvalidStatus(format!(
+          "property '{}' cannot be converted to an unsigned, 32-bit integer: {err}",
+          Self::REVOCATION_BITMAP_INDEX_PROPERTY
+        ))
+      })?
+    } else {
+      return Err(Error::InvalidStatus(format!(
+        "property '{}' is not a string",
+        Self::REVOCATION_BITMAP_INDEX_PROPERTY
+      )));
+    };
+
+    // If the index query is present it must match the revocationBitmapIndex.
+    // It is allowed to not be present to maintain backwards-compatibility
+    // with an earlier version of the RevocationBitmap spec.
+    for pair in status.id.query_pairs() {
+      if pair.0 == "index" {
+        let index: u32 = pair.1.parse::<u32>().map_err(|err| {
+          Error::InvalidStatus(format!(
+            "value of index query cannot be converted to an unsigned, 32-bit integer: {err}"
+          ))
+        })?;
+
+        if index != revocation_bitmap_index {
+          return Err(Error::InvalidStatus(format!(
+            "value of index query `{index}` does not match revocationBitmapIndex `{revocation_bitmap_index}`"
+          )));
+        }
+      }
+    }
+
+    Ok(Self(status))
   }
 }
 
@@ -103,14 +164,14 @@ mod tests {
 
   #[test]
   fn test_embedded_status_invariants() {
-    let url: Url = Url::parse(format!("did:iota:{}#{}", TAG, SERVICE)).unwrap();
+    let url: Url = Url::parse(format!("did:iota:{}?index=0#{}", TAG, SERVICE)).unwrap();
     let did_url: DIDUrl<CoreDID> = DIDUrl::parse(url.clone().into_string()).unwrap();
     let revocation_list_index: u32 = 0;
     let embedded_revocation_status: RevocationBitmapStatus =
       RevocationBitmapStatus::new(did_url, revocation_list_index);
 
     let object: Object = Object::from([(
-      RevocationBitmapStatus::INDEX_PROPERTY_NAME.to_owned(),
+      RevocationBitmapStatus::REVOCATION_BITMAP_INDEX_PROPERTY.to_owned(),
       Value::String(revocation_list_index.to_string()),
     )]);
     let status: Status =

--- a/identity_credential/src/credential/revocation_bitmap_status.rs
+++ b/identity_credential/src/credential/revocation_bitmap_status.rs
@@ -162,12 +162,9 @@ mod tests {
   use super::RevocationBitmapStatus;
   use super::Status;
 
-  const TAG: &str = "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV";
-  const SERVICE: &str = "revocation";
-
   #[test]
   fn test_embedded_status_invariants() {
-    let url: Url = Url::parse(format!("did:iota:{}?index=0#{}", TAG, SERVICE)).unwrap();
+    let url: Url = Url::parse(format!("did:method:0xabcd?index=0#revocation")).unwrap();
     let did_url: DIDUrl<CoreDID> = DIDUrl::parse(url.clone().into_string()).unwrap();
     let revocation_list_index: u32 = 0;
     let embedded_revocation_status: RevocationBitmapStatus =
@@ -226,7 +223,7 @@ mod tests {
     .unwrap();
 
     // matching index is fine.
-    RevocationBitmapStatus::try_from(status).unwrap();
+    assert!(RevocationBitmapStatus::try_from(status).is_ok());
 
     let status: Status = Status::from_json_value(serde_json::json!({
       "id": "did:method:0xffff#rev-0",
@@ -236,6 +233,6 @@ mod tests {
     .unwrap();
 
     // missing index in id is allowed to be backwards-compatible.
-    RevocationBitmapStatus::try_from(status).unwrap();
+    assert!(RevocationBitmapStatus::try_from(status).is_ok());
   }
 }


### PR DESCRIPTION
# Description of change

Changes the spec and implementation of `RevocationBitmap2022` to recommend making the `id` of `credentialStatus` unique. This is recommended by the VC spec as mentioned in #911.

We decided to go with a backwards-compatible change that only RECOMMENDS setting the `index`, and omitting it is allowed spec-wise. The implementation will always set the index to match the recommendation.

## Links to any relevant issues

fixes #911

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Extended and modified existing tests to test the new behavior.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
