### PR TITLE
Don't disable default features of `form_urlencoded`

### DIFF
--- a/identity_did/Cargo.toml
+++ b/identity_did/Cargo.toml
@@ -12,7 +12,7 @@ description = "Agnostic implementation of the Decentralized Identifiers (DID) st
 
 [dependencies]
 did_url = { version = "0.1", default-features = false, features = ["std", "serde"] }
-form_urlencoded = { version = "1.0.1", default-features = false }
+form_urlencoded = "1.1.0"
 identity_core = { version = "=0.7.0-alpha.5", path = "../identity_core" }
 serde.workspace = true
 strum.workspace = true

--- a/identity_document/Cargo.toml
+++ b/identity_document/Cargo.toml
@@ -13,7 +13,7 @@ description = "Method-agnostic implementation of the Decentralized Identifiers (
 
 [dependencies]
 did_url = { version = "0.1", default-features = false, features = ["std", "serde"] }
-form_urlencoded = { version = "1.0.1", default-features = false }
+form_urlencoded = "1.1.0"
 identity_core = { version = "=0.7.0-alpha.5", path = "../identity_core" }
 identity_did = { version = "=0.7.0-alpha.5", path = "../identity_did" }
 identity_verification = { version = "=0.7.0-alpha.5", path = "../identity_verification", default-features = false }


### PR DESCRIPTION
# Description of change
In servo/rust-url#722, we would like to make the crate potentially not need `alloc` in the future, but to do so, we must now introduce a required `alloc` feature.

Since this project uses `default-features = false` on `form_urlencoded` (which previously did nothing), it will break once that change lands.

## Links to any relevant issues
Also requires https://github.com/l1h3r/did_url/pull/2 to land (since this crate depends on `did_url`).

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
