### PR TITLE
Use Bech32-encoded state controller and governor addresses

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -102,6 +102,8 @@ See <code>IVerifierOptions</code>.</p>
 ## Members
 
 <dl>
+<dt><a href="#KeyType">KeyType</a></dt>
+<dd></dd>
 <dt><a href="#MethodRelationship">MethodRelationship</a></dt>
 <dd></dd>
 <dt><a href="#StateMetadataEncoding">StateMetadataEncoding</a></dt>
@@ -148,8 +150,6 @@ This variant is the default used if no other variant is specified when construct
 <dt><a href="#FirstError">FirstError</a></dt>
 <dd><p>Return after the first error occurs.</p>
 </dd>
-<dt><a href="#KeyType">KeyType</a></dt>
-<dd></dd>
 </dl>
 
 ## Functions
@@ -513,7 +513,7 @@ A method-agnostic DID Document.
         * [.insertService(service)](#CoreDocument+insertService) ⇒ <code>boolean</code>
         * [.removeService(didUrl)](#CoreDocument+removeService) ⇒ <code>boolean</code>
         * [.resolveService(query)](#CoreDocument+resolveService) ⇒ [<code>CoreService</code>](#CoreService) \| <code>undefined</code>
-        * [.methods()](#CoreDocument+methods) ⇒ [<code>Array.&lt;CoreVerificationMethod&gt;</code>](#CoreVerificationMethod)
+        * [.methods(scope)](#CoreDocument+methods) ⇒ [<code>Array.&lt;CoreVerificationMethod&gt;</code>](#CoreVerificationMethod)
         * [.verificationRelationships()](#CoreDocument+verificationRelationships) ⇒ <code>Array.&lt;(CoreDIDUrl\|CoreVerificationMethod)&gt;</code>
         * [.insertMethod(method, scope)](#CoreDocument+insertMethod)
         * [.removeMethod(did)](#CoreDocument+removeMethod)
@@ -697,10 +697,18 @@ if present.
 
 <a name="CoreDocument+methods"></a>
 
-### coreDocument.methods() ⇒ [<code>Array.&lt;CoreVerificationMethod&gt;</code>](#CoreVerificationMethod)
-Returns a list of all [CoreVerificationMethod](#CoreVerificationMethod) in the DID Document.
+### coreDocument.methods(scope) ⇒ [<code>Array.&lt;CoreVerificationMethod&gt;</code>](#CoreVerificationMethod)
+Returns a list of all [CoreVerificationMethod](#CoreVerificationMethod) in the DID Document,
+whose verification relationship matches `scope`.
+
+If `scope` is not set, a list over the **embedded** methods is returned.
 
 **Kind**: instance method of [<code>CoreDocument</code>](#CoreDocument)  
+
+| Param | Type |
+| --- | --- |
+| scope | [<code>MethodScope</code>](#MethodScope) \| <code>undefined</code> | 
+
 <a name="CoreDocument+verificationRelationships"></a>
 
 ### coreDocument.verificationRelationships() ⇒ <code>Array.&lt;(CoreDIDUrl\|CoreVerificationMethod)&gt;</code>
@@ -1722,7 +1730,7 @@ Clones the `DID` into a `DIDUrl`.
 <a name="IotaDID+toAliasId"></a>
 
 ### did.toAliasId() ⇒ <code>string</code>
-Creates an AliasId from the DID tag.
+Returns the hex-encoded AliasId with a '0x' prefix, from the DID tag.
 
 **Kind**: instance method of [<code>IotaDID</code>](#IotaDID)  
 <a name="IotaDID+intoUrl"></a>
@@ -1961,7 +1969,7 @@ Deserializes an instance from a JSON object.
         * [.insertService(service)](#IotaDocument+insertService) ⇒ <code>boolean</code>
         * [.removeService(did)](#IotaDocument+removeService) ⇒ <code>boolean</code>
         * [.resolveService(query)](#IotaDocument+resolveService) ⇒ [<code>IotaService</code>](#IotaService) \| <code>undefined</code>
-        * [.methods()](#IotaDocument+methods) ⇒ [<code>Array.&lt;IotaVerificationMethod&gt;</code>](#IotaVerificationMethod)
+        * [.methods(scope)](#IotaDocument+methods) ⇒ [<code>Array.&lt;IotaVerificationMethod&gt;</code>](#IotaVerificationMethod)
         * [.insertMethod(method, scope)](#IotaDocument+insertMethod)
         * [.removeMethod(did)](#IotaDocument+removeMethod)
         * [.resolveMethod(query, scope)](#IotaDocument+resolveMethod) ⇒ [<code>IotaVerificationMethod</code>](#IotaVerificationMethod) \| <code>undefined</code>
@@ -1980,6 +1988,8 @@ Deserializes an instance from a JSON object.
         * [.setMetadataUpdated(timestamp)](#IotaDocument+setMetadataUpdated)
         * [.metadataDeactivated()](#IotaDocument+metadataDeactivated) ⇒ <code>boolean</code> \| <code>undefined</code>
         * [.setMetadataDeactivated(deactivated)](#IotaDocument+setMetadataDeactivated)
+        * [.metadataStateControllerAddress()](#IotaDocument+metadataStateControllerAddress) ⇒ <code>string</code> \| <code>undefined</code>
+        * [.metadataGovernorAddress()](#IotaDocument+metadataGovernorAddress) ⇒ <code>string</code> \| <code>undefined</code>
         * [.setMetadataPropertyUnchecked(key, value)](#IotaDocument+setMetadataPropertyUnchecked)
         * [.revokeCredentials(serviceQuery, indices)](#IotaDocument+revokeCredentials)
         * [.unrevokeCredentials(serviceQuery, indices)](#IotaDocument+unrevokeCredentials)
@@ -1987,7 +1997,7 @@ Deserializes an instance from a JSON object.
         * [.clone()](#IotaDocument+clone) ⇒ [<code>IotaDocument</code>](#IotaDocument)
     * _static_
         * [.newWithId(id)](#IotaDocument.newWithId) ⇒ [<code>IotaDocument</code>](#IotaDocument)
-        * [.unpack(did, stateMetadata, allowEmpty)](#IotaDocument.unpack) ⇒ [<code>IotaDocument</code>](#IotaDocument)
+        * [.unpackFromOutput(did, aliasDto, allowEmpty)](#IotaDocument.unpackFromOutput) ⇒ [<code>IotaDocument</code>](#IotaDocument)
         * [.unpackFromBlock(network, block)](#IotaDocument.unpackFromBlock) ⇒ [<code>Array.&lt;IotaDocument&gt;</code>](#IotaDocument)
         * [.fromJSON(json)](#IotaDocument.fromJSON) ⇒ [<code>IotaDocument</code>](#IotaDocument)
 
@@ -2102,10 +2112,18 @@ if present.
 
 <a name="IotaDocument+methods"></a>
 
-### iotaDocument.methods() ⇒ [<code>Array.&lt;IotaVerificationMethod&gt;</code>](#IotaVerificationMethod)
-Returns a list of all [IotaVerificationMethod](#IotaVerificationMethod) in the DID Document.
+### iotaDocument.methods(scope) ⇒ [<code>Array.&lt;IotaVerificationMethod&gt;</code>](#IotaVerificationMethod)
+Returns a list of all [IotaVerificationMethod](#IotaVerificationMethod) in the DID Document,
+whose verification relationship matches `scope`.
+
+If `scope` is not set, a list over the **embedded** methods is returned.
 
 **Kind**: instance method of [<code>IotaDocument</code>](#IotaDocument)  
+
+| Param | Type |
+| --- | --- |
+| scope | [<code>MethodScope</code>](#MethodScope) \| <code>undefined</code> | 
+
 <a name="IotaDocument+insertMethod"></a>
 
 ### iotaDocument.insertMethod(method, scope)
@@ -2307,6 +2325,18 @@ Sets the deactivated status of the DID document.
 | --- | --- |
 | deactivated | <code>boolean</code> \| <code>undefined</code> | 
 
+<a name="IotaDocument+metadataStateControllerAddress"></a>
+
+### iotaDocument.metadataStateControllerAddress() ⇒ <code>string</code> \| <code>undefined</code>
+Returns a copy of the Bech32-encoded state controller address, if present.
+
+**Kind**: instance method of [<code>IotaDocument</code>](#IotaDocument)  
+<a name="IotaDocument+metadataGovernorAddress"></a>
+
+### iotaDocument.metadataGovernorAddress() ⇒ <code>string</code> \| <code>undefined</code>
+Returns a copy of the Bech32-encoded governor address, if present.
+
+**Kind**: instance method of [<code>IotaDocument</code>](#IotaDocument)  
 <a name="IotaDocument+setMetadataPropertyUnchecked"></a>
 
 ### iotaDocument.setMetadataPropertyUnchecked(key, value)
@@ -2369,9 +2399,9 @@ Constructs an empty DID Document with the given identifier.
 | --- | --- |
 | id | [<code>IotaDID</code>](#IotaDID) | 
 
-<a name="IotaDocument.unpack"></a>
+<a name="IotaDocument.unpackFromOutput"></a>
 
-### IotaDocument.unpack(did, stateMetadata, allowEmpty) ⇒ [<code>IotaDocument</code>](#IotaDocument)
+### IotaDocument.unpackFromOutput(did, aliasDto, allowEmpty) ⇒ [<code>IotaDocument</code>](#IotaDocument)
 Deserializes the document from the state metadata bytes of an Alias Output.
 
 If `allowEmpty` is true, this will return an empty DID document marked as `deactivated`
@@ -2386,7 +2416,7 @@ encoded in the `AliasId` alone.
 | Param | Type |
 | --- | --- |
 | did | [<code>IotaDID</code>](#IotaDID) | 
-| stateMetadata | <code>Uint8Array</code> | 
+| aliasDto | <code>any</code> | 
 | allowEmpty | <code>boolean</code> | 
 
 <a name="IotaDocument.unpackFromBlock"></a>
@@ -2427,6 +2457,8 @@ Additional attributes related to an IOTA DID Document.
         * [.created()](#IotaDocumentMetadata+created) ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
         * [.updated()](#IotaDocumentMetadata+updated) ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
         * [.deactivated()](#IotaDocumentMetadata+deactivated) ⇒ <code>boolean</code> \| <code>undefined</code>
+        * [.stateControllerAddress()](#IotaDocumentMetadata+stateControllerAddress) ⇒ <code>string</code> \| <code>undefined</code>
+        * [.governorAddress()](#IotaDocumentMetadata+governorAddress) ⇒ <code>string</code> \| <code>undefined</code>
         * [.properties()](#IotaDocumentMetadata+properties) ⇒ <code>Map.&lt;string, any&gt;</code>
         * [.toJSON()](#IotaDocumentMetadata+toJSON) ⇒ <code>any</code>
         * [.clone()](#IotaDocumentMetadata+clone) ⇒ [<code>IotaDocumentMetadata</code>](#IotaDocumentMetadata)
@@ -2449,6 +2481,18 @@ Returns a copy of the timestamp of the last DID document update.
 
 ### iotaDocumentMetadata.deactivated() ⇒ <code>boolean</code> \| <code>undefined</code>
 Returns a copy of the deactivated status of the DID document.
+
+**Kind**: instance method of [<code>IotaDocumentMetadata</code>](#IotaDocumentMetadata)  
+<a name="IotaDocumentMetadata+stateControllerAddress"></a>
+
+### iotaDocumentMetadata.stateControllerAddress() ⇒ <code>string</code> \| <code>undefined</code>
+Returns a copy of the Bech32-encoded state controller address, if present.
+
+**Kind**: instance method of [<code>IotaDocumentMetadata</code>](#IotaDocumentMetadata)  
+<a name="IotaDocumentMetadata+governorAddress"></a>
+
+### iotaDocumentMetadata.governorAddress() ⇒ <code>string</code> \| <code>undefined</code>
+Returns a copy of the Bech32-encoded governor address, if present.
 
 **Kind**: instance method of [<code>IotaDocumentMetadata</code>](#IotaDocumentMetadata)  
 <a name="IotaDocumentMetadata+properties"></a>
@@ -3991,6 +4035,10 @@ This is possible because Ed25519 is birationally equivalent to Curve25519 used b
 | --- | --- |
 | publicKey | <code>Uint8Array</code> | 
 
+<a name="KeyType"></a>
+
+## KeyType
+**Kind**: global variable  
 <a name="MethodRelationship"></a>
 
 ## MethodRelationship
@@ -4076,10 +4124,6 @@ Return all errors that occur during validation.
 ## FirstError
 Return after the first error occurs.
 
-**Kind**: global variable  
-<a name="KeyType"></a>
-
-## KeyType
 **Kind**: global variable  
 <a name="start"></a>
 

--- a/bindings/wasm/src/iota/iota_document.rs
+++ b/bindings/wasm/src/iota/iota_document.rs
@@ -493,6 +493,18 @@ impl WasmIotaDocument {
     self.0.metadata.deactivated = deactivated;
   }
 
+  /// Returns a copy of the Bech32-encoded state controller address, if present.
+  #[wasm_bindgen(js_name = metadataStateControllerAddress)]
+  pub fn metadata_state_controller_address(&self) -> Option<String> {
+    self.0.metadata.state_controller_address.clone()
+  }
+
+  /// Returns a copy of the Bech32-encoded governor address, if present.
+  #[wasm_bindgen(js_name = metadataGovernorAddress)]
+  pub fn metadata_governor_address(&self) -> Option<String> {
+    self.0.metadata.governor_address.clone()
+  }
+
   /// Sets a custom property in the document metadata.
   /// If the value is set to `null`, the custom property will be removed.
   #[wasm_bindgen(js_name = setMetadataPropertyUnchecked)]

--- a/bindings/wasm/src/iota/iota_document_metadata.rs
+++ b/bindings/wasm/src/iota/iota_document_metadata.rs
@@ -34,6 +34,18 @@ impl WasmIotaDocumentMetadata {
     self.0.deactivated
   }
 
+  /// Returns a copy of the Bech32-encoded state controller address, if present.
+  #[wasm_bindgen(js_name = stateControllerAddress)]
+  pub fn state_controller_address(&self) -> Option<String> {
+    self.0.state_controller_address.clone()
+  }
+
+  /// Returns a copy of the Bech32-encoded governor address, if present.
+  #[wasm_bindgen(js_name = governorAddress)]
+  pub fn governor_address(&self) -> Option<String> {
+    self.0.governor_address.clone()
+  }
+
   /// Returns a copy of the custom metadata properties.
   #[wasm_bindgen]
   pub fn properties(&self) -> Result<MapStringAny> {

--- a/identity_iota_core/src/did/iota_did.rs
+++ b/identity_iota_core/src/did/iota_did.rs
@@ -93,7 +93,7 @@ impl IotaDID {
   ///
   /// Returns `Err` if the input does not conform to the [`IotaDID`] specification.
   pub fn parse(input: impl AsRef<str>) -> Result<Self> {
-    CoreDID::parse(input).and_then(Self::try_from_core)
+    CoreDID::parse(input.as_ref().to_lowercase()).and_then(Self::try_from_core)
   }
 
   /// Converts a [`CoreDID`] to a [`IotaDID`].

--- a/identity_iota_core/src/document/iota_document_metadata.rs
+++ b/identity_iota_core/src/document/iota_document_metadata.rs
@@ -11,8 +11,6 @@ use identity_core::convert::FmtJson;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::block::address::Address;
-
 /// Additional attributes related to a [`IotaDocument`][crate::IotaDocument].
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct IotaDocumentMetadata {
@@ -23,10 +21,12 @@ pub struct IotaDocumentMetadata {
   pub updated: Option<Timestamp>,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub deactivated: Option<bool>,
+  /// Bech32-encoded address of the governor unlock condition.
   #[serde(rename = "governorAddress", skip_serializing_if = "Option::is_none")]
-  pub governor_address: Option<Address>,
+  pub governor_address: Option<String>,
+  /// Bech32-encoded address of the state controller unlock condition.
   #[serde(rename = "stateControllerAddress", skip_serializing_if = "Option::is_none")]
-  pub state_controller_address: Option<Address>,
+  pub state_controller_address: Option<String>,
   #[serde(flatten)]
   pub properties: Object,
 }


### PR DESCRIPTION
# Description of change
Changes the address type in `IotaDocumentMetadata` from `bee_block::address::Address` to a Bech32-encoded `String`. This is to avoid a hard dependency on `bee_block`.

Also adds some missing convenience getters in the Wasm bindings.

## Links to any relevant issues
Fixes `--non-default-features` failing in #1042.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested
Updated unit test.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
