### PR TITLE
Move release config flag

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,6 +3,8 @@ name = "examples"
 version = "0.6.1"
 edition = "2021"
 publish = false
+
+[package.metadata.release]
 release = false
 
 [dependencies]


### PR DESCRIPTION
# Description of change

Move the `release` flag of `cargo-release` to its proper place, i.e. `[package.metadata.release]`, according to https://github.com/crate-ci/cargo-release/blob/v0.21.4/docs/reference.md.

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

## How the change has been tested

n/a

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
