### PR TITLE
Adapt StorageError to be more generic

### DIFF
--- a/identity_core/src/common/mod.rs
+++ b/identity_core/src/common/mod.rs
@@ -14,6 +14,7 @@ pub use self::ordered_set::OrderedSet;
 pub use self::timestamp::Duration;
 pub use self::timestamp::Timestamp;
 pub use self::url::Url;
+pub use single_struct_error::*;
 
 mod context;
 mod fragment;
@@ -22,5 +23,6 @@ mod object;
 mod one_or_many;
 mod one_or_set;
 mod ordered_set;
+mod single_struct_error;
 mod timestamp;
 mod url;

--- a/identity_core/src/common/single_struct_error.rs
+++ b/identity_core/src/common/single_struct_error.rs
@@ -8,27 +8,24 @@ use std::fmt::Display;
 
 /// A container implementing the [`std::error::Error`] trait.
 ///
-/// Instances always carry a corresponding [`ErrorCause`] and may be extended with custom error messages and
-/// source.
+/// Instances always carry a corresponding `kind` of type `T` and may be extended with custom error
+/// messages, source and recovery data.
 ///
 /// This type is mainly designed to accommodate for the [single struct error design pattern](https://nrc.github.io/error-docs/error-design/error-type-design.html#single-struct-style).
+///
+/// When used in a specialized context it is recommended to use a type alias (i.e. `type MyError =
+/// SingleStructError<MyErrorKind>` or `type MyError = SingleStructError<MyErrorKind, MyRecoveryData>`).
 #[derive(Debug)]
-pub struct SingleStructError<T: ErrorCause> {
-  repr: Repr<T>,
+pub struct SingleStructError<T: Debug + Display, S: Debug = ()> {
+  repr: Repr<T, S>,
 }
 
-/// The cause of an error which does not necessarily implement the [`std::error::Error`] trait.  
-pub trait ErrorCause: Display + Debug {
-  /// Describes the cause of an error as a string slice.
-  fn description(&self) -> &str;
-}
-
-impl<T: ErrorCause> Display for SingleStructError<T> {
+impl<T: Display + Debug, S: Debug> Display for SingleStructError<T, S> {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self.repr {
-      Repr::Simple(ref cause) => write!(f, "{}", cause.description()),
+      Repr::Simple(ref cause) => write!(f, "{}", cause),
       Repr::Extensive(ref extensive) => {
-        write!(f, "{}", extensive.cause.description())?;
+        write!(f, "{}", &extensive.cause)?;
         let Some(ref message) = extensive.message else {return Ok(())};
         write!(f, " message: {}", message.as_ref())
       }
@@ -36,7 +33,7 @@ impl<T: ErrorCause> Display for SingleStructError<T> {
   }
 }
 
-impl<T: ErrorCause> Error for SingleStructError<T> {
+impl<T: Debug + Display, S: Debug> Error for SingleStructError<T, S> {
   fn source(&self) -> Option<&(dyn Error + 'static)> {
     self.extensive().and_then(|err| {
       err
@@ -48,33 +45,34 @@ impl<T: ErrorCause> Error for SingleStructError<T> {
 }
 
 #[derive(Debug)]
-struct Extensive<T: ErrorCause> {
+struct Extensive<T: Debug + Display, S: Debug> {
   cause: T,
   source: Option<Box<dyn Error + Send + Sync + 'static>>,
   message: Option<Cow<'static, str>>,
+  recovery_data: Option<S>,
 }
 
 #[derive(Debug)]
-enum Repr<T: ErrorCause> {
+enum Repr<T: Debug + Display, S: Debug> {
   Simple(T),
-  Extensive(Box<Extensive<T>>),
+  Extensive(Box<Extensive<T, S>>),
 }
 
-impl<T: ErrorCause> From<T> for SingleStructError<T> {
+impl<T: Debug + Display, S: Debug> From<T> for SingleStructError<T, S> {
   fn from(cause: T) -> Self {
     Self::new(cause)
   }
 }
 
-impl<T: ErrorCause> From<Box<Extensive<T>>> for SingleStructError<T> {
-  fn from(extensive: Box<Extensive<T>>) -> Self {
+impl<T: Debug + Display, S: Debug> From<Box<Extensive<T, S>>> for SingleStructError<T, S> {
+  fn from(extensive: Box<Extensive<T, S>>) -> Self {
     Self {
       repr: Repr::Extensive(extensive),
     }
   }
 }
 
-impl<T: ErrorCause> SingleStructError<T> {
+impl<T: Debug + Display, S: Debug> SingleStructError<T, S> {
   /// Constructs a new [`SingleStructError`].  
   pub fn new(cause: T) -> Self {
     Self {
@@ -117,20 +115,31 @@ impl<T: ErrorCause> SingleStructError<T> {
     self.into_extensive().source
   }
 
-  fn extensive(&self) -> Option<&Extensive<T>> {
+  /// Returns a reference to the attached recovery data of the [`SingleStructError`] if it was set.
+  pub fn recovery_data(&self) -> Option<&S> {
+    self.extensive().and_then(|extensive| extensive.recovery_data.as_ref())
+  }
+
+  /// Converts this error into the recovery data if it was set.
+  pub fn into_recovery_data(self) -> Option<S> {
+    self.into_extensive().recovery_data
+  }
+
+  fn extensive(&self) -> Option<&Extensive<T, S>> {
     match self.repr {
       Repr::Extensive(ref extensive) => Some(extensive.as_ref()),
       _ => None,
     }
   }
 
-  fn into_extensive(self) -> Box<Extensive<T>> {
+  fn into_extensive(self) -> Box<Extensive<T, S>> {
     match self.repr {
       Repr::Extensive(extensive) => extensive,
       Repr::Simple(cause) => Box::new(Extensive {
         cause,
         source: None,
         message: None,
+        recovery_data: None,
       }),
     }
   }
@@ -154,6 +163,17 @@ impl<T: ErrorCause> SingleStructError<T> {
   fn _with_custom_message(self, message: Cow<'static, str>) -> Self {
     let mut extensive = self.into_extensive();
     extensive.as_mut().message = Some(message);
+    Self::from(extensive)
+  }
+
+  /// Add recovery data to the [`SingleStructError`].
+  pub fn with_recovery_data(self, data: S) -> Self {
+    self._with_recovery_data(data)
+  }
+
+  fn _with_recovery_data(self, data: S) -> Self {
+    let mut extensive = self.into_extensive();
+    extensive.as_mut().recovery_data = Some(data);
     Self::from(extensive)
   }
 }

--- a/identity_core/src/common/single_struct_error.rs
+++ b/identity_core/src/common/single_struct_error.rs
@@ -16,11 +16,11 @@ use std::fmt::Display;
 /// When used in a specialized context it is recommended to use a type alias (i.e. `type MyError =
 /// SingleStructError<MyErrorKind>` or `type MyError = SingleStructError<MyErrorKind, MyRecoveryData>`).
 #[derive(Debug)]
-pub struct SingleStructError<T: Debug + Display, S: Debug = ()> {
-  repr: Repr<T, S>,
+pub struct SingleStructError<T: Debug + Display> {
+  repr: Repr<T>,
 }
 
-impl<T: Display + Debug, S: Debug> Display for SingleStructError<T, S> {
+impl<T: Display + Debug> Display for SingleStructError<T> {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self.repr {
       Repr::Simple(ref kind) => write!(f, "{}", kind),
@@ -33,7 +33,7 @@ impl<T: Display + Debug, S: Debug> Display for SingleStructError<T, S> {
   }
 }
 
-impl<T: Debug + Display, S: Debug> Error for SingleStructError<T, S> {
+impl<T: Debug + Display> Error for SingleStructError<T> {
   fn source(&self) -> Option<&(dyn Error + 'static)> {
     self.extensive().and_then(|err| {
       err
@@ -45,34 +45,33 @@ impl<T: Debug + Display, S: Debug> Error for SingleStructError<T, S> {
 }
 
 #[derive(Debug)]
-struct Extensive<T: Debug + Display, S: Debug> {
+struct Extensive<T: Debug + Display> {
   kind: T,
   source: Option<Box<dyn Error + Send + Sync + 'static>>,
   message: Option<Cow<'static, str>>,
-  recovery_data: Option<S>,
 }
 
 #[derive(Debug)]
-enum Repr<T: Debug + Display, S: Debug> {
+enum Repr<T: Debug + Display> {
   Simple(T),
-  Extensive(Box<Extensive<T, S>>),
+  Extensive(Box<Extensive<T>>),
 }
 
-impl<T: Debug + Display, S: Debug> From<T> for SingleStructError<T, S> {
+impl<T: Debug + Display> From<T> for SingleStructError<T> {
   fn from(kind: T) -> Self {
     Self::new(kind)
   }
 }
 
-impl<T: Debug + Display, S: Debug> From<Box<Extensive<T, S>>> for SingleStructError<T, S> {
-  fn from(extensive: Box<Extensive<T, S>>) -> Self {
+impl<T: Debug + Display> From<Box<Extensive<T>>> for SingleStructError<T> {
+  fn from(extensive: Box<Extensive<T>>) -> Self {
     Self {
       repr: Repr::Extensive(extensive),
     }
   }
 }
 
-impl<T: Debug + Display, S: Debug> SingleStructError<T, S> {
+impl<T: Debug + Display> SingleStructError<T> {
   /// Constructs a new [`SingleStructError`].  
   pub fn new(kind: T) -> Self {
     Self {
@@ -115,31 +114,20 @@ impl<T: Debug + Display, S: Debug> SingleStructError<T, S> {
     self.into_extensive().source
   }
 
-  /// Returns a reference to the attached recovery data of the [`SingleStructError`] if it was set.
-  pub fn recovery_data(&self) -> Option<&S> {
-    self.extensive().and_then(|extensive| extensive.recovery_data.as_ref())
-  }
-
-  /// Converts this error into the recovery data if it was set.
-  pub fn into_recovery_data(self) -> Option<S> {
-    self.into_extensive().recovery_data
-  }
-
-  fn extensive(&self) -> Option<&Extensive<T, S>> {
+  fn extensive(&self) -> Option<&Extensive<T>> {
     match self.repr {
       Repr::Extensive(ref extensive) => Some(extensive.as_ref()),
       _ => None,
     }
   }
 
-  fn into_extensive(self) -> Box<Extensive<T, S>> {
+  fn into_extensive(self) -> Box<Extensive<T>> {
     match self.repr {
       Repr::Extensive(extensive) => extensive,
       Repr::Simple(kind) => Box::new(Extensive {
         kind,
         source: None,
         message: None,
-        recovery_data: None,
       }),
     }
   }
@@ -163,17 +151,6 @@ impl<T: Debug + Display, S: Debug> SingleStructError<T, S> {
   fn _with_custom_message(self, message: Cow<'static, str>) -> Self {
     let mut extensive = self.into_extensive();
     extensive.as_mut().message = Some(message);
-    Self::from(extensive)
-  }
-
-  /// Add recovery data to the [`SingleStructError`].
-  pub fn with_recovery_data(self, data: S) -> Self {
-    self._with_recovery_data(data)
-  }
-
-  fn _with_recovery_data(self, data: S) -> Self {
-    let mut extensive = self.into_extensive();
-    extensive.as_mut().recovery_data = Some(data);
     Self::from(extensive)
   }
 }

--- a/identity_core/src/common/single_struct_error.rs
+++ b/identity_core/src/common/single_struct_error.rs
@@ -8,13 +8,13 @@ use std::fmt::Display;
 
 /// A container implementing the [`std::error::Error`] trait.
 ///
-/// Instances always carry a corresponding `kind` of type `T` and may be extended with custom error
-/// messages, source and recovery data.
+/// Instances always carry a corresponding `kind` of type `T` and may be extended with a custom error
+/// message and source.
 ///
 /// This type is mainly designed to accommodate for the [single struct error design pattern](https://nrc.github.io/error-docs/error-design/error-type-design.html#single-struct-style).
 ///
 /// When used in a specialized context it is recommended to use a type alias (i.e. `type MyError =
-/// SingleStructError<MyErrorKind>` or `type MyError = SingleStructError<MyErrorKind, MyRecoveryData>`).
+/// SingleStructError<MyErrorKind>`).
 #[derive(Debug)]
 pub struct SingleStructError<T: Debug + Display> {
   repr: Repr<T>,

--- a/identity_jose/Cargo.toml
+++ b/identity_jose/Cargo.toml
@@ -13,7 +13,7 @@ description = "A library for JOSE (JSON Object Signing and Encryption)"
 
 [dependencies]
 base64 = { version = "0.21.0", default-features = false, features = ["std"] }
-identity_core = { version = "0.7.0-alpha.5", path = "../identity_core", default-features = false }
+identity_core = { version = "0.7.0-alpha.6", path = "../identity_core", default-features = false }
 iota-crypto = { version = "0.15.3", default-features = false, features = ["std", "sha"] }
 serde.workspace = true
 serde_json = { version = "1.0", default-features = false, features = ["std"] }

--- a/identity_jose/src/jws/custom_verification/error.rs
+++ b/identity_jose/src/jws/custom_verification/error.rs
@@ -4,43 +4,7 @@
 use std::fmt::Display;
 
 /// Error type for a failed jws signature verification. See [`JwsSignatureVerifier`](super::JwsSignatureVerifier).
-#[derive(Debug, thiserror::Error)]
-#[error("jws signature verification failed: {kind}")]
-pub struct SignatureVerificationError {
-  kind: SignatureVerificationErrorKind,
-  #[source]
-  source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
-}
-
-impl SignatureVerificationError {
-  /// Constructs a new [`SignatureVerificationError`].
-  pub fn new(cause: SignatureVerificationErrorKind) -> Self {
-    Self {
-      kind: cause,
-      source: None,
-    }
-  }
-
-  /// Returns the cause of the [`SignatureVerificationError`].
-  pub fn kind(&self) -> &SignatureVerificationErrorKind {
-    &self.kind
-  }
-  /// Updates the `source` of the [`SignatureVerificationError`].
-  pub fn with_source(self, source: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>) -> Self {
-    self._with_source(source.into())
-  }
-
-  fn _with_source(mut self, source: Box<dyn std::error::Error + Send + Sync + 'static>) -> Self {
-    self.source = Some(source);
-    self
-  }
-}
-
-impl From<SignatureVerificationErrorKind> for SignatureVerificationError {
-  fn from(value: SignatureVerificationErrorKind) -> Self {
-    Self::new(value)
-  }
-}
+pub type SignatureVerificationError = identity_core::common::SingleStructError<SignatureVerificationErrorKind>;
 
 /// The cause of a failed jws signature verification.
 #[derive(Debug)]

--- a/identity_storage/src/key_id_storage/key_id_storage_error.rs
+++ b/identity_storage/src/key_id_storage/key_id_storage_error.rs
@@ -3,7 +3,6 @@
 
 use std::fmt::Display;
 
-use identity_core::common::ErrorCause;
 use identity_core::common::SingleStructError;
 
 /// Error type for key id storage operations.
@@ -45,8 +44,8 @@ pub enum KeyIdStorageErrorKind {
   Unspecified,
 }
 
-impl ErrorCause for KeyIdStorageErrorKind {
-  fn description(&self) -> &str {
+impl KeyIdStorageErrorKind {
+  pub const fn as_str(&self) -> &str {
     match self {
       Self::KeyIdAlreadyExists => "Key id already exists in storage",
       Self::KeyIdNotFound => "key id not found",
@@ -59,8 +58,14 @@ impl ErrorCause for KeyIdStorageErrorKind {
   }
 }
 
+impl AsRef<str> for KeyIdStorageErrorKind {
+  fn as_ref(&self) -> &str {
+    self.as_str()
+  }
+}
+
 impl Display for KeyIdStorageErrorKind {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}", self.description())
+    write!(f, "{}", self.as_str())
   }
 }

--- a/identity_storage/src/key_id_storage/key_id_storage_error.rs
+++ b/identity_storage/src/key_id_storage/key_id_storage_error.rs
@@ -3,11 +3,11 @@
 
 use std::fmt::Display;
 
-use crate::StorageError;
-use crate::StorageErrorKind;
+use identity_core::common::ErrorCause;
+use identity_core::common::SingleStructError;
 
 /// Error type for key id storage operations.
-pub type KeyIdStorageError = StorageError<KeyIdStorageErrorKind>;
+pub type KeyIdStorageError = SingleStructError<KeyIdStorageErrorKind>;
 
 /// The cause of the failed key id storage operation.
 #[derive(Debug, Clone)]
@@ -39,13 +39,13 @@ pub enum KeyIdStorageErrorKind {
 
   /// Indicates that something went wrong, but it is unclear whether the reason matches any of the other variants.
   ///
-  /// When using this variant one may want to attach additional context to the corresponding [`StorageError`]. See
-  /// [`KeyStorageError::with_custom_message`](KeyIdStorageError::with_custom_message()) and
-  /// [`KeyStorageError::with_source`](KeyIdStorageError::with_source()).
+  /// When using this variant one may want to attach additional context to the corresponding [`KeyIdStorageError`]. See
+  /// [`KeyIdStorageError::with_custom_message`](KeyIdStorageError::with_custom_message()) and
+  /// [`KeyIdStorageError::with_source`](KeyIdStorageError::with_source()).
   Unspecified,
 }
 
-impl StorageErrorKind for KeyIdStorageErrorKind {
+impl ErrorCause for KeyIdStorageErrorKind {
   fn description(&self) -> &str {
     match self {
       Self::KeyIdAlreadyExists => "Key id already exists in storage",

--- a/identity_storage/src/key_id_storage/key_id_storage_error.rs
+++ b/identity_storage/src/key_id_storage/key_id_storage_error.rs
@@ -48,7 +48,7 @@ impl KeyIdStorageErrorKind {
   pub const fn as_str(&self) -> &str {
     match self {
       Self::KeyIdAlreadyExists => "Key id already exists in storage",
-      Self::KeyIdNotFound => "key id not found",
+      Self::KeyIdNotFound => "key id not found in storage",
       Self::Unavailable => "key id storage unavailable",
       Self::Unauthenticated => "authentication with the key id storage failed",
       Self::Unspecified => "key storage operation failed",

--- a/identity_storage/src/key_id_storage/method_digest.rs
+++ b/identity_storage/src/key_id_storage/method_digest.rs
@@ -61,8 +61,8 @@ impl MethodDigest {
 
 #[cfg(test)]
 mod test {
+  use crate::key_id_storage::KeyIdStorageError;
   use crate::key_id_storage::KeyIdStorageErrorKind;
-  use crate::StorageError;
   use identity_core::convert::FromJson;
   use identity_core::crypto::KeyPair;
   use identity_core::crypto::KeyType;
@@ -118,25 +118,25 @@ mod test {
   pub fn invalid_unpack() {
     let packed: Vec<u8> = vec![1, 255, 212, 82, 63, 57, 19, 134, 193];
     let method_digest_unpacked = MethodDigest::unpack(packed).unwrap_err();
-    let _expected_error = StorageError::new(KeyIdStorageErrorKind::SerializationError);
+    let _expected_error = KeyIdStorageError::new(KeyIdStorageErrorKind::SerializationError);
     assert!(matches!(method_digest_unpacked, _expected_error));
 
     // Vec size > 9.
     let packed: Vec<u8> = vec![1, 255, 212, 82, 63, 57, 19, 134, 193, 200];
     let method_digest_unpacked = MethodDigest::unpack(packed).unwrap_err();
-    let _expected_error = StorageError::new(KeyIdStorageErrorKind::SerializationError);
+    let _expected_error = KeyIdStorageError::new(KeyIdStorageErrorKind::SerializationError);
     assert!(matches!(method_digest_unpacked, _expected_error));
 
     // Vec size < 9.
     let packed: Vec<u8> = vec![1, 255, 212, 82, 63, 57, 19, 134];
     let method_digest_unpacked = MethodDigest::unpack(packed).unwrap_err();
-    let _expected_error = StorageError::new(KeyIdStorageErrorKind::SerializationError);
+    let _expected_error = KeyIdStorageError::new(KeyIdStorageErrorKind::SerializationError);
     assert!(matches!(method_digest_unpacked, _expected_error));
 
     // Vec size 0;
     let packed: Vec<u8> = vec![];
     let method_digest_unpacked = MethodDigest::unpack(packed).unwrap_err();
-    let _expected_error = StorageError::new(KeyIdStorageErrorKind::SerializationError);
+    let _expected_error = KeyIdStorageError::new(KeyIdStorageErrorKind::SerializationError);
     assert!(matches!(method_digest_unpacked, _expected_error));
   }
 

--- a/identity_storage/src/key_storage/key_storage_error.rs
+++ b/identity_storage/src/key_storage/key_storage_error.rs
@@ -3,7 +3,6 @@
 
 use std::fmt::Display;
 
-use identity_core::common::ErrorCause;
 use identity_core::common::SingleStructError;
 
 /// Error type for key storage operations.
@@ -53,8 +52,8 @@ pub enum KeyStorageErrorKind {
   Unspecified,
 }
 
-impl ErrorCause for KeyStorageErrorKind {
-  fn description(&self) -> &str {
+impl KeyStorageErrorKind {
+  pub const fn as_str(&self) -> &str {
     match self {
       Self::UnsupportedKeyType => "key generation failed: the provided multikey schema is not supported",
       Self::KeyAlgorithmMismatch => "the key type cannot be used with the algorithm",
@@ -68,9 +67,14 @@ impl ErrorCause for KeyStorageErrorKind {
     }
   }
 }
+impl AsRef<str> for KeyStorageErrorKind {
+  fn as_ref(&self) -> &str {
+    self.as_str()
+  }
+}
 
 impl Display for KeyStorageErrorKind {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}", self.description())
+    write!(f, "{}", self.as_str())
   }
 }

--- a/identity_storage/src/key_storage/key_storage_error.rs
+++ b/identity_storage/src/key_storage/key_storage_error.rs
@@ -58,7 +58,7 @@ impl KeyStorageErrorKind {
       Self::UnsupportedKeyType => "key generation failed: the provided multikey schema is not supported",
       Self::KeyAlgorithmMismatch => "the key type cannot be used with the algorithm",
       Self::UnsupportedSignatureAlgorithm => "signing algorithm parsing failed",
-      Self::KeyNotFound => "key not found",
+      Self::KeyNotFound => "key not found in storage",
       Self::Unavailable => "key storage unavailable",
       Self::Unauthenticated => "authentication with the key storage failed",
       Self::Unspecified => "key storage operation failed",

--- a/identity_storage/src/key_storage/key_storage_error.rs
+++ b/identity_storage/src/key_storage/key_storage_error.rs
@@ -3,11 +3,11 @@
 
 use std::fmt::Display;
 
-use crate::error::StorageError;
-use crate::error::StorageErrorKind;
+use identity_core::common::ErrorCause;
+use identity_core::common::SingleStructError;
 
 /// Error type for key storage operations.
-pub type KeyStorageError = StorageError<KeyStorageErrorKind>;
+pub type KeyStorageError = SingleStructError<KeyStorageErrorKind>;
 
 /// The cause of the failed key storage operation.
 #[derive(Debug, Clone)]
@@ -53,7 +53,7 @@ pub enum KeyStorageErrorKind {
   Unspecified,
 }
 
-impl StorageErrorKind for KeyStorageErrorKind {
+impl ErrorCause for KeyStorageErrorKind {
   fn description(&self) -> &str {
     match self {
       Self::UnsupportedKeyType => "key generation failed: the provided multikey schema is not supported",

--- a/identity_storage/src/lib.rs
+++ b/identity_storage/src/lib.rs
@@ -1,8 +1,5 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod error;
 pub mod key_id_storage;
 pub mod key_storage;
-
-pub use error::*;


### PR DESCRIPTION
# Description of change
This PR renames and moves `StorageError` to `identity_core` so that it may be used in more contexts where the [single struct error design pattern](https://nrc.github.io/error-docs/error-design/error-type-design.html#single-struct-style) is desirable. A first example of this is the additional use in `SignatureVerificationError` in `identity_jose`. 

Also uses `Debug + Display` as trait bounds directly on the error kind and removes the `ErrorKind` trait in order to reuse existing traits and not introduce too many new traits. 

Finally I added the possibility to add recovery data to the generic error. This is not needed as of now, but might become useful in the future. This required an additional generic parameter which is the unit type `()` by default. Since we always type alias errors built with this type that extra parameter should not be a concern. 

## Type of change
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Runs under `cargo test` locally and the bindings build without problems. 

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
