### PR TITLE
Add initial PublicKeyJwk support

### DIFF
--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -37,7 +37,7 @@ default-features = false
 features = ["client", "revocation-bitmap", "resolver"]
 
 [dependencies.identity_jose]
-version = "0.7.0-alpha.4"
+version = "0.7.0-alpha.6"
 path = "../../identity_jose"
 default-features = false
 features = []

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -156,11 +156,11 @@ This variant is the default used if no other variant is specified when construct
 <dt><a href="#FirstError">FirstError</a></dt>
 <dd><p>Return after the first error occurs.</p>
 </dd>
-<dt><a href="#StateMetadataEncoding">StateMetadataEncoding</a></dt>
-<dd></dd>
 <dt><a href="#KeyType">KeyType</a></dt>
 <dd></dd>
 <dt><a href="#MethodRelationship">MethodRelationship</a></dt>
+<dd></dd>
+<dt><a href="#StateMetadataEncoding">StateMetadataEncoding</a></dt>
 <dd></dd>
 </dl>
 
@@ -2865,6 +2865,7 @@ Supported verification method data formats.
     * _static_
         * [.newBase58(data)](#MethodData.newBase58) ⇒ [<code>MethodData</code>](#MethodData)
         * [.newMultibase(data)](#MethodData.newMultibase) ⇒ [<code>MethodData</code>](#MethodData)
+        * [.newJwk(key)](#MethodData.newJwk) ⇒ [<code>MethodData</code>](#MethodData)
         * [.fromJSON(json)](#MethodData.fromJSON) ⇒ [<code>MethodData</code>](#MethodData)
 
 <a name="MethodData+tryDecode"></a>
@@ -2912,6 +2913,20 @@ Creates a new `MethodData` variant with Multibase-encoded content.
 | Param | Type |
 | --- | --- |
 | data | <code>Uint8Array</code> | 
+
+<a name="MethodData.newJwk"></a>
+
+### MethodData.newJwk(key) ⇒ [<code>MethodData</code>](#MethodData)
+Creates a new `MethodData` variant consisting of the given `key`.
+
+### Errors
+An error is thrown if the given `key` contains any private components.
+
+**Kind**: static method of [<code>MethodData</code>](#MethodData)  
+
+| Param | Type |
+| --- | --- |
+| key | [<code>Jwk</code>](#Jwk) | 
 
 <a name="MethodData.fromJSON"></a>
 
@@ -3013,6 +3028,7 @@ Supported verification method types.
     * _static_
         * [.Ed25519VerificationKey2018()](#MethodType.Ed25519VerificationKey2018) ⇒ [<code>MethodType</code>](#MethodType)
         * [.X25519KeyAgreementKey2019()](#MethodType.X25519KeyAgreementKey2019) ⇒ [<code>MethodType</code>](#MethodType)
+        * [.JwkMethodType()](#MethodType.JwkMethodType) ⇒ [<code>MethodType</code>](#MethodType)
         * [.fromJSON(json)](#MethodType.fromJSON) ⇒ [<code>MethodType</code>](#MethodType)
 
 <a name="MethodType+toString"></a>
@@ -3040,6 +3056,13 @@ Deep clones the object.
 <a name="MethodType.X25519KeyAgreementKey2019"></a>
 
 ### MethodType.X25519KeyAgreementKey2019() ⇒ [<code>MethodType</code>](#MethodType)
+**Kind**: static method of [<code>MethodType</code>](#MethodType)  
+<a name="MethodType.JwkMethodType"></a>
+
+### MethodType.JwkMethodType() ⇒ [<code>MethodType</code>](#MethodType)
+A verification method for use with JWT verification as prescribed by the `Jwk`
+in the `publicKeyJwk` entry.
+
 **Kind**: static method of [<code>MethodType</code>](#MethodType)  
 <a name="MethodType.fromJSON"></a>
 
@@ -3917,6 +3940,7 @@ A DID Document Verification Method.
         * [.toJSON()](#VerificationMethod+toJSON) ⇒ <code>any</code>
         * [.clone()](#VerificationMethod+clone) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
     * _static_
+        * [.newFromJwk(did, key, fragment)](#VerificationMethod.newFromJwk) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
         * [.fromJSON(json)](#VerificationMethod.fromJSON) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
 
 <a name="new_VerificationMethod_new"></a>
@@ -4035,6 +4059,27 @@ Serializes this to a JSON object.
 Deep clones the object.
 
 **Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)  
+<a name="VerificationMethod.newFromJwk"></a>
+
+### VerificationMethod.newFromJwk(did, key, fragment) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
+Creates a new `VerificationMethod` from the given `did` and `Jwk`. If a `fragment` is not given an attempt
+will be made to generate it from the `kid` value of the given `key`.
+
+### Recommendations
+The following recommendations are essentially taken from the `publicKeyJwk` description from the [DID specification](https://www.w3.org/TR/did-core/#dfn-publickeyjwk):
+- It is recommended that verification methods that use `Jwks` to represent their public keys use the value of
+  `kid` as their fragment identifier. This is
+done automatically if `None` is passed in as the fragment.
+- It is recommended that `Jwk` kid values are set to the public key fingerprint. See `Jwk::thumbprint_b64`.
+
+**Kind**: static method of [<code>VerificationMethod</code>](#VerificationMethod)  
+
+| Param | Type |
+| --- | --- |
+| did | [<code>CoreDID</code>](#CoreDID) \| <code>IToCoreDID</code> | 
+| key | [<code>Jwk</code>](#Jwk) | 
+| fragment | <code>string</code> \| <code>undefined</code> | 
+
 <a name="VerificationMethod.fromJSON"></a>
 
 ### VerificationMethod.fromJSON(json) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
@@ -4247,10 +4292,6 @@ Return all errors that occur during validation.
 Return after the first error occurs.
 
 **Kind**: global variable  
-<a name="StateMetadataEncoding"></a>
-
-## StateMetadataEncoding
-**Kind**: global variable  
 <a name="KeyType"></a>
 
 ## KeyType
@@ -4258,6 +4299,10 @@ Return after the first error occurs.
 <a name="MethodRelationship"></a>
 
 ## MethodRelationship
+**Kind**: global variable  
+<a name="StateMetadataEncoding"></a>
+
+## StateMetadataEncoding
 **Kind**: global variable  
 <a name="start"></a>
 

--- a/bindings/wasm/src/did/wasm_method_data.rs
+++ b/bindings/wasm/src/did/wasm_method_data.rs
@@ -6,6 +6,8 @@ use wasm_bindgen::prelude::*;
 
 use crate::error::Result;
 use crate::error::WasmResult;
+use crate::error::WasmError;
+use std::borrow::Cow; 
 
 /// Supported verification method data formats.
 #[wasm_bindgen(js_name = MethodData, inspectable)]
@@ -23,6 +25,19 @@ impl WasmMethodData {
   #[wasm_bindgen(js_name = newMultibase)]
   pub fn new_multibase(data: Vec<u8>) -> Self {
     Self(MethodData::new_multibase(data))
+  }
+
+  /// Creates a new `MethodData` variant consisting of the given `key`.
+  /// 
+  /// ### Errors
+  /// An error is thrown if the given `key` contains any private components. 
+  #[wasm_bindgen(js_name = newJwk)]
+  pub fn new_jwk(key: &WasmJwk) -> Result<Self> {
+    if !key.0.is_public() {
+      return Err(WasmError::new(Cow::Borrowed("PrivateKeyMaterialExposed"), Cow::Borrowed("jwk with private key components is not permitted"))).wasm_result();
+    };
+    
+    Self(MethodData::PublicKeyJwk(key.0.clone()))
   }
 
   /// Returns a `Uint8Array` containing the decoded bytes of the `MethodData`.

--- a/bindings/wasm/src/did/wasm_method_data.rs
+++ b/bindings/wasm/src/did/wasm_method_data.rs
@@ -5,9 +5,10 @@ use identity_iota::verification::MethodData;
 use wasm_bindgen::prelude::*;
 
 use crate::error::Result;
-use crate::error::WasmResult;
 use crate::error::WasmError;
-use std::borrow::Cow; 
+use crate::error::WasmResult;
+use crate::jose::WasmJwk;
+use std::borrow::Cow;
 
 /// Supported verification method data formats.
 #[wasm_bindgen(js_name = MethodData, inspectable)]
@@ -28,16 +29,20 @@ impl WasmMethodData {
   }
 
   /// Creates a new `MethodData` variant consisting of the given `key`.
-  /// 
+  ///
   /// ### Errors
-  /// An error is thrown if the given `key` contains any private components. 
+  /// An error is thrown if the given `key` contains any private components.
   #[wasm_bindgen(js_name = newJwk)]
-  pub fn new_jwk(key: &WasmJwk) -> Result<Self> {
+  pub fn new_jwk(key: &WasmJwk) -> Result<WasmMethodData> {
     if !key.0.is_public() {
-      return Err(WasmError::new(Cow::Borrowed("PrivateKeyMaterialExposed"), Cow::Borrowed("jwk with private key components is not permitted"))).wasm_result();
+      return Err(WasmError::new(
+        Cow::Borrowed("PrivateKeyMaterialExposed"),
+        Cow::Borrowed("jwk with private key components is not permitted"),
+      ))
+      .wasm_result();
     };
-    
-    Self(MethodData::PublicKeyJwk(key.0.clone()))
+
+    Ok(Self(MethodData::PublicKeyJwk(key.0.clone())))
   }
 
   /// Returns a `Uint8Array` containing the decoded bytes of the `MethodData`.

--- a/bindings/wasm/src/did/wasm_method_type.rs
+++ b/bindings/wasm/src/did/wasm_method_type.rs
@@ -20,6 +20,13 @@ impl WasmMethodType {
     WasmMethodType(MethodType::X25519_KEY_AGREEMENT_KEY_2019)
   }
 
+  /// A verification method for use with JWT verification as prescribed by the `Jwk`
+  /// in the `publicKeyJwk` entry.
+  #[wasm_bindgen(js_name = JwkMethodType)]
+  pub fn jwk_method_type() -> WasmMethodType {
+    WasmMethodType(MethodType::JWK)
+  }
+
   /// Returns the `MethodType` as a string.
   #[allow(clippy::inherent_to_string)]
   #[wasm_bindgen(js_name = toString)]

--- a/bindings/wasm/src/did/wasm_verification_method.rs
+++ b/bindings/wasm/src/did/wasm_verification_method.rs
@@ -15,6 +15,7 @@ use identity_iota::verification::VerificationMethod;
 use wasm_bindgen::prelude::*;
 
 use super::wasm_core_did::IToCoreDID;
+use crate::jose::WasmJwk;
 
 /// A DID Document Verification Method.
 #[wasm_bindgen(js_name = VerificationMethod, inspectable)]
@@ -33,6 +34,22 @@ impl WasmVerificationMethod {
   ) -> Result<WasmVerificationMethod> {
     let public_key: PublicKey = PublicKey::from(publicKey);
     VerificationMethod::new(CoreDID::from(did), keyType.into(), &public_key, &fragment)
+      .map(Self)
+      .wasm_result()
+  }
+
+  /// Creates a new `VerificationMethod` from the given `did` and `Jwk`. If a `fragment` is not given an attempt
+  /// will be made to generate it from the `kid` value of the given `key`.
+  ///
+  /// ### Recommendations
+  /// - It is recommended that verification methods that use `Jwks` to represent their public keys use the value of
+  ///   `kid` as their fragment identifier. This is
+  /// done automatically if `None` is passed in as the fragment.
+  /// - It is recommended that `Jwk` kid values are set to the public key fingerprint. See `Jwk::thumbprint_b64`.
+  // TODO: These recommendations were taken from https://w3c.github.io/vc-data-integrity/#dfn-publickeyjwk. Perhaps add that to the documentation once that specification/link becomes stable?
+  #[wasm_bindgen(js_name = newFromJwk)]
+  pub fn new_from_jwk(did: &IToCoreDID, key: &WasmJwk, fragment: Option<String>) -> Result<WasmVerificationMethod> {
+    VerificationMethod::new_from_jwk(&CoreDID::from(did), key.0.clone(), fragment.as_deref())
       .map(Self)
       .wasm_result()
   }

--- a/bindings/wasm/src/did/wasm_verification_method.rs
+++ b/bindings/wasm/src/did/wasm_verification_method.rs
@@ -42,11 +42,11 @@ impl WasmVerificationMethod {
   /// will be made to generate it from the `kid` value of the given `key`.
   ///
   /// ### Recommendations
+  /// The following recommendations are essentially taken from the `publicKeyJwk` description from the [DID specification](https://www.w3.org/TR/did-core/#dfn-publickeyjwk):
   /// - It is recommended that verification methods that use `Jwks` to represent their public keys use the value of
   ///   `kid` as their fragment identifier. This is
   /// done automatically if `None` is passed in as the fragment.
   /// - It is recommended that `Jwk` kid values are set to the public key fingerprint. See `Jwk::thumbprint_b64`.
-  // TODO: These recommendations were taken from https://w3c.github.io/vc-data-integrity/#dfn-publickeyjwk. Perhaps add that to the documentation once that specification/link becomes stable?
   #[wasm_bindgen(js_name = newFromJwk)]
   pub fn new_from_jwk(did: &IToCoreDID, key: &WasmJwk, fragment: Option<String>) -> Result<WasmVerificationMethod> {
     VerificationMethod::new_from_jwk(&CoreDID::from(did), key.0.clone(), fragment.as_deref())

--- a/bindings/wasm/src/jose/jwk.rs
+++ b/bindings/wasm/src/jose/jwk.rs
@@ -9,6 +9,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::common::ArrayString;
 use crate::error::WasmResult;
+use core::ops::Deref;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[wasm_bindgen(js_name = Jwk, inspectable)]
@@ -77,7 +78,12 @@ impl WasmJwk {
   /// Returns the value of the X.509 URL property (x5u).
   #[wasm_bindgen]
   pub fn x5u(&self) -> Option<String> {
-    self.0.x5u().map(AsRef::<str>::as_ref).map(ToOwned::to_owned)
+    self
+      .0
+      .x5u()
+      .map(Deref::deref)
+      .map(AsRef::<str>::as_ref)
+      .map(ToOwned::to_owned)
   }
 
   /// Returns the value of the X.509 certificate chain property (x5c).

--- a/identity_core/Cargo.toml
+++ b/identity_core/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 description = "The core traits and types for the identity-rs library."
 
 [dependencies]
-identity-diff = { version = "=0.7.0-alpha.6", path = "../identity_diff", default-features = false }
+identity-diff = { version = "=0.7.0-alpha.6", path = "../identity_diff", default-features = false, optional = true }
 multibase = { version = "0.9", default-features = false, features = ["std"] }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
 serde_jcs = { version = "0.1", default-features = false }

--- a/identity_core/Cargo.toml
+++ b/identity_core/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 description = "The core traits and types for the identity-rs library."
 
 [dependencies]
-identity-diff = { version = "=0.7.0-alpha.5", path = "../identity_diff", default-features = false }
+identity-diff = { version = "=0.7.0-alpha.5", path = "../identity_diff", default-features = false, optional = true }
 multibase = { version = "0.9", default-features = false, features = ["std"] }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
 serde_jcs = { version = "0.1", default-features = false }
@@ -35,6 +35,10 @@ js-sys = { version = "0.3.55", default-features = false }
 proptest = { version = "1.0.0" }
 quickcheck = { version = "1.0" }
 quickcheck_macros = { version = "1.0" }
+
+[features]
+diff = ["identity-diff"]
+diff-derive = ["diff", "identity-diff/derive"]
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/identity_core/Cargo.toml
+++ b/identity_core/Cargo.toml
@@ -38,7 +38,6 @@ quickcheck_macros = { version = "1.0" }
 
 [features]
 diff = ["identity-diff"]
-diff-derive = ["diff", "identity-diff/derive"]
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/identity_core/src/common/ordered_set.rs
+++ b/identity_core/src/common/ordered_set.rs
@@ -13,9 +13,6 @@ use std::vec::IntoIter;
 use serde::Deserialize;
 use serde::Serialize;
 
-use identity_diff::Diff;
-use identity_diff::DiffVec;
-
 use crate::common::KeyComparable;
 use crate::error::Error;
 use crate::error::Result;
@@ -288,30 +285,36 @@ where
   }
 }
 
-impl<T> Diff for OrderedSet<T>
-where
-  T: Diff + KeyComparable + Serialize + for<'de> Deserialize<'de>,
-{
-  type Type = DiffVec<T>;
+#[cfg(feature = "diff")]
+mod diff {
+  use super::*;
+  use identity_diff::Diff;
+  use identity_diff::DiffVec;
+  impl<T> Diff for OrderedSet<T>
+  where
+    T: Diff + KeyComparable + Serialize + for<'de> Deserialize<'de>,
+  {
+    type Type = DiffVec<T>;
 
-  fn diff(&self, other: &Self) -> identity_diff::Result<Self::Type> {
-    self.clone().into_vec().diff(&other.clone().into_vec())
-  }
+    fn diff(&self, other: &Self) -> identity_diff::Result<Self::Type> {
+      self.clone().into_vec().diff(&other.clone().into_vec())
+    }
 
-  fn merge(&self, diff: Self::Type) -> identity_diff::Result<Self> {
-    self
-      .clone()
-      .into_vec()
-      .merge(diff)
-      .and_then(|this| Self::try_from(this).map_err(identity_diff::Error::merge))
-  }
+    fn merge(&self, diff: Self::Type) -> identity_diff::Result<Self> {
+      self
+        .clone()
+        .into_vec()
+        .merge(diff)
+        .and_then(|this| Self::try_from(this).map_err(identity_diff::Error::merge))
+    }
 
-  fn from_diff(diff: Self::Type) -> identity_diff::Result<Self> {
-    Vec::from_diff(diff).and_then(|this| Self::try_from(this).map_err(identity_diff::Error::convert))
-  }
+    fn from_diff(diff: Self::Type) -> identity_diff::Result<Self> {
+      Vec::from_diff(diff).and_then(|this| Self::try_from(this).map_err(identity_diff::Error::convert))
+    }
 
-  fn into_diff(self) -> identity_diff::Result<Self::Type> {
-    self.into_vec().into_diff()
+    fn into_diff(self) -> identity_diff::Result<Self::Type> {
+      self.into_vec().into_diff()
+    }
   }
 }
 

--- a/identity_core/src/common/ordered_set.rs
+++ b/identity_core/src/common/ordered_set.rs
@@ -252,7 +252,7 @@ where
   where
     I: IntoIterator<Item = T>,
   {
-    let iter: _ = iter.into_iter();
+    let iter = iter.into_iter();
     let size: usize = iter.size_hint().1.unwrap_or(0);
 
     let mut this: Self = Self::with_capacity(size);

--- a/identity_core/src/common/url.rs
+++ b/identity_core/src/common/url.rs
@@ -13,9 +13,6 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::common::KeyComparable;
-use crate::diff;
-use crate::diff::Diff;
-use crate::diff::DiffString;
 use crate::error::Error;
 use crate::error::Result;
 
@@ -91,26 +88,33 @@ where
   }
 }
 
-impl Diff for Url {
-  type Type = DiffString;
+#[cfg(feature = "diff")]
+mod diff {
+  use super::*;
+  use crate::diff;
+  use crate::diff::Diff;
+  use crate::diff::DiffString;
+  impl Diff for Url {
+    type Type = DiffString;
 
-  fn diff(&self, other: &Self) -> diff::Result<Self::Type> {
-    self.to_string().diff(&other.to_string())
-  }
+    fn diff(&self, other: &Self) -> diff::Result<Self::Type> {
+      self.to_string().diff(&other.to_string())
+    }
 
-  fn merge(&self, diff: Self::Type) -> diff::Result<Self> {
-    self
-      .to_string()
-      .merge(diff)
-      .and_then(|this| Self::parse(this).map_err(diff::Error::merge))
-  }
+    fn merge(&self, diff: Self::Type) -> diff::Result<Self> {
+      self
+        .to_string()
+        .merge(diff)
+        .and_then(|this| Self::parse(this).map_err(diff::Error::merge))
+    }
 
-  fn from_diff(diff: Self::Type) -> diff::Result<Self> {
-    String::from_diff(diff).and_then(|this| Self::parse(this).map_err(diff::Error::convert))
-  }
+    fn from_diff(diff: Self::Type) -> diff::Result<Self> {
+      String::from_diff(diff).and_then(|this| Self::parse(this).map_err(diff::Error::convert))
+    }
 
-  fn into_diff(self) -> diff::Result<Self::Type> {
-    self.to_string().into_diff()
+    fn into_diff(self) -> diff::Result<Self::Type> {
+      self.to_string().into_diff()
+    }
   }
 }
 

--- a/identity_core/src/error.rs
+++ b/identity_core/src/error.rs
@@ -10,6 +10,7 @@ pub type Result<T, E = Error> = ::core::result::Result<T, E>;
 
 /// This type represents all possible errors that can occur in the library.
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[non_exhaustive]
 pub enum Error {
   /// Caused when a cryptographic operation fails.
   #[error("Crypto Error: {0}")]
@@ -26,6 +27,7 @@ pub enum Error {
   /// Caused by a failure to decode multibase-encoded data.
   #[error("Failed to decode multibase data: {0}")]
   DecodeMultibase(#[from] multibase::Error),
+  #[cfg(feature = "diff")]
   /// Caused by attempting to perform an invalid `Diff` operation.
   #[deprecated(since = "0.5.0", note = "diff chain features are slated for removal")]
   #[error("Invalid Document Diff: {0}")]

--- a/identity_core/src/lib.rs
+++ b/identity_core/src/lib.rs
@@ -20,6 +20,7 @@
 #[doc(inline)]
 pub use serde_json::json;
 
+#[cfg(feature = "diff")]
 #[deprecated(since = "0.5.0", note = "diff chain features are slated for removal")]
 #[doc(inline)]
 pub use identity_diff as diff;

--- a/identity_credential/src/credential/domain_linkage_configuration.rs
+++ b/identity_credential/src/credential/domain_linkage_configuration.rs
@@ -129,7 +129,7 @@ mod __fetch_configuration {
         .map_err(|err| DomainLinkageError(Box::new(err)))?;
 
       // We use a stream so we can limit the size of the response to 1 MiB.
-      let mut stream: _ = client
+      let mut stream = client
         .get(domain.to_string())
         .send()
         .await

--- a/identity_credential/src/credential/policy.rs
+++ b/identity_credential/src/credential/policy.rs
@@ -36,7 +36,7 @@ impl Policy {
   }
 
   /// Creates a new `Policy` instance with the given `id`.
-  pub fn with_id<T, U>(types: T, id: Url) -> Self
+  pub fn with_id<T>(types: T, id: Url) -> Self
   where
     T: Into<OneOrMany<String>>,
   {
@@ -48,7 +48,7 @@ impl Policy {
   }
 
   /// Creates a new `Policy` instance with the given `properties`.
-  pub fn with_properties<T, U>(types: T, properties: Object) -> Self
+  pub fn with_properties<T>(types: T, properties: Object) -> Self
   where
     T: Into<OneOrMany<String>>,
   {
@@ -60,7 +60,7 @@ impl Policy {
   }
 
   /// Creates a new `Policy` instance with the given `id` and `properties`.
-  pub fn with_id_and_properties<T, U, V>(types: T, id: Url, properties: Object) -> Self
+  pub fn with_id_and_properties<T>(types: T, id: Url, properties: Object) -> Self
   where
     T: Into<OneOrMany<String>>,
   {

--- a/identity_did/Cargo.toml
+++ b/identity_did/Cargo.toml
@@ -22,6 +22,9 @@ thiserror.workspace = true
 proptest = { version = "1.0" }
 serde_json.workspace = true
 
+[features]
+diff = ["identity_core/diff"]
+
 [package.metadata.docs.rs]
 # To build locally:
 # RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --workspace --open

--- a/identity_did/src/did.rs
+++ b/identity_did/src/did.rs
@@ -11,8 +11,6 @@ use std::hash::Hash;
 use did_url::DID as BaseDIDUrl;
 
 use identity_core::common::KeyComparable;
-use identity_core::diff::Diff;
-use identity_core::diff::DiffString;
 
 use crate::DIDUrl;
 use crate::Error;
@@ -239,26 +237,32 @@ impl From<CoreDID> for String {
   }
 }
 
-impl Diff for CoreDID {
-  type Type = DiffString;
+#[cfg(feature = "diff")]
+mod diff {
+  use super::*;
+  use identity_core::diff::Diff;
+  use identity_core::diff::DiffString;
+  impl Diff for CoreDID {
+    type Type = DiffString;
 
-  fn diff(&self, other: &Self) -> identity_core::diff::Result<Self::Type> {
-    self.to_string().diff(&other.to_string())
-  }
+    fn diff(&self, other: &Self) -> identity_core::diff::Result<Self::Type> {
+      self.to_string().diff(&other.to_string())
+    }
 
-  fn merge(&self, diff: Self::Type) -> identity_core::diff::Result<Self> {
-    self
-      .to_string()
-      .merge(diff)
-      .and_then(|this| Self::parse(this).map_err(identity_core::diff::Error::merge))
-  }
+    fn merge(&self, diff: Self::Type) -> identity_core::diff::Result<Self> {
+      self
+        .to_string()
+        .merge(diff)
+        .and_then(|this| Self::parse(this).map_err(identity_core::diff::Error::merge))
+    }
 
-  fn from_diff(diff: Self::Type) -> identity_core::diff::Result<Self> {
-    String::from_diff(diff).and_then(|this| Self::parse(this).map_err(identity_core::diff::Error::convert))
-  }
+    fn from_diff(diff: Self::Type) -> identity_core::diff::Result<Self> {
+      String::from_diff(diff).and_then(|this| Self::parse(this).map_err(identity_core::diff::Error::convert))
+    }
 
-  fn into_diff(self) -> identity_core::diff::Result<Self::Type> {
-    self.to_string().into_diff()
+    fn into_diff(self) -> identity_core::diff::Result<Self::Type> {
+      self.to_string().into_diff()
+    }
   }
 }
 

--- a/identity_did/src/did_url.rs
+++ b/identity_did/src/did_url.rs
@@ -14,8 +14,6 @@ use did_url::DID as BaseDIDUrl;
 
 use identity_core::common::KeyComparable;
 use identity_core::common::Url;
-use identity_core::diff::Diff;
-use identity_core::diff::DiffString;
 
 use crate::did::is_char_method_id;
 use crate::did::CoreDID;
@@ -517,26 +515,32 @@ impl Display for DIDUrl {
   }
 }
 
-impl Diff for DIDUrl {
-  type Type = DiffString;
+#[cfg(feature = "diff")]
+mod diff {
+  use super::*;
+  use identity_core::diff::Diff;
+  use identity_core::diff::DiffString;
+  impl Diff for DIDUrl {
+    type Type = DiffString;
 
-  fn diff(&self, other: &Self) -> identity_core::diff::Result<Self::Type> {
-    self.to_string().diff(&other.to_string())
-  }
+    fn diff(&self, other: &Self) -> identity_core::diff::Result<Self::Type> {
+      self.to_string().diff(&other.to_string())
+    }
 
-  fn merge(&self, diff: Self::Type) -> identity_core::diff::Result<Self> {
-    self
-      .to_string()
-      .merge(diff)
-      .and_then(|this| Self::parse(this).map_err(identity_core::diff::Error::merge))
-  }
+    fn merge(&self, diff: Self::Type) -> identity_core::diff::Result<Self> {
+      self
+        .to_string()
+        .merge(diff)
+        .and_then(|this| Self::parse(this).map_err(identity_core::diff::Error::merge))
+    }
 
-  fn from_diff(diff: Self::Type) -> identity_core::diff::Result<Self> {
-    String::from_diff(diff).and_then(|this| Self::parse(this).map_err(identity_core::diff::Error::convert))
-  }
+    fn from_diff(diff: Self::Type) -> identity_core::diff::Result<Self> {
+      String::from_diff(diff).and_then(|this| Self::parse(this).map_err(identity_core::diff::Error::convert))
+    }
 
-  fn into_diff(self) -> identity_core::diff::Result<Self::Type> {
-    self.to_string().into_diff()
+    fn into_diff(self) -> identity_core::diff::Result<Self::Type> {
+      self.to_string().into_diff()
+    }
   }
 }
 

--- a/identity_diff/src/option.rs
+++ b/identity_diff/src/option.rs
@@ -21,7 +21,7 @@ pub enum DiffOption<T: Diff> {
 /// `Diff` Implementation for `Option<T>`
 impl<T> Diff for Option<T>
 where
-  T: Diff + Clone + Debug + PartialEq + Default + for<'de> Deserialize<'de> + Serialize,
+  T: Diff + Clone + Debug + PartialEq + for<'de> Deserialize<'de> + Serialize,
 {
   /// The Corresponding Diff type for `Option<T>`
   type Type = DiffOption<T>;

--- a/identity_document/Cargo.toml
+++ b/identity_document/Cargo.toml
@@ -26,6 +26,9 @@ thiserror.workspace = true
 criterion = { version = "0.4.0", default-features = false, features = ["cargo_bench_support"] }
 serde_json.workspace = true
 
+[features]
+diff = ["identity_core/diff", "identity_did/diff"]
+
 [[bench]]
 name = "deserialize_document"
 harness = false

--- a/identity_document/src/document/mod.rs
+++ b/identity_document/src/document/mod.rs
@@ -8,6 +8,7 @@
 pub use self::builder::DocumentBuilder;
 pub use self::core_document::CoreDocument;
 
+#[cfg(feature = "diff")]
 pub(crate) use core_document::CoreDocumentData;
 mod builder;
 mod core_document;

--- a/identity_document/src/lib.rs
+++ b/identity_document/src/lib.rs
@@ -20,6 +20,7 @@
 #[macro_use]
 extern crate serde;
 
+#[cfg(feature = "diff")]
 #[deprecated(since = "0.5.0", note = "diff chain features are slated for removal")]
 pub mod diff;
 

--- a/identity_document/src/verifiable/properties.rs
+++ b/identity_document/src/verifiable/properties.rs
@@ -9,7 +9,6 @@ use identity_core::crypto::GetSignature;
 use identity_core::crypto::GetSignatureMut;
 use identity_core::crypto::Proof;
 use identity_core::crypto::SetSignature;
-use identity_core::diff::Diff;
 
 use identity_verification::MethodUriType;
 use identity_verification::TryMethod;
@@ -42,34 +41,39 @@ impl<T> VerifiableProperties<T> {
   }
 }
 
-/// NOTE: excludes the `proof` Signature from the diff to save space on the Tangle and because
-/// a merged signature will be invalid in general.
-impl<T> Diff for VerifiableProperties<T>
-where
-  T: Diff,
-{
-  type Type = <T as Diff>::Type;
+#[cfg(feature = "diff")]
+mod diff {
+  use super::*;
+  use identity_core::diff::Diff;
+  /// NOTE: excludes the `proof` Signature from the diff to save space on the Tangle and because
+  /// a merged signature will be invalid in general.
+  impl<T> Diff for VerifiableProperties<T>
+  where
+    T: Diff,
+  {
+    type Type = <T as Diff>::Type;
 
-  fn diff(&self, other: &Self) -> identity_core::diff::Result<Self::Type> {
-    self.properties.diff(&other.properties)
-  }
+    fn diff(&self, other: &Self) -> identity_core::diff::Result<Self::Type> {
+      self.properties.diff(&other.properties)
+    }
 
-  fn merge(&self, diff: Self::Type) -> identity_core::diff::Result<Self> {
-    let mut this: VerifiableProperties<T> = self.clone();
-    this.properties = this.properties.merge(diff)?;
-    Ok(this)
-  }
+    fn merge(&self, diff: Self::Type) -> identity_core::diff::Result<Self> {
+      let mut this: VerifiableProperties<T> = self.clone();
+      this.properties = this.properties.merge(diff)?;
+      Ok(this)
+    }
 
-  fn from_diff(diff: Self::Type) -> identity_core::diff::Result<Self> {
-    let properties: T = T::from_diff(diff)?;
-    Ok(VerifiableProperties {
-      properties,
-      proof: None, // proof intentionally excluded
-    })
-  }
+    fn from_diff(diff: Self::Type) -> identity_core::diff::Result<Self> {
+      let properties: T = T::from_diff(diff)?;
+      Ok(VerifiableProperties {
+        properties,
+        proof: None, // proof intentionally excluded
+      })
+    }
 
-  fn into_diff(self) -> identity_core::diff::Result<Self::Type> {
-    self.properties.into_diff()
+    fn into_diff(self) -> identity_core::diff::Result<Self::Type> {
+      self.properties.into_diff()
+    }
   }
 }
 

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1.17.0", features = ["full"] }
 
 [features]
 default = ["revocation-bitmap", "client", "iota-client", "resolver"]
+diff = ["identity_core/diff", "identity_did/diff", "identity_verification/diff"]
 
 # Exposes the `IotaIdentityClient` and `IotaIdentityClientExt` traits.
 client = ["identity_iota_core/client"]

--- a/identity_iota/src/lib.rs
+++ b/identity_iota/src/lib.rs
@@ -26,6 +26,7 @@ pub mod core {
   pub use identity_core::error::*;
   pub use identity_core::utils::*;
 
+  #[cfg(feature = "diff")]
   #[deprecated(since = "0.5.0", note = "diff chain features are slated for removal")]
   #[doc(inline)]
   pub use identity_core::diff;

--- a/identity_jose/Cargo.toml
+++ b/identity_jose/Cargo.toml
@@ -13,17 +13,16 @@ description = "A library for JOSE (JSON Object Signing and Encryption)"
 
 [dependencies]
 base64 = { version = "0.21.0", default-features = false, features = ["std"] }
-identity-diff = { version = "=0.7.0-alpha.5", path = "../identity_diff", default-features = false, optional = true }
+identity_core = { version = "0.7.0-alpha.5", path = "../identity_core", default-features = false }
 iota-crypto = { version = "0.15.3", default-features = false, features = ["std", "sha"] }
 serde.workspace = true
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 subtle = { version = "2.4.1", default-features = false }
 thiserror.workspace = true
-url = { version = "2.3.1", default-features = false, features = ["serde"] }
 zeroize = { version = "1.5.7", default-features = false, features = ["std", "zeroize_derive"] }
 
 [features]
-diff = ["dep:identity-diff"]
+diff = ["identity_core/diff"]
 default = ["diff"]
 
 [dev-dependencies]

--- a/identity_jose/Cargo.toml
+++ b/identity_jose/Cargo.toml
@@ -13,6 +13,7 @@ description = "A library for JOSE (JSON Object Signing and Encryption)"
 
 [dependencies]
 base64 = { version = "0.21.0", default-features = false, features = ["std"] }
+identity-diff = { version = "=0.7.0-alpha.5", path = "../identity_diff", default-features = false, optional = true }
 iota-crypto = { version = "0.15.3", default-features = false, features = ["std", "sha"] }
 serde.workspace = true
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
@@ -20,6 +21,10 @@ subtle = { version = "2.4.1", default-features = false }
 thiserror.workspace = true
 url = { version = "2.3.1", default-features = false, features = ["serde"] }
 zeroize = { version = "1.5.7", default-features = false, features = ["std", "zeroize_derive"] }
+
+[features]
+diff = ["dep:identity-diff"]
+default = ["diff"]
 
 [dev-dependencies]
 anyhow = "1"

--- a/identity_jose/Cargo.toml
+++ b/identity_jose/Cargo.toml
@@ -26,7 +26,7 @@ zeroize = { version = "1.5.7", default-features = false, features = ["std", "zer
 eddsa = ["iota-crypto/ed25519"]
 # Enables Diff implementation for Jwk
 diff = ["identity_core/diff"]
-default = ["diff", "eddsa"]
+default = ["eddsa"]
 
 [dev-dependencies]
 anyhow = "1"

--- a/identity_jose/Cargo.toml
+++ b/identity_jose/Cargo.toml
@@ -20,9 +20,11 @@ serde_json = { version = "1.0", default-features = false, features = ["std"] }
 subtle = { version = "2.4.1", default-features = false }
 thiserror.workspace = true
 zeroize = { version = "1.5.7", default-features = false, features = ["std", "zeroize_derive"] }
+
 [features]
 # Enables jws verification based on the EdDSA algorithm.
 eddsa = ["iota-crypto/ed25519"]
+# Enables Diff implementation for Jwk
 diff = ["identity_core/diff"]
 default = ["diff", "eddsa"]
 

--- a/identity_jose/src/jwk/diff/key.rs
+++ b/identity_jose/src/jwk/diff/key.rs
@@ -1,2 +1,20 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+
+use identity_core::common::Url;
+use identity_core::diff::Diff;
+use identity_core::diff::DiffString;
+use identity_core::diff::DiffVec;
+
+use crate::jwk::JwkOperation;
+use crate::jwk::JwkType;
+use crate::jwk::JwkUse;
+
+pub struct DiffJwk {
+  kty: <JwkType as Diff>::Type,
+  use_: Option<<JwkUse as Diff>::Type>,
+  key_ops: Option<DiffVec<JwkOperation>>,
+  alg: Option<DiffString>,
+  kid: Option<DiffString>,
+  x5u: Option<<Url as Diff>::Type>,
+}

--- a/identity_jose/src/jwk/diff/key.rs
+++ b/identity_jose/src/jwk/diff/key.rs
@@ -1,0 +1,2 @@
+// Copyright 2020-2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0

--- a/identity_jose/src/jwk/diff/key.rs
+++ b/identity_jose/src/jwk/diff/key.rs
@@ -1,20 +1,155 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use identity_core::common::Url;
-use identity_core::diff::Diff;
-use identity_core::diff::DiffString;
-use identity_core::diff::DiffVec;
-
+use crate::jwk::Jwk;
 use crate::jwk::JwkOperation;
 use crate::jwk::JwkType;
 use crate::jwk::JwkUse;
+use identity_core::common::Url;
+use identity_core::diff::Diff;
+use identity_core::diff::DiffOption;
+use identity_core::diff::Result as DiffResult;
+use serde::Deserialize;
+use serde::Serialize;
 
+use super::DiffJwkParams;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DiffJwk {
   kty: <JwkType as Diff>::Type,
-  use_: Option<<JwkUse as Diff>::Type>,
-  key_ops: Option<DiffVec<JwkOperation>>,
-  alg: Option<DiffString>,
-  kid: Option<DiffString>,
-  x5u: Option<<Url as Diff>::Type>,
+  use_: DiffOption<JwkUse>,
+  key_ops: DiffOption<Vec<JwkOperation>>,
+  alg: DiffOption<String>,
+  kid: DiffOption<String>,
+  x5u: DiffOption<Url>,
+  x5c: DiffOption<Vec<String>>,
+  x5t: DiffOption<String>,
+  x5t_s256: DiffOption<String>,
+  params: DiffJwkParams,
+}
+
+impl Diff for Jwk {
+  type Type = DiffJwk;
+  /// Finds the difference of `self` and `other`. This is guaranteed to error if either
+  /// `self` or `other` contain params with private key components.
+  fn diff(&self, other: &Self) -> DiffResult<Self::Type> {
+    let kty = self.kty.diff(&other.kty)?;
+    let use_ = self.use_.diff(&other.use_)?;
+    let key_ops = self.key_ops.diff(&other.key_ops)?;
+    let alg = self.alg.diff(&other.alg)?;
+    let kid = self.kid.diff(&other.kid)?;
+    let x5u = self.x5u.diff(&other.x5u)?;
+    let x5c = self.x5c.diff(&other.x5c)?;
+    let x5t = self.x5t.diff(&other.x5t)?;
+    let x5t_s256 = self.x5t_s256.diff(&other.x5t_s256)?;
+    let params = self.params.diff(&other.params)?;
+    Ok(DiffJwk {
+      kty,
+      use_,
+      key_ops,
+      alg,
+      kid,
+      x5u,
+      x5c,
+      x5t,
+      x5t_s256,
+      params,
+    })
+  }
+  fn merge(&self, diff: Self::Type) -> DiffResult<Self> {
+    let DiffJwk {
+      kty,
+      use_,
+      key_ops,
+      alg,
+      kid,
+      x5u,
+      x5c,
+      x5t,
+      x5t_s256,
+      params,
+    } = diff;
+    let kty = self.kty.merge(kty)?;
+    let use_ = self.use_.merge(use_)?;
+    let key_ops = self.key_ops.merge(key_ops)?;
+    let alg = self.alg.merge(alg)?;
+    let kid = self.kid.merge(kid)?;
+    let x5u = self.x5u.merge(x5u)?;
+    let x5c = self.x5c.merge(x5c)?;
+    let x5t = self.x5t.merge(x5t)?;
+    let x5t_s256 = self.x5t_s256.merge(x5t_s256)?;
+    let params = self.params.merge(params)?;
+    Ok(Jwk {
+      kty,
+      use_,
+      key_ops,
+      alg,
+      kid,
+      x5u,
+      x5c,
+      x5t,
+      x5t_s256,
+      params,
+    })
+  }
+
+  fn from_diff(diff: Self::Type) -> identity_core::diff::Result<Self> {
+    let DiffJwk {
+      kty,
+      use_,
+      key_ops,
+      alg,
+      kid,
+      x5u,
+      x5c,
+      x5t,
+      x5t_s256,
+      params,
+    } = diff;
+    let kty = Diff::from_diff(kty)?;
+    let use_ = Diff::from_diff(use_)?;
+    let key_ops = Diff::from_diff(key_ops)?;
+    let alg = Diff::from_diff(alg)?;
+    let kid = Diff::from_diff(kid)?;
+    let x5u = Diff::from_diff(x5u)?;
+    let x5c = Diff::from_diff(x5c)?;
+    let x5t = Diff::from_diff(x5t)?;
+    let x5t_s256 = Diff::from_diff(x5t_s256)?;
+    let params = Diff::from_diff(params)?;
+    Ok(Jwk {
+      kty,
+      use_,
+      key_ops,
+      alg,
+      kid,
+      x5u,
+      x5c,
+      x5t,
+      x5t_s256,
+      params,
+    })
+  }
+
+  /// Convert `self` into [`DiffJwk`]. This is guaranteed to error if `self`
+  /// contains params with private key components.
+  fn into_diff(mut self) -> identity_core::diff::Result<Self::Type> {
+    self.take_diff()
+  }
+}
+
+impl Jwk {
+  fn take_diff(&mut self) -> DiffResult<DiffJwk> {
+    Ok(DiffJwk {
+      kty: self.kty.into_diff()?,
+      use_: self.use_.into_diff()?,
+      key_ops: self.key_ops.take().into_diff()?,
+      alg: self.alg.take().into_diff()?,
+      kid: self.kid.take().into_diff()?,
+      x5u: self.x5u.take().into_diff()?,
+      x5c: self.x5c.take().into_diff()?,
+      x5t: self.x5t.take().into_diff()?,
+      x5t_s256: self.x5t_s256.take().into_diff()?,
+      params: self.params.take_diff()?,
+    })
+  }
 }

--- a/identity_jose/src/jwk/diff/key_operations.rs
+++ b/identity_jose/src/jwk/diff/key_operations.rs
@@ -1,0 +1,27 @@
+// Copyright 2020-2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use identity_diff::Diff;
+use identity_diff::Result;
+
+use crate::jwk::JwkOperation;
+
+impl Diff for JwkOperation {
+  type Type = JwkOperation;
+
+  fn diff(&self, other: &Self) -> Result<Self::Type> {
+    Ok(*other)
+  }
+
+  fn merge(&self, diff: Self::Type) -> Result<Self> {
+    Ok(diff)
+  }
+
+  fn from_diff(diff: Self::Type) -> Result<Self> {
+    Ok(diff)
+  }
+
+  fn into_diff(self) -> Result<Self::Type> {
+    Ok(self)
+  }
+}

--- a/identity_jose/src/jwk/diff/key_operations.rs
+++ b/identity_jose/src/jwk/diff/key_operations.rs
@@ -23,7 +23,7 @@ impl Diff for JwkOperation {
   }
 
   fn merge(&self, diff: Self::Type) -> Result<Self> {
-    Ok(diff.0.unwrap_or_else(|| *self))
+    Ok(diff.0.unwrap_or(*self))
   }
 
   fn from_diff(diff: Self::Type) -> Result<Self> {

--- a/identity_jose/src/jwk/diff/key_operations.rs
+++ b/identity_jose/src/jwk/diff/key_operations.rs
@@ -3,25 +3,36 @@
 
 use identity_core::diff::Diff;
 use identity_core::diff::Result;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::jwk::JwkOperation;
 
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct DiffJwkOperation(#[serde(skip_serializing_if = "Option::is_none")] Option<JwkOperation>);
+
 impl Diff for JwkOperation {
-  type Type = JwkOperation;
+  type Type = DiffJwkOperation;
 
   fn diff(&self, other: &Self) -> Result<Self::Type> {
-    Ok(*other)
+    if self == other {
+      Ok(DiffJwkOperation(None))
+    } else {
+      Ok(DiffJwkOperation(Some(*other)))
+    }
   }
 
   fn merge(&self, diff: Self::Type) -> Result<Self> {
-    Ok(diff)
+    Ok(diff.0.unwrap_or_else(|| *self))
   }
 
   fn from_diff(diff: Self::Type) -> Result<Self> {
-    Ok(diff)
+    diff
+      .0
+      .ok_or_else(|| identity_core::diff::Error::ConversionError("cannot convert from empty diff".to_owned()))
   }
 
   fn into_diff(self) -> Result<Self::Type> {
-    Ok(self)
+    Ok(DiffJwkOperation(Some(self)))
   }
 }

--- a/identity_jose/src/jwk/diff/key_operations.rs
+++ b/identity_jose/src/jwk/diff/key_operations.rs
@@ -1,8 +1,8 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use identity_diff::Diff;
-use identity_diff::Result;
+use identity_core::diff::Diff;
+use identity_core::diff::Result;
 
 use crate::jwk::JwkOperation;
 

--- a/identity_jose/src/jwk/diff/key_params.rs
+++ b/identity_jose/src/jwk/diff/key_params.rs
@@ -1,0 +1,85 @@
+// Copyright 2020-2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use identity_diff::Diff;
+use identity_diff::DiffString;
+use identity_diff::Result;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::jwk::JwkParamsEc;
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct DiffJwkParamsEc {
+  pub crv: DiffString, // Curve
+  pub x: DiffString,   // X Coordinate
+  pub y: DiffString,   // Y Coordinate
+}
+
+impl Diff for JwkParamsEc {
+  type Type = DiffJwkParamsEc;
+
+  /// Finds the difference between `self` and `other` and returns the result as
+  /// a [`DiffJwkParamsEc`].
+  ///
+  /// # Errors
+  /// Errors if either `self` or `other` contains private components.
+  fn diff(&self, other: &Self) -> identity_diff::Result<Self::Type> {
+    if !(self.is_public() && other.is_public()) {
+      return Err(identity_diff::Error::DiffError(
+        "cannot diff jwk with private components".to_owned(),
+      ));
+    }
+    Ok(DiffJwkParamsEc {
+      crv: self.crv.diff(&other.crv)?,
+      x: self.x.diff(&other.x)?,
+      y: self.y.diff(&other.y)?,
+    })
+  }
+
+  fn merge(&self, diff: Self::Type) -> identity_diff::Result<Self> {
+    let crv = self.crv.merge(diff.crv)?;
+    let x = self.x.merge(diff.x)?;
+    let y = self.y.merge(diff.y)?;
+    Ok(JwkParamsEc { crv, x, y, d: None })
+  }
+
+  fn from_diff(diff: Self::Type) -> identity_diff::Result<Self> {
+    let DiffJwkParamsEc { crv, x, y } = diff;
+    Ok(Self {
+      crv: Diff::from_diff(crv)?,
+      x: Diff::from_diff(x)?,
+      y: Diff::from_diff(y)?,
+      d: None,
+    })
+  }
+
+  /// Converts the [`JwkParamsEc`] into [`DiffJwkParamsEc`].
+  ///
+  /// # Errors
+  /// Errors if the params contain a private component.
+  fn into_diff(mut self) -> identity_diff::Result<Self::Type> {
+    if !self.is_public() {
+      return Err(identity_diff::Error::ConversionError(
+        "cannot convert jwk with private components to diff".to_owned(),
+      ));
+    }
+
+    let (crv, x, y): (String, String, String) = {
+      // Cannot directly destructure because of #[zeroize(drop)]
+      let JwkParamsEc {
+        ref mut crv,
+        ref mut x,
+        ref mut y,
+        ..
+      } = self;
+      (std::mem::take(crv), std::mem::take(x), std::mem::take(y))
+    };
+
+    Ok(DiffJwkParamsEc {
+      crv: crv.into_diff()?,
+      x: x.into_diff()?,
+      y: y.into_diff()?,
+    })
+  }
+}

--- a/identity_jose/src/jwk/diff/key_params/ec.rs
+++ b/identity_jose/src/jwk/diff/key_params/ec.rs
@@ -26,7 +26,7 @@ impl Diff for JwkParamsEc {
   /// Errors if either `self` or `other` contains private components.
   fn diff(&self, other: &Self) -> DiffResult<Self::Type> {
     if !(self.is_public() && other.is_public()) {
-      return Err(identity_diff::Error::DiffError(
+      return Err(identity_core::diff::Error::DiffError(
         "cannot diff jwk with private components".to_owned(),
       ));
     }
@@ -75,7 +75,7 @@ impl JwkParamsEc {
   /// hence this provides workaround to enable a cheap implementation of `into_diff`.
   pub(super) fn take_diff(&mut self) -> DiffResult<DiffJwkParamsEc> {
     if !self.is_public() {
-      return Err(identity_diff::Error::ConversionError(
+      return Err(identity_core::diff::Error::ConversionError(
         "cannot convert jwk with private components to diff".to_owned(),
       ));
     }

--- a/identity_jose/src/jwk/diff/key_params/ec.rs
+++ b/identity_jose/src/jwk/diff/key_params/ec.rs
@@ -1,15 +1,15 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-
-use identity_diff::Diff;
-use identity_diff::DiffString;
-use identity_diff::Result;
-use serde::Deserialize;
-use serde::Serialize;
-
+use super::Deserialize;
+use super::Diff;
+use super::DiffResult;
+use super::DiffString;
+use super::Serialize;
 use crate::jwk::JwkParamsEc;
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+/// Represents the difference of two [`JwkParamsEcs`](JwkParamsEc) without any private
+/// components.   
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DiffJwkParamsEc {
   pub crv: DiffString, // Curve
   pub x: DiffString,   // X Coordinate
@@ -24,7 +24,7 @@ impl Diff for JwkParamsEc {
   ///
   /// # Errors
   /// Errors if either `self` or `other` contains private components.
-  fn diff(&self, other: &Self) -> identity_diff::Result<Self::Type> {
+  fn diff(&self, other: &Self) -> DiffResult<Self::Type> {
     if !(self.is_public() && other.is_public()) {
       return Err(identity_diff::Error::DiffError(
         "cannot diff jwk with private components".to_owned(),
@@ -37,14 +37,14 @@ impl Diff for JwkParamsEc {
     })
   }
 
-  fn merge(&self, diff: Self::Type) -> identity_diff::Result<Self> {
+  fn merge(&self, diff: Self::Type) -> DiffResult<Self> {
     let crv = self.crv.merge(diff.crv)?;
     let x = self.x.merge(diff.x)?;
     let y = self.y.merge(diff.y)?;
     Ok(JwkParamsEc { crv, x, y, d: None })
   }
 
-  fn from_diff(diff: Self::Type) -> identity_diff::Result<Self> {
+  fn from_diff(diff: Self::Type) -> DiffResult<Self> {
     let DiffJwkParamsEc { crv, x, y } = diff;
     Ok(Self {
       crv: Diff::from_diff(crv)?,
@@ -58,7 +58,22 @@ impl Diff for JwkParamsEc {
   ///
   /// # Errors
   /// Errors if the params contain a private component.
-  fn into_diff(mut self) -> identity_diff::Result<Self::Type> {
+  fn into_diff(mut self) -> DiffResult<Self::Type> {
+    self.take_diff()
+  }
+}
+
+impl JwkParamsEc {
+  /// Obtain a [`DiffJwkParamsEc`] from a [`&mut JwkParamsEc`](JwkParamsEc) leaving
+  /// empty strings as public parameters in `self`.
+  ///
+  /// # Errors
+  /// Errors immediately if the params contain a private component.
+  ///
+  /// # Motivation
+  /// [`JwkParamsEc`] cannot directly be destructured because of [zeroize(drop)]
+  /// hence this provides workaround to enable a cheap implementation of `into_diff`.
+  pub(super) fn take_diff(&mut self) -> DiffResult<DiffJwkParamsEc> {
     if !self.is_public() {
       return Err(identity_diff::Error::ConversionError(
         "cannot convert jwk with private components to diff".to_owned(),

--- a/identity_jose/src/jwk/diff/key_params/ec.rs
+++ b/identity_jose/src/jwk/diff/key_params/ec.rs
@@ -27,7 +27,7 @@ impl Diff for JwkParamsEc {
   fn diff(&self, other: &Self) -> DiffResult<Self::Type> {
     if !(self.is_public() && other.is_public()) {
       return Err(identity_core::diff::Error::DiffError(
-        "cannot diff jwk with private components".to_owned(),
+        "cannot diff jwk ec params with private components".to_owned(),
       ));
     }
     Ok(DiffJwkParamsEc {
@@ -76,7 +76,7 @@ impl JwkParamsEc {
   pub(super) fn take_diff(&mut self) -> DiffResult<DiffJwkParamsEc> {
     if !self.is_public() {
       return Err(identity_core::diff::Error::ConversionError(
-        "cannot convert jwk with private components to diff".to_owned(),
+        "cannot convert jwk ec params with private components to diff".to_owned(),
       ));
     }
 

--- a/identity_jose/src/jwk/diff/key_params/mod.rs
+++ b/identity_jose/src/jwk/diff/key_params/mod.rs
@@ -1,11 +1,8 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-//! Provides [`Diff`] implementations for [`JwkParams`].
-//!
-//! # Warning: This module has not been tested.  
-use identity_diff::Diff;
-use identity_diff::DiffString;
-use identity_diff::Result as DiffResult;
+use identity_core::diff::Diff;
+use identity_core::diff::DiffString;
+use identity_core::diff::Result as DiffResult;
 use serde::Deserialize;
 use serde::Serialize;
 mod ec;
@@ -57,10 +54,10 @@ impl Diff for JwkParams {
 
   fn from_diff(diff: Self::Type) -> DiffResult<Self> {
     match diff {
-      DiffJwkParams::Okp(a) => Diff::from_diff(a).map(Self::Okp),
-      DiffJwkParams::Ec(a) => Diff::from_diff(a).map(Self::Ec),
-      DiffJwkParams::Oct(a) => Diff::from_diff(a).map(Self::Oct),
-      DiffJwkParams::Rsa(a) => Diff::from_diff(a).map(Self::Rsa),
+      DiffJwkParams::Okp(diff_params) => Diff::from_diff(diff_params).map(Self::Okp),
+      DiffJwkParams::Ec(diff_params) => Diff::from_diff(diff_params).map(Self::Ec),
+      DiffJwkParams::Oct(diff_params) => Diff::from_diff(diff_params).map(Self::Oct),
+      DiffJwkParams::Rsa(diff_params) => Diff::from_diff(diff_params).map(Self::Rsa),
     }
   }
 
@@ -70,10 +67,10 @@ impl Diff for JwkParams {
   /// Errors if the [`JwkParams`] contain private components.
   fn into_diff(mut self) -> DiffResult<Self::Type> {
     match &mut self {
-      Self::Okp(a) => a.take_diff().map(DiffJwkParams::Okp),
-      Self::Ec(a) => a.take_diff().map(DiffJwkParams::Ec),
-      Self::Oct(a) => a.take_diff().map(DiffJwkParams::Oct),
-      Self::Rsa(a) => a.take_diff().map(DiffJwkParams::Rsa),
+      Self::Okp(params) => params.take_diff().map(DiffJwkParams::Okp),
+      Self::Ec(params) => params.take_diff().map(DiffJwkParams::Ec),
+      Self::Oct(params) => params.take_diff().map(DiffJwkParams::Oct),
+      Self::Rsa(params) => params.take_diff().map(DiffJwkParams::Rsa),
     }
   }
 }

--- a/identity_jose/src/jwk/diff/key_params/mod.rs
+++ b/identity_jose/src/jwk/diff/key_params/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+
 use identity_core::diff::Diff;
 use identity_core::diff::DiffString;
 use identity_core::diff::Result as DiffResult;

--- a/identity_jose/src/jwk/diff/key_params/mod.rs
+++ b/identity_jose/src/jwk/diff/key_params/mod.rs
@@ -1,0 +1,79 @@
+// Copyright 2020-2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+//! Provides [`Diff`] implementations for [`JwkParams`].
+//!
+//! # Warning: This module has not been tested.  
+use identity_diff::Diff;
+use identity_diff::DiffString;
+use identity_diff::Result as DiffResult;
+use serde::Deserialize;
+use serde::Serialize;
+mod ec;
+mod oct;
+mod okp;
+mod rsa;
+pub use ec::*;
+pub use oct::*;
+pub use okp::*;
+pub use rsa::*;
+
+use crate::jwk::JwkParams;
+
+/// The difference of two [`JwkParams`].
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub enum DiffJwkParams {
+  Ec(DiffJwkParamsEc),
+  Rsa(DiffJwkParamsRsa),
+  Oct(DiffJwkParamsOct),
+  Okp(DiffJwkParamsOkp),
+}
+
+impl Diff for JwkParams {
+  type Type = DiffJwkParams;
+
+  /// Finds the difference between `self` and `other` and returns the result represented as a [`DiffJwkParams`].
+  ///
+  /// # Errors
+  /// Errors if `self` or `others` contain private components.
+  fn diff(&self, other: &Self) -> DiffResult<Self::Type> {
+    match (self, other) {
+      (Self::Okp(a), Self::Okp(b)) => Ok(DiffJwkParams::Okp(a.diff(b)?)),
+      (Self::Ec(a), Self::Ec(b)) => Ok(DiffJwkParams::Ec(a.diff(b)?)),
+      (Self::Oct(a), Self::Oct(b)) => Ok(DiffJwkParams::Oct(a.diff(b)?)),
+      (Self::Rsa(a), Self::Rsa(b)) => Ok(DiffJwkParams::Rsa(a.diff(b)?)),
+      (_, _) => other.clone().into_diff(),
+    }
+  }
+
+  fn merge(&self, diff: Self::Type) -> DiffResult<Self> {
+    match (self, diff) {
+      (Self::Okp(a), DiffJwkParams::Okp(b)) => a.merge(b).map(Self::Okp),
+      (Self::Ec(a), DiffJwkParams::Ec(b)) => a.merge(b).map(Self::Ec),
+      (Self::Oct(a), DiffJwkParams::Oct(b)) => a.merge(b).map(Self::Oct),
+      (Self::Rsa(a), DiffJwkParams::Rsa(b)) => a.merge(b).map(Self::Rsa),
+      (_, diff) => Self::from_diff(diff),
+    }
+  }
+
+  fn from_diff(diff: Self::Type) -> DiffResult<Self> {
+    match diff {
+      DiffJwkParams::Okp(a) => Diff::from_diff(a).map(Self::Okp),
+      DiffJwkParams::Ec(a) => Diff::from_diff(a).map(Self::Ec),
+      DiffJwkParams::Oct(a) => Diff::from_diff(a).map(Self::Oct),
+      DiffJwkParams::Rsa(a) => Diff::from_diff(a).map(Self::Rsa),
+    }
+  }
+
+  /// Converts the [`JwkParams`] into [`DiffJwkParams`].
+  ///
+  /// # Errors
+  /// Errors if the [`JwkParams`] contain private components.
+  fn into_diff(mut self) -> DiffResult<Self::Type> {
+    match &mut self {
+      Self::Okp(a) => a.take_diff().map(DiffJwkParams::Okp),
+      Self::Ec(a) => a.take_diff().map(DiffJwkParams::Ec),
+      Self::Oct(a) => a.take_diff().map(DiffJwkParams::Oct),
+      Self::Rsa(a) => a.take_diff().map(DiffJwkParams::Rsa),
+    }
+  }
+}

--- a/identity_jose/src/jwk/diff/key_params/mod.rs
+++ b/identity_jose/src/jwk/diff/key_params/mod.rs
@@ -66,7 +66,22 @@ impl Diff for JwkParams {
   /// # Errors
   /// Errors if the [`JwkParams`] contain private components.
   fn into_diff(mut self) -> DiffResult<Self::Type> {
-    match &mut self {
+    self.take_diff()
+  }
+}
+
+impl JwkParams {
+  /// Obtain [`DiffJwkParams`] from [`&mut JwkParams`](JwkParams) leaving
+  /// empty strings as public parameters in `self`.
+  ///
+  /// # Errors
+  /// Errors immediately if the params contain a private component.
+  ///
+  /// # Motivation
+  /// [`JwkParams`] cannot directly be destructured because of [zeroize(drop)]
+  /// hence this provides workaround to enable a cheap implementation of `into_diff`.
+  pub(super) fn take_diff(&mut self) -> DiffResult<DiffJwkParams> {
+    match self {
       Self::Okp(params) => params.take_diff().map(DiffJwkParams::Okp),
       Self::Ec(params) => params.take_diff().map(DiffJwkParams::Ec),
       Self::Oct(params) => params.take_diff().map(DiffJwkParams::Oct),

--- a/identity_jose/src/jwk/diff/key_params/oct.rs
+++ b/identity_jose/src/jwk/diff/key_params/oct.rs
@@ -1,0 +1,60 @@
+// Copyright 2020-2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+use super::Deserialize;
+use super::Diff;
+use super::DiffResult;
+use super::DiffString;
+use super::Serialize;
+
+use crate::jwk::JwkParamsOct;
+
+/// Represents the difference of two [`JwkParamsOct`].
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct DiffJwkParamsOct {
+  pub k: DiffString, // Key value
+}
+
+impl Diff for JwkParamsOct {
+  type Type = DiffJwkParamsOct;
+
+  /// Finds the difference between `self` and `other` and returns the result as
+  /// a [`DiffJwkParamsOct`].
+  fn diff(&self, other: &Self) -> identity_diff::Result<Self::Type> {
+    Ok(DiffJwkParamsOct {
+      k: self.k.diff(&other.k)?,
+    })
+  }
+
+  fn merge(&self, diff: Self::Type) -> identity_diff::Result<Self> {
+    let k: String = self.k.merge(diff.k)?;
+    Ok(Self { k })
+  }
+
+  fn from_diff(diff: Self::Type) -> identity_diff::Result<Self> {
+    let k: String = Diff::from_diff(diff.k)?;
+    Ok(Self { k })
+  }
+
+  /// Converts the [`JwkParamsOct`] into [`DiffJwkParamsOct`].
+  fn into_diff(mut self) -> DiffResult<Self::Type> {
+    self.take_diff()
+  }
+}
+
+impl JwkParamsOct {
+  /// Converts a [`&mut JwkParamsOct`](JwkParamsOct) to [`DiffJwkParamsOct`] leaving
+  /// empty strings as public parameters in `self`.
+  ///
+  ///
+  /// # Motivation
+  /// [`JwkParamsOct`] cannot directly be destructured because of [zeroize(drop)]
+  /// hence this provides workaround to enable a cheap implementation of `into_diff`.
+  pub(super) fn take_diff(&mut self) -> DiffResult<DiffJwkParamsOct> {
+    let k: String = {
+      let JwkParamsOct { ref mut k } = self;
+      std::mem::take(k)
+    };
+
+    Ok(DiffJwkParamsOct { k: k.into_diff()? })
+  }
+}

--- a/identity_jose/src/jwk/diff/key_params/oct.rs
+++ b/identity_jose/src/jwk/diff/key_params/oct.rs
@@ -19,18 +19,18 @@ impl Diff for JwkParamsOct {
 
   /// Finds the difference between `self` and `other` and returns the result as
   /// a [`DiffJwkParamsOct`].
-  fn diff(&self, other: &Self) -> identity_diff::Result<Self::Type> {
+  fn diff(&self, other: &Self) -> identity_core::diff::Result<Self::Type> {
     Ok(DiffJwkParamsOct {
       k: self.k.diff(&other.k)?,
     })
   }
 
-  fn merge(&self, diff: Self::Type) -> identity_diff::Result<Self> {
+  fn merge(&self, diff: Self::Type) -> identity_core::diff::Result<Self> {
     let k: String = self.k.merge(diff.k)?;
     Ok(Self { k })
   }
 
-  fn from_diff(diff: Self::Type) -> identity_diff::Result<Self> {
+  fn from_diff(diff: Self::Type) -> identity_core::diff::Result<Self> {
     let k: String = Diff::from_diff(diff.k)?;
     Ok(Self { k })
   }

--- a/identity_jose/src/jwk/diff/key_params/okp.rs
+++ b/identity_jose/src/jwk/diff/key_params/okp.rs
@@ -1,0 +1,92 @@
+// Copyright 2020-2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+use super::Deserialize;
+use super::Diff;
+use super::DiffResult;
+use super::DiffString;
+use super::Serialize;
+
+use crate::jwk::JwkParamsOkp;
+/// Represents the difference of two [`JwkParamsOkps`](JwkParamsOkp) without any private
+/// components.   
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct DiffJwkParamsOkp {
+  pub crv: DiffString, // Key SubType
+  pub x: DiffString,   // Public Key
+}
+
+impl Diff for JwkParamsOkp {
+  type Type = DiffJwkParamsOkp;
+
+  /// Finds the difference between `self` and `other` and returns the result as
+  /// a [`DiffJwkParamsOkp`].
+  ///
+  /// # Errors
+  /// Errors if either `self` or `other` contains private components.
+  fn diff(&self, other: &Self) -> DiffResult<Self::Type> {
+    if !(self.is_public() && other.is_public()) {
+      return Err(identity_diff::Error::DiffError(
+        "cannot diff jwk with private components".to_owned(),
+      ));
+    }
+    Ok(DiffJwkParamsOkp {
+      crv: self.crv.diff(&other.crv)?,
+      x: self.x.diff(&other.x)?,
+    })
+  }
+
+  fn merge(&self, diff: Self::Type) -> DiffResult<Self> {
+    let crv = self.crv.merge(diff.crv)?;
+    let x = self.x.merge(diff.x)?;
+    Ok(JwkParamsOkp { crv, x, d: None })
+  }
+
+  fn from_diff(diff: Self::Type) -> DiffResult<Self> {
+    let DiffJwkParamsOkp { crv, x } = diff;
+    Ok(Self {
+      crv: Diff::from_diff(crv)?,
+      x: Diff::from_diff(x)?,
+      d: None,
+    })
+  }
+
+  /// Converts the [`JwkParamsOkp`] into [`DiffJwkParamsOkp`].
+  ///
+  /// # Errors
+  /// Errors if the params contain a private component.
+  fn into_diff(mut self) -> DiffResult<Self::Type> {
+    self.take_diff()
+  }
+}
+
+impl JwkParamsOkp {
+  /// Obtain a [`DiffJwkParamsOkp`] from a [`&mut JwkParamsOkp`](JwkParamsOkp) leaving
+  /// empty strings as public parameters in `self`.
+  ///
+  /// # Errors
+  /// Errors immediately if the params contain a private component.
+  ///
+  /// # Motivation
+  /// [`JwkParamsOkp`] cannot directly be destructured because of [zeroize(drop)]
+  /// hence this provides workaround to enable a cheap implementation of `into_diff`.
+  pub(super) fn take_diff(&mut self) -> DiffResult<DiffJwkParamsOkp> {
+    if !self.is_public() {
+      return Err(identity_diff::Error::ConversionError(
+        "cannot convert jwk with private components to diff".to_owned(),
+      ));
+    }
+
+    let (crv, x): (String, String) = {
+      // Cannot directly destructure because of #[zeroize(drop)]
+      let JwkParamsOkp {
+        ref mut crv, ref mut x, ..
+      } = self;
+      (std::mem::take(crv), std::mem::take(x))
+    };
+
+    Ok(DiffJwkParamsOkp {
+      crv: crv.into_diff()?,
+      x: x.into_diff()?,
+    })
+  }
+}

--- a/identity_jose/src/jwk/diff/key_params/okp.rs
+++ b/identity_jose/src/jwk/diff/key_params/okp.rs
@@ -26,7 +26,7 @@ impl Diff for JwkParamsOkp {
   fn diff(&self, other: &Self) -> DiffResult<Self::Type> {
     if !(self.is_public() && other.is_public()) {
       return Err(identity_core::diff::Error::DiffError(
-        "cannot diff jwk with private components".to_owned(),
+        "cannot diff jwk okp params with private components".to_owned(),
       ));
     }
     Ok(DiffJwkParamsOkp {
@@ -72,7 +72,7 @@ impl JwkParamsOkp {
   pub(super) fn take_diff(&mut self) -> DiffResult<DiffJwkParamsOkp> {
     if !self.is_public() {
       return Err(identity_core::diff::Error::ConversionError(
-        "cannot convert jwk with private components to diff".to_owned(),
+        "cannot convert jwk okp params with private components to diff".to_owned(),
       ));
     }
 

--- a/identity_jose/src/jwk/diff/key_params/okp.rs
+++ b/identity_jose/src/jwk/diff/key_params/okp.rs
@@ -25,7 +25,7 @@ impl Diff for JwkParamsOkp {
   /// Errors if either `self` or `other` contains private components.
   fn diff(&self, other: &Self) -> DiffResult<Self::Type> {
     if !(self.is_public() && other.is_public()) {
-      return Err(identity_diff::Error::DiffError(
+      return Err(identity_core::diff::Error::DiffError(
         "cannot diff jwk with private components".to_owned(),
       ));
     }
@@ -71,7 +71,7 @@ impl JwkParamsOkp {
   /// hence this provides workaround to enable a cheap implementation of `into_diff`.
   pub(super) fn take_diff(&mut self) -> DiffResult<DiffJwkParamsOkp> {
     if !self.is_public() {
-      return Err(identity_diff::Error::ConversionError(
+      return Err(identity_core::diff::Error::ConversionError(
         "cannot convert jwk with private components to diff".to_owned(),
       ));
     }

--- a/identity_jose/src/jwk/diff/key_params/rsa.rs
+++ b/identity_jose/src/jwk/diff/key_params/rsa.rs
@@ -1,0 +1,109 @@
+// Copyright 2020-2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+use super::Deserialize;
+use super::Diff;
+use super::DiffResult;
+use super::DiffString;
+use super::Serialize;
+
+use crate::jwk::JwkParamsRsa;
+
+/// Represents the difference of two [`JwkParamsRsa`](JwkParamsRsa) without any private
+/// components.   
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct DiffJwkParamsRsa {
+  pub n: DiffString, // Modulus
+  pub e: DiffString, // Exponent
+}
+
+impl Diff for JwkParamsRsa {
+  type Type = DiffJwkParamsRsa;
+
+  /// Finds the difference between `self` and `other` and returns the result as
+  /// a [`DiffJwkParamsRsa`].
+  ///
+  /// # Errors
+  /// Errors if either `self` or `other` contains private components.
+  fn diff(&self, other: &Self) -> DiffResult<Self::Type> {
+    if !(self.is_public() && other.is_public()) {
+      return Err(identity_diff::Error::DiffError(
+        "cannot diff jwk with private components".to_owned(),
+      ));
+    }
+    Ok(DiffJwkParamsRsa {
+      n: self.n.diff(&other.n)?,
+      e: self.e.diff(&other.e)?,
+    })
+  }
+
+  fn merge(&self, diff: Self::Type) -> DiffResult<Self> {
+    let n = self.n.merge(diff.n)?;
+    let e = self.e.merge(diff.e)?;
+    Ok(JwkParamsRsa {
+      n,
+      e,
+      d: None,
+      p: None,
+      q: None,
+      dp: None,
+      dq: None,
+      qi: None,
+      oth: None,
+    })
+  }
+
+  fn from_diff(diff: Self::Type) -> DiffResult<Self> {
+    let DiffJwkParamsRsa { n, e } = diff;
+    Ok(JwkParamsRsa {
+      n: Diff::from_diff(n)?,
+      e: Diff::from_diff(e)?,
+      d: None,
+      p: None,
+      q: None,
+      dp: None,
+      dq: None,
+      qi: None,
+      oth: None,
+    })
+  }
+
+  /// Converts the [`JwkParamsRsa`] into [`DiffJwkParamsRsa`].
+  ///
+  /// # Errors
+  /// Errors if the params contain a private component.
+  fn into_diff(mut self) -> DiffResult<Self::Type> {
+    self.take_diff()
+  }
+}
+
+impl JwkParamsRsa {
+  /// Obtain a [`DiffJwkParamsRsa`] from a [`&mut JwkParamsRsa`](JwkParamsRsa) leaving
+  /// empty strings as public parameters in `self`.
+  ///
+  /// # Errors
+  /// Errors immediately if the params contain a private component.
+  ///
+  /// # Motivation
+  /// [`JwkParamsRsa`] cannot directly be destructured because of [zeroize(drop)]
+  /// hence this provides workaround to enable a cheap implementation of `into_diff`.
+  pub(super) fn take_diff(&mut self) -> DiffResult<DiffJwkParamsRsa> {
+    if !self.is_public() {
+      return Err(identity_diff::Error::ConversionError(
+        "cannot convert jwk with private components to diff".to_owned(),
+      ));
+    }
+
+    let (n, e): (String, String) = {
+      // Cannot directly destructure because of #[zeroize(drop)]
+      let JwkParamsRsa {
+        ref mut n, ref mut e, ..
+      } = self;
+      (std::mem::take(n), std::mem::take(e))
+    };
+
+    Ok(DiffJwkParamsRsa {
+      n: n.into_diff()?,
+      e: e.into_diff()?,
+    })
+  }
+}

--- a/identity_jose/src/jwk/diff/key_params/rsa.rs
+++ b/identity_jose/src/jwk/diff/key_params/rsa.rs
@@ -27,7 +27,7 @@ impl Diff for JwkParamsRsa {
   fn diff(&self, other: &Self) -> DiffResult<Self::Type> {
     if !(self.is_public() && other.is_public()) {
       return Err(identity_core::diff::Error::DiffError(
-        "cannot diff jwk with private components".to_owned(),
+        "cannot diff jwk rsa params with private components".to_owned(),
       ));
     }
     Ok(DiffJwkParamsRsa {
@@ -89,7 +89,7 @@ impl JwkParamsRsa {
   pub(super) fn take_diff(&mut self) -> DiffResult<DiffJwkParamsRsa> {
     if !self.is_public() {
       return Err(identity_core::diff::Error::ConversionError(
-        "cannot convert jwk with private components to diff".to_owned(),
+        "cannot convert jwk rsa params with private components to diff".to_owned(),
       ));
     }
 

--- a/identity_jose/src/jwk/diff/key_params/rsa.rs
+++ b/identity_jose/src/jwk/diff/key_params/rsa.rs
@@ -26,7 +26,7 @@ impl Diff for JwkParamsRsa {
   /// Errors if either `self` or `other` contains private components.
   fn diff(&self, other: &Self) -> DiffResult<Self::Type> {
     if !(self.is_public() && other.is_public()) {
-      return Err(identity_diff::Error::DiffError(
+      return Err(identity_core::diff::Error::DiffError(
         "cannot diff jwk with private components".to_owned(),
       ));
     }
@@ -88,7 +88,7 @@ impl JwkParamsRsa {
   /// hence this provides workaround to enable a cheap implementation of `into_diff`.
   pub(super) fn take_diff(&mut self) -> DiffResult<DiffJwkParamsRsa> {
     if !self.is_public() {
-      return Err(identity_diff::Error::ConversionError(
+      return Err(identity_core::diff::Error::ConversionError(
         "cannot convert jwk with private components to diff".to_owned(),
       ));
     }

--- a/identity_jose/src/jwk/diff/key_type.rs
+++ b/identity_jose/src/jwk/diff/key_type.rs
@@ -1,0 +1,27 @@
+// Copyright 2020-2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use identity_diff::Diff;
+use identity_diff::Result;
+
+use crate::jwk::JwkType;
+
+impl Diff for JwkType {
+  type Type = JwkType;
+
+  fn diff(&self, other: &Self) -> Result<Self::Type> {
+    Ok(*other)
+  }
+
+  fn merge(&self, diff: Self::Type) -> Result<Self> {
+    Ok(diff)
+  }
+
+  fn from_diff(diff: Self::Type) -> Result<Self> {
+    Ok(diff)
+  }
+
+  fn into_diff(self) -> Result<Self::Type> {
+    Ok(self)
+  }
+}

--- a/identity_jose/src/jwk/diff/key_type.rs
+++ b/identity_jose/src/jwk/diff/key_type.rs
@@ -1,8 +1,8 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use identity_diff::Diff;
-use identity_diff::Result;
+use identity_core::diff::Diff;
+use identity_core::diff::Result;
 
 use crate::jwk::JwkType;
 

--- a/identity_jose/src/jwk/diff/key_type.rs
+++ b/identity_jose/src/jwk/diff/key_type.rs
@@ -23,7 +23,7 @@ impl Diff for JwkType {
   }
 
   fn merge(&self, diff: Self::Type) -> Result<Self> {
-    Ok(diff.0.unwrap_or_else(|| *self))
+    Ok(diff.0.unwrap_or(*self))
   }
 
   fn from_diff(diff: Self::Type) -> Result<Self> {

--- a/identity_jose/src/jwk/diff/key_use.rs
+++ b/identity_jose/src/jwk/diff/key_use.rs
@@ -23,7 +23,7 @@ impl Diff for JwkUse {
   }
 
   fn merge(&self, diff: Self::Type) -> Result<Self> {
-    Ok(diff.0.unwrap_or_else(|| *self))
+    Ok(diff.0.unwrap_or(*self))
   }
 
   fn from_diff(diff: Self::Type) -> Result<Self> {

--- a/identity_jose/src/jwk/diff/key_use.rs
+++ b/identity_jose/src/jwk/diff/key_use.rs
@@ -1,8 +1,8 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use identity_diff::Diff;
-use identity_diff::Result;
+use identity_core::diff::Diff;
+use identity_core::diff::Result;
 
 use crate::jwk::JwkUse;
 

--- a/identity_jose/src/jwk/diff/key_use.rs
+++ b/identity_jose/src/jwk/diff/key_use.rs
@@ -1,0 +1,27 @@
+// Copyright 2020-2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use identity_diff::Diff;
+use identity_diff::Result;
+
+use crate::jwk::JwkUse;
+
+impl Diff for JwkUse {
+  type Type = JwkUse;
+
+  fn diff(&self, other: &Self) -> Result<Self::Type> {
+    Ok(*other)
+  }
+
+  fn merge(&self, diff: Self::Type) -> Result<Self> {
+    Ok(diff)
+  }
+
+  fn from_diff(diff: Self::Type) -> Result<Self> {
+    Ok(diff)
+  }
+
+  fn into_diff(self) -> Result<Self::Type> {
+    Ok(self)
+  }
+}

--- a/identity_jose/src/jwk/diff/key_use.rs
+++ b/identity_jose/src/jwk/diff/key_use.rs
@@ -3,25 +3,36 @@
 
 use identity_core::diff::Diff;
 use identity_core::diff::Result;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::jwk::JwkUse;
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
+pub struct DiffJwkUse(#[serde(skip_serializing_if = "Option::is_none")] Option<JwkUse>);
+
 impl Diff for JwkUse {
-  type Type = JwkUse;
+  type Type = DiffJwkUse;
 
   fn diff(&self, other: &Self) -> Result<Self::Type> {
-    Ok(*other)
+    if self == other {
+      Ok(DiffJwkUse(None))
+    } else {
+      Ok(DiffJwkUse(Some(*other)))
+    }
   }
 
   fn merge(&self, diff: Self::Type) -> Result<Self> {
-    Ok(diff)
+    Ok(diff.0.unwrap_or_else(|| *self))
   }
 
   fn from_diff(diff: Self::Type) -> Result<Self> {
-    Ok(diff)
+    diff
+      .0
+      .ok_or_else(|| identity_core::diff::Error::ConversionError("cannot convert from empty diff".to_owned()))
   }
 
   fn into_diff(self) -> Result<Self::Type> {
-    Ok(self)
+    Ok(DiffJwkUse(Some(self)))
   }
 }

--- a/identity_jose/src/jwk/diff/mod.rs
+++ b/identity_jose/src/jwk/diff/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-//! Provides a [`Diff`](::identity_diff::Diff) implementation for [`Jwk`](crate::jwk::Jwk).
+//! Provides a [`Diff`](::identity_core::diff::Diff) implementation for [`Jwk`](crate::jwk::Jwk).
 //!
 //! # Warning: This module has not been tested.  
 #![allow(deprecated)]

--- a/identity_jose/src/jwk/diff/mod.rs
+++ b/identity_jose/src/jwk/diff/mod.rs
@@ -3,6 +3,7 @@
 //! Provides a [`Diff`](::identity_diff::Diff) implementation for [`Jwk`](crate::jwk::Jwk).
 //!
 //! # Warning: This module has not been tested.  
+#![allow(deprecated)]
 mod key;
 mod key_operations;
 mod key_params;

--- a/identity_jose/src/jwk/diff/mod.rs
+++ b/identity_jose/src/jwk/diff/mod.rs
@@ -1,7 +1,15 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+//! Provides a [`Diff`](::identity_diff::Diff) implementation for [`Jwk`](crate::jwk::Jwk).
+//!
+//! # Warning: This module has not been tested.  
 mod key;
 mod key_operations;
 mod key_params;
 mod key_type;
 mod key_use;
+pub use key::*;
+pub use key_operations::*;
+pub use key_params::*;
+pub use key_type::*;
+pub use key_use::*;

--- a/identity_jose/src/jwk/diff/mod.rs
+++ b/identity_jose/src/jwk/diff/mod.rs
@@ -1,0 +1,7 @@
+// Copyright 2020-2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+mod key;
+mod key_operations;
+mod key_params;
+mod key_type;
+mod key_use;

--- a/identity_jose/src/jwk/key.rs
+++ b/identity_jose/src/jwk/key.rs
@@ -34,35 +34,35 @@ pub struct Jwk {
   /// Identifies the cryptographic algorithm family used with the key.
   ///
   /// [More Info](https://tools.ietf.org/html/rfc7517#section-4.1)
-  kty: JwkType,
+  pub(super) kty: JwkType,
   /// Public Key Use.
   ///
   /// Identifies the intended use of the public key.
   ///
   /// [More Info](https://tools.ietf.org/html/rfc7517#section-4.2)
   #[serde(rename = "use", skip_serializing_if = "Option::is_none")]
-  use_: Option<JwkUse>,
+  pub(super) use_: Option<JwkUse>,
   /// Key Operations.
   ///
   /// Identifies the operation(s) for which the key is intended to be used.
   ///
   /// [More Info](https://tools.ietf.org/html/rfc7517#section-4.3)
   #[serde(skip_serializing_if = "Option::is_none")]
-  key_ops: Option<Vec<JwkOperation>>,
+  pub(super) key_ops: Option<Vec<JwkOperation>>,
   /// Algorithm.
   ///
   /// Identifies the algorithm intended for use with the key.
   ///
   /// [More Info](https://tools.ietf.org/html/rfc7517#section-4.4)
   #[serde(skip_serializing_if = "Option::is_none")]
-  alg: Option<String>,
+  pub(super) alg: Option<String>,
   /// Key ID.
   ///
   /// Used to match a specific key among a set of keys within a JWK Set.
   ///
   /// [More Info](https://tools.ietf.org/html/rfc7517#section-4.5)
   #[serde(skip_serializing_if = "Option::is_none")]
-  kid: Option<String>,
+  pub(super) kid: Option<String>,
   /// X.509 URL.
   ///
   /// A URI that refers to a resource for an X.509 public key certificate or
@@ -70,14 +70,14 @@ pub struct Jwk {
   ///
   /// [More Info](https://tools.ietf.org/html/rfc7517#section-4.6)
   #[serde(skip_serializing_if = "Option::is_none")]
-  x5u: Option<Url>,
+  pub(super) x5u: Option<Url>,
   /// X.509 Certificate Chain.
   ///
   /// Contains a chain of one or more PKIX certificates.
   ///
   /// [More Info](https://tools.ietf.org/html/rfc7517#section-4.7)
   #[serde(skip_serializing_if = "Option::is_none")]
-  x5c: Option<Vec<String>>,
+  pub(super) x5c: Option<Vec<String>>,
   /// X.509 Certificate SHA-1 Thumbprint.
   ///
   /// A base64url-encoded SHA-1 thumbprint of the DER encoding of an X.509
@@ -85,7 +85,7 @@ pub struct Jwk {
   ///
   /// [More Info](https://tools.ietf.org/html/rfc7517#section-4.8)
   #[serde(skip_serializing_if = "Option::is_none")]
-  x5t: Option<String>,
+  pub(super) x5t: Option<String>,
   /// X.509 Certificate SHA-256 Thumbprint.
   ///
   /// A base64url-encoded SHA-256 thumbprint of the DER encoding of an X.509
@@ -93,12 +93,12 @@ pub struct Jwk {
   ///
   /// [More Info](https://tools.ietf.org/html/rfc7517#section-4.9)
   #[serde(rename = "x5t#S256", skip_serializing_if = "Option::is_none")]
-  x5t_s256: Option<String>,
+  pub(super) x5t_s256: Option<String>,
   /// Type-Specific Key Properties.
   ///
   /// [More Info](https://tools.ietf.org/html/rfc7517#section-4)
   #[serde(flatten)]
-  params: JwkParams,
+  pub(super) params: JwkParams,
 }
 
 impl Jwk {

--- a/identity_jose/src/jwk/key.rs
+++ b/identity_jose/src/jwk/key.rs
@@ -3,7 +3,7 @@
 
 use crypto::hashes::sha::SHA256;
 use crypto::hashes::sha::SHA256_LEN;
-use url::Url;
+use identity_core::common::Url;
 use zeroize::Zeroize;
 
 use crate::error::Error;

--- a/identity_jose/src/jwk/mod.rs
+++ b/identity_jose/src/jwk/mod.rs
@@ -4,6 +4,9 @@
 //! JSON Web Keys ([JWK](https://tools.ietf.org/html/rfc7517))
 
 mod curve;
+#[cfg(feature = "diff")]
+#[deprecated(since = "0.5.0", note = "diff chain features are slated for removal")]
+mod diff;
 mod key;
 mod key_operation;
 mod key_params;

--- a/identity_jose/src/jwk/mod.rs
+++ b/identity_jose/src/jwk/mod.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! JSON Web Keys ([JWK](https://tools.ietf.org/html/rfc7517))
-
 mod curve;
 #[cfg(feature = "diff")]
 #[deprecated(since = "0.5.0", note = "diff chain features are slated for removal")]

--- a/identity_jose/src/jwk/mod.rs
+++ b/identity_jose/src/jwk/mod.rs
@@ -5,7 +5,7 @@
 mod curve;
 #[cfg(feature = "diff")]
 #[deprecated(since = "0.5.0", note = "diff chain features are slated for removal")]
-mod diff;
+pub mod diff;
 mod key;
 mod key_operation;
 mod key_params;

--- a/identity_jose/src/jwt/header.rs
+++ b/identity_jose/src/jwt/header.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use url::Url;
+use identity_core::common::Url;
 
 use crate::jose::JoseHeader;
 use crate::jwk::Jwk;

--- a/identity_jose/src/jwt/header_set.rs
+++ b/identity_jose/src/jwt/header_set.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::ops::Deref;
-use url::Url;
+use identity_core::common::Url;
 
 use crate::error::Error;
 use crate::error::Result;

--- a/identity_verification/Cargo.toml
+++ b/identity_verification/Cargo.toml
@@ -16,5 +16,8 @@ serde.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 
+[features]
+diff = ["identity_core/diff"]
+
 [dev-dependencies]
 serde_json.workspace = true

--- a/identity_verification/Cargo.toml
+++ b/identity_verification/Cargo.toml
@@ -18,7 +18,6 @@ thiserror.workspace = true
 
 [features]
 diff = ["identity_core/diff", "identity_did/diff", "identity_jose/diff"]
-defualt = ["diff"]
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/identity_verification/Cargo.toml
+++ b/identity_verification/Cargo.toml
@@ -11,6 +11,7 @@ description = "Verification data types and functionality for identity.rs"
 [dependencies]
 identity_core = { version = "=0.7.0-alpha.5", path = "./../identity_core", default-features = false }
 identity_did = { version = "=0.7.0-alpha.5", path = "./../identity_did", default-features = false }
+identity_jose = { version = "=0.7.0-alpha.5", path = "./../identity_jose", default-features = false }
 serde.workspace = true
 strum.workspace = true
 thiserror.workspace = true

--- a/identity_verification/Cargo.toml
+++ b/identity_verification/Cargo.toml
@@ -17,7 +17,8 @@ strum.workspace = true
 thiserror.workspace = true
 
 [features]
-diff = ["identity_core/diff"]
+diff = ["identity_core/diff", "identity_did/diff", "identity_jose/diff"]
+defualt = ["diff"]
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/identity_verification/src/error.rs
+++ b/identity_verification/src/error.rs
@@ -25,6 +25,8 @@ pub enum Error {
   InvalidKeyDataBase58,
   #[error("Invalid Multibase Key Data")]
   InvalidKeyDataMultibase,
-  #[error("can only decode multibase verification material, but received publicKeyJwk")]
-  InvalidDecodingRequest, 
+  #[error("the method data could not be transformed to the desired type")]
+  InvalidMethodDataTransformation(&'static str),
+  #[error("invalid verification material: private key material exposed")]
+  PrivateKeyMaterialExposed,
 }

--- a/identity_verification/src/error.rs
+++ b/identity_verification/src/error.rs
@@ -25,4 +25,6 @@ pub enum Error {
   InvalidKeyDataBase58,
   #[error("Invalid Multibase Key Data")]
   InvalidKeyDataMultibase,
+  #[error("can only decode multibase verification material, but received publicKeyJwk")]
+  InvalidDecodingRequest, 
 }

--- a/identity_verification/src/verification_method/diff/method_data.rs
+++ b/identity_verification/src/verification_method/diff/method_data.rs
@@ -9,6 +9,7 @@ use crate::verification_method::MethodData;
 use identity_jose::jwk::diff::DiffJwk;
 
 // TODO: Test the `PublicKeyJwk` variant.
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum DiffMethodData {
   PublicKeyMultibase(#[serde(skip_serializing_if = "Option::is_none")] Option<DiffString>),

--- a/identity_verification/src/verification_method/diff/method_data.rs
+++ b/identity_verification/src/verification_method/diff/method_data.rs
@@ -6,11 +6,14 @@ use identity_core::diff::DiffString;
 use identity_core::diff::Result;
 
 use crate::verification_method::MethodData;
+use identity_jose::jwk::diff::DiffJwk;
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+// TODO: Test the `PublicKeyJwk` variant.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum DiffMethodData {
   PublicKeyMultibase(#[serde(skip_serializing_if = "Option::is_none")] Option<DiffString>),
   PublicKeyBase58(#[serde(skip_serializing_if = "Option::is_none")] Option<DiffString>),
+  PublicKeyJwk(#[serde(skip_serializing_if = "Option::is_none")] Option<DiffJwk>),
 }
 
 impl Diff for MethodData {
@@ -18,6 +21,8 @@ impl Diff for MethodData {
 
   fn diff(&self, other: &Self) -> Result<Self::Type> {
     match (self, other) {
+      (Self::PublicKeyJwk(a), Self::PublicKeyJwk(b)) if a == b => Ok(DiffMethodData::PublicKeyJwk(None)),
+      (Self::PublicKeyJwk(a), Self::PublicKeyJwk(b)) => a.diff(b).map(Some).map(DiffMethodData::PublicKeyJwk),
       (Self::PublicKeyMultibase(a), Self::PublicKeyMultibase(b)) if a == b => {
         Ok(DiffMethodData::PublicKeyMultibase(None))
       }
@@ -32,6 +37,8 @@ impl Diff for MethodData {
 
   fn merge(&self, diff: Self::Type) -> Result<Self> {
     match (self, diff) {
+      (Self::PublicKeyJwk(a), DiffMethodData::PublicKeyJwk(Some(b))) => a.merge(b).map(Self::PublicKeyJwk),
+      (Self::PublicKeyJwk(a), DiffMethodData::PublicKeyJwk(None)) => Ok(Self::PublicKeyJwk(a.clone())),
       (Self::PublicKeyMultibase(a), DiffMethodData::PublicKeyMultibase(Some(b))) => {
         a.merge(b).map(Self::PublicKeyMultibase)
       }
@@ -50,13 +57,16 @@ impl Diff for MethodData {
       DiffMethodData::PublicKeyMultibase(None) => Ok(Self::PublicKeyMultibase(Default::default())),
       DiffMethodData::PublicKeyBase58(Some(value)) => Diff::from_diff(value).map(Self::PublicKeyBase58),
       DiffMethodData::PublicKeyBase58(None) => Ok(Self::PublicKeyBase58(Default::default())),
+      DiffMethodData::PublicKeyJwk(Some(value)) => Diff::from_diff(value).map(Self::PublicKeyJwk),
+      DiffMethodData::PublicKeyJwk(None) => Err(identity_core::diff::Error::ConversionError(
+        "cannot convert empty diff to jwk method data".to_owned(),
+      )),
     }
   }
 
   fn into_diff(self) -> Result<Self::Type> {
     match self {
-      // TODO: Provide an implementation for PublicKeyJwk
-      Self::PublicKeyJwk(_) => unimplemented!("Diff has not been implemented for publicKeyJwk yet"),
+      Self::PublicKeyJwk(value) => value.into_diff().map(Some).map(DiffMethodData::PublicKeyJwk),
       Self::PublicKeyMultibase(value) => value.into_diff().map(Some).map(DiffMethodData::PublicKeyMultibase),
       Self::PublicKeyBase58(value) => value.into_diff().map(Some).map(DiffMethodData::PublicKeyBase58),
     }

--- a/identity_verification/src/verification_method/diff/method_data.rs
+++ b/identity_verification/src/verification_method/diff/method_data.rs
@@ -55,6 +55,8 @@ impl Diff for MethodData {
 
   fn into_diff(self) -> Result<Self::Type> {
     match self {
+      // TODO: Provide an implementation for PublicKeyJwk
+      Self::PublicKeyJwk(_) => unimplemented!("Diff has not been implemented for publicKeyJwk yet"),
       Self::PublicKeyMultibase(value) => value.into_diff().map(Some).map(DiffMethodData::PublicKeyMultibase),
       Self::PublicKeyBase58(value) => value.into_diff().map(Some).map(DiffMethodData::PublicKeyBase58),
     }

--- a/identity_verification/src/verification_method/material.rs
+++ b/identity_verification/src/verification_method/material.rs
@@ -19,6 +19,9 @@ pub enum MethodData {
   PublicKeyJwk(Jwk),
 }
 
+// TODO: Do we need checks that the Jwk does not contain private key components?
+// Perhaps this can be done at the DID document level?
+
 impl MethodData {
   /// Creates a new `MethodData` variant with base58-encoded content.
   pub fn new_base58(data: impl AsRef<[u8]>) -> Self {
@@ -37,12 +40,13 @@ impl MethodData {
   /// This is generally a public key identified by a `MethodType` value.
   ///
   /// # Errors
-  /// 
-  /// Decoding can fail if `MethodData` has invalid content or cannot be
+  /// Decoding will fail if `MethodData` is a [`Jwk`], has invalid content or cannot be
   /// represented as a vector of bytes.
   pub fn try_decode(&self) -> Result<Vec<u8>> {
     match self {
-      Self::PublicKeyJwk(_) => Err(Error::InvalidDecodingRequest), 
+      Self::PublicKeyJwk(_) => Err(Error::InvalidMethodDataTransformation(
+        "method data is not base encoded",
+      )),
       Self::PublicKeyMultibase(input) => {
         BaseEncoding::decode_multibase(input).map_err(|_| Error::InvalidKeyDataMultibase)
       }
@@ -54,7 +58,7 @@ impl MethodData {
 impl Debug for MethodData {
   fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     match self {
-      Self::PublicKeyJwk(inner) => f.write_fmt(format_args!("PublicKeyJwk({inner})")), 
+      Self::PublicKeyJwk(inner) => f.write_fmt(format_args!("PublicKeyJwk({:#?})", inner)),
       Self::PublicKeyMultibase(inner) => f.write_fmt(format_args!("PublicKeyMultibase({inner})")),
       Self::PublicKeyBase58(inner) => f.write_fmt(format_args!("PublicKeyBase58({inner})")),
     }

--- a/identity_verification/src/verification_method/material.rs
+++ b/identity_verification/src/verification_method/material.rs
@@ -4,6 +4,7 @@
 use core::fmt::Debug;
 use core::fmt::Formatter;
 use identity_core::utils::BaseEncoding;
+use identity_jose::jwk::Jwk;
 
 use crate::error::Error;
 use crate::error::Result;
@@ -15,6 +16,7 @@ use crate::error::Result;
 pub enum MethodData {
   PublicKeyMultibase(String),
   PublicKeyBase58(String),
+  PublicKeyJwk(Jwk),
 }
 
 impl MethodData {
@@ -35,11 +37,12 @@ impl MethodData {
   /// This is generally a public key identified by a `MethodType` value.
   ///
   /// # Errors
-  ///
+  /// 
   /// Decoding can fail if `MethodData` has invalid content or cannot be
   /// represented as a vector of bytes.
   pub fn try_decode(&self) -> Result<Vec<u8>> {
     match self {
+      Self::PublicKeyJwk(_) => Err(Error::InvalidDecodingRequest), 
       Self::PublicKeyMultibase(input) => {
         BaseEncoding::decode_multibase(input).map_err(|_| Error::InvalidKeyDataMultibase)
       }
@@ -51,6 +54,7 @@ impl MethodData {
 impl Debug for MethodData {
   fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
     match self {
+      Self::PublicKeyJwk(inner) => f.write_fmt(format_args!("PublicKeyJwk({inner})")), 
       Self::PublicKeyMultibase(inner) => f.write_fmt(format_args!("PublicKeyMultibase({inner})")),
       Self::PublicKeyBase58(inner) => f.write_fmt(format_args!("PublicKeyBase58({inner})")),
     }

--- a/identity_verification/src/verification_method/material.rs
+++ b/identity_verification/src/verification_method/material.rs
@@ -10,6 +10,7 @@ use crate::error::Error;
 use crate::error::Result;
 
 /// Supported verification method data formats.
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]

--- a/identity_verification/src/verification_method/method.rs
+++ b/identity_verification/src/verification_method/method.rs
@@ -219,7 +219,7 @@ impl VerificationMethod {
   /// done automatically if `None` is passed in as the fragment.
   /// - It is recommended that [`Jwk`] kid values are set to the public key fingerprint. See
   ///   [`Jwk::thumbprint_b64`](Jwk::thumbprint_b64()).
-  // TODO: These recommendations were taken from https://w3c.github.io/vc-data-integrity/#dfn-publickeyjwk. Perhaps add that to the documentation once that specification/link becomes stable.
+  // TODO: These recommendations were taken from https://w3c.github.io/vc-data-integrity/#dfn-publickeyjwk. Perhaps add that to the documentation once that specification/link becomes stable?
   pub fn new_from_jwk<D: DID>(did: &D, key: Jwk, fragment: Option<&str>) -> Result<Self> {
     if !key.is_public() {
       return Err(crate::error::Error::PrivateKeyMaterialExposed);

--- a/identity_verification/src/verification_method/method.rs
+++ b/identity_verification/src/verification_method/method.rs
@@ -230,7 +230,7 @@ impl VerificationMethod {
         .or_else(|| key.kid())
         .ok_or(crate::error::Error::InvalidMethod("could not construct fragment"))?;
       // Make sure the fragment starts with "#"
-      if given_fragment.starts_with("#") {
+      if given_fragment.starts_with('#') {
         Cow::Borrowed(given_fragment)
       } else {
         Cow::Owned(format!("#{}", given_fragment))

--- a/identity_verification/src/verification_method/method.rs
+++ b/identity_verification/src/verification_method/method.rs
@@ -214,12 +214,13 @@ impl VerificationMethod {
   /// will be made to generate it from the `kid` value of the given `key`.
   ///
   /// # Recommendations
+  /// The following recommendations are essentially taken from the `publicKeyJwk` description from the [DID specification](https://www.w3.org/TR/did-core/#dfn-publickeyjwk):
   /// - It is recommended that verification methods that use [`Jwks`](Jwk) to represent their public keys use the value
   ///   of `kid` as their fragment identifier. This is
   /// done automatically if `None` is passed in as the fragment.
   /// - It is recommended that [`Jwk`] kid values are set to the public key fingerprint. See
   ///   [`Jwk::thumbprint_b64`](Jwk::thumbprint_b64()).
-  // TODO: These recommendations were taken from https://w3c.github.io/vc-data-integrity/#dfn-publickeyjwk. Perhaps add that to the documentation once that specification/link becomes stable?
+  //
   pub fn new_from_jwk<D: DID>(did: &D, key: Jwk, fragment: Option<&str>) -> Result<Self> {
     if !key.is_public() {
       return Err(crate::error::Error::PrivateKeyMaterialExposed);

--- a/identity_verification/src/verification_method/method_type.rs
+++ b/identity_verification/src/verification_method/method_type.rs
@@ -11,8 +11,10 @@ use crate::error::Result;
 
 const ED25519_VERIFICATION_KEY_2018_STR: &str = "Ed25519VerificationKey2018";
 const X25519_KEY_AGREEMENT_KEY_2019_STR: &str = "X25519KeyAgreementKey2019";
+// TODO: Update this if/when the VC-JWT or Data Integrity spec defines a recommendation for use with `VC-JWT`.
+const JWK_METHOD_TYPE: &str = "JWK";
 
-/// Supported verification method types.
+/// verification method types.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 pub struct MethodType(Cow<'static, str>);
 
@@ -23,8 +25,7 @@ impl MethodType {
   pub const X25519_KEY_AGREEMENT_KEY_2019: Self = Self(Cow::Borrowed(X25519_KEY_AGREEMENT_KEY_2019_STR));
   /// A verification method for use with JWT verification as prescribed by the [`Jwk`](::identity_jose::jwk::Jwk)
   /// in the [`publicKeyJwk`](crate::MethodData::PublicKeyJwk) entry.
-  // TODO: Update this if/when the VC-JWT or Data Integrity spec defines a recommendation for use with `VC-JWT`.
-  pub const JWK: Self = Self(Cow::Borrowed("JWK"));
+  pub const JWK: Self = Self(Cow::Borrowed(JWK_METHOD_TYPE));
 }
 
 impl MethodType {
@@ -52,6 +53,7 @@ impl FromStr for MethodType {
     match string {
       ED25519_VERIFICATION_KEY_2018_STR => Ok(Self::ED25519_VERIFICATION_KEY_2018),
       X25519_KEY_AGREEMENT_KEY_2019_STR => Ok(Self::X25519_KEY_AGREEMENT_KEY_2019),
+      JWK_METHOD_TYPE => Ok(Self::JWK),
       _ => Ok(Self(Cow::Owned(string.to_owned()))),
     }
   }

--- a/identity_verification/src/verification_method/method_type.rs
+++ b/identity_verification/src/verification_method/method_type.rs
@@ -21,6 +21,10 @@ impl MethodType {
   pub const ED25519_VERIFICATION_KEY_2018: Self = Self(Cow::Borrowed(ED25519_VERIFICATION_KEY_2018_STR));
   // The `X25519KeyAgreementKey2019` method type.
   pub const X25519_KEY_AGREEMENT_KEY_2019: Self = Self(Cow::Borrowed(X25519_KEY_AGREEMENT_KEY_2019_STR));
+  /// A verification method for use with JWT verification as prescribed by the [`Jwk`](::identity_jose::jwk::Jwk)
+  /// in the [`publicKeyJwk`](crate::MethodData::PublicKeyJwk) entry.
+  // TODO: Update this if/when the VC-JWT or Data Integrity spec defines a recommendation for use with `VC-JWT`.
+  pub const JWK: Self = Self(Cow::Borrowed("JWK"));
 }
 
 impl MethodType {

--- a/identity_verification/src/verification_method/mod.rs
+++ b/identity_verification/src/verification_method/mod.rs
@@ -7,6 +7,7 @@
 //! `identity_iota_core_legacy` crate.
 
 mod builder;
+#[cfg(feature = "diff")]
 #[deprecated(since = "0.5.0", note = "diff chain features are slated for removal")]
 pub mod diff;
 mod material;


### PR DESCRIPTION
# Description of change
This PR makes verification material described by `publicKeyJwk` representable in DID Documents. See [the specification](https://www.w3.org/TR/did-core/#dfn-publickeyjwk). 

This PR also feature gates the `diff` logic. 

## What is not included in this PR
- The new functionality introduced here has not been tested. 
- There are not enough checks ensuring JWK-based Verification methods with private key components cannot be constructed. 

In order to iterate faster on the upcoming features I suggest we return to these items once we have an initial implementation of the new KMS API. 

## Links to any relevant issues
Part of #1103. 

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Runs under `cargo test` and builds the bindings without problems. 

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
