### PR TITLE
Fix 0.6 Wasm build

### DIFF
--- a/identity_iota_client/Cargo.toml
+++ b/identity_iota_client/Cargo.toml
@@ -45,6 +45,11 @@ version = ">=0.7, <0.10"
 default-features = false
 features = ["blake2b"]
 
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies.iota-crypto]
+version = ">=0.7, <0.10"
+default-features = false
+features = ["curl-p"]
+
 [dev-dependencies]
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 tokio = { version = "1.17.0", default-features = false, features = ["macros"] }


### PR DESCRIPTION
# Description of change

Fixes the Wasm build for `0.6`. It is unclear why it broke in the first place, but the build failed due to the `curl-p` feature not being activated for `iota-crypto`, so it was added explicitly.

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
