### PR TITLE
Fix unresolved import in TS artifacts

### DIFF
--- a/bindings/wasm/build/replace_paths.js
+++ b/bindings/wasm/build/replace_paths.js
@@ -1,0 +1,40 @@
+const fs = require("fs/promises");
+const path = require("path");
+
+/**
+ * Replaces aliases defined in `tsconfig.json` files with their corresponding paths.
+ * If more than one path is defined. The second path is used. Otherwise the first path.
+ */
+async function main() {
+  if (process.argv[2] === "node") await replace("tsconfig.json", "node");
+  if (process.argv[2] === "web") await replace("tsconfig.web.json", "web");
+}
+
+async function replace(tsconfig, dist) {
+  // Read tsconfig file.
+  let data = JSON.parse(await fs.readFile(path.join(__dirname, `../lib/${tsconfig}`), "utf8"));
+  let a = data.compilerOptions.paths;
+  let keys = Object.keys(a);
+
+  // Get `.js` and `.ts` file names from directory.
+  let files = await fs.readdir(path.join(__dirname, `../${dist}`), {withFileTypes: true});
+  files = files.filter((directoryItem) => directoryItem.isFile()).map((file) => file.name);
+  files = files.filter((fileName) => fileName.endsWith(".ts") || fileName.endsWith(".js"));
+
+  // Replace the Alias with the second path if present, otherwise use first path.
+  for (let file of files) {
+    let fileData = await fs.readFile(path.join(__dirname, `../${dist}/${file}`), "utf8");
+    for (let key of keys) {
+      let value = a[key][1] ?? a[key][0];
+      fileData = fileData.replace(key, value);
+    }
+    await fs.writeFile(path.join(__dirname, `../${dist}/${file}`), fileData, "utf8");
+  }
+}
+
+try {
+  main().then(() => {});
+} catch (e) {
+  console.log(e);
+  return e;
+}

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -1773,7 +1773,7 @@ The default Tangle network (`"iota"`).
 <a name="IotaDID.fromAliasId"></a>
 
 ### IotaDID.fromAliasId(aliasId, network) ⇒ [<code>IotaDID</code>](#IotaDID)
-Constructs a new `IotaDID` from a hex representation of the tag and the given
+Constructs a new `IotaDID` from a hex representation of an Alias Id and the given
 network name.
 
 **Kind**: static method of [<code>IotaDID</code>](#IotaDID)  
@@ -2012,7 +2012,7 @@ Deserializes an instance from a JSON object.
     * _static_
         * [.newWithId(id)](#IotaDocument.newWithId) ⇒ [<code>IotaDocument</code>](#IotaDocument)
         * [.unpackFromOutput(did, aliasOutput, allowEmpty, tokenSupply)](#IotaDocument.unpackFromOutput) ⇒ [<code>IotaDocument</code>](#IotaDocument)
-        * [.unpackFromBlock(network, block, protocolParametersJSON)](#IotaDocument.unpackFromBlock) ⇒ [<code>Array.&lt;IotaDocument&gt;</code>](#IotaDocument)
+        * [.unpackFromBlock(network, block, protocolResponseJson)](#IotaDocument.unpackFromBlock) ⇒ [<code>Array.&lt;IotaDocument&gt;</code>](#IotaDocument)
         * [.fromJSON(json)](#IotaDocument.fromJSON) ⇒ [<code>IotaDocument</code>](#IotaDocument)
 
 <a name="new_IotaDocument_new"></a>
@@ -2438,13 +2438,13 @@ encoded in the `AliasId` alone.
 
 <a name="IotaDocument.unpackFromBlock"></a>
 
-### IotaDocument.unpackFromBlock(network, block, protocolParametersJSON) ⇒ [<code>Array.&lt;IotaDocument&gt;</code>](#IotaDocument)
+### IotaDocument.unpackFromBlock(network, block, protocolResponseJson) ⇒ [<code>Array.&lt;IotaDocument&gt;</code>](#IotaDocument)
 Returns all DID documents of the Alias Outputs contained in the block's transaction payload
 outputs, if any.
 
 Errors if any Alias Output does not contain a valid or empty DID Document.
 
-protocolParametersJSON can be obtained from a `Client`.
+`protocolResponseJson` can be obtained from a `Client`.
 
 **Kind**: static method of [<code>IotaDocument</code>](#IotaDocument)  
 
@@ -2452,7 +2452,7 @@ protocolParametersJSON can be obtained from a `Client`.
 | --- | --- |
 | network | <code>string</code> | 
 | block | <code>IBlock</code> | 
-| protocolParametersJSON | <code>string</code> | 
+| protocolResponseJson | <code>string</code> | 
 
 <a name="IotaDocument.fromJSON"></a>
 
@@ -3676,7 +3676,7 @@ Constructs a new `Resolver`.
 
 # Errors
 If both a `client` is given and the `handlers` map contains the "iota" key the construction process
-will throw an error as it is then ambiguous what should be .
+will throw an error because the handler for the "iota" method then becomes ambiguous.
 
 
 | Param | Type |

--- a/bindings/wasm/lib/iota_identity_client.ts
+++ b/bindings/wasm/lib/iota_identity_client.ts
@@ -60,7 +60,7 @@ export class IotaIdentityClient implements IIotaIdentityClient {
      * The `address` will be set as the state controller and governor unlock conditions.
      * The minimum required token deposit amount will be set according to the given
      * `rent_structure`, which will be fetched from the node if not provided.
-     * The returned Alias Output can be further customised before publication, if desired.
+     * The returned Alias Output can be further customized before publication, if desired.
      *
      * NOTE: this does *not* publish the Alias Output.
      */

--- a/bindings/wasm/lib/tsconfig.json
+++ b/bindings/wasm/lib/tsconfig.json
@@ -1,12 +1,12 @@
 {
-    "extends": "../tsconfig.node.json",
-    "compilerOptions": {
-        "baseUrl": "./",
-        "paths": {
-            "~identity_wasm": ["../node/identity_wasm"],
-            "~iota-client-wasm": ["../node_modules/@iota/iota-client-wasm/node"],
-        },
-        "outDir": "../node",
-        "declarationDir": "../node",
+  "extends": "../tsconfig.node.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "~identity_wasm": ["../node/identity_wasm"],
+      "~iota-client-wasm": ["../node_modules/@iota/iota-client-wasm/node", "@iota/iota-client-wasm/node"]
     },
+    "outDir": "../node",
+    "declarationDir": "../node"
+  }
 }

--- a/bindings/wasm/lib/tsconfig.web.json
+++ b/bindings/wasm/lib/tsconfig.web.json
@@ -1,13 +1,13 @@
 {
-    "extends": "../tsconfig.json",
-    "compilerOptions": {
-        "baseUrl": "./",
-        "paths": {
-            "~identity_wasm": ["../web/identity_wasm"],
-            "~iota-client-wasm": ["../node_modules/@iota/iota-client-wasm/web"],
-        },
-        "outDir": "../web",
-        "declarationDir": "../web",
-        "module": "ES2020"
-    }
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "~identity_wasm": ["../web/identity_wasm"],
+      "~iota-client-wasm": ["../node_modules/@iota/iota-client-wasm/web", "@iota/iota-client-wasm/web"]
+    },
+    "outDir": "../web",
+    "declarationDir": "../web",
+    "module": "ES2020"
+  }
 }

--- a/bindings/wasm/package-lock.json
+++ b/bindings/wasm/package-lock.json
@@ -29,7 +29,6 @@
         "mocha": "^9.2.0",
         "ts-mocha": "^9.0.2",
         "ts-node": "^10.9.1",
-        "tsc-alias": "^1.7.0",
         "txm": "^8.0.1",
         "typescript": "^4.7.2",
         "wasm-opt": "^1.3.0",
@@ -4899,19 +4898,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/mylas": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.11.tgz",
-      "integrity": "sha512-krnPUl3n9/k52FGCltWMYcqp9SttxjRJEy0sWLk+g7mIa7wnZrmNSZ40Acx7ghzRSOsxt2rEqMbaq4jWlnTDKg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/raouldeheer"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
@@ -5161,15 +5147,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/plimit-lit": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.4.0.tgz",
-      "integrity": "sha512-e4VKIdzc5+vvTuNZeWDTWHCNPLZ1+jXeQ9HqZhAS+vlAodNr8A26IcTA9OudjLXj8fV+KRW/ZzsoyrTZzoWD/A==",
-      "dev": true,
-      "dependencies": {
-        "queue-lit": "^1.4.0"
-      }
-    },
     "node_modules/portfinder": {
       "version": "1.0.32",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
@@ -5265,12 +5242,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/queue-lit": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.4.0.tgz",
-      "integrity": "sha512-l1+4YHm4vHWpCnvTg8JMsnPETmPvLGWhqjvNOc8TSbqscGplHVSWXOxybA3vYeMNNIR9Z1PQt85U+S3wFJX2uQ==",
-      "dev": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -6276,32 +6247,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/tsc-alias": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.7.0.tgz",
-      "integrity": "sha512-n/K6g8S7Ec7Y/A2Z77Ikp2Uv1S1ERtT63ni69XV4W1YPT4rnNmz8ItgIiJYvKfFnKfqcZQ81UPjoKpMTxaC/rg==",
-      "dev": true,
-      "dependencies": {
-        "chokidar": "^3.5.3",
-        "commander": "^9.0.0",
-        "globby": "^11.0.4",
-        "mylas": "^2.1.9",
-        "normalize-path": "^3.0.0",
-        "plimit-lit": "^1.2.6"
-      },
-      "bin": {
-        "tsc-alias": "dist/bin/index.js"
-      }
-    },
-    "node_modules/tsc-alias/node_modules/commander": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
-      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -10620,12 +10565,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "mylas": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.11.tgz",
-      "integrity": "sha512-krnPUl3n9/k52FGCltWMYcqp9SttxjRJEy0sWLk+g7mIa7wnZrmNSZ40Acx7ghzRSOsxt2rEqMbaq4jWlnTDKg==",
-      "dev": true
-    },
     "nanoid": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
@@ -10798,15 +10737,6 @@
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "dev": true
     },
-    "plimit-lit": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.4.0.tgz",
-      "integrity": "sha512-e4VKIdzc5+vvTuNZeWDTWHCNPLZ1+jXeQ9HqZhAS+vlAodNr8A26IcTA9OudjLXj8fV+KRW/ZzsoyrTZzoWD/A==",
-      "dev": true,
-      "requires": {
-        "queue-lit": "^1.4.0"
-      }
-    },
     "portfinder": {
       "version": "1.0.32",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
@@ -10885,12 +10815,6 @@
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "dev": true
-    },
-    "queue-lit": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.4.0.tgz",
-      "integrity": "sha512-l1+4YHm4vHWpCnvTg8JMsnPETmPvLGWhqjvNOc8TSbqscGplHVSWXOxybA3vYeMNNIR9Z1PQt85U+S3wFJX2uQ==",
       "dev": true
     },
     "queue-microtask": {
@@ -11626,28 +11550,6 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
           "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-          "dev": true
-        }
-      }
-    },
-    "tsc-alias": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.7.0.tgz",
-      "integrity": "sha512-n/K6g8S7Ec7Y/A2Z77Ikp2Uv1S1ERtT63ni69XV4W1YPT4rnNmz8ItgIiJYvKfFnKfqcZQ81UPjoKpMTxaC/rg==",
-      "dev": true,
-      "requires": {
-        "chokidar": "^3.5.3",
-        "commander": "^9.0.0",
-        "globby": "^11.0.4",
-        "mylas": "^2.1.9",
-        "normalize-path": "^3.0.0",
-        "plimit-lit": "^1.2.6"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "9.4.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
-          "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
           "dev": true
         }
       }

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -11,8 +11,8 @@
   },
   "scripts": {
     "build:src": "cargo build --lib --release --target wasm32-unknown-unknown",
-    "bundle:nodejs": "wasm-bindgen target/wasm32-unknown-unknown/release/identity_wasm.wasm --typescript --weak-refs --target nodejs --out-dir node && node ./build/node && tsc --project ./lib/tsconfig.json && tsc-alias -p ./lib/tsconfig.json",
-    "bundle:web": "wasm-bindgen target/wasm32-unknown-unknown/release/identity_wasm.wasm --typescript --weak-refs --target web --out-dir web && node ./build/web && tsc --project ./lib/tsconfig.web.json && tsc-alias -p ./lib/tsconfig.web.json",
+    "bundle:nodejs": "wasm-bindgen target/wasm32-unknown-unknown/release/identity_wasm.wasm --typescript --weak-refs --target nodejs --out-dir node && node ./build/node && tsc --project ./lib/tsconfig.json && node ./build/replace_paths node",
+    "bundle:web": "wasm-bindgen target/wasm32-unknown-unknown/release/identity_wasm.wasm --typescript --weak-refs --target web --out-dir web && node ./build/web && tsc --project ./lib/tsconfig.web.json && node ./build/replace_paths web",
     "build:nodejs": "npm run build:src && npm run bundle:nodejs && wasm-opt -O node/identity_wasm_bg.wasm -o node/identity_wasm_bg.wasm",
     "build:web": "npm run build:src && npm run bundle:web && wasm-opt -O web/identity_wasm_bg.wasm -o web/identity_wasm_bg.wasm",
     "build:docs": "node ./build/docs",
@@ -69,7 +69,6 @@
     "mocha": "^9.2.0",
     "ts-mocha": "^9.0.2",
     "ts-node": "^10.9.1",
-    "tsc-alias": "^1.7.0",
     "txm": "^8.0.1",
     "typescript": "^4.7.2",
     "wasm-opt": "^1.3.0",

--- a/bindings/wasm/tsconfig.json
+++ b/bindings/wasm/tsconfig.json
@@ -8,7 +8,7 @@
         "importsNotUsedAsValues": "error",
         "noImplicitAny": true,
         "preserveConstEnums": true,
-        "forceConsistentCasingInFileNames": true,
+        "forceConsistentCasingInFileNames": true
     },
     "exclude": ["node_modules"]
 }


### PR DESCRIPTION
# Description of change
Some imports were replaced by the relative paths in `tsconfig.json` using [tsc-alias](https://www.npmjs.com/package/tsc-alias). These relative paths work fine locally, but not in the npm package.
For example, the path `"../node_modules/@iota/iota-client-wasm/node"` doesn't exist when importing the identity package from npm. and it should be `"@iota/iota-client-wasm/node"` instead.

To fix this, the `tsc-alias` is removed and replaced with a custom script that will replace the aliases defined in the `tsconfig.json` file with the path (only for `.ts` and `.js` files). If two paths are defined in the `tsconfig` file, the second path is used as a replacement for the alias. 
This allows to use the first path for local compilation and the second one to be used for the package.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

