### PR TITLE
Polish `identity_credential`

### DIFF
--- a/bindings/wasm/examples/src/0_basic/7_revoke_vc.ts
+++ b/bindings/wasm/examples/src/0_basic/7_revoke_vc.ts
@@ -72,11 +72,8 @@ export async function revokeVC() {
     const revocationBitmap = new RevocationBitmap();
 
     // Add the revocation bitmap to the DID Document of the issuer as a service.
-    const service: Service = new Service({
-        id: issuerDocument.id().join("#my-revocation-service"),
-        type: RevocationBitmap.type(),
-        serviceEndpoint: revocationBitmap.toEndpoint(),
-    });
+    const serviceId = issuerDocument.id().join("#my-revocation-service");
+    const service: Service = revocationBitmap.toService(serviceId);
     issuerDocument.insertService(service);
 
     // Resolve the latest output and update it with the given document.

--- a/bindings/wasm/src/revocation/bitmap.rs
+++ b/bindings/wasm/src/revocation/bitmap.rs
@@ -4,10 +4,10 @@
 use std::borrow::Cow;
 
 use identity_iota::credential::RevocationBitmap;
-use identity_iota::document::ServiceEndpoint;
 use wasm_bindgen::prelude::*;
 
-use crate::did::UServiceEndpoint;
+use crate::did::WasmDIDUrl;
+use crate::did::WasmService;
 use crate::error::Result;
 use crate::error::WasmError;
 use crate::error::WasmResult;
@@ -61,17 +61,25 @@ impl WasmRevocationBitmap {
       .map_err(|err| WasmError::new(Cow::Borrowed("TryFromIntError"), Cow::Owned(err.to_string())).into())
   }
 
-  /// Return the bitmap as a data url embedded in a service endpoint.
-  #[wasm_bindgen(js_name = toEndpoint)]
-  pub fn to_enpdoint(&self) -> Result<UServiceEndpoint> {
-    self.0.to_endpoint().map(UServiceEndpoint::from).wasm_result()
+  /// Return a `Service` with:
+  /// - the service's id set to `serviceId`,
+  /// - of type `RevocationBitmap2022`,
+  /// - and with the bitmap embedded in a data url in the service's endpoint.
+  #[wasm_bindgen(js_name = toService)]
+  #[allow(non_snake_case)]
+  pub fn to_service(&self, serviceId: &WasmDIDUrl) -> Result<WasmService> {
+    self
+      .0
+      .to_service(serviceId.0.clone())
+      .map(WasmService::from)
+      .wasm_result()
   }
 
-  /// Construct a `RevocationBitmap` from a data `url`.
+  /// Try to construct a `RevocationBitmap` from a service
+  /// if it is a valid Revocation Bitmap Service.
   #[wasm_bindgen(js_name = fromEndpoint)]
-  pub fn from_endpoint(endpoint: UServiceEndpoint) -> Result<WasmRevocationBitmap> {
-    let endpoint: ServiceEndpoint = endpoint.into_serde().wasm_result()?;
-    RevocationBitmap::from_endpoint(&endpoint).map(Self).wasm_result()
+  pub fn from_service(service: &WasmService) -> Result<WasmRevocationBitmap> {
+    RevocationBitmap::try_from(&service.0).map(Self).wasm_result()
   }
 }
 

--- a/examples/0_basic/7_revoke_vc.rs
+++ b/examples/0_basic/7_revoke_vc.rs
@@ -89,11 +89,9 @@ async fn main() -> anyhow::Result<()> {
   let revocation_bitmap: RevocationBitmap = RevocationBitmap::new();
 
   // Add the revocation bitmap to the DID document of the issuer as a service.
-  let service: Service = Service::from_json_value(json!({
-    "id": issuer_document.id().to_url().join("#my-revocation-service")?,
-    "type": RevocationBitmap::TYPE,
-    "serviceEndpoint": revocation_bitmap.to_endpoint()?
-  }))?;
+  let service_id: DIDUrl = issuer_document.id().to_url().join("#my-revocation-service")?;
+  let service: Service = revocation_bitmap.to_service(service_id)?;
+
   assert!(issuer_document.insert_service(service).is_ok());
 
   // Resolve the latest output and update it with the given document.

--- a/identity_credential/src/credential/credential.rs
+++ b/identity_credential/src/credential/credential.rs
@@ -5,6 +5,7 @@ use core::fmt::Display;
 use core::fmt::Formatter;
 
 use identity_core::convert::ToJson;
+use serde::Deserialize;
 use serde::Serialize;
 
 use identity_core::common::Context;
@@ -27,7 +28,7 @@ use crate::error::Result;
 
 use super::jwt_serialization::CredentialJwtClaims;
 
-lazy_static! {
+lazy_static::lazy_static! {
   static ref BASE_CONTEXT: Context = Context::Url(Url::parse("https://www.w3.org/2018/credentials/v1").unwrap());
 }
 

--- a/identity_credential/src/credential/evidence.rs
+++ b/identity_credential/src/credential/evidence.rs
@@ -1,6 +1,9 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::Deserialize;
+use serde::Serialize;
+
 use identity_core::common::Object;
 use identity_core::common::OneOrMany;
 

--- a/identity_credential/src/credential/issuer.rs
+++ b/identity_credential/src/credential/issuer.rs
@@ -1,6 +1,9 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::Deserialize;
+use serde::Serialize;
+
 use identity_core::common::Object;
 use identity_core::common::Url;
 

--- a/identity_credential/src/credential/jwt.rs
+++ b/identity_credential/src/credential/jwt.rs
@@ -1,6 +1,9 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::Deserialize;
+use serde::Serialize;
+
 /// A wrapper around a JSON Web Token (JWK).
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Jwt(String);

--- a/identity_credential/src/credential/mod.rs
+++ b/identity_credential/src/credential/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! The core types used to create Verifiable Credentials
+//! The core types used to create Verifiable Credentials.
 
 #![allow(clippy::module_inception)]
 

--- a/identity_credential/src/credential/policy.rs
+++ b/identity_credential/src/credential/policy.rs
@@ -1,6 +1,9 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::Deserialize;
+use serde::Serialize;
+
 use identity_core::common::Object;
 use identity_core::common::OneOrMany;
 use identity_core::common::Url;

--- a/identity_credential/src/credential/refresh.rs
+++ b/identity_credential/src/credential/refresh.rs
@@ -1,6 +1,9 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::Deserialize;
+use serde::Serialize;
+
 use identity_core::common::Object;
 use identity_core::common::OneOrMany;
 use identity_core::common::Url;

--- a/identity_credential/src/credential/schema.rs
+++ b/identity_credential/src/credential/schema.rs
@@ -1,6 +1,9 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::Deserialize;
+use serde::Serialize;
+
 use identity_core::common::Object;
 use identity_core::common::OneOrMany;
 use identity_core::common::Url;

--- a/identity_credential/src/credential/status.rs
+++ b/identity_credential/src/credential/status.rs
@@ -1,6 +1,9 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::Deserialize;
+use serde::Serialize;
+
 use identity_core::common::Object;
 use identity_core::common::Url;
 

--- a/identity_credential/src/credential/subject.rs
+++ b/identity_credential/src/credential/subject.rs
@@ -1,6 +1,9 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::Deserialize;
+use serde::Serialize;
+
 use identity_core::common::Object;
 use identity_core::common::Url;
 

--- a/identity_credential/src/domain_linkage/domain_linkage_configuration.rs
+++ b/identity_credential/src/domain_linkage/domain_linkage_configuration.rs
@@ -10,12 +10,13 @@ use identity_core::common::Url;
 use identity_core::convert::FmtJson;
 use identity_did::CoreDID;
 use serde::Deserialize;
+use serde::Serialize;
 use std::fmt::Display;
 use std::fmt::Formatter;
 
 use crate::Error::DomainLinkageError;
 
-lazy_static! {
+lazy_static::lazy_static! {
   static ref WELL_KNOWN_CONTEXT: Context =
     Context::Url(Url::parse("https://identity.foundation/.well-known/did-configuration/v1").unwrap());
 }

--- a/identity_credential/src/domain_linkage/domain_linkage_configuration.rs
+++ b/identity_credential/src/domain_linkage/domain_linkage_configuration.rs
@@ -22,6 +22,7 @@ lazy_static::lazy_static! {
 }
 
 /// DID Configuration Resource which contains Domain Linkage Credentials.
+///
 /// It can be placed in an origin's `.well-known` directory to prove linkage between the origin and a DID.
 /// See: <https://identity.foundation/.well-known/resources/did-configuration/#did-configuration-resource>
 ///

--- a/identity_credential/src/domain_linkage/error.rs
+++ b/identity_credential/src/domain_linkage/error.rs
@@ -30,36 +30,43 @@ impl From<DomainLinkageValidationError> for &str {
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 pub enum DomainLinkageValidationErrorCause {
+  /// Caused when a Domain Linkage Credential cannot be successfully validated.
   #[error("invalid credential")]
   CredentialValidationError,
+  /// Caused by an invalid JWT.
   #[error("invalid JWT")]
   InvalidJwt,
+  /// Caused by a missing expiration date.
   #[error("the expiration date is missing")]
   MissingExpirationDate,
+  /// Caused by the presence of an id property on a Domain Linkage Credential.
   #[error("id property is not allowed")]
   ImpermissibleIdProperty,
+  /// Caused by a mismatch of the issuer and subject of the Domain Linkage Credential.
   #[error("issuer DID does not match the subject")]
   IssuerSubjectMismatch,
+  /// Caused by an invalid Domain Linkage Credential subject.
   #[error("subject id is invalid")]
   InvalidSubjectId,
+  /// Caused by the presence of multiple subjects on a Domain Linkage Credential.
   #[error("credential contains multiple subjects")]
   MultipleCredentialSubjects,
+  /// Caused by an invalid issuer DID.
   #[error("invalid issuer DID")]
   InvalidIssuer,
+  /// Caused by a missing id property on the Domain Linkage Credential subject.
   #[error("subject id property is missing")]
   MissingSubjectId,
+  /// Caused by an invalid `type` property on the Domain Linkage Credential.
   #[error("credential type is invalid")]
   InvalidTypeProperty,
-  #[error("the issuer's id does not match the provided DID Document(s)")]
-  DocumentMismatch,
+  /// Caused by a mismatch between the Domain Linkage Credential subject's origin and the provided domain origin.
   #[error("the subject's origin does not match the provided domain origin")]
   OriginMismatch,
+  /// Caused by a missing or invalid Domain Linkage Credential subject's origin.
   #[error("the subject's origin property is either invalid or missing")]
   InvalidSubjectOrigin,
+  /// Caused by an invalid semantic structure of the Domain Linkage Configuration.
   #[error("invalid semantic structure of the domain linkage configuration")]
   InvalidStructure,
-  #[error("multiple domain linkage credentials reference the same DID")]
-  AmbiguousCredential,
-  #[error("a domain linkage credential referencing the provided DID is not found")]
-  CredentialNotFound,
 }

--- a/identity_credential/src/domain_linkage/mod.rs
+++ b/identity_credential/src/domain_linkage/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! Implementation of Domain Linkage according to <https://identity.foundation/.well-known/resources/did-configuration/>.
+
 mod domain_linkage_configuration;
 mod domain_linkage_credential_builder;
 mod domain_linkage_validator;

--- a/identity_credential/src/domain_linkage/mod.rs
+++ b/identity_credential/src/domain_linkage/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Implementation of Domain Linkage according to <https://identity.foundation/.well-known/resources/did-configuration/>.
+//! Implementation of [Domain Linkage](https://identity.foundation/.well-known/resources/did-configuration/).
 
 mod domain_linkage_configuration;
 mod domain_linkage_credential_builder;

--- a/identity_credential/src/lib.rs
+++ b/identity_credential/src/lib.rs
@@ -6,22 +6,13 @@
 #![warn(
   rust_2018_idioms,
   unreachable_pub,
-  // missing_docs,
+  missing_docs,
   rustdoc::missing_crate_level_docs,
   rustdoc::broken_intra_doc_links,
   rustdoc::private_intra_doc_links,
   rustdoc::private_doc_tests,
-  clippy::missing_safety_doc,
-  // clippy::missing_errors_doc
+  clippy::missing_safety_doc
 )]
-
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate serde;
-
-pub use self::error::Error;
-pub use self::error::Result;
 
 #[cfg(feature = "credential")]
 pub mod credential;
@@ -32,6 +23,13 @@ pub mod error;
 pub mod presentation;
 #[cfg(feature = "revocation-bitmap")]
 pub mod revocation;
-
 #[cfg(feature = "validator")]
 pub mod validator;
+
+pub use error::Error;
+pub use error::Result;
+
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate serde;

--- a/identity_credential/src/lib.rs
+++ b/identity_credential/src/lib.rs
@@ -28,8 +28,3 @@ pub mod validator;
 
 pub use error::Error;
 pub use error::Result;
-
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate serde;

--- a/identity_credential/src/presentation/jwt_presentation_options.rs
+++ b/identity_credential/src/presentation/jwt_presentation_options.rs
@@ -1,6 +1,9 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::Deserialize;
+use serde::Serialize;
+
 use identity_core::common::Timestamp;
 use identity_core::common::Url;
 

--- a/identity_credential/src/presentation/mod.rs
+++ b/identity_credential/src/presentation/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! The core types used to create Verifiable Presentations
+//! The core types used to create Verifiable Presentations.
 
 #![allow(clippy::module_inception)]
 

--- a/identity_credential/src/presentation/presentation.rs
+++ b/identity_credential/src/presentation/presentation.rs
@@ -4,7 +4,7 @@
 use core::fmt::Display;
 use core::fmt::Formatter;
 
-use identity_core::convert::ToJson;
+use serde::Deserialize;
 use serde::Serialize;
 
 use identity_core::common::Context;
@@ -12,6 +12,7 @@ use identity_core::common::Object;
 use identity_core::common::OneOrMany;
 use identity_core::common::Url;
 use identity_core::convert::FmtJson;
+use identity_core::convert::ToJson;
 
 use crate::credential::Credential;
 use crate::credential::Policy;

--- a/identity_credential/src/revocation/bitmap.rs
+++ b/identity_credential/src/revocation/bitmap.rs
@@ -90,7 +90,7 @@ impl RevocationBitmap {
   }
 
   /// Construct a `RevocationBitmap` from a data url embedded in `service_endpoint`.
-  pub fn try_from_endpoint(service_endpoint: &ServiceEndpoint) -> Result<Self, RevocationError> {
+  pub(crate) fn try_from_endpoint(service_endpoint: &ServiceEndpoint) -> Result<Self, RevocationError> {
     if let ServiceEndpoint::One(url) = service_endpoint {
       let data_url: DataUrl = DataUrl::parse(url.as_str())
         .map_err(|_| RevocationError::InvalidService("invalid url - expected a data url"))?;

--- a/identity_credential/src/revocation/bitmap.rs
+++ b/identity_credential/src/revocation/bitmap.rs
@@ -74,7 +74,7 @@ impl RevocationBitmap {
   }
 
   /// Construct a `RevocationBitmap` from a data url embedded in `service_endpoint`.
-  pub fn from_endpoint(service_endpoint: &ServiceEndpoint) -> Result<Self, RevocationError> {
+  pub fn try_from_endpoint(service_endpoint: &ServiceEndpoint) -> Result<Self, RevocationError> {
     if let ServiceEndpoint::One(url) = service_endpoint {
       let data_url: DataUrl = DataUrl::parse(url.as_str())
         .map_err(|_| RevocationError::InvalidService("invalid url - expected a data url"))?;
@@ -159,7 +159,7 @@ impl TryFrom<&Service> for RevocationBitmap {
       ));
     }
 
-    Self::from_endpoint(service.service_endpoint())
+    Self::try_from_endpoint(service.service_endpoint())
   }
 }
 
@@ -199,7 +199,7 @@ mod tests {
   fn test_revocation_bitmap_test_vector_1() {
     const URL: &str = "data:application/octet-stream;base64,ZUp5ek1tQUFBd0FES0FCcg==";
 
-    let bitmap: RevocationBitmap = RevocationBitmap::from_endpoint(&identity_document::service::ServiceEndpoint::One(
+    let bitmap: RevocationBitmap = RevocationBitmap::try_from_endpoint(&identity_document::service::ServiceEndpoint::One(
       Url::parse(URL).unwrap(),
     ))
     .unwrap();
@@ -212,7 +212,7 @@ mod tests {
     const URL: &str = "data:application/octet-stream;base64,ZUp5ek1tQmdZR0lBQVVZZ1pHQ1FBR0laSUdabDZHUGN3UW9BRXVvQjlB";
     const EXPECTED: &[u32] = &[5, 398, 67000];
 
-    let bitmap: RevocationBitmap = RevocationBitmap::from_endpoint(&identity_document::service::ServiceEndpoint::One(
+    let bitmap: RevocationBitmap = RevocationBitmap::try_from_endpoint(&identity_document::service::ServiceEndpoint::One(
       Url::parse(URL).unwrap(),
     ))
     .unwrap();
@@ -228,7 +228,7 @@ mod tests {
   fn test_revocation_bitmap_test_vector_3() {
     const URL: &str = "data:application/octet-stream;base64,ZUp6dHhERVJBQ0FNQkxESEFWS1lXZkN2Q3E0MmFESmtyMlNrM0ROckFLQ2RBQUFBQUFBQTMzbGhHZm9q";
 
-    let bitmap: RevocationBitmap = RevocationBitmap::from_endpoint(&identity_document::service::ServiceEndpoint::One(
+    let bitmap: RevocationBitmap = RevocationBitmap::try_from_endpoint(&identity_document::service::ServiceEndpoint::One(
       Url::parse(URL).unwrap(),
     ))
     .unwrap();

--- a/identity_credential/src/revocation/bitmap.rs
+++ b/identity_credential/src/revocation/bitmap.rs
@@ -7,9 +7,11 @@ use dataurl::DataUrl;
 use flate2::write::ZlibDecoder;
 use flate2::write::ZlibEncoder;
 use flate2::Compression;
+use identity_core::common::Object;
 use identity_core::common::Url;
 use identity_core::convert::Base;
 use identity_core::convert::BaseEncoding;
+use identity_did::DIDUrl;
 use roaring::RoaringBitmap;
 
 use super::error::RevocationError;
@@ -60,8 +62,22 @@ impl RevocationBitmap {
     self.0.is_empty()
   }
 
+  /// Return a [`Service`] with:
+  /// - the service's id set to `service_id`,
+  /// - of type `RevocationBitmap2022`,
+  /// - and with the bitmap embedded in a data url in the service's endpoint.
+  pub fn to_service(&self, service_id: DIDUrl) -> Result<Service, RevocationError> {
+    let endpoint: ServiceEndpoint = self.to_endpoint()?;
+    Service::builder(Object::new())
+      .id(service_id)
+      .type_(RevocationBitmap::TYPE)
+      .service_endpoint(endpoint)
+      .build()
+      .map_err(|_| RevocationError::InvalidService("service builder error"))
+  }
+
   /// Return the bitmap as a data url embedded in a service endpoint.
-  pub fn to_endpoint(&self) -> Result<ServiceEndpoint, RevocationError> {
+  pub(crate) fn to_endpoint(&self) -> Result<ServiceEndpoint, RevocationError> {
     let endpoint_data: String = self.serialize_compressed_base64()?;
 
     let mut data_url: DataUrl = DataUrl::new();
@@ -199,9 +215,9 @@ mod tests {
   fn test_revocation_bitmap_test_vector_1() {
     const URL: &str = "data:application/octet-stream;base64,ZUp5ek1tQUFBd0FES0FCcg==";
 
-    let bitmap: RevocationBitmap = RevocationBitmap::try_from_endpoint(&identity_document::service::ServiceEndpoint::One(
-      Url::parse(URL).unwrap(),
-    ))
+    let bitmap: RevocationBitmap = RevocationBitmap::try_from_endpoint(
+      &identity_document::service::ServiceEndpoint::One(Url::parse(URL).unwrap()),
+    )
     .unwrap();
 
     assert!(bitmap.is_empty());
@@ -212,9 +228,9 @@ mod tests {
     const URL: &str = "data:application/octet-stream;base64,ZUp5ek1tQmdZR0lBQVVZZ1pHQ1FBR0laSUdabDZHUGN3UW9BRXVvQjlB";
     const EXPECTED: &[u32] = &[5, 398, 67000];
 
-    let bitmap: RevocationBitmap = RevocationBitmap::try_from_endpoint(&identity_document::service::ServiceEndpoint::One(
-      Url::parse(URL).unwrap(),
-    ))
+    let bitmap: RevocationBitmap = RevocationBitmap::try_from_endpoint(
+      &identity_document::service::ServiceEndpoint::One(Url::parse(URL).unwrap()),
+    )
     .unwrap();
 
     for revoked in EXPECTED {
@@ -228,9 +244,9 @@ mod tests {
   fn test_revocation_bitmap_test_vector_3() {
     const URL: &str = "data:application/octet-stream;base64,ZUp6dHhERVJBQ0FNQkxESEFWS1lXZkN2Q3E0MmFESmtyMlNrM0ROckFLQ2RBQUFBQUFBQTMzbGhHZm9q";
 
-    let bitmap: RevocationBitmap = RevocationBitmap::try_from_endpoint(&identity_document::service::ServiceEndpoint::One(
-      Url::parse(URL).unwrap(),
-    ))
+    let bitmap: RevocationBitmap = RevocationBitmap::try_from_endpoint(
+      &identity_document::service::ServiceEndpoint::One(Url::parse(URL).unwrap()),
+    )
     .unwrap();
 
     for index in 0..2u32.pow(14) {

--- a/identity_credential/src/revocation/bitmap.rs
+++ b/identity_credential/src/revocation/bitmap.rs
@@ -168,6 +168,8 @@ impl RevocationBitmap {
 impl TryFrom<&Service> for RevocationBitmap {
   type Error = RevocationError;
 
+  /// Try to construct a `RevocationBitmap` from a service
+  /// if it is a valid Revocation Bitmap Service.
   fn try_from(service: &Service) -> Result<Self, RevocationError> {
     if !service.type_().contains(Self::TYPE) {
       return Err(RevocationError::InvalidService(

--- a/identity_credential/src/revocation/document_ext.rs
+++ b/identity_credential/src/revocation/document_ext.rs
@@ -97,7 +97,6 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
-  use identity_core::common::Object;
   use identity_core::convert::FromJson;
   use identity_did::DID;
 
@@ -156,15 +155,9 @@ mod tests {
     for index in indices_1.iter() {
       bitmap.revoke(*index);
     }
+
     assert!(document
-      .insert_service(
-        Service::builder(Object::new())
-          .id(service_id.clone())
-          .type_(crate::revocation::RevocationBitmap::TYPE)
-          .service_endpoint(bitmap.to_endpoint().unwrap())
-          .build()
-          .unwrap()
-      )
+      .insert_service(bitmap.to_service(service_id.clone()).unwrap())
       .is_ok());
 
     // Revoke indices_2.

--- a/identity_credential/src/revocation/mod.rs
+++ b/identity_credential/src/revocation/mod.rs
@@ -1,10 +1,12 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Contains a bitmap for managing credential revocation.
+//! Contains an implementation of RevocationBitmap2022 for managing credential revocation.
+
 mod bitmap;
 mod document_ext;
 mod error;
+
 pub use self::bitmap::RevocationBitmap;
 pub use self::document_ext::RevocationDocumentExt;
 pub use self::error::RevocationError;

--- a/identity_credential/src/validator/mod.rs
+++ b/identity_credential/src/validator/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Verifiable Credential and Presentation validators.
+
 pub use self::options::FailFast;
 pub use self::options::StatusCheck;
 pub use self::options::SubjectHolderRelationship;

--- a/identity_credential/src/validator/vc_jwt_validation/credential_jwt_validation_options.rs
+++ b/identity_credential/src/validator/vc_jwt_validation/credential_jwt_validation_options.rs
@@ -1,7 +1,6 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO: Replace or update the equivalent types in the parent module.
 use identity_core::common::Timestamp;
 use identity_core::common::Url;
 use identity_document::verifiable::JwsVerificationOptions;
@@ -10,7 +9,7 @@ use serde::Serialize;
 
 use crate::validator::SubjectHolderRelationship;
 
-/// Options to declare validation criteria for credentials.
+/// Options to declare validation criteria for [`Credential`](crate::credential::Credential)s.
 #[non_exhaustive]
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/identity_credential/src/validator/vc_jwt_validation/credential_jwt_validator.rs
+++ b/identity_credential/src/validator/vc_jwt_validation/credential_jwt_validator.rs
@@ -224,9 +224,7 @@ where
     }
 
     // Parse the `kid` to a DID Url which should be the identifier of a verification method in a trusted issuer's DID
-    // document TODO: Consider factoring this section into a private method that the (future) PresentationValidator
-    // can also use. In that case The `SignerContext` used in the error would have to be passed as an additional
-    // parameter.
+    // document.
     let method_id: DIDUrl = {
       let kid: &str =
         decoded

--- a/identity_credential/src/validator/vc_jwt_validation/decoded_jwt_credential.rs
+++ b/identity_credential/src/validator/vc_jwt_validation/decoded_jwt_credential.rs
@@ -6,6 +6,7 @@ use identity_core::common::Object;
 use identity_verification::jose::jws::JwsHeader;
 
 /// Decoded [`Credential`] from a cryptographically verified JWS.
+///
 /// Note that having an instance of this type only means the JWS it was constructed from was verified.
 /// It does not imply anything about a potentially present proof property on the credential itself.
 #[non_exhaustive]

--- a/identity_credential/src/validator/vc_jwt_validation/error.rs
+++ b/identity_credential/src/validator/vc_jwt_validation/error.rs
@@ -123,7 +123,7 @@ impl Display for SignerContext {
   }
 }
 
-/// Errors caused by a failure to validate a credential.
+/// Errors caused by a failure to validate a [`Credential`](crate::credential::Credential).
 #[derive(Debug)]
 pub struct CompoundCredentialValidationError {
   /// List of credential validation errors.

--- a/identity_credential/src/validator/vp_jwt_validation/error.rs
+++ b/identity_credential/src/validator/vp_jwt_validation/error.rs
@@ -1,19 +1,14 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt::Display;
 
-use crate::validator::vc_jwt_validation::CompoundCredentialValidationError;
 use crate::validator::vc_jwt_validation::ValidationError;
 
+/// Errors caused by a failure to validate a [`Presentation`](crate::presentation::Presentation).
 #[derive(Debug)]
-/// An error caused by a failure to validate a `Presentation`.
 pub struct CompoundJwtPresentationValidationError {
-  /// Errors that occurred during validation of individual credentials, mapped by index of their
-  /// order in the presentation.
-  pub credential_errors: BTreeMap<usize, CompoundCredentialValidationError>,
   /// Errors that occurred during validation of the presentation.
   pub presentation_validation_errors: Vec<ValidationError>,
 }
@@ -21,7 +16,6 @@ pub struct CompoundJwtPresentationValidationError {
 impl CompoundJwtPresentationValidationError {
   pub(crate) fn one_presentation_error(error: ValidationError) -> Self {
     Self {
-      credential_errors: BTreeMap::new(),
       presentation_validation_errors: vec![error],
     }
   }
@@ -29,15 +23,11 @@ impl CompoundJwtPresentationValidationError {
 
 impl Display for CompoundJwtPresentationValidationError {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    let credential_error_formatter = |(position, reason): (&usize, &CompoundCredentialValidationError)| -> String {
-      format!("credential num. {} errors: {}", position, reason.to_string().as_str())
-    };
-
     let error_string_iter = self
       .presentation_validation_errors
       .iter()
-      .map(|error| error.to_string())
-      .chain(self.credential_errors.iter().map(credential_error_formatter));
+      .map(|error| error.to_string());
+
     let detailed_information: String = itertools::intersperse(error_string_iter, "; ".to_string()).collect();
     write!(f, "[{detailed_information}]")
   }

--- a/identity_credential/src/validator/vp_jwt_validation/jwt_presentation_validation_options.rs
+++ b/identity_credential/src/validator/vp_jwt_validation/jwt_presentation_validation_options.rs
@@ -1,6 +1,9 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::Deserialize;
+use serde::Serialize;
+
 use identity_core::common::Timestamp;
 use identity_document::verifiable::JwsVerificationOptions;
 

--- a/identity_storage/src/storage/tests/credential_validation.rs
+++ b/identity_storage/src/storage/tests/credential_validation.rs
@@ -516,15 +516,7 @@ where
   // Add a RevocationBitmap service to the issuer.
   let bitmap: RevocationBitmap = RevocationBitmap::new();
 
-  insert_service(
-    &mut issuer_doc,
-    Service::builder(Object::new())
-      .id(service_url.clone())
-      .type_(RevocationBitmap::TYPE)
-      .service_endpoint(bitmap.to_endpoint().unwrap())
-      .build()
-      .unwrap(),
-  );
+  insert_service(&mut issuer_doc, bitmap.to_service(service_url.clone()).unwrap());
 
   // 3: un-revoked index always succeeds.
   for status_check in [StatusCheck::Strict, StatusCheck::SkipUnsupported, StatusCheck::SkipAll] {


### PR DESCRIPTION
# Description of change

Polish `identity_credential` by enabling various lints, removing Rust 2015-style `#[macro_use]` statements, adding missing docs and adding more safety to RevocationBitmap. The latter means making private the `RevocationBitmap` <-> `ServiceEndpoint` conversion functions and instead convert to and from `Service` directly. This provides more safety as users can not forget to set the correct type and is more convenient as evident by the updated examples.

## Links to any relevant issues

part of #1103.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

`cargo test && cargo clippy`

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
