### PR TITLE
Make `StateMetadataDocument` public

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.62"
-did-key = { version = "0.1.1", default-features = false }
+# did-key = { version = "0.1.1", default-features = false }
 identity_iota = { path = "../identity_iota" }
 iota-client = { version = "2.0.1-rc.3", default-features = false, features = ["tls", "stronghold"] }
 # Remove once iota-client 2.0.1-rc.4 is released.
@@ -75,6 +75,6 @@ name = "4_key_exchange"
 path = "1_advanced/5_alias_output_history.rs"
 name = "5_alias_output_history"
 
-[[example]]
-path = "1_advanced/6_custom_resolution.rs"
-name = "6_custom_resolution"
+# [[example]]
+# path = "1_advanced/6_custom_resolution.rs"
+# name = "6_custom_resolution"

--- a/identity_iota_core/src/state_metadata/document.rs
+++ b/identity_iota_core/src/state_metadata/document.rs
@@ -29,8 +29,8 @@ const DID_MARKER: &[u8] = b"DID";
 /// an Alias Output.
 ///
 /// DID instances in the document are replaced by the `PLACEHOLDER_DID`.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub(crate) struct StateMetadataDocument {
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct StateMetadataDocument {
   #[serde(rename = "doc")]
   pub(crate) document: CoreDocument,
   #[serde(rename = "meta")]

--- a/identity_iota_core/src/state_metadata/mod.rs
+++ b/identity_iota_core/src/state_metadata/mod.rs
@@ -5,6 +5,6 @@ mod document;
 mod encoding;
 mod version;
 
-pub(crate) use document::*;
+pub use document::*;
 pub use encoding::*;
 pub(crate) use version::*;


### PR DESCRIPTION
# Description of change

We currently get warnings that `StateMetadataDocument::{into_iota_document,unpack}` are unused when running `cargo check --no-default-features`.

This PR makes `StateMetadata` public to get rid of those warnings. Another approach would have been to feature-gate everything state metadata related behind the `client` feature. The reasoning for making it public is that `StateMetadata` can be used with clients other than `iota-client` and there's no inherent reason why it has to be tied to that specific client. We may also want to use it from the Wasm bindings without adding a dependency to iota-client in order to decode the state metadata of an Alias Output resolved by, say, `iota.js`.

`Eq` was also derived for `StateMetadataDocument` to satisfy a clippy lint.

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

None.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
