### PR TITLE
Remove legacy example tests from CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -110,14 +110,6 @@ jobs:
           command: test
           args: --workspace --all-features --release
 
-      - name: Run legacy examples
-        # run examples only on ubuntu for now
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          cargo metadata --format-version 1 --manifest-path ./examples_legacy/Cargo.toml | \
-          jq -r '.packages[] | select(.name == "examples_legacy") | .targets[].name' | \
-          parallel -k -j 4 --retries 3 ./target/release/examples/{}
-
       - name: Run Rust examples
         # run examples only on ubuntu for now
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
# Description of change
Remove the step to run `examples_legacy` from GitHub Actions, since they (along with the other legacy projects) are no longer built in CI and are intended to be removed.

## Type of change

- [x] Chore (a non-breaking change which fixes an issue)

## How the change has been tested
CI should pass now.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
