### PR TITLE
Use `Record` type for unknown credentials in Wasm

### DIFF
--- a/bindings/wasm/src/common/types.rs
+++ b/bindings/wasm/src/common/types.rs
@@ -30,6 +30,9 @@ extern "C" {
   #[wasm_bindgen(typescript_type = "Map<string, any>")]
   pub type MapStringAny;
 
+  #[wasm_bindgen(typescript_type = "Record<string, any>")]
+  pub type RecordStringAny;
+
   #[wasm_bindgen(typescript_type = "number | number[]")]
   pub type UOneOrManyNumber;
 

--- a/bindings/wasm/src/credential/jwt_credential_validation/unknown_credential.rs
+++ b/bindings/wasm/src/credential/jwt_credential_validation/unknown_credential.rs
@@ -6,6 +6,7 @@ use identity_iota::credential::Credential;
 use identity_iota::credential::Jwt;
 use wasm_bindgen::prelude::*;
 
+use crate::common::RecordStringAny;
 use crate::credential::WasmCredential;
 use crate::credential::WasmJwt;
 
@@ -46,14 +47,13 @@ impl WasmUnknownCredentialContainer {
 
   /// Returns the contained value as JSON, if it can be converted, `undefined` otherwise.
   #[wasm_bindgen(js_name = tryIntoRaw)]
-  pub fn try_into_raw(&self) -> JsValue {
-    let js_value: Option<JsValue> = match &self.0 {
-      UnknownCredential::Jwt(jwt) => JsValue::from_serde(jwt).ok(),
-      UnknownCredential::Credential(credential) => JsValue::from_serde(credential).ok(),
-      UnknownCredential::Other(object) => JsValue::from_serde(object).ok(),
-    };
-
-    js_value.unwrap_or_else(JsValue::undefined)
+  pub fn try_into_raw(&self) -> Option<RecordStringAny> {
+    match &self.0 {
+      UnknownCredential::Other(object) => JsValue::from_serde(object)
+        .map(|js_val| js_val.unchecked_into::<RecordStringAny>())
+        .ok(),
+      _ => None,
+    }
   }
 }
 

--- a/bindings/wasm/src/credential/jwt_presentation/jwt_presentation_builder.rs
+++ b/bindings/wasm/src/credential/jwt_presentation/jwt_presentation_builder.rs
@@ -87,7 +87,7 @@ struct IJwtPresentationHelper {
   #[typescript(
     optional = false,
     name = "verifiableCredential",
-    type = "Jwt | Credential | any | Array<Jwt | Credential | any>"
+    type = "Jwt | Credential | Record<string, any> | Array<Jwt | Credential | Record<string, any>>"
   )]
   verifiable_credential: OneOrMany<UnknownCredential>,
   /// The entity that generated the presentation.

--- a/bindings/wasm/tests/credentials.ts
+++ b/bindings/wasm/tests/credentials.ts
@@ -261,7 +261,7 @@ describe("Presentation", function() {
 
             assert.deepStrictEqual(credentials[0].tryIntoJwt()?.toString(), credentialJwt.toString());
             assert.deepStrictEqual(credentials[1].tryIntoCredential()?.toJSON(), unsignedVc.toJSON());
-            assert.deepStrictEqual(credentials[2].tryIntoRaw(), otherCredential);
+            assert.deepStrictEqual(credentials[2].tryIntoRaw()!, otherCredential);
         });
     });
 });


### PR DESCRIPTION
# Description of change

Use `Record` type for unknown credentials in Wasm and finish an incomplete test for `IotaDocument`.

## Links to any relevant issues

part of #1103 

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

`npm run test:unit:node`

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
