### PR TITLE
Remove outdated lint

### DIFF
--- a/bindings/wasm/build/lints.js
+++ b/bindings/wasm/build/lints.js
@@ -1,35 +1,3 @@
-/**
- * Rejects any `<obj>.ptr = 0;` occurrence, excluding `this.ptr = 0;` in `free()` implementations.
- *
- * Prevents generated code that nulls out Wasm pointers without de-registering the finalizer, since they cause
- * runtime errors during automatic garbage collection from WasmRefCell thinking the instance is still borrowed.
- *
- * Functions which take owned parameters cause this situation; the solution is to borrow and clone the parameter
- * instead.
- */
-function lintPtrNullWithoutFree(content) {
-    // Find line numbers of offending code.
-    const lines = content.split(/\r?\n/);
-    const matches = lines.flatMap(function(line, number) {
-        if (/(?<!this).ptr = 0;/.test(line)) {
-            return [(number + 1) + " " + line.trim()];
-        } else {
-            return [];
-        }
-    });
-    if (matches.length > 0) {
-        throw (`ERROR: generated Javascript should not include 'obj.ptr = 0;'. 
-When weak references are enabled with '--weak-refs', WasmRefCell in wasm-bindgen causes 
-runtime errors from automatic garbage collection trying to free objects taken as owned parameters. 
-
-Matches:
-${matches}
-
-SUGGESTION: change any exported functions which take an owned parameter (excluding flat enums) to use a borrow instead.
-See: https://github.com/rustwasm/wasm-bindgen/pull/2677`);
-    }
-}
-
 /** Rejects any `imports['env']` occurrences, which cause failures at runtime.
  *
  *  This is typically due to Wasm compatibility features not being enabled on crate dependencies. **/
@@ -66,7 +34,6 @@ See:
 /** Runs all custom lints on the generated code. Exits the process immediately with code 1 if any fail. **/
 function lintAll(content) {
     try {
-        lintPtrNullWithoutFree(content);
         lintImportEnv(content);
     } catch (err) {
         console.error("Custom lint failed!");


### PR DESCRIPTION
# Description of change
This removes the `lintPtrNullWithoutFree(content)` function which is used when building the Wasm/TS/JS bindings.

The lint was introduced to catch generated code that nulls out Wasm pointers without de-registering the finalizer (we build our bindings with the `--weak-refs` flag for automatic garbage collection see [this section of the wasm-bindgen reference](https://rustwasm.github.io/wasm-bindgen/reference/weak-references.html)). 

As of [wasm-bindgen PR #3117](https://github.com/rustwasm/wasm-bindgen/pull/3117)  which is included in version `0.2.84` of `wasm-bindgen` such problematic code is no longer generated hence the lint is no longer needed. 


## How the change has been tested
Tested building this code (in `wasm_core_did.rs`) 
```
impl WasmCoreDID {
  //.. 

  /// Swaps the contents and consumes `other`.  
  #[wasm_bindgen]
  pub fn swap(&mut self, mut other: WasmCoreDID) {
    std::mem::swap(&mut self.0, &mut other.0);
  }
  
  #[wasm_bindgen(js_name = moveOther)]
  pub fn move_other(other: WasmCoreDID) -> WasmCoreDID {
    other
    }
 }

#[wasm_bindgen]
extern "C" {
  #[wasm_bindgen(typescript_type = "CoreDID | ICoreDID")]
  pub type ICoreDID;

  #[wasm_bindgen(method, js_name= toCoreDid)]
  pub fn to_core_did(this: &ICoreDID) -> WasmCoreDID;

}
```
with `wasm-bindgen` version `0.2.83` and `0.2.84`. In the former the lint is triggered by all three of those functions, while in version `0.2.84` the lint passes. 


## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
