### PR TITLE
Add `resolve_multiple` to Resolver.

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -208,9 +208,9 @@ This variant is the default used if no other variant is specified when construct
 <dt><a href="#FirstError">FirstError</a></dt>
 <dd><p>Return after the first error occurs.</p>
 </dd>
-<dt><a href="#KeyType">KeyType</a></dt>
-<dd></dd>
 <dt><a href="#MethodRelationship">MethodRelationship</a></dt>
+<dd></dd>
+<dt><a href="#KeyType">KeyType</a></dt>
 <dd></dd>
 </dl>
 
@@ -5239,6 +5239,7 @@ The resolver will only be able to resolve DID documents for methods it has been 
 * [Resolver](#Resolver)
     * [new Resolver(config)](#new_Resolver_new)
     * [.resolve(did)](#Resolver+resolve) ⇒ <code>Promise.&lt;(CoreDocument\|IToCoreDocument)&gt;</code>
+    * [.resolveMultiple(did)](#Resolver+resolveMultiple) ⇒ <code>Promise.&lt;Array.&lt;(CoreDocument\|IToCoreDocument)&gt;&gt;</code>
 
 <a name="new_Resolver_new"></a>
 
@@ -5269,6 +5270,26 @@ corresponding to the given DID or the resolution process itself fails.
 | Param | Type |
 | --- | --- |
 | did | <code>string</code> | 
+
+<a name="Resolver+resolveMultiple"></a>
+
+### resolver.resolveMultiple(did) ⇒ <code>Promise.&lt;Array.&lt;(CoreDocument\|IToCoreDocument)&gt;&gt;</code>
+Concurrently fetches the DID Documents of the multiple given DIDs.
+
+# Errors
+* If the resolver has not been configured to handle the method of any of the given DIDs.
+* If the resolution process of any DID fails.
+
+## Note
+* The order of the documents in the returned vector matches that in `dids`.
+* If `dids` contains duplicates, these will be resolved only once and the resolved document
+is copied into the returned vector to match the order of `dids`.
+
+**Kind**: instance method of [<code>Resolver</code>](#Resolver)  
+
+| Param | Type |
+| --- | --- |
+| did | <code>Array.&lt;string&gt;</code> | 
 
 <a name="RevocationBitmap"></a>
 
@@ -5931,13 +5952,13 @@ Return all errors that occur during validation.
 Return after the first error occurs.
 
 **Kind**: global variable  
-<a name="KeyType"></a>
-
-## KeyType
-**Kind**: global variable  
 <a name="MethodRelationship"></a>
 
 ## MethodRelationship
+**Kind**: global variable  
+<a name="KeyType"></a>
+
+## KeyType
 **Kind**: global variable  
 <a name="verifyEdDSA"></a>
 

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -5239,7 +5239,7 @@ The resolver will only be able to resolve DID documents for methods it has been 
 * [Resolver](#Resolver)
     * [new Resolver(config)](#new_Resolver_new)
     * [.resolve(did)](#Resolver+resolve) ⇒ <code>Promise.&lt;(CoreDocument\|IToCoreDocument)&gt;</code>
-    * [.resolveMultiple(did)](#Resolver+resolveMultiple) ⇒ <code>Promise.&lt;Array.&lt;(CoreDocument\|IToCoreDocument)&gt;&gt;</code>
+    * [.resolveMultiple(dids)](#Resolver+resolveMultiple) ⇒ <code>Promise.&lt;Array.&lt;(CoreDocument\|IToCoreDocument)&gt;&gt;</code>
 
 <a name="new_Resolver_new"></a>
 
@@ -5273,7 +5273,7 @@ corresponding to the given DID or the resolution process itself fails.
 
 <a name="Resolver+resolveMultiple"></a>
 
-### resolver.resolveMultiple(did) ⇒ <code>Promise.&lt;Array.&lt;(CoreDocument\|IToCoreDocument)&gt;&gt;</code>
+### resolver.resolveMultiple(dids) ⇒ <code>Promise.&lt;Array.&lt;(CoreDocument\|IToCoreDocument)&gt;&gt;</code>
 Concurrently fetches the DID Documents of the multiple given DIDs.
 
 # Errors
@@ -5289,7 +5289,7 @@ is copied into the returned vector to match the order of `dids`.
 
 | Param | Type |
 | --- | --- |
-| did | <code>Array.&lt;string&gt;</code> | 
+| dids | <code>Array.&lt;string&gt;</code> | 
 
 <a name="RevocationBitmap"></a>
 

--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -5281,9 +5281,9 @@ Concurrently fetches the DID Documents of the multiple given DIDs.
 * If the resolution process of any DID fails.
 
 ## Note
-* The order of the documents in the returned vector matches that in `dids`.
+* The order of the documents in the returned array matches that in `dids`.
 * If `dids` contains duplicates, these will be resolved only once and the resolved document
-is copied into the returned vector to match the order of `dids`.
+is copied into the returned array to match the order of `dids`.
 
 **Kind**: instance method of [<code>Resolver</code>](#Resolver)  
 

--- a/bindings/wasm/src/resolver/wasm_resolver.rs
+++ b/bindings/wasm/src/resolver/wasm_resolver.rs
@@ -211,8 +211,17 @@ impl WasmResolver {
         .map_err(WasmError::from)
         .map_err(JsValue::from)
         .map(|documents| {
+          let mut ordered_documents: Vec<JsValue> = Vec::with_capacity(core_dids.len());
+          // Reconstructs the order of `dids`.
+          for did in core_dids {
+            let doc: JsValue = documents.get(&did).cloned().unwrap();
+            ordered_documents.push(doc);
+          }
+          ordered_documents
+        })
+        .map(|documents| {
           documents
-            .iter()
+            .into_iter()
             .map(JsValue::from)
             .collect::<js_sys::Array>()
             .unchecked_into::<JsValue>()

--- a/bindings/wasm/src/resolver/wasm_resolver.rs
+++ b/bindings/wasm/src/resolver/wasm_resolver.rs
@@ -9,11 +9,14 @@ use identity_iota::did::DID;
 use identity_iota::iota::IotaDID;
 use identity_iota::iota::IotaIdentityClientExt;
 use identity_iota::resolver::SingleThreadedResolver;
+use js_sys::Array;
 use js_sys::Function;
+use js_sys::JsString;
 use js_sys::Map;
 use js_sys::Promise;
 use wasm_bindgen_futures::JsFuture;
 
+use crate::common::ArrayString;
 use crate::error::JsValueResult;
 use crate::error::WasmError;
 use crate::iota::IotaDocumentLock;
@@ -22,6 +25,7 @@ use crate::iota::WasmIotaDocument;
 use crate::iota::WasmIotaIdentityClient;
 use crate::resolver::constructor_input::MapResolutionHandler;
 use crate::resolver::constructor_input::ResolverConfig;
+use crate::resolver::PromiseArrayIToCoreDocument;
 
 use super::type_definitions::PromiseIToCoreDocument;
 use crate::error::Result;
@@ -174,5 +178,47 @@ impl WasmResolver {
     });
 
     Ok(promise.unchecked_into::<PromiseIToCoreDocument>())
+  }
+
+  /// Concurrently fetches the DID Documents of the multiple given DIDs.
+  ///
+  /// # Errors
+  /// * If the resolver has not been configured to handle the method of any of the given DIDs.
+  /// * If the resolution process of any DID fails.
+  ///
+  /// ## Note
+  /// * The order of the documents in the returned vector matches that in `dids`.
+  /// * If `dids` contains duplicates, these will be resolved only once and the resolved document
+  /// is copied into the returned vector to match the order of `dids`.
+  #[wasm_bindgen(js_name=resolveMultiple)]
+  pub fn resolve_multiple(&self, did: ArrayString) -> Result<PromiseArrayIToCoreDocument> {
+    let array: Array = did.dyn_into()?;
+    let values: Result<Vec<String>> = array
+      .iter()
+      .map(|item| item.dyn_into::<JsString>().map(String::from))
+      .collect();
+
+    let values: Vec<String> = values?;
+    let core_dids: std::result::Result<Vec<CoreDID>, identity_iota::did::Error> =
+      values.iter().map(CoreDID::parse).collect();
+    let core_dids: Vec<CoreDID> = core_dids.wasm_result()?;
+    let resolver: Rc<JsDocumentResolver> = self.0.clone();
+
+    let promise: Promise = future_to_promise(async move {
+      resolver
+        .resolve_multiple(&core_dids)
+        .await
+        .map_err(WasmError::from)
+        .map_err(JsValue::from)
+        .map(|documents| {
+          documents
+            .iter()
+            .map(JsValue::from)
+            .collect::<js_sys::Array>()
+            .unchecked_into::<JsValue>()
+        })
+    });
+
+    Ok(promise.unchecked_into::<PromiseArrayIToCoreDocument>())
   }
 }

--- a/bindings/wasm/src/resolver/wasm_resolver.rs
+++ b/bindings/wasm/src/resolver/wasm_resolver.rs
@@ -187,9 +187,9 @@ impl WasmResolver {
   /// * If the resolution process of any DID fails.
   ///
   /// ## Note
-  /// * The order of the documents in the returned vector matches that in `dids`.
+  /// * The order of the documents in the returned array matches that in `dids`.
   /// * If `dids` contains duplicates, these will be resolved only once and the resolved document
-  /// is copied into the returned vector to match the order of `dids`.
+  /// is copied into the returned array to match the order of `dids`.
   #[wasm_bindgen(js_name=resolveMultiple)]
   pub fn resolve_multiple(&self, dids: ArrayString) -> Result<PromiseArrayIToCoreDocument> {
     let dids: Vec<String> = dids

--- a/bindings/wasm/tests/resolver.ts
+++ b/bindings/wasm/tests/resolver.ts
@@ -1,4 +1,4 @@
-export { };
+export {};
 
 import { CoreDID, CoreDocument, IotaDID, IotaDocument, IToCoreDocument, Resolver } from "../node";
 import assert = require("assert");
@@ -105,7 +105,8 @@ describe("Resolver", function() {
             assert.deepStrictEqual(iotaDoc.toJSON(), (resolvedIotaDoc as IotaDocument).toJSON());
             assert.deepStrictEqual(fooDoc.toJSON(), (resolvedFooDoc as MockFooDocument).toCoreDocument().toJSON());
 
-            let dids = [barDoc.id().toString(), iotaDoc.id().toString(), fooDoc.id().toString(), iotaDoc.id().toString()];
+            let dids = [barDoc.id().toString(), iotaDoc.id().toString(), fooDoc.id().toString(),
+                iotaDoc.id().toString()];
             let documents = await resolver.resolveMultiple(dids);
 
             assert.equal(documents.length, 4);

--- a/bindings/wasm/tests/resolver.ts
+++ b/bindings/wasm/tests/resolver.ts
@@ -1,4 +1,4 @@
-export {};
+export { };
 
 import { CoreDID, CoreDocument, IotaDID, IotaDocument, IToCoreDocument, Resolver } from "../node";
 import assert = require("assert");
@@ -104,6 +104,15 @@ describe("Resolver", function() {
             assert.deepStrictEqual(barDoc.toJSON(), (resolvedBarDoc as CoreDocument).toJSON());
             assert.deepStrictEqual(iotaDoc.toJSON(), (resolvedIotaDoc as IotaDocument).toJSON());
             assert.deepStrictEqual(fooDoc.toJSON(), (resolvedFooDoc as MockFooDocument).toCoreDocument().toJSON());
+
+            let dids = [barDoc.id().toString(), iotaDoc.id().toString(), fooDoc.id().toString(), iotaDoc.id().toString()];
+            let documents = await resolver.resolveMultiple(dids);
+
+            assert.equal(documents.length, 4);
+            assert.deepStrictEqual(barDoc.toJSON(), (documents[0] as CoreDocument).toJSON());
+            assert.deepStrictEqual(iotaDoc.toJSON(), (documents[1] as IotaDocument).toJSON());
+            assert.deepStrictEqual(fooDoc.toJSON(), (documents[2] as MockFooDocument).toCoreDocument().toJSON());
+            assert.deepStrictEqual(iotaDoc.toJSON(), (documents[3] as IotaDocument).toJSON());
         });
 
         it("should fail resolution when configured incorrectly", async () => {

--- a/identity_resolver/src/error.rs
+++ b/identity_resolver/src/error.rs
@@ -62,7 +62,4 @@ pub enum ErrorCause {
   /// [`Resolver`](crate::resolution::Resolver).
   #[error("did resolution failed: the DID method \"{method}\" is not supported by the resolver")]
   UnsupportedMethodError { method: String },
-
-  #[error("Unspecific error")]
-  UnspecificError { message: String },
 }

--- a/identity_resolver/src/error.rs
+++ b/identity_resolver/src/error.rs
@@ -62,4 +62,7 @@ pub enum ErrorCause {
   /// [`Resolver`](crate::resolution::Resolver).
   #[error("did resolution failed: the DID method \"{method}\" is not supported by the resolver")]
   UnsupportedMethodError { method: String },
+
+  #[error("Unspecific error")]
+  UnspecificError { message: String },
 }

--- a/identity_resolver/src/resolution/tests/mod.rs
+++ b/identity_resolver/src/resolution/tests/mod.rs
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::resolver::*;
-mod resolution_errors;
+mod resolution;
 mod send_sync;

--- a/identity_resolver/src/resolution/tests/resolution.rs
+++ b/identity_resolver/src/resolution/tests/resolution.rs
@@ -1,6 +1,7 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::Debug;
 use std::str::FromStr;
@@ -239,35 +240,34 @@ async fn resolve_multiple() {
   let did_1: CoreDID = CoreDID::parse(format!("did:{method_name}:1111")).unwrap();
   let did_2: CoreDID = CoreDID::parse(format!("did:{method_name}:2222")).unwrap();
   let did_3: CoreDID = CoreDID::parse(format!("did:{method_name}:3333")).unwrap();
-  let did_4: CoreDID = CoreDID::parse(format!("did:{method_name}:4444")).unwrap();
+  let did_1_clone: CoreDID = CoreDID::parse(format!("did:{method_name}:1111")).unwrap();
 
   let mut resolver: Resolver<CoreDocument> = Resolver::new();
   resolver.attach_handler(method_name, mock_handler);
 
   // Resolve with duplicate `did_3`.
-  let resolved_dids: Vec<CoreDocument> = resolver
+  let resolved_dids: HashMap<CoreDID, CoreDocument> = resolver
     .resolve_multiple(&[
       did_1.clone(),
       did_2.clone(),
       did_3.clone(),
-      did_4.clone(),
+      did_1_clone.clone(),
       did_3.clone(),
     ])
     .await
     .unwrap();
 
-  assert_eq!(resolved_dids.len(), 5);
-  assert_eq!(resolved_dids.get(0).unwrap().id(), &did_1);
-  assert_eq!(resolved_dids.get(1).unwrap().id(), &did_2);
-  assert_eq!(resolved_dids.get(2).unwrap().id(), &did_3);
-  assert_eq!(resolved_dids.get(3).unwrap().id(), &did_4);
-  assert_eq!(resolved_dids.get(4).unwrap().id(), &did_3);
+  assert_eq!(resolved_dids.len(), 3);
+  assert_eq!(resolved_dids.get(&did_1).unwrap().id(), &did_1);
+  assert_eq!(resolved_dids.get(&did_2).unwrap().id(), &did_2);
+  assert_eq!(resolved_dids.get(&did_3).unwrap().id(), &did_3);
+  assert_eq!(resolved_dids.get(&did_1_clone).unwrap().id(), &did_1_clone);
 
   let dids: &[CoreDID] = &[];
-  let resolved_dids: Vec<CoreDocument> = resolver.resolve_multiple(dids).await.unwrap();
+  let resolved_dids: HashMap<CoreDID, CoreDocument> = resolver.resolve_multiple(dids).await.unwrap();
   assert_eq!(resolved_dids.len(), 0);
 
-  let resolved_dids: Vec<CoreDocument> = resolver.resolve_multiple(&[did_1.clone()]).await.unwrap();
+  let resolved_dids: HashMap<CoreDID, CoreDocument> = resolver.resolve_multiple(&[did_1.clone()]).await.unwrap();
   assert_eq!(resolved_dids.len(), 1);
-  assert_eq!(resolved_dids.get(0).unwrap().id(), &did_1);
+  assert_eq!(resolved_dids.get(&did_1).unwrap().id(), &did_1);
 }

--- a/identity_resolver/src/resolution/tests/resolution.rs
+++ b/identity_resolver/src/resolution/tests/resolution.rs
@@ -262,4 +262,12 @@ async fn resolve_multiple() {
   assert_eq!(resolved_dids.get(2).unwrap().id(), &did_3);
   assert_eq!(resolved_dids.get(3).unwrap().id(), &did_4);
   assert_eq!(resolved_dids.get(4).unwrap().id(), &did_3);
+
+  let dids: &[CoreDID] = &[];
+  let resolved_dids: Vec<CoreDocument> = resolver.resolve_multiple(dids).await.unwrap();
+  assert_eq!(resolved_dids.len(), 0);
+
+  let resolved_dids: Vec<CoreDocument> = resolver.resolve_multiple(&[did_1.clone()]).await.unwrap();
+  assert_eq!(resolved_dids.len(), 1);
+  assert_eq!(resolved_dids.get(0).unwrap().id(), &did_1);
 }

--- a/identity_resolver/src/resolution/tests/resolution.rs
+++ b/identity_resolver/src/resolution/tests/resolution.rs
@@ -27,7 +27,7 @@ fn core_document(did: CoreDID) -> CoreDocument {
 }
 
 /// A custom document type
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct FooDocument(CoreDocument);
 impl AsRef<CoreDocument> for FooDocument {
   fn as_ref(&self) -> &CoreDocument {
@@ -256,39 +256,10 @@ async fn resolve_multiple() {
     .await
     .unwrap();
 
-  // Check duplicate only resolved once.
-  assert_eq!(resolved_dids.len(), 4);
-
-  assert_eq!(
-    resolved_dids
-      .iter()
-      .filter(|doc| doc.id().clone() == did_1)
-      .collect::<Vec<&CoreDocument>>()
-      .len(),
-    1
-  );
-  assert_eq!(
-    resolved_dids
-      .iter()
-      .filter(|doc| doc.id().clone() == did_2)
-      .collect::<Vec<&CoreDocument>>()
-      .len(),
-    1
-  );
-  assert_eq!(
-    resolved_dids
-      .iter()
-      .filter(|doc| doc.id().clone() == did_3)
-      .collect::<Vec<&CoreDocument>>()
-      .len(),
-    1
-  );
-  assert_eq!(
-    resolved_dids
-      .iter()
-      .filter(|doc| doc.id().clone() == did_4)
-      .collect::<Vec<&CoreDocument>>()
-      .len(),
-    1
-  );
+  assert_eq!(resolved_dids.len(), 5);
+  assert_eq!(resolved_dids.get(0).unwrap().id(), &did_1);
+  assert_eq!(resolved_dids.get(1).unwrap().id(), &did_2);
+  assert_eq!(resolved_dids.get(2).unwrap().id(), &did_3);
+  assert_eq!(resolved_dids.get(3).unwrap().id(), &did_4);
+  assert_eq!(resolved_dids.get(4).unwrap().id(), &did_3);
 }


### PR DESCRIPTION
# Description of change
Allow resolving multiple DID documents in parallel.

The method first removes any did duplicates before resolving, since duplicates can be common, for example if a verificable presentation has multiple credentials issued by the same DID. The order is then re-established for convenience and to avoid the need of filtering to retrieve the correct DID. To allow this, the documents must be clonable. 


## Links to any relevant issues
https://github.com/iotaledger/identity.rs/pull/1183

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix