### PR TITLE
Remove docs version info

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -5,19 +5,12 @@ module.exports = {
         [
             '@docusaurus/plugin-content-docs',
             {
-                id: 'identity-rs-develop',
+                id: 'identity-rs',
                 path: path.resolve(__dirname, 'docs'),
                 routeBasePath: 'identity.rs',
                 sidebarPath: path.resolve(__dirname, 'sidebars.js'),
                 editUrl: 'https://github.com/iotaledger/identity.rs/edit/dev/documentation',
                 remarkPlugins: [require('remark-code-import'), require('remark-import-partial'), require('remark-remove-comments')],
-                versions: {
-                    current: {
-                        label: 'Develop',
-                        path: 'develop',
-                        badge: true
-                    },
-                },
             }
         ],
     ],


### PR DESCRIPTION
# Description of change

With version 3 of the wiki we don't need to separate docs that aren't part of the same network. And as this is shimmer content it will be hosted under /shimmer/identity.rs

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
