### PR TITLE
Update method spec and JWK method type

### DIFF
--- a/bindings/wasm/src/verification/wasm_method_type.rs
+++ b/bindings/wasm/src/verification/wasm_method_type.rs
@@ -24,7 +24,7 @@ impl WasmMethodType {
   /// in the `publicKeyJwk` entry.
   #[wasm_bindgen(js_name = JwkMethodType)]
   pub fn jwk_method_type() -> WasmMethodType {
-    WasmMethodType(MethodType::JWK)
+    WasmMethodType(MethodType::JSON_WEB_KEY)
   }
 
   /// Returns the `MethodType` as a string.

--- a/documentation/docs/specs/did/iota_did_method_spec.mdx
+++ b/documentation/docs/specs/did/iota_did_method_spec.mdx
@@ -18,7 +18,7 @@ import Announcement from '../../../src/partials/_announcement.mdx';
 
 <Announcement/>
 
-Draft 11 August 2022
+Version 1.0 2023-06-01
 
 ## Abstract
 
@@ -61,6 +61,7 @@ The state controller can unlock a state transition. It is identified by an incre
 The governor, on the other hand, can unlock a governance transition indicated by an unchanged `State Index`. A governance transition can change the addresses of the state controller and governor. It also allows destroying the Alias Output.
 
 ### Ledger and DID
+
 Storing DID Documents in the ledger state means they inherently benefit from the guarantees the ledger provides.
 
 1. Conflicts among nodes are sorted out and dealt with by the ledger.
@@ -80,13 +81,13 @@ The DIDs that follow this method have the following ABNF syntax. It uses the syn
 ```
 iota-did = "did:iota:" iota-specific-idstring
 iota-specific-idstring = [ iota-network ":" ] iota-tag 
-iota-network = 0*6lowercase-alpha
+iota-network = 1*6network-char
 iota-tag = "0x" 64lowercase-hex
-lowercase-alpha = %x61-7A ; corresponds to the character range from "a" to "z".
 lowercase-hex = digit / "a" / "b" / "c" / "d" / "e" / "f"
+network-char = %x61-7A / digit ; corresponds to the character range from "a" to "z" and "0" to "9".
 ```
 
-It starts with the string "did:iota:", followed by an optional network name (0 to 6 lowercase alpha characters) and a colon, then the tag.
+It starts with the string "did:iota:", followed by an optional network name (1 to 6 lowercase alpha characters) and a colon, then the tag.
 The tag starts with "0x" followed by a hex-encoded `Alias ID` with lower case a-f.
 
 ### IOTA-Network
@@ -108,6 +109,7 @@ did:iota:0xe4edef97da1257e83cbeb49159cfdd2da6ac971ac447f233f8439cf29376ebfe
 ```
 
 ### IOTA-Tag
+
 An IOTA-tag is a hex-encoded `Alias ID`. The `Alias ID` itself is a unique identifier of the alias, which is the BLAKE2b-256 hash of the Output ID that created it.
 This tag identifies the Alias Output where the DID Document is stored, and it will not be known before the generation of the DID since it will be assigned when the Alias Output is created.
 
@@ -134,7 +136,7 @@ The payload must contain the following fields:
 
 Example State Metadata Document:
 
-```Json
+```json
 {
    "document":{
       "id":"did:0:0",
@@ -168,6 +170,7 @@ Create, Read, Update and Delete (CRUD) operations that change the DID Documents 
 **These operations require fund transfer to cover byte cost. Transactions must be carefully done in order to avoid fund loss.** For example, the amount of funds in the inputs should equal these in the outputs. Additionally, private keys of controllers must be stored securely.
 
 ### Create
+
 In order to create a simple self controlled DID two things are required:
 1. An Ed25519 Address for which the private key is available, or control over an Alias or NFT Output.
 2. A Basic, Alias or NFT Output with enough coins to cover the byte cost.
@@ -243,8 +246,8 @@ Currently standardized `services`:
 * [Revocation Bitmap Service](../revocation_bitmap_2022.mdx#revocation-bitmap-service)
 
 ## Security Considerations
-The `did:iota` method is implemented on the [IOTA](https://iota.org), a public permissionless and feeless Distributed Ledger Technology (DLT), making it resistant against almost all censorship attack vectors. Up until the `Coordicide` update for the IOTA network, a reliability on the coordinator exists for resolving ordering conflicts. This has a minor censorship possibility, that, in the wrost case, can prevent transactions from getting confirmed.
 
+The `did:iota` method is implemented on the [IOTA](https://iota.org), a public permissionless and feeless Distributed Ledger Technology (DLT), making it resistant against almost all censorship attack vectors. Up until the `Coordicide` update for the IOTA network, a reliability on the coordinator exists for resolving ordering conflicts. This has a minor censorship possibility, that, in the wrost case, can prevent transactions from getting confirmed.
 
 ### Private Key Management
 

--- a/identity_storage/src/key_storage/memstore.rs
+++ b/identity_storage/src/key_storage/memstore.rs
@@ -70,6 +70,7 @@ impl JwkStorage for JwkMemStore {
 
     let mut jwk: Jwk = ed25519::encode_jwk(&private_key, &public_key);
     jwk.set_alg(alg.name());
+    // Unwrapping is OK because the None variant only occurs for kty = oct.
     let mut public_jwk: Jwk = jwk.to_public().unwrap();
     public_jwk.set_kid(kid.clone());
 

--- a/identity_verification/src/verification_method/method.rs
+++ b/identity_verification/src/verification_method/method.rs
@@ -245,7 +245,7 @@ impl VerificationMethod {
     MethodBuilder::default()
       .id(id)
       .controller(did.into())
-      .type_(MethodType::JWK)
+      .type_(MethodType::JSON_WEB_KEY)
       .data(MethodData::PublicKeyJwk(key))
       .build()
   }

--- a/identity_verification/src/verification_method/method_type.rs
+++ b/identity_verification/src/verification_method/method_type.rs
@@ -12,7 +12,7 @@ use crate::error::Result;
 const ED25519_VERIFICATION_KEY_2018_STR: &str = "Ed25519VerificationKey2018";
 const X25519_KEY_AGREEMENT_KEY_2019_STR: &str = "X25519KeyAgreementKey2019";
 // TODO: Update this if/when the VC-JWT or Data Integrity spec defines a recommendation for use with `VC-JWT`.
-const JWK_METHOD_TYPE: &str = "JWK";
+const JSON_WEB_KEY_METHOD_TYPE: &str = "JsonWebKey";
 
 /// verification method types.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
@@ -25,7 +25,7 @@ impl MethodType {
   pub const X25519_KEY_AGREEMENT_KEY_2019: Self = Self(Cow::Borrowed(X25519_KEY_AGREEMENT_KEY_2019_STR));
   /// A verification method for use with JWT verification as prescribed by the [`Jwk`](::identity_jose::jwk::Jwk)
   /// in the [`publicKeyJwk`](crate::MethodData::PublicKeyJwk) entry.
-  pub const JWK: Self = Self(Cow::Borrowed(JWK_METHOD_TYPE));
+  pub const JSON_WEB_KEY: Self = Self(Cow::Borrowed(JSON_WEB_KEY_METHOD_TYPE));
 }
 
 impl MethodType {
@@ -53,7 +53,7 @@ impl FromStr for MethodType {
     match string {
       ED25519_VERIFICATION_KEY_2018_STR => Ok(Self::ED25519_VERIFICATION_KEY_2018),
       X25519_KEY_AGREEMENT_KEY_2019_STR => Ok(Self::X25519_KEY_AGREEMENT_KEY_2019),
-      JWK_METHOD_TYPE => Ok(Self::JWK),
+      JSON_WEB_KEY_METHOD_TYPE => Ok(Self::JSON_WEB_KEY),
       _ => Ok(Self(Cow::Owned(string.to_owned()))),
     }
   }


### PR DESCRIPTION
# Description of change

Update the method spec and JWK method type.

- Method spec previously incorrectly allowed for a network name to be of length 0. If present, its length must be > 0. This is already correctly checked in code. The code also allows for the presence of digits in the network name and the spec was updated to match that, too.
- Use `JsonWebKey` as the method type according to https://github.com/w3c/vc-jwt/issues/83, as it is the best recommendation we have for now.

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

## How the change has been tested

None.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
