### PR TITLE
Test `JWTCredentialValidator`

### DIFF
--- a/identity_credential/src/revocation/document_ext.rs
+++ b/identity_credential/src/revocation/document_ext.rs
@@ -9,6 +9,7 @@ use identity_document::utils::Queryable;
 
 use super::RevocationError;
 use super::RevocationResult;
+
 /// Extension trait providing convenience methods to update a `RevocationBitmap2022` service
 /// in a [`CoreDocument`](::identity_document::document::CoreDocument).   
 pub trait RevocationDocumentExt: private::Sealed {
@@ -30,7 +31,6 @@ pub trait RevocationDocumentExt: private::Sealed {
   ///
   /// Fails if the referenced service is not found, or is not a
   /// valid `RevocationBitmap2022` service.
-  #[cfg(feature = "revocation-bitmap")]
   fn resolve_revocation_bitmap(&self, query: DIDUrlQuery<'_>) -> RevocationResult<RevocationBitmap>;
 }
 

--- a/identity_storage/Cargo.toml
+++ b/identity_storage/Cargo.toml
@@ -29,7 +29,7 @@ thiserror.workspace = true
 tokio = { version = "1.23.0", default-features = false, features = ["macros", "sync"], optional = true }
 
 [dev-dependencies]
-identity_did = { version = "=0.7.0-alpha.6", path = "../identity_did", default-features = false }
+identity_credential = { version = "=0.7.0-alpha.6", path = "../identity_credential", features = ["revocation-bitmap"] }
 once_cell = { version = "1.17.1", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 tokio = { version = "1.23.0", default-features = false, features = ["macros", "sync", "rt"] }

--- a/identity_storage/src/storage/tests/credential_validation.rs
+++ b/identity_storage/src/storage/tests/credential_validation.rs
@@ -4,13 +4,17 @@
 use identity_core::common::Duration;
 use identity_core::common::Object;
 use identity_core::common::Timestamp;
+use identity_core::common::Url;
 use identity_core::convert::FromJson;
 use identity_credential::credential::Credential;
 use identity_credential::credential::Jwt;
+use identity_credential::credential::Subject;
 use identity_credential::validator::vc_jwt_validation::CredentialValidationOptions;
 use identity_credential::validator::vc_jwt_validation::CredentialValidator;
 use identity_credential::validator::vc_jwt_validation::ValidationError;
 use identity_credential::validator::FailFast;
+use identity_credential::validator::SubjectHolderRelationship;
+use identity_did::DID;
 use identity_document::document::CoreDocument;
 use identity_document::verifiable::JwsVerificationOptions;
 use once_cell::sync::Lazy;
@@ -314,4 +318,119 @@ async fn verify_invalid_signature() {
     fragment,
   )
   .await;
+}
+
+async fn check_subject_holder_relationship_impl<T>(setup: Setup<T>)
+where
+  T: JwkStorageDocumentExt + AsRef<CoreDocument>,
+{
+  let Setup { issuer_doc, .. } = setup;
+
+  let mut credential: Credential = SIMPLE_CREDENTIAL.clone();
+
+  // first ensure that holder_url is the subject and set the nonTransferable property
+  let actual_holder_url = credential.credential_subject.first().unwrap().id.clone().unwrap();
+  assert_eq!(credential.credential_subject.len(), 1);
+  credential.non_transferable = Some(true);
+
+  // checking with holder = subject passes for all defined subject holder relationships:
+  assert!(CredentialValidator::check_subject_holder_relationship(
+    &credential,
+    &actual_holder_url,
+    SubjectHolderRelationship::AlwaysSubject
+  )
+  .is_ok());
+
+  assert!(CredentialValidator::check_subject_holder_relationship(
+    &credential,
+    &actual_holder_url,
+    SubjectHolderRelationship::SubjectOnNonTransferable
+  )
+  .is_ok());
+
+  assert!(CredentialValidator::check_subject_holder_relationship(
+    &credential,
+    &actual_holder_url,
+    SubjectHolderRelationship::Any
+  )
+  .is_ok());
+
+  // check with a holder different from the subject of the credential:
+  let issuer_url = Url::parse(issuer_doc.as_ref().id().as_str()).unwrap();
+  assert!(actual_holder_url != issuer_url);
+
+  assert!(CredentialValidator::check_subject_holder_relationship(
+    &credential,
+    &issuer_url,
+    SubjectHolderRelationship::AlwaysSubject
+  )
+  .is_err());
+
+  assert!(CredentialValidator::check_subject_holder_relationship(
+    &credential,
+    &issuer_url,
+    SubjectHolderRelationship::SubjectOnNonTransferable
+  )
+  .is_err());
+
+  assert!(CredentialValidator::check_subject_holder_relationship(
+    &credential,
+    &issuer_url,
+    SubjectHolderRelationship::Any
+  )
+  .is_ok());
+
+  let mut credential_transferable = credential.clone();
+
+  credential_transferable.non_transferable = Some(false);
+
+  assert!(CredentialValidator::check_subject_holder_relationship(
+    &credential_transferable,
+    &issuer_url,
+    SubjectHolderRelationship::SubjectOnNonTransferable
+  )
+  .is_ok());
+
+  credential_transferable.non_transferable = None;
+
+  assert!(CredentialValidator::check_subject_holder_relationship(
+    &credential_transferable,
+    &issuer_url,
+    SubjectHolderRelationship::SubjectOnNonTransferable
+  )
+  .is_ok());
+
+  // two subjects (even when they are both the holder) should fail for all defined values except "Any"
+
+  let mut credential_duplicated_holder = credential;
+  credential_duplicated_holder
+    .credential_subject
+    .push(Subject::with_id(actual_holder_url));
+
+  assert!(CredentialValidator::check_subject_holder_relationship(
+    &credential_duplicated_holder,
+    &issuer_url,
+    SubjectHolderRelationship::AlwaysSubject
+  )
+  .is_err());
+
+  assert!(CredentialValidator::check_subject_holder_relationship(
+    &credential_duplicated_holder,
+    &issuer_url,
+    SubjectHolderRelationship::SubjectOnNonTransferable
+  )
+  .is_err());
+
+  assert!(CredentialValidator::check_subject_holder_relationship(
+    &credential_duplicated_holder,
+    &issuer_url,
+    SubjectHolderRelationship::Any
+  )
+  .is_ok());
+}
+
+#[tokio::test]
+async fn check_subject_holder_relationship() {
+  check_subject_holder_relationship_impl(test_utils::setup_coredocument(None).await).await;
+  check_subject_holder_relationship_impl(test_utils::setup_iotadocument(None).await).await;
 }

--- a/identity_storage/src/storage/tests/credential_validation.rs
+++ b/identity_storage/src/storage/tests/credential_validation.rs
@@ -8,14 +8,20 @@ use identity_core::common::Url;
 use identity_core::convert::FromJson;
 use identity_credential::credential::Credential;
 use identity_credential::credential::Jwt;
+use identity_credential::credential::RevocationBitmapStatus;
+use identity_credential::credential::Status;
 use identity_credential::credential::Subject;
+use identity_credential::revocation::RevocationBitmap;
+use identity_credential::revocation::RevocationDocumentExt;
 use identity_credential::validator::vc_jwt_validation::CredentialValidationOptions;
 use identity_credential::validator::vc_jwt_validation::CredentialValidator;
 use identity_credential::validator::vc_jwt_validation::ValidationError;
 use identity_credential::validator::FailFast;
+use identity_credential::validator::StatusCheck;
 use identity_credential::validator::SubjectHolderRelationship;
 use identity_did::DID;
 use identity_document::document::CoreDocument;
+use identity_document::service::Service;
 use identity_document::verifiable::JwsVerificationOptions;
 use once_cell::sync::Lazy;
 use proptest::proptest;
@@ -434,3 +440,103 @@ async fn check_subject_holder_relationship() {
   check_subject_holder_relationship_impl(test_utils::setup_coredocument(None).await).await;
   check_subject_holder_relationship_impl(test_utils::setup_iotadocument(None).await).await;
 }
+
+// fn check_status_impl<T, F>(setup: Setup<T>, insert_service: F)
+// where
+//   T: JwkStorageDocumentExt + AsRef<CoreDocument> + RevocationDocumentExt,
+//   F: Fn(&mut T, Service),
+// {
+//   let Setup {
+//     mut issuer_doc,
+//     subject_doc,
+//     ..
+//   } = setup;
+//   let CredentialSetup { mut credential, .. } =
+//     test_utils::generate_credential(&issuer_doc, &[&subject_doc], None, None);
+
+//   // 0: missing status always succeeds.
+//   for status_check in [StatusCheck::Strict, StatusCheck::SkipUnsupported, StatusCheck::SkipAll] {
+//     assert!(CredentialValidator::check_status(&credential, &[&issuer_doc], status_check).is_ok());
+//   }
+
+//   // 1: unsupported status type.
+//   credential.credential_status = Some(Status::new(
+//     Url::parse("https://example.com/").unwrap(),
+//     "UnsupportedStatus2023".to_owned(),
+//   ));
+//   for (status_check, expected) in [
+//     (StatusCheck::Strict, false),
+//     (StatusCheck::SkipUnsupported, true),
+//     (StatusCheck::SkipAll, true),
+//   ] {
+//     assert_eq!(
+//       CredentialValidator::check_status(&credential, &[&issuer_doc], status_check).is_ok(),
+//       expected
+//     );
+//   }
+
+//   // Add a RevocationBitmap status to the credential.
+//   let service_url: identity_did::DIDUrl = issuer_doc.as_ref().id().to_url().join("#revocation-service").unwrap();
+//   let index: u32 = 42;
+//   credential.credential_status = Some(RevocationBitmapStatus::new(service_url.clone(), index).into());
+
+//   // 2: missing service in DID Document.
+//   for (status_check, expected) in [
+//     (StatusCheck::Strict, false),
+//     (StatusCheck::SkipUnsupported, false),
+//     (StatusCheck::SkipAll, true),
+//   ] {
+//     assert_eq!(
+//       CredentialValidator::check_status(&credential, &[&issuer_doc], status_check).is_ok(),
+//       expected
+//     );
+//   }
+
+//   // Add a RevocationBitmap service to the issuer.
+//   let bitmap: RevocationBitmap = RevocationBitmap::new();
+
+//   insert_service(
+//     &mut issuer_doc,
+//     Service::builder(Object::new())
+//       .id(service_url.clone())
+//       .type_(RevocationBitmap::TYPE)
+//       .service_endpoint(bitmap.to_endpoint().unwrap())
+//       .build()
+//       .unwrap(),
+//   );
+
+//   // 3: un-revoked index always succeeds.
+//   for status_check in [StatusCheck::Strict, StatusCheck::SkipUnsupported, StatusCheck::SkipAll] {
+//     assert!(CredentialValidator::check_status(&credential, &[&issuer_doc], status_check).is_ok());
+//   }
+
+//   // 4: revoked index.
+//   <T as RevocationDocumentExt>::revoke_credentials(&mut issuer_doc, &service_url, &[index]).unwrap();
+//   for (status_check, expected) in [
+//     (StatusCheck::Strict, false),
+//     (StatusCheck::SkipUnsupported, false),
+//     (StatusCheck::SkipAll, true),
+//   ] {
+//     assert_eq!(
+//       CredentialValidator::check_status(&credential, &[&issuer_doc], status_check).is_ok(),
+//       expected
+//     );
+//   }
+// }
+
+// TODO: IotaDocument doesn't implement RevocationDocumentExt.
+// #[tokio::test]
+// async fn check_status() {
+//   check_status_impl(
+//     test_utils::setup_coredocument(None).await,
+//     |document: &mut CoreDocument, service: Service| {
+//       document.insert_service(service).unwrap();
+//     },
+//   );
+//   check_status_impl(
+//     test_utils::setup_iotadocument(None).await,
+//     |document: &mut IotaDocument, service: Service| {
+//       document.insert_service(service).unwrap();
+//     },
+//   );
+// }

--- a/identity_storage/src/storage/tests/test_utils.rs
+++ b/identity_storage/src/storage/tests/test_utils.rs
@@ -9,6 +9,7 @@ use identity_credential::credential::CredentialBuilder;
 use identity_credential::credential::Subject;
 use identity_did::DID;
 use identity_document::document::CoreDocument;
+use identity_iota_core::IotaDocument;
 use identity_verification::jws::JwsAlgorithm;
 use identity_verification::MethodScope;
 use serde_json::json;
@@ -30,30 +31,30 @@ const SUBJECT_DOCUMENT_JSON: &str = r#"
     "id": "did:foo:0xabcdef"
 }"#;
 
-pub struct Setup {
-  pub issuer_doc: CoreDocument,
+const ISSUER_IOTA_DOCUMENT_JSON: &str = r#"
+{
+  "doc": {
+    "id": "did:iota:tst:0xdfda8bcfb959c3e6ef261343c3e1a8310e9c8294eeafee326a4e96d65dbeaca0"
+  },
+  "meta": {
+    "created": "2023-05-12T15:09:50Z",
+    "updated": "2023-05-12T15:09:50Z"
+  }
+}"#;
+
+pub(super) struct Setup<T: JwkStorageDocumentExt> {
+  pub issuer_doc: T,
   pub subject_doc: CoreDocument,
   pub storage: MemStorage,
   pub kid: String,
 }
 
-pub async fn setup() -> Setup {
-  let mut issuer_doc = CoreDocument::from_json(ISSUER_DOCUMENT_JSON).unwrap();
+pub(super) async fn setup_iotadocument() -> Setup<IotaDocument> {
+  let mut issuer_doc = IotaDocument::from_json(ISSUER_IOTA_DOCUMENT_JSON).unwrap();
   let subject_doc = CoreDocument::from_json(SUBJECT_DOCUMENT_JSON).unwrap();
   let storage = Storage::new(JwkMemStore::new(), KeyIdMemstore::new());
 
-  // Generate a method with the kid as fragment.
-  let kid: String = issuer_doc
-    .generate_method(
-      &storage,
-      JwkMemStore::ED25519_KEY_TYPE,
-      JwsAlgorithm::EdDSA,
-      None,
-      MethodScope::assertion_method(),
-    )
-    .await
-    .unwrap()
-    .unwrap();
+  let kid: String = generate_method(&storage, &mut issuer_doc).await;
 
   Setup {
     issuer_doc,
@@ -63,12 +64,53 @@ pub async fn setup() -> Setup {
   }
 }
 
-pub(super) fn generate_credential(
-  issuer: &CoreDocument,
+pub(super) async fn setup_coredocument() -> Setup<CoreDocument> {
+  let mut issuer_doc = CoreDocument::from_json(ISSUER_DOCUMENT_JSON).unwrap();
+  let subject_doc = CoreDocument::from_json(SUBJECT_DOCUMENT_JSON).unwrap();
+  let storage = Storage::new(JwkMemStore::new(), KeyIdMemstore::new());
+
+  let kid: String = generate_method(&storage, &mut issuer_doc).await;
+
+  Setup {
+    issuer_doc,
+    subject_doc,
+    storage,
+    kid,
+  }
+}
+
+async fn generate_method<T>(storage: &MemStorage, document: &mut T) -> String
+where
+  T: JwkStorageDocumentExt,
+{
+  document
+    .generate_method(
+      storage,
+      JwkMemStore::ED25519_KEY_TYPE,
+      JwsAlgorithm::EdDSA,
+      None,
+      MethodScope::assertion_method(),
+    )
+    .await
+    .unwrap()
+    .unwrap()
+}
+
+pub(super) struct CredentialSetup {
+  pub credential: Credential,
+  pub issuance_date: Timestamp,
+  pub expiration_date: Timestamp,
+}
+
+pub(super) fn generate_credential<T: AsRef<CoreDocument>>(
+  issuer: T,
   subjects: &[CoreDocument],
-  issuance_date: Timestamp,
-  expiration_date: Timestamp,
-) -> Credential {
+  issuance_date: Option<Timestamp>,
+  expiration_date: Option<Timestamp>,
+) -> CredentialSetup {
+  let issuance_date = issuance_date.unwrap_or_else(|| Timestamp::parse("2020-01-01T00:00:00Z").unwrap());
+  let expiration_date = expiration_date.unwrap_or_else(|| Timestamp::parse("2024-01-01T00:00:00Z").unwrap());
+
   let credential_subjects: Vec<Subject> = subjects
     .iter()
     .map(|subject| {
@@ -86,13 +128,19 @@ pub(super) fn generate_credential(
     .collect();
 
   // Build credential using subject above and issuer.
-  CredentialBuilder::default()
+  let credential: Credential = CredentialBuilder::default()
     .id(Url::parse("https://example.edu/credentials/3732").unwrap())
-    .issuer(Url::parse(issuer.id().as_str()).unwrap())
+    .issuer(Url::parse(issuer.as_ref().id().as_str()).unwrap())
     .type_("UniversityDegreeCredential")
     .subjects(credential_subjects)
     .issuance_date(issuance_date)
     .expiration_date(expiration_date)
     .build()
-    .unwrap()
+    .unwrap();
+
+  CredentialSetup {
+    credential,
+    issuance_date,
+    expiration_date,
+  }
 }

--- a/identity_storage/src/storage/tests/test_utils.rs
+++ b/identity_storage/src/storage/tests/test_utils.rs
@@ -104,7 +104,7 @@ pub(super) struct CredentialSetup {
 
 pub(super) fn generate_credential<T: AsRef<CoreDocument>>(
   issuer: T,
-  subjects: &[CoreDocument],
+  subjects: &[&CoreDocument],
   issuance_date: Option<Timestamp>,
   expiration_date: Option<Timestamp>,
 ) -> CredentialSetup {

--- a/identity_storage/src/storage/tests/test_utils.rs
+++ b/identity_storage/src/storage/tests/test_utils.rs
@@ -49,12 +49,12 @@ pub(super) struct Setup<T: JwkStorageDocumentExt> {
   pub kid: String,
 }
 
-pub(super) async fn setup_iotadocument() -> Setup<IotaDocument> {
+pub(super) async fn setup_iotadocument(fragment: Option<&'static str>) -> Setup<IotaDocument> {
   let mut issuer_doc = IotaDocument::from_json(ISSUER_IOTA_DOCUMENT_JSON).unwrap();
   let subject_doc = CoreDocument::from_json(SUBJECT_DOCUMENT_JSON).unwrap();
   let storage = Storage::new(JwkMemStore::new(), KeyIdMemstore::new());
 
-  let kid: String = generate_method(&storage, &mut issuer_doc).await;
+  let kid: String = generate_method(&storage, &mut issuer_doc, fragment).await;
 
   Setup {
     issuer_doc,
@@ -64,12 +64,12 @@ pub(super) async fn setup_iotadocument() -> Setup<IotaDocument> {
   }
 }
 
-pub(super) async fn setup_coredocument() -> Setup<CoreDocument> {
+pub(super) async fn setup_coredocument(fragment: Option<&'static str>) -> Setup<CoreDocument> {
   let mut issuer_doc = CoreDocument::from_json(ISSUER_DOCUMENT_JSON).unwrap();
   let subject_doc = CoreDocument::from_json(SUBJECT_DOCUMENT_JSON).unwrap();
   let storage = Storage::new(JwkMemStore::new(), KeyIdMemstore::new());
 
-  let kid: String = generate_method(&storage, &mut issuer_doc).await;
+  let kid: String = generate_method(&storage, &mut issuer_doc, fragment).await;
 
   Setup {
     issuer_doc,
@@ -79,7 +79,7 @@ pub(super) async fn setup_coredocument() -> Setup<CoreDocument> {
   }
 }
 
-async fn generate_method<T>(storage: &MemStorage, document: &mut T) -> String
+async fn generate_method<T>(storage: &MemStorage, document: &mut T, fragment: Option<&'static str>) -> String
 where
   T: JwkStorageDocumentExt,
 {
@@ -88,7 +88,7 @@ where
       storage,
       JwkMemStore::ED25519_KEY_TYPE,
       JwsAlgorithm::EdDSA,
-      None,
+      fragment,
       MethodScope::assertion_method(),
     )
     .await


### PR DESCRIPTION
# Description of change

Port every test from the current `identity_credential::validator::credential_validator` module except `test_full_validation_invalid_structure` since it is much harder to get wrong with JWS-based credentials than with the legacy ones.

Tests are executed for both `CoreDocument` and `IotaDocument` with the exception of the revocation functions, since `IotaDocument` does not implement `RevocationDocumentExt` (it exposes those methods inherently) making a generic test harder to write.

## Links to any relevant issues

part of #1103

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

`cargo test`

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
