### PR TITLE
Temporarily pin `iota-types` version

### DIFF
--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -19,7 +19,8 @@ crate-type = ["cdylib", "rlib"]
 async-trait = { version = "0.1", default-features = false }
 console_error_panic_hook = { version = "0.1" }
 futures = { version = "0.3" }
-iota-types = { version = "1.0.0-rc.1", default-features = false, features = ["block", "api", "dto", "std"] }
+# Pin until iota-client v2.0.1-rc.4 is released
+iota-types = { version = "=1.0.0-rc.1", default-features = false, features = ["block", "api", "dto", "std"] }
 js-sys = { version = "0.3.60" }
 proc_typescript = { version = "0.1.0", path = "./proc_typescript" }
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,6 +9,8 @@ publish = false
 anyhow = "1.0.62"
 did-key = { version = "0.1.1", default-features = false }
 identity_iota = { path = "../identity_iota" }
+# Remove once iota-client 2.0.1-rc.4 is released. 
+iota-types = { version = "=1.0.0-rc.1", default-features = false, features = ["block", "std"], optional = true}
 iota-client = { version = "2.0.1-rc.3", default-features = false, features = ["tls", "stronghold"] }
 primitive-types = "0.12.1"
 rand = "0.8.5"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 anyhow = "1.0.62"
 did-key = { version = "0.1.1", default-features = false }
 identity_iota = { path = "../identity_iota" }
-# Remove once iota-client 2.0.1-rc.4 is released. 
-iota-types = { version = "=1.0.0-rc.1", default-features = false, features = ["block", "std"], optional = true}
 iota-client = { version = "2.0.1-rc.3", default-features = false, features = ["tls", "stronghold"] }
+# Remove once iota-client 2.0.1-rc.4 is released.
+iota-types = { version = "=1.0.0-rc.1", default-features = false, features = ["block", "std"], optional = true }
 primitive-types = "0.12.1"
 rand = "0.8.5"
 tokio = { version = "1.20.1", default-features = false, features = ["rt"] }

--- a/identity_iota_core/Cargo.toml
+++ b/identity_iota_core/Cargo.toml
@@ -15,7 +15,7 @@ description = "An IOTA Ledger integration for the IOTA DID Method."
 identity_core = { version = "=0.7.0-alpha.3", path = "../identity_core", default-features = false }
 identity_credential = { version = "=0.7.0-alpha.3", path = "../identity_credential", default-features = false, features = ["validator"] }
 identity_did = { version = "=0.7.0-alpha.3", path = "../identity_did", default-features = false }
-# Pin until iota-client v2.0.1-rc.4 is released 
+# Pin until iota-client v2.0.1-rc.4 is released
 iota-types = { version = "=1.0.0-rc.1", default-features = false, features = ["block", "std"], optional = true }
 
 async-trait = { version = "0.1.56", default-features = false, optional = true }

--- a/identity_iota_core/Cargo.toml
+++ b/identity_iota_core/Cargo.toml
@@ -15,7 +15,8 @@ description = "An IOTA Ledger integration for the IOTA DID Method."
 identity_core = { version = "=0.7.0-alpha.3", path = "../identity_core", default-features = false }
 identity_credential = { version = "=0.7.0-alpha.3", path = "../identity_credential", default-features = false, features = ["validator"] }
 identity_did = { version = "=0.7.0-alpha.3", path = "../identity_did", default-features = false }
-iota-types = { version = "1.0.0-rc.1", default-features = false, features = ["block", "std"], optional = true }
+# Pin until iota-client v2.0.1-rc.4 is released 
+iota-types = { version = "=1.0.0-rc.1", default-features = false, features = ["block", "std"], optional = true }
 
 async-trait = { version = "0.1.56", default-features = false, optional = true }
 futures = { version = "0.3" }


### PR DESCRIPTION
# Description of change
This is a temporary fix for breaking builds. Should be removed/rolled back once `iota-client 2.0.1-rc.4` is released. 

## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Runs under `cargo build --all-features`, `cargo check --examples` and the TS bindings also build. 

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
