### PR TITLE
Fix broken links in Wasm Api-reference

### DIFF
--- a/bindings/wasm/docs/api-reference.md
+++ b/bindings/wasm/docs/api-reference.md
@@ -53,7 +53,7 @@ and resolution of DID documents in Alias Outputs.</p>
 <dt><a href="#Jwk">Jwk</a></dt>
 <dd></dd>
 <dt><a href="#JwkGenOutput">JwkGenOutput</a></dt>
-<dd><p>The result of a key generation in <code>JwkStorage</code>.</p>
+<dd><p>The result of a key generation in <a href="JwkStorage">JwkStorage</a>.</p>
 </dd>
 <dt><a href="#Jws">Jws</a></dt>
 <dd><p>A wrapper around a JSON Web Signature (JWS).</p>
@@ -71,7 +71,7 @@ and resolution of DID documents in Alias Outputs.</p>
 <dd><p>Options to declare validation criteria when validating credentials.</p>
 </dd>
 <dt><a href="#JwtCredentialValidator">JwtCredentialValidator</a></dt>
-<dd><p>A type for decoding and validating <code>Credentials</code>.</p>
+<dd><p>A type for decoding and validating <a href="#Credential">Credential</a>.</p>
 </dd>
 <dt><a href="#JwtDomainLinkageValidator">JwtDomainLinkageValidator</a></dt>
 <dd><p>A validator for a Domain Linkage Configuration and Credentials.</p>
@@ -89,7 +89,7 @@ and resolution of DID documents in Alias Outputs.</p>
 <dd><p>Supported verification method data formats.</p>
 </dd>
 <dt><a href="#MethodDigest">MethodDigest</a></dt>
-<dd><p>Unique identifier of a [<code>VerificationMethod</code>].</p>
+<dd><p>Unique identifier of a <a href="#VerificationMethod">VerificationMethod</a>.</p>
 <p>NOTE:
 This class does not have a JSON representation,
 use the methods <code>pack</code> and <code>unpack</code> instead.</p>
@@ -102,10 +102,19 @@ use the methods <code>pack</code> and <code>unpack</code> instead.</p>
 </dd>
 <dt><a href="#Presentation">Presentation</a></dt>
 <dd></dd>
+<dt><a href="#Proof">Proof</a></dt>
+<dd><p>Represents a cryptographic proof that can be used to validate verifiable credentials and
+presentations.</p>
+<p>This representation does not inherently implement any standard; instead, it
+can be utilized to implement standards or user-defined proofs. The presence of the
+<code>type</code> field is necessary to accommodate different types of cryptographic proofs.</p>
+<p>Note that this proof is not related to JWT and can be used in combination or as an alternative
+to it.</p>
+</dd>
 <dt><a href="#Resolver">Resolver</a></dt>
 <dd><p>Convenience type for resolving DID documents from different DID methods.</p>
 <p>Also provides methods for resolving DID Documents associated with
-verifiable <code>Credentials</code> and <code>Presentations</code>.</p>
+verifiable <a href="#Credential">Credential</a>s and <a href="#Presentation">Presentation</a>s.</p>
 <h1 id="configuration">Configuration</h1>
 <p>The resolver will only be able to resolve DID documents for methods it has been configured for in the constructor.</p>
 </dd>
@@ -131,6 +140,10 @@ working with storage backed DID documents.</p>
 ## Members
 
 <dl>
+<dt><a href="#StateMetadataEncoding">StateMetadataEncoding</a></dt>
+<dd></dd>
+<dt><a href="#MethodRelationship">MethodRelationship</a></dt>
+<dd></dd>
 <dt><a href="#StatusCheck">StatusCheck</a></dt>
 <dd><p>Controls validation behaviour when checking whether or not a credential has been revoked by its
 <a href="https://www.w3.org/TR/vc-data-model/#status"><code>credentialStatus</code></a>.</p>
@@ -149,14 +162,12 @@ working with storage backed DID documents.</p>
 <dd><p>Skip all status checks.</p>
 </dd>
 <dt><a href="#SubjectHolderRelationship">SubjectHolderRelationship</a></dt>
-<dd><p>Declares how credential subjects must relate to the presentation holder during validation.
-See <code>PresentationValidationOptions::subject_holder_relationship</code>.</p>
+<dd><p>Declares how credential subjects must relate to the presentation holder.</p>
 <p>See also the <a href="https://www.w3.org/TR/vc-data-model/#subject-holder-relationships">Subject-Holder Relationship</a> section of the specification.</p>
 </dd>
 <dt><a href="#AlwaysSubject">AlwaysSubject</a></dt>
 <dd><p>The holder must always match the subject on all credentials, regardless of their <a href="https://www.w3.org/TR/vc-data-model/#nontransferable-property"><code>nonTransferable</code></a> property.
-This variant is the default used if no other variant is specified when constructing a new
-<code>PresentationValidationOptions</code>.</p>
+This variant is the default.</p>
 </dd>
 <dt><a href="#SubjectOnNonTransferable">SubjectOnNonTransferable</a></dt>
 <dd><p>The holder must match the subject only for credentials where the <a href="https://www.w3.org/TR/vc-data-model/#nontransferable-property"><code>nonTransferable</code></a> property is <code>true</code>.</p>
@@ -173,23 +184,19 @@ This variant is the default used if no other variant is specified when construct
 <dt><a href="#FirstError">FirstError</a></dt>
 <dd><p>Return after the first error occurs.</p>
 </dd>
-<dt><a href="#MethodRelationship">MethodRelationship</a></dt>
-<dd></dd>
-<dt><a href="#StateMetadataEncoding">StateMetadataEncoding</a></dt>
-<dd></dd>
 </dl>
 
 ## Functions
 
 <dl>
-<dt><a href="#start">start()</a></dt>
-<dd><p>Initializes the console error panic hook for better error messages</p>
-</dd>
 <dt><a href="#encodeB64">encodeB64(data)</a> ⇒ <code>string</code></dt>
 <dd><p>Encode the given bytes in url-safe base64.</p>
 </dd>
 <dt><a href="#decodeB64">decodeB64(data)</a> ⇒ <code>Uint8Array</code></dt>
 <dd><p>Decode the given url-safe base64-encoded slice into its raw bytes.</p>
+</dd>
+<dt><a href="#start">start()</a></dt>
+<dd><p>Initializes the console error panic hook for better error messages</p>
 </dd>
 <dt><a href="#verifyEdDSA">verifyEdDSA(alg, signingInput, decodedSignature, publicKey)</a></dt>
 <dd><p>Verify a JWS signature secured with the <code>JwsAlgorithm::EdDSA</code> algorithm.
@@ -233,7 +240,7 @@ A method-agnostic Decentralized Identifier (DID).
 <a name="CoreDID+setMethodName"></a>
 
 ### coreDID.setMethodName(value)
-Set the method name of the `CoreDID`.
+Set the method name of the [CoreDID](#CoreDID).
 
 **Kind**: instance method of [<code>CoreDID</code>](#CoreDID)  
 
@@ -255,7 +262,7 @@ Set the method-specific-id of the `DID`.
 <a name="CoreDID+scheme"></a>
 
 ### coreDID.scheme() ⇒ <code>string</code>
-Returns the `CoreDID` scheme.
+Returns the [CoreDID](#CoreDID) scheme.
 
 E.g.
 - `"did:example:12345678" -> "did"`
@@ -265,7 +272,7 @@ E.g.
 <a name="CoreDID+authority"></a>
 
 ### coreDID.authority() ⇒ <code>string</code>
-Returns the `CoreDID` authority: the method name and method-id.
+Returns the [CoreDID](#CoreDID) authority: the method name and method-id.
 
 E.g.
 - `"did:example:12345678" -> "example:12345678"`
@@ -275,7 +282,7 @@ E.g.
 <a name="CoreDID+method"></a>
 
 ### coreDID.method() ⇒ <code>string</code>
-Returns the `CoreDID` method name.
+Returns the [CoreDID](#CoreDID) method name.
 
 E.g.
 - `"did:example:12345678" -> "example"`
@@ -285,7 +292,7 @@ E.g.
 <a name="CoreDID+methodId"></a>
 
 ### coreDID.methodId() ⇒ <code>string</code>
-Returns the `CoreDID` method-specific ID.
+Returns the [CoreDID](#CoreDID) method-specific ID.
 
 E.g.
 - `"did:example:12345678" -> "12345678"`
@@ -295,7 +302,7 @@ E.g.
 <a name="CoreDID+join"></a>
 
 ### coreDID.join(segment) ⇒ [<code>DIDUrl</code>](#DIDUrl)
-Construct a new `DIDUrl` by joining with a relative DID Url string.
+Construct a new [DIDUrl](#DIDUrl) by joining with a relative DID Url string.
 
 **Kind**: instance method of [<code>CoreDID</code>](#CoreDID)  
 
@@ -306,19 +313,19 @@ Construct a new `DIDUrl` by joining with a relative DID Url string.
 <a name="CoreDID+toUrl"></a>
 
 ### coreDID.toUrl() ⇒ [<code>DIDUrl</code>](#DIDUrl)
-Clones the `CoreDID` into a `DIDUrl`.
+Clones the [CoreDID](#CoreDID) into a [DIDUrl](#DIDUrl).
 
 **Kind**: instance method of [<code>CoreDID</code>](#CoreDID)  
 <a name="CoreDID+intoUrl"></a>
 
 ### coreDID.intoUrl() ⇒ [<code>DIDUrl</code>](#DIDUrl)
-Converts the `CoreDID` into a `DIDUrl`, consuming it.
+Converts the [CoreDID](#CoreDID) into a [DIDUrl](#DIDUrl), consuming it.
 
 **Kind**: instance method of [<code>CoreDID</code>](#CoreDID)  
 <a name="CoreDID+toString"></a>
 
 ### coreDID.toString() ⇒ <code>string</code>
-Returns the `CoreDID` as a string.
+Returns the [CoreDID](#CoreDID) as a string.
 
 **Kind**: instance method of [<code>CoreDID</code>](#CoreDID)  
 <a name="CoreDID+toCoreDid"></a>
@@ -340,11 +347,11 @@ Deep clones the object.
 <a name="CoreDID.parse"></a>
 
 ### CoreDID.parse(input) ⇒ [<code>CoreDID</code>](#CoreDID)
-Parses a `CoreDID` from the given `input`.
+Parses a [CoreDID](#CoreDID) from the given `input`.
 
 ### Errors
 
-Throws an error if the input is not a valid `CoreDID`.
+Throws an error if the input is not a valid [CoreDID](#CoreDID).
 
 **Kind**: static method of [<code>CoreDID</code>](#CoreDID)  
 
@@ -438,7 +445,7 @@ A method-agnostic DID Document.
 <a name="new_CoreDocument_new"></a>
 
 ### new CoreDocument(values)
-Creates a new `CoreDocument` with the given properties.
+Creates a new [CoreDocument](#CoreDocument) with the given properties.
 
 
 | Param | Type |
@@ -459,8 +466,8 @@ Sets the DID of the document.
 ### Warning
 
 Changing the identifier can drastically alter the results of
-[`Self::resolve_method`](CoreDocument::resolve_method()),
-[`Self::resolve_service`](CoreDocument::resolve_service()) and the related [DID URL dereferencing](https://w3c-ccg.github.io/did-resolution/#dereferencing) algorithm.
+`resolve_method`, `resolve_service` and the related
+[DID URL dereferencing](https://w3c-ccg.github.io/did-resolution/#dereferencing) algorithm.
 
 **Kind**: instance method of [<code>CoreDocument</code>](#CoreDocument)  
 
@@ -716,7 +723,7 @@ take place.
 <a name="CoreDocument+revokeCredentials"></a>
 
 ### coreDocument.revokeCredentials(serviceQuery, indices)
-If the document has a `RevocationBitmap` service identified by `serviceQuery`,
+If the document has a [RevocationBitmap](#RevocationBitmap) service identified by `serviceQuery`,
 revoke all specified `indices`.
 
 **Kind**: instance method of [<code>CoreDocument</code>](#CoreDocument)  
@@ -729,7 +736,7 @@ revoke all specified `indices`.
 <a name="CoreDocument+unrevokeCredentials"></a>
 
 ### coreDocument.unrevokeCredentials(serviceQuery, indices)
-If the document has a `RevocationBitmap` service identified by `serviceQuery`,
+If the document has a [RevocationBitmap](#RevocationBitmap) service identified by `serviceQuery`,
 unrevoke all specified `indices`.
 
 **Kind**: instance method of [<code>CoreDocument</code>](#CoreDocument)  
@@ -742,7 +749,7 @@ unrevoke all specified `indices`.
 <a name="CoreDocument+clone"></a>
 
 ### coreDocument.clone() ⇒ [<code>CoreDocument</code>](#CoreDocument)
-Deep clones the `CoreDocument`.
+Deep clones the [CoreDocument](#CoreDocument).
 
 **Kind**: instance method of [<code>CoreDocument</code>](#CoreDocument)  
 <a name="CoreDocument+_shallowCloneInternal"></a>
@@ -887,8 +894,9 @@ Deserializes an instance from a plain JS representation.
         * [.termsOfUse()](#Credential+termsOfUse) ⇒ <code>Array.&lt;Policy&gt;</code>
         * [.evidence()](#Credential+evidence) ⇒ <code>Array.&lt;Evidence&gt;</code>
         * [.nonTransferable()](#Credential+nonTransferable) ⇒ <code>boolean</code> \| <code>undefined</code>
-        * [.proof()](#Credential+proof) ⇒ <code>any</code>
+        * [.proof()](#Credential+proof) ⇒ [<code>Proof</code>](#Proof) \| <code>undefined</code>
         * [.properties()](#Credential+properties) ⇒ <code>Map.&lt;string, any&gt;</code>
+        * [.setProof(proof)](#Credential+setProof)
         * [.toJSON()](#Credential+toJSON) ⇒ <code>any</code>
         * [.clone()](#Credential+clone) ⇒ [<code>Credential</code>](#Credential)
     * _static_
@@ -900,7 +908,7 @@ Deserializes an instance from a plain JS representation.
 <a name="new_Credential_new"></a>
 
 ### new Credential(values)
-Constructs a new `Credential`.
+Constructs a new [Credential](#Credential).
 
 
 | Param | Type |
@@ -910,94 +918,107 @@ Constructs a new `Credential`.
 <a name="Credential+context"></a>
 
 ### credential.context() ⇒ <code>Array.&lt;(string\|Record.&lt;string, any&gt;)&gt;</code>
-Returns a copy of the JSON-LD context(s) applicable to the `Credential`.
+Returns a copy of the JSON-LD context(s) applicable to the [Credential](#Credential).
 
 **Kind**: instance method of [<code>Credential</code>](#Credential)  
 <a name="Credential+id"></a>
 
 ### credential.id() ⇒ <code>string</code> \| <code>undefined</code>
-Returns a copy of the unique `URI` identifying the `Credential` .
+Returns a copy of the unique `URI` identifying the [Credential](#Credential) .
 
 **Kind**: instance method of [<code>Credential</code>](#Credential)  
 <a name="Credential+type"></a>
 
 ### credential.type() ⇒ <code>Array.&lt;string&gt;</code>
-Returns a copy of the URIs defining the type of the `Credential`.
+Returns a copy of the URIs defining the type of the [Credential](#Credential).
 
 **Kind**: instance method of [<code>Credential</code>](#Credential)  
 <a name="Credential+credentialSubject"></a>
 
 ### credential.credentialSubject() ⇒ <code>Array.&lt;Subject&gt;</code>
-Returns a copy of the `Credential` subject(s).
+Returns a copy of the [Credential](#Credential) subject(s).
 
 **Kind**: instance method of [<code>Credential</code>](#Credential)  
 <a name="Credential+issuer"></a>
 
 ### credential.issuer() ⇒ <code>string</code> \| <code>Issuer</code>
-Returns a copy of the issuer of the `Credential`.
+Returns a copy of the issuer of the [Credential](#Credential).
 
 **Kind**: instance method of [<code>Credential</code>](#Credential)  
 <a name="Credential+issuanceDate"></a>
 
 ### credential.issuanceDate() ⇒ [<code>Timestamp</code>](#Timestamp)
-Returns a copy of the timestamp of when the `Credential` becomes valid.
+Returns a copy of the timestamp of when the [Credential](#Credential) becomes valid.
 
 **Kind**: instance method of [<code>Credential</code>](#Credential)  
 <a name="Credential+expirationDate"></a>
 
 ### credential.expirationDate() ⇒ [<code>Timestamp</code>](#Timestamp) \| <code>undefined</code>
-Returns a copy of the timestamp of when the `Credential` should no longer be considered valid.
+Returns a copy of the timestamp of when the [Credential](#Credential) should no longer be considered valid.
 
 **Kind**: instance method of [<code>Credential</code>](#Credential)  
 <a name="Credential+credentialStatus"></a>
 
 ### credential.credentialStatus() ⇒ <code>Array.&lt;Status&gt;</code>
-Returns a copy of the information used to determine the current status of the `Credential`.
+Returns a copy of the information used to determine the current status of the [Credential](#Credential).
 
 **Kind**: instance method of [<code>Credential</code>](#Credential)  
 <a name="Credential+credentialSchema"></a>
 
 ### credential.credentialSchema() ⇒ <code>Array.&lt;Schema&gt;</code>
-Returns a copy of the information used to assist in the enforcement of a specific `Credential` structure.
+Returns a copy of the information used to assist in the enforcement of a specific [Credential](#Credential) structure.
 
 **Kind**: instance method of [<code>Credential</code>](#Credential)  
 <a name="Credential+refreshService"></a>
 
 ### credential.refreshService() ⇒ <code>Array.&lt;RefreshService&gt;</code>
-Returns a copy of the service(s) used to refresh an expired `Credential`.
+Returns a copy of the service(s) used to refresh an expired [Credential](#Credential).
 
 **Kind**: instance method of [<code>Credential</code>](#Credential)  
 <a name="Credential+termsOfUse"></a>
 
 ### credential.termsOfUse() ⇒ <code>Array.&lt;Policy&gt;</code>
-Returns a copy of the terms-of-use specified by the `Credential` issuer.
+Returns a copy of the terms-of-use specified by the [Credential](#Credential) issuer.
 
 **Kind**: instance method of [<code>Credential</code>](#Credential)  
 <a name="Credential+evidence"></a>
 
 ### credential.evidence() ⇒ <code>Array.&lt;Evidence&gt;</code>
-Returns a copy of the human-readable evidence used to support the claims within the `Credential`.
+Returns a copy of the human-readable evidence used to support the claims within the [Credential](#Credential).
 
 **Kind**: instance method of [<code>Credential</code>](#Credential)  
 <a name="Credential+nonTransferable"></a>
 
 ### credential.nonTransferable() ⇒ <code>boolean</code> \| <code>undefined</code>
-Returns whether or not the `Credential` must only be contained within a  `Presentation`
-with a proof issued from the `Credential` subject.
+Returns whether or not the [Credential](#Credential) must only be contained within a  [Presentation](#Presentation)
+with a proof issued from the [Credential](#Credential) subject.
 
 **Kind**: instance method of [<code>Credential</code>](#Credential)  
 <a name="Credential+proof"></a>
 
-### credential.proof() ⇒ <code>any</code>
-Returns a copy of the proof used to verify the `Credential`.
+### credential.proof() ⇒ [<code>Proof</code>](#Proof) \| <code>undefined</code>
+Optional cryptographic proof, unrelated to JWT.
 
 **Kind**: instance method of [<code>Credential</code>](#Credential)  
 <a name="Credential+properties"></a>
 
 ### credential.properties() ⇒ <code>Map.&lt;string, any&gt;</code>
-Returns a copy of the miscellaneous properties on the `Credential`.
+Returns a copy of the miscellaneous properties on the [Credential](#Credential).
 
 **Kind**: instance method of [<code>Credential</code>](#Credential)  
+<a name="Credential+setProof"></a>
+
+### credential.setProof(proof)
+Sets the `proof` property of the [Credential](#Credential).
+
+Note that this proof is not related to JWT.
+
+**Kind**: instance method of [<code>Credential</code>](#Credential)  
+
+| Param | Type |
+| --- | --- |
+| proof | [<code>Proof</code>](#Proof) \| <code>undefined</code> | 
+
 <a name="Credential+toJSON"></a>
 
 ### credential.toJSON() ⇒ <code>any</code>
@@ -1070,7 +1091,7 @@ A method agnostic DID Url.
 <a name="DIDUrl+did"></a>
 
 ### didUrl.did() ⇒ [<code>CoreDID</code>](#CoreDID)
-Return a copy of the `CoreDID` section of the `DIDUrl`.
+Return a copy of the [CoreDID](#CoreDID) section of the [DIDUrl](#DIDUrl).
 
 **Kind**: instance method of [<code>DIDUrl</code>](#DIDUrl)  
 <a name="DIDUrl+urlStr"></a>
@@ -1082,13 +1103,13 @@ Return a copy of the relative DID Url as a string, including only the path, quer
 <a name="DIDUrl+fragment"></a>
 
 ### didUrl.fragment() ⇒ <code>string</code> \| <code>undefined</code>
-Returns a copy of the `DIDUrl` method fragment, if any. Excludes the leading '#'.
+Returns a copy of the [DIDUrl](#DIDUrl) method fragment, if any. Excludes the leading '#'.
 
 **Kind**: instance method of [<code>DIDUrl</code>](#DIDUrl)  
 <a name="DIDUrl+setFragment"></a>
 
 ### didUrl.setFragment(value)
-Sets the `fragment` component of the `DIDUrl`.
+Sets the `fragment` component of the [DIDUrl](#DIDUrl).
 
 **Kind**: instance method of [<code>DIDUrl</code>](#DIDUrl)  
 
@@ -1099,13 +1120,13 @@ Sets the `fragment` component of the `DIDUrl`.
 <a name="DIDUrl+path"></a>
 
 ### didUrl.path() ⇒ <code>string</code> \| <code>undefined</code>
-Returns a copy of the `DIDUrl` path.
+Returns a copy of the [DIDUrl](#DIDUrl) path.
 
 **Kind**: instance method of [<code>DIDUrl</code>](#DIDUrl)  
 <a name="DIDUrl+setPath"></a>
 
 ### didUrl.setPath(value)
-Sets the `path` component of the `DIDUrl`.
+Sets the `path` component of the [DIDUrl](#DIDUrl).
 
 **Kind**: instance method of [<code>DIDUrl</code>](#DIDUrl)  
 
@@ -1116,13 +1137,13 @@ Sets the `path` component of the `DIDUrl`.
 <a name="DIDUrl+query"></a>
 
 ### didUrl.query() ⇒ <code>string</code> \| <code>undefined</code>
-Returns a copy of the `DIDUrl` method query, if any. Excludes the leading '?'.
+Returns a copy of the [DIDUrl](#DIDUrl) method query, if any. Excludes the leading '?'.
 
 **Kind**: instance method of [<code>DIDUrl</code>](#DIDUrl)  
 <a name="DIDUrl+setQuery"></a>
 
 ### didUrl.setQuery(value)
-Sets the `query` component of the `DIDUrl`.
+Sets the `query` component of the [DIDUrl](#DIDUrl).
 
 **Kind**: instance method of [<code>DIDUrl</code>](#DIDUrl)  
 
@@ -1133,7 +1154,7 @@ Sets the `query` component of the `DIDUrl`.
 <a name="DIDUrl+join"></a>
 
 ### didUrl.join(segment) ⇒ [<code>DIDUrl</code>](#DIDUrl)
-Append a string representing a path, query, and/or fragment, returning a new `DIDUrl`.
+Append a string representing a path, query, and/or fragment, returning a new [DIDUrl](#DIDUrl).
 
 Must begin with a valid delimiter character: '/', '?', '#'. Overwrites the existing URL
 segment and any following segments in order of path, query, then fragment.
@@ -1152,7 +1173,7 @@ I.e.
 <a name="DIDUrl+toString"></a>
 
 ### didUrl.toString() ⇒ <code>string</code>
-Returns the `DIDUrl` as a string.
+Returns the [DIDUrl](#DIDUrl) as a string.
 
 **Kind**: instance method of [<code>DIDUrl</code>](#DIDUrl)  
 <a name="DIDUrl+toJSON"></a>
@@ -1170,7 +1191,7 @@ Deep clones the object.
 <a name="DIDUrl.parse"></a>
 
 ### DIDUrl.parse(input) ⇒ [<code>DIDUrl</code>](#DIDUrl)
-Parses a `DIDUrl` from the input string.
+Parses a [DIDUrl](#DIDUrl) from the input string.
 
 **Kind**: static method of [<code>DIDUrl</code>](#DIDUrl)  
 
@@ -1273,7 +1294,8 @@ Returns a copy of the protected header parsed from the decoded JWS.
 Consumes the object and returns the decoded credential.
 
 ### Warning
-This destroys the `DecodedCredential` object.
+
+This destroys the [DecodedJwtCredential](#DecodedJwtCredential) object.
 
 **Kind**: instance method of [<code>DecodedJwtCredential</code>](#DecodedJwtCredential)  
 <a name="DecodedJwtPresentation"></a>
@@ -1310,7 +1332,7 @@ Returns a copy of the protected header parsed from the decoded JWS.
 Consumes the object and returns the decoded presentation.
 
 ### Warning
-This destroys the `DecodedJwtPresentation` object.
+This destroys the [DecodedJwtPresentation](#DecodedJwtPresentation) object.
 
 **Kind**: instance method of [<code>DecodedJwtPresentation</code>](#DecodedJwtPresentation)  
 <a name="DecodedJwtPresentation+expirationDate"></a>
@@ -1344,7 +1366,7 @@ Note:
 **Kind**: global class  
 
 * [DomainLinkageConfiguration](#DomainLinkageConfiguration)
-    * [new DomainLinkageConfiguration(linked_dids)](#new_DomainLinkageConfiguration_new)
+    * [new DomainLinkageConfiguration(linkedDids)](#new_DomainLinkageConfiguration_new)
     * _instance_
         * [.linkedDids()](#DomainLinkageConfiguration+linkedDids) ⇒ [<code>Array.&lt;Jwt&gt;</code>](#Jwt)
         * [.issuers()](#DomainLinkageConfiguration+issuers) ⇒ [<code>Array.&lt;CoreDID&gt;</code>](#CoreDID)
@@ -1355,13 +1377,13 @@ Note:
 
 <a name="new_DomainLinkageConfiguration_new"></a>
 
-### new DomainLinkageConfiguration(linked_dids)
-Constructs a new `DomainLinkageConfiguration`.
+### new DomainLinkageConfiguration(linkedDids)
+Constructs a new [DomainLinkageConfiguration](#DomainLinkageConfiguration).
 
 
 | Param | Type |
 | --- | --- |
-| linked_dids | [<code>Array.&lt;Jwt&gt;</code>](#Jwt) | 
+| linkedDids | [<code>Array.&lt;Jwt&gt;</code>](#Jwt) | 
 
 <a name="DomainLinkageConfiguration+linkedDids"></a>
 
@@ -1425,7 +1447,7 @@ Serializes this to a JSON object.
 <a name="Duration.seconds"></a>
 
 ### Duration.seconds(seconds) ⇒ [<code>Duration</code>](#Duration)
-Create a new `Duration` with the given number of seconds.
+Create a new [Duration](#Duration) with the given number of seconds.
 
 **Kind**: static method of [<code>Duration</code>](#Duration)  
 
@@ -1436,7 +1458,7 @@ Create a new `Duration` with the given number of seconds.
 <a name="Duration.minutes"></a>
 
 ### Duration.minutes(minutes) ⇒ [<code>Duration</code>](#Duration)
-Create a new `Duration` with the given number of minutes.
+Create a new [Duration](#Duration) with the given number of minutes.
 
 **Kind**: static method of [<code>Duration</code>](#Duration)  
 
@@ -1447,7 +1469,7 @@ Create a new `Duration` with the given number of minutes.
 <a name="Duration.hours"></a>
 
 ### Duration.hours(hours) ⇒ [<code>Duration</code>](#Duration)
-Create a new `Duration` with the given number of hours.
+Create a new [Duration](#Duration) with the given number of hours.
 
 **Kind**: static method of [<code>Duration</code>](#Duration)  
 
@@ -1458,7 +1480,7 @@ Create a new `Duration` with the given number of hours.
 <a name="Duration.days"></a>
 
 ### Duration.days(days) ⇒ [<code>Duration</code>](#Duration)
-Create a new `Duration` with the given number of days.
+Create a new [Duration](#Duration) with the given number of days.
 
 **Kind**: static method of [<code>Duration</code>](#Duration)  
 
@@ -1469,7 +1491,7 @@ Create a new `Duration` with the given number of days.
 <a name="Duration.weeks"></a>
 
 ### Duration.weeks(weeks) ⇒ [<code>Duration</code>](#Duration)
-Create a new `Duration` with the given number of weeks.
+Create a new [Duration](#Duration) with the given number of weeks.
 
 **Kind**: static method of [<code>Duration</code>](#Duration)  
 
@@ -1523,7 +1545,7 @@ A DID conforming to the IOTA DID method specification.
 <a name="new_IotaDID_new"></a>
 
 ### new IotaDID(bytes, network)
-Constructs a new `IotaDID` from a byte representation of the tag and the given
+Constructs a new [IotaDID](#IotaDID) from a byte representation of the tag and the given
 network name.
 
 See also [placeholder](#IotaDID.placeholder).
@@ -1537,19 +1559,19 @@ See also [placeholder](#IotaDID.placeholder).
 <a name="IotaDID+network"></a>
 
 ### did.network() ⇒ <code>string</code>
-Returns the Tangle network name of the `IotaDID`.
+Returns the Tangle network name of the [IotaDID](#IotaDID).
 
 **Kind**: instance method of [<code>IotaDID</code>](#IotaDID)  
 <a name="IotaDID+tag"></a>
 
 ### did.tag() ⇒ <code>string</code>
-Returns a copy of the unique tag of the `IotaDID`.
+Returns a copy of the unique tag of the [IotaDID](#IotaDID).
 
 **Kind**: instance method of [<code>IotaDID</code>](#IotaDID)  
 <a name="IotaDID+toCoreDid"></a>
 
 ### did.toCoreDid() ⇒ [<code>CoreDID</code>](#CoreDID)
-Returns the DID represented as a `CoreDID`.
+Returns the DID represented as a [CoreDID](#CoreDID).
 
 **Kind**: instance method of [<code>IotaDID</code>](#IotaDID)  
 <a name="IotaDID+scheme"></a>
@@ -1595,7 +1617,7 @@ E.g.
 <a name="IotaDID+join"></a>
 
 ### did.join(segment) ⇒ [<code>DIDUrl</code>](#DIDUrl)
-Construct a new `DIDUrl` by joining with a relative DID Url string.
+Construct a new [DIDUrl](#DIDUrl) by joining with a relative DID Url string.
 
 **Kind**: instance method of [<code>IotaDID</code>](#IotaDID)  
 
@@ -1606,7 +1628,7 @@ Construct a new `DIDUrl` by joining with a relative DID Url string.
 <a name="IotaDID+toUrl"></a>
 
 ### did.toUrl() ⇒ [<code>DIDUrl</code>](#DIDUrl)
-Clones the `DID` into a `DIDUrl`.
+Clones the `DID` into a [DIDUrl](#DIDUrl).
 
 **Kind**: instance method of [<code>IotaDID</code>](#IotaDID)  
 <a name="IotaDID+toAliasId"></a>
@@ -1618,7 +1640,7 @@ Returns the hex-encoded AliasId with a '0x' prefix, from the DID tag.
 <a name="IotaDID+intoUrl"></a>
 
 ### did.intoUrl() ⇒ [<code>DIDUrl</code>](#DIDUrl)
-Converts the `DID` into a `DIDUrl`, consuming it.
+Converts the `DID` into a [DIDUrl](#DIDUrl), consuming it.
 
 **Kind**: instance method of [<code>IotaDID</code>](#IotaDID)  
 <a name="IotaDID+toString"></a>
@@ -1654,7 +1676,7 @@ The default Tangle network (`"iota"`).
 <a name="IotaDID.fromAliasId"></a>
 
 ### IotaDID.fromAliasId(aliasId, network) ⇒ [<code>IotaDID</code>](#IotaDID)
-Constructs a new `IotaDID` from a hex representation of an Alias Id and the given
+Constructs a new [IotaDID](#IotaDID) from a hex representation of an Alias Id and the given
 network name.
 
 **Kind**: static method of [<code>IotaDID</code>](#IotaDID)  
@@ -1667,7 +1689,7 @@ network name.
 <a name="IotaDID.placeholder"></a>
 
 ### IotaDID.placeholder(network) ⇒ [<code>IotaDID</code>](#IotaDID)
-Creates a new placeholder [`IotaDID`] with the given network name.
+Creates a new placeholder [IotaDID](#IotaDID) with the given network name.
 
 E.g. `did:iota:smr:0x0000000000000000000000000000000000000000000000000000000000000000`.
 
@@ -1680,7 +1702,7 @@ E.g. `did:iota:smr:0x00000000000000000000000000000000000000000000000000000000000
 <a name="IotaDID.parse"></a>
 
 ### IotaDID.parse(input) ⇒ [<code>IotaDID</code>](#IotaDID)
-Parses a `IotaDID` from the input string.
+Parses a [IotaDID](#IotaDID) from the input string.
 
 **Kind**: static method of [<code>IotaDID</code>](#IotaDID)  
 
@@ -1750,14 +1772,14 @@ Deserializes an instance from a JSON object.
         * [.createPresentationJwt(storage, fragment, presentation, signature_options, presentation_options)](#IotaDocument+createPresentationJwt) ⇒ [<code>Promise.&lt;Jwt&gt;</code>](#Jwt)
     * _static_
         * [.newWithId(id)](#IotaDocument.newWithId) ⇒ [<code>IotaDocument</code>](#IotaDocument)
-        * [.unpackFromOutput(did, aliasOutput, allowEmpty, tokenSupply)](#IotaDocument.unpackFromOutput) ⇒ [<code>IotaDocument</code>](#IotaDocument)
-        * [.unpackFromBlock(network, block, protocol_parameters)](#IotaDocument.unpackFromBlock) ⇒ [<code>Array.&lt;IotaDocument&gt;</code>](#IotaDocument)
+        * [.unpackFromOutput(did, aliasOutput, allowEmpty)](#IotaDocument.unpackFromOutput) ⇒ [<code>IotaDocument</code>](#IotaDocument)
+        * [.unpackFromBlock(network, block)](#IotaDocument.unpackFromBlock) ⇒ [<code>Array.&lt;IotaDocument&gt;</code>](#IotaDocument)
         * [.fromJSON(json)](#IotaDocument.fromJSON) ⇒ [<code>IotaDocument</code>](#IotaDocument)
 
 <a name="new_IotaDocument_new"></a>
 
 ### new IotaDocument(network)
-Constructs an empty DID Document with a [placeholder](#IotaDID.placeholder) identifier
+Constructs an empty IOTA DID Document with a [placeholder](#IotaDID.placeholder) identifier
 for the given `network`.
 
 
@@ -2069,7 +2091,7 @@ If the value is set to `null`, the custom property will be removed.
 <a name="IotaDocument+revokeCredentials"></a>
 
 ### iotaDocument.revokeCredentials(serviceQuery, indices)
-If the document has a `RevocationBitmap` service identified by `serviceQuery`,
+If the document has a [RevocationBitmap](#RevocationBitmap) service identified by `serviceQuery`,
 revoke all specified `indices`.
 
 **Kind**: instance method of [<code>IotaDocument</code>](#IotaDocument)  
@@ -2082,7 +2104,7 @@ revoke all specified `indices`.
 <a name="IotaDocument+unrevokeCredentials"></a>
 
 ### iotaDocument.unrevokeCredentials(serviceQuery, indices)
-If the document has a `RevocationBitmap` service identified by `serviceQuery`,
+If the document has a [RevocationBitmap](#RevocationBitmap) service identified by `serviceQuery`,
 unrevoke all specified `indices`.
 
 **Kind**: instance method of [<code>IotaDocument</code>](#IotaDocument)  
@@ -2095,7 +2117,7 @@ unrevoke all specified `indices`.
 <a name="IotaDocument+clone"></a>
 
 ### iotaDocument.clone() ⇒ [<code>IotaDocument</code>](#IotaDocument)
-Returns a deep clone of the `IotaDocument`.
+Returns a deep clone of the [IotaDocument](#IotaDocument).
 
 **Kind**: instance method of [<code>IotaDocument</code>](#IotaDocument)  
 <a name="IotaDocument+_shallowCloneInternal"></a>
@@ -2121,7 +2143,7 @@ Serializes to a plain JS representation.
 <a name="IotaDocument+toCoreDocument"></a>
 
 ### iotaDocument.toCoreDocument() ⇒ [<code>CoreDocument</code>](#CoreDocument)
-Transforms the `IotaDocument` to its `CoreDocument` representation.
+Transforms the [IotaDocument](#IotaDocument) to its [CoreDocument](#CoreDocument) representation.
 
 **Kind**: instance method of [<code>IotaDocument</code>](#IotaDocument)  
 <a name="IotaDocument+generateMethod"></a>
@@ -2227,7 +2249,7 @@ Constructs an empty DID Document with the given identifier.
 
 <a name="IotaDocument.unpackFromOutput"></a>
 
-### IotaDocument.unpackFromOutput(did, aliasOutput, allowEmpty, tokenSupply) ⇒ [<code>IotaDocument</code>](#IotaDocument)
+### IotaDocument.unpackFromOutput(did, aliasOutput, allowEmpty) ⇒ [<code>IotaDocument</code>](#IotaDocument)
 Deserializes the document from an Alias Output.
 
 If `allowEmpty` is true, this will return an empty DID document marked as `deactivated`
@@ -2244,27 +2266,23 @@ encoded in the `AliasId` alone.
 | Param | Type |
 | --- | --- |
 | did | [<code>IotaDID</code>](#IotaDID) | 
-| aliasOutput | <code>IAliasOutput</code> | 
+| aliasOutput | <code>AliasOutputBuilderParams</code> | 
 | allowEmpty | <code>boolean</code> | 
-| tokenSupply | <code>bigint</code> | 
 
 <a name="IotaDocument.unpackFromBlock"></a>
 
-### IotaDocument.unpackFromBlock(network, block, protocol_parameters) ⇒ [<code>Array.&lt;IotaDocument&gt;</code>](#IotaDocument)
+### IotaDocument.unpackFromBlock(network, block) ⇒ [<code>Array.&lt;IotaDocument&gt;</code>](#IotaDocument)
 Returns all DID documents of the Alias Outputs contained in the block's transaction payload
 outputs, if any.
 
 Errors if any Alias Output does not contain a valid or empty DID Document.
-
-`protocolResponseJson` can be obtained from a `Client`.
 
 **Kind**: static method of [<code>IotaDocument</code>](#IotaDocument)  
 
 | Param | Type |
 | --- | --- |
 | network | <code>string</code> | 
-| block | <code>IBlock</code> | 
-| protocol_parameters | <code>INodeInfoProtocol</code> | 
+| block | <code>Block</code> | 
 
 <a name="IotaDocument.fromJSON"></a>
 
@@ -2365,15 +2383,15 @@ and resolution of DID documents in Alias Outputs.
 **Kind**: global class  
 
 * [IotaIdentityClientExt](#IotaIdentityClientExt)
-    * [.newDidOutput(client, address, document, rentStructure)](#IotaIdentityClientExt.newDidOutput) ⇒ <code>Promise.&lt;IAliasOutput&gt;</code>
-    * [.updateDidOutput(client, document)](#IotaIdentityClientExt.updateDidOutput) ⇒ <code>Promise.&lt;IAliasOutput&gt;</code>
-    * [.deactivateDidOutput(client, did)](#IotaIdentityClientExt.deactivateDidOutput) ⇒ <code>Promise.&lt;IAliasOutput&gt;</code>
+    * [.newDidOutput(client, address, document, rentStructure)](#IotaIdentityClientExt.newDidOutput) ⇒ <code>Promise.&lt;AliasOutputBuilderParams&gt;</code>
+    * [.updateDidOutput(client, document)](#IotaIdentityClientExt.updateDidOutput) ⇒ <code>Promise.&lt;AliasOutputBuilderParams&gt;</code>
+    * [.deactivateDidOutput(client, did)](#IotaIdentityClientExt.deactivateDidOutput) ⇒ <code>Promise.&lt;AliasOutputBuilderParams&gt;</code>
     * [.resolveDid(client, did)](#IotaIdentityClientExt.resolveDid) ⇒ [<code>Promise.&lt;IotaDocument&gt;</code>](#IotaDocument)
-    * [.resolveDidOutput(client, did)](#IotaIdentityClientExt.resolveDidOutput) ⇒ <code>Promise.&lt;IAliasOutput&gt;</code>
+    * [.resolveDidOutput(client, did)](#IotaIdentityClientExt.resolveDidOutput) ⇒ <code>Promise.&lt;AliasOutputBuilderParams&gt;</code>
 
 <a name="IotaIdentityClientExt.newDidOutput"></a>
 
-### IotaIdentityClientExt.newDidOutput(client, address, document, rentStructure) ⇒ <code>Promise.&lt;IAliasOutput&gt;</code>
+### IotaIdentityClientExt.newDidOutput(client, address, document, rentStructure) ⇒ <code>Promise.&lt;AliasOutputBuilderParams&gt;</code>
 Create a DID with a new Alias Output containing the given `document`.
 
 The `address` will be set as the state controller and governor unlock conditions.
@@ -2388,13 +2406,13 @@ NOTE: this does *not* publish the Alias Output.
 | Param | Type |
 | --- | --- |
 | client | <code>IIotaIdentityClient</code> | 
-| address | <code>AddressTypes</code> | 
+| address | <code>Address</code> | 
 | document | [<code>IotaDocument</code>](#IotaDocument) | 
 | rentStructure | <code>IRent</code> \| <code>undefined</code> | 
 
 <a name="IotaIdentityClientExt.updateDidOutput"></a>
 
-### IotaIdentityClientExt.updateDidOutput(client, document) ⇒ <code>Promise.&lt;IAliasOutput&gt;</code>
+### IotaIdentityClientExt.updateDidOutput(client, document) ⇒ <code>Promise.&lt;AliasOutputBuilderParams&gt;</code>
 Fetches the associated Alias Output and updates it with `document` in its state metadata.
 The storage deposit on the output is left unchanged. If the size of the document increased,
 the amount should be increased manually.
@@ -2410,7 +2428,7 @@ NOTE: this does *not* publish the updated Alias Output.
 
 <a name="IotaIdentityClientExt.deactivateDidOutput"></a>
 
-### IotaIdentityClientExt.deactivateDidOutput(client, did) ⇒ <code>Promise.&lt;IAliasOutput&gt;</code>
+### IotaIdentityClientExt.deactivateDidOutput(client, did) ⇒ <code>Promise.&lt;AliasOutputBuilderParams&gt;</code>
 Removes the DID document from the state metadata of its Alias Output,
 effectively deactivating it. The storage deposit on the output is left unchanged,
 and should be reallocated manually.
@@ -2442,7 +2460,7 @@ of the Alias Output is empty.
 
 <a name="IotaIdentityClientExt.resolveDidOutput"></a>
 
-### IotaIdentityClientExt.resolveDidOutput(client, did) ⇒ <code>Promise.&lt;IAliasOutput&gt;</code>
+### IotaIdentityClientExt.resolveDidOutput(client, did) ⇒ <code>Promise.&lt;AliasOutputBuilderParams&gt;</code>
 Fetches the `IAliasOutput` associated with the given DID.
 
 **Kind**: static method of [<code>IotaIdentityClientExt</code>](#IotaIdentityClientExt)  
@@ -2568,7 +2586,7 @@ If this JWK is of kty RSA, returns those parameters.
 <a name="Jwk+toPublic"></a>
 
 ### jwk.toPublic() ⇒ [<code>Jwk</code>](#Jwk) \| <code>undefined</code>
-Returns a clone of the Jwk with _all_ private key components unset.
+Returns a clone of the [Jwk](#Jwk) with _all_ private key components unset.
 Nothing is returned when `kty = oct` as this key type is not considered public by this library.
 
 **Kind**: instance method of [<code>Jwk</code>](#Jwk)  
@@ -2610,7 +2628,7 @@ Deserializes an instance from a JSON object.
 <a name="JwkGenOutput"></a>
 
 ## JwkGenOutput
-The result of a key generation in `JwkStorage`.
+The result of a key generation in [JwkStorage](JwkStorage).
 
 **Kind**: global class  
 
@@ -2636,13 +2654,13 @@ The result of a key generation in `JwkStorage`.
 <a name="JwkGenOutput+jwk"></a>
 
 ### jwkGenOutput.jwk() ⇒ [<code>Jwk</code>](#Jwk)
-Returns the generated public JWK.
+Returns the generated public [Jwk](#Jwk).
 
 **Kind**: instance method of [<code>JwkGenOutput</code>](#JwkGenOutput)  
 <a name="JwkGenOutput+keyId"></a>
 
 ### jwkGenOutput.keyId() ⇒ <code>string</code>
-Returns the key id of the generated jwk.
+Returns the key id of the generated [Jwk](#Jwk).
 
 **Kind**: instance method of [<code>JwkGenOutput</code>](#JwkGenOutput)  
 <a name="JwkGenOutput+toJSON"></a>
@@ -2682,7 +2700,7 @@ A wrapper around a JSON Web Signature (JWS).
 <a name="new_Jws_new"></a>
 
 ### new Jws(jws_string)
-Creates a new `Jws` from the given string.
+Creates a new [Jws](#Jws) from the given string.
 
 
 | Param | Type |
@@ -2741,7 +2759,7 @@ Returns a clone of the JWS string.
 <a name="new_JwsHeader_new"></a>
 
 ### new JwsHeader()
-Create a new empty `JwsHeader`.
+Create a new empty [JwsHeader](#JwsHeader).
 
 <a name="JwsHeader+alg"></a>
 
@@ -3172,6 +3190,8 @@ Deserializes an instance from a JSON object.
 <a name="new_JwsVerificationOptions_new"></a>
 
 ### new JwsVerificationOptions(options)
+Creates a new [JwsVerificationOptions](#JwsVerificationOptions) from the given fields.
+
 
 | Param | Type |
 | --- | --- |
@@ -3241,7 +3261,7 @@ A wrapper around a JSON Web Token (JWK).
 <a name="new_Jwt_new"></a>
 
 ### new Jwt(jwt_string)
-Creates a new `Jwt` from the given string.
+Creates a new [Jwt](#Jwt) from the given string.
 
 
 | Param | Type |
@@ -3290,7 +3310,6 @@ Options to declare validation criteria when validating credentials.
         * [.toJSON()](#JwtCredentialValidationOptions+toJSON) ⇒ <code>any</code>
         * [.clone()](#JwtCredentialValidationOptions+clone) ⇒ [<code>JwtCredentialValidationOptions</code>](#JwtCredentialValidationOptions)
     * _static_
-        * [.default()](#JwtCredentialValidationOptions.default) ⇒ [<code>JwtCredentialValidationOptions</code>](#JwtCredentialValidationOptions)
         * [.fromJSON(json)](#JwtCredentialValidationOptions.fromJSON) ⇒ [<code>JwtCredentialValidationOptions</code>](#JwtCredentialValidationOptions)
 
 <a name="new_JwtCredentialValidationOptions_new"></a>
@@ -3313,12 +3332,6 @@ Serializes this to a JSON object.
 Deep clones the object.
 
 **Kind**: instance method of [<code>JwtCredentialValidationOptions</code>](#JwtCredentialValidationOptions)  
-<a name="JwtCredentialValidationOptions.default"></a>
-
-### JwtCredentialValidationOptions.default() ⇒ [<code>JwtCredentialValidationOptions</code>](#JwtCredentialValidationOptions)
-Creates a new `JwtCredentialValidationOptions` with defaults.
-
-**Kind**: static method of [<code>JwtCredentialValidationOptions</code>](#JwtCredentialValidationOptions)  
 <a name="JwtCredentialValidationOptions.fromJSON"></a>
 
 ### JwtCredentialValidationOptions.fromJSON(json) ⇒ [<code>JwtCredentialValidationOptions</code>](#JwtCredentialValidationOptions)
@@ -3333,7 +3346,7 @@ Deserializes an instance from a JSON object.
 <a name="JwtCredentialValidator"></a>
 
 ## JwtCredentialValidator
-A type for decoding and validating `Credentials`.
+A type for decoding and validating [Credential](#Credential).
 
 **Kind**: global class  
 
@@ -3353,7 +3366,7 @@ A type for decoding and validating `Credentials`.
 <a name="new_JwtCredentialValidator_new"></a>
 
 ### new JwtCredentialValidator(signatureVerifier)
-Creates a new `JwtCredentialValidator`. If a `signatureVerifier` is provided it will be used when
+Creates a new [JwtCredentialValidator](#JwtCredentialValidator). If a `signatureVerifier` is provided it will be used when
 verifying decoded JWS signatures, otherwise the default which is only capable of handling the `EdDSA`
 algorithm will be used.
 
@@ -3365,7 +3378,8 @@ algorithm will be used.
 <a name="JwtCredentialValidator+validate"></a>
 
 ### jwtCredentialValidator.validate(credential_jwt, issuer, options, fail_fast) ⇒ [<code>DecodedJwtCredential</code>](#DecodedJwtCredential)
-Decodes and validates a `Credential` issued as a JWS. A `DecodedJwtCredential` is returned upon success.
+Decodes and validates a [Credential](#Credential) issued as a JWS. A [DecodedJwtCredential](#DecodedJwtCredential) is returned upon
+success.
 
 The following properties are validated according to `options`:
 - the issuer's signature on the JWS,
@@ -3401,17 +3415,17 @@ An error is returned whenever a validated condition is not satisfied.
 <a name="JwtCredentialValidator+verifySignature"></a>
 
 ### jwtCredentialValidator.verifySignature(credential, trustedIssuers, options) ⇒ [<code>DecodedJwtCredential</code>](#DecodedJwtCredential)
-Decode and verify the JWS signature of a `Credential` issued as a JWT using the DID Document of a trusted
+Decode and verify the JWS signature of a [Credential](#Credential) issued as a JWT using the DID Document of a trusted
 issuer.
 
-A `DecodedJwtCredential` is returned upon success.
+A [DecodedJwtCredential](#DecodedJwtCredential) is returned upon success.
 
 # Warning
 The caller must ensure that the DID Documents of the trusted issuers are up-to-date.
 
 ## Proofs
- Only the JWS signature is verified. If the `Credential` contains a `proof` property this will not be verified
-by this method.
+ Only the JWS signature is verified. If the [Credential](#Credential) contains a `proof` property this will not be
+verified by this method.
 
 # Errors
 This method immediately returns an error if
@@ -3469,7 +3483,7 @@ Validate that the relationship between the `holder` and the credential subjects 
 ### JwtCredentialValidator.checkStatus(credential, trustedIssuers, statusCheck)
 Checks whether the credential status has been revoked.
 
-Only supports `BitmapRevocation2022`.
+Only supports `RevocationBitmap2022`.
 
 **Kind**: static method of [<code>JwtCredentialValidator</code>](#JwtCredentialValidator)  
 
@@ -3482,7 +3496,7 @@ Only supports `BitmapRevocation2022`.
 <a name="JwtCredentialValidator.extractIssuer"></a>
 
 ### JwtCredentialValidator.extractIssuer(credential) ⇒ [<code>CoreDID</code>](#CoreDID)
-Utility for extracting the issuer field of a `Credential` as a DID.
+Utility for extracting the issuer field of a [Credential](#Credential) as a DID.
 
 ### Errors
 
@@ -3524,7 +3538,7 @@ A validator for a Domain Linkage Configuration and Credentials.
 <a name="new_JwtDomainLinkageValidator_new"></a>
 
 ### new JwtDomainLinkageValidator(signatureVerifier)
-Creates a new `JwtDomainLinkageValidator`. If a `signatureVerifier` is provided it will be used when
+Creates a new [JwtDomainLinkageValidator](#JwtDomainLinkageValidator). If a `signatureVerifier` is provided it will be used when
 verifying decoded JWS signatures, otherwise the default which is only capable of handling the `EdDSA`
 algorithm will be used.
 
@@ -3537,15 +3551,17 @@ algorithm will be used.
 
 ### jwtDomainLinkageValidator.validateLinkage(issuer, configuration, domain, options)
 Validates the linkage between a domain and a DID.
-[`DomainLinkageConfiguration`] is validated according to [DID Configuration Resource Verification](https://identity.foundation/.well-known/resources/did-configuration/#did-configuration-resource-verification).
+[DomainLinkageConfiguration](#DomainLinkageConfiguration) is validated according to [DID Configuration Resource Verification](https://identity.foundation/.well-known/resources/did-configuration/#did-configuration-resource-verification).
 
 Linkage is valid if no error is thrown.
 
 # Note:
 - Only the [JSON Web Token Proof Format](https://identity.foundation/.well-known/resources/did-configuration/#json-web-token-proof-format)
+  is supported.
 - Only the Credential issued by `issuer` is verified.
 
 # Errors
+
  - Semantic structure of `configuration` is invalid.
  - `configuration` includes multiple credentials issued by `issuer`.
  - Validation of the matched Domain Linkage Credential fails.
@@ -3563,6 +3579,7 @@ Linkage is valid if no error is thrown.
 
 ### jwtDomainLinkageValidator.validateCredential(issuer, credentialJwt, domain, options)
 Validates a [Domain Linkage Credential](https://identity.foundation/.well-known/resources/did-configuration/#domain-linkage-credential).
+
 Error will be thrown in case the validation fails.
 
 **Kind**: instance method of [<code>JwtDomainLinkageValidator</code>](#JwtDomainLinkageValidator)  
@@ -3585,13 +3602,12 @@ Error will be thrown in case the validation fails.
         * [.toJSON()](#JwtPresentationOptions+toJSON) ⇒ <code>any</code>
         * [.clone()](#JwtPresentationOptions+clone) ⇒ [<code>JwtPresentationOptions</code>](#JwtPresentationOptions)
     * _static_
-        * [.default()](#JwtPresentationOptions.default) ⇒ [<code>JwtPresentationOptions</code>](#JwtPresentationOptions)
         * [.fromJSON(json)](#JwtPresentationOptions.fromJSON) ⇒ [<code>JwtPresentationOptions</code>](#JwtPresentationOptions)
 
 <a name="new_JwtPresentationOptions_new"></a>
 
 ### new JwtPresentationOptions(options)
-Creates a new `JwtPresentationOptions` from the given fields.
+Creates a new [JwtPresentationOptions](#JwtPresentationOptions) from the given fields.
 
 Throws an error if any of the options are invalid.
 
@@ -3612,12 +3628,6 @@ Serializes this to a JSON object.
 Deep clones the object.
 
 **Kind**: instance method of [<code>JwtPresentationOptions</code>](#JwtPresentationOptions)  
-<a name="JwtPresentationOptions.default"></a>
-
-### JwtPresentationOptions.default() ⇒ [<code>JwtPresentationOptions</code>](#JwtPresentationOptions)
-Creates a new `JwtPresentationOptions` with defaults.
-
-**Kind**: static method of [<code>JwtPresentationOptions</code>](#JwtPresentationOptions)  
 <a name="JwtPresentationOptions.fromJSON"></a>
 
 ### JwtPresentationOptions.fromJSON(json) ⇒ [<code>JwtPresentationOptions</code>](#JwtPresentationOptions)
@@ -3642,13 +3652,12 @@ Options to declare validation criteria when validating presentation.
         * [.toJSON()](#JwtPresentationValidationOptions+toJSON) ⇒ <code>any</code>
         * [.clone()](#JwtPresentationValidationOptions+clone) ⇒ [<code>JwtPresentationValidationOptions</code>](#JwtPresentationValidationOptions)
     * _static_
-        * [.default()](#JwtPresentationValidationOptions.default) ⇒ [<code>JwtPresentationValidationOptions</code>](#JwtPresentationValidationOptions)
         * [.fromJSON(json)](#JwtPresentationValidationOptions.fromJSON) ⇒ [<code>JwtPresentationValidationOptions</code>](#JwtPresentationValidationOptions)
 
 <a name="new_JwtPresentationValidationOptions_new"></a>
 
 ### new JwtPresentationValidationOptions(options)
-Creates a new `JwtPresentationValidationOptions` from the given fields.
+Creates a new [JwtPresentationValidationOptions](#JwtPresentationValidationOptions) from the given fields.
 
 Throws an error if any of the options are invalid.
 
@@ -3669,12 +3678,6 @@ Serializes this to a JSON object.
 Deep clones the object.
 
 **Kind**: instance method of [<code>JwtPresentationValidationOptions</code>](#JwtPresentationValidationOptions)  
-<a name="JwtPresentationValidationOptions.default"></a>
-
-### JwtPresentationValidationOptions.default() ⇒ [<code>JwtPresentationValidationOptions</code>](#JwtPresentationValidationOptions)
-Creates a new `JwtPresentationValidationOptions` with defaults.
-
-**Kind**: static method of [<code>JwtPresentationValidationOptions</code>](#JwtPresentationValidationOptions)  
 <a name="JwtPresentationValidationOptions.fromJSON"></a>
 
 ### JwtPresentationValidationOptions.fromJSON(json) ⇒ [<code>JwtPresentationValidationOptions</code>](#JwtPresentationValidationOptions)
@@ -3692,29 +3695,29 @@ Deserializes an instance from a JSON object.
 **Kind**: global class  
 
 * [JwtPresentationValidator](#JwtPresentationValidator)
-    * [new JwtPresentationValidator(signature_verifier)](#new_JwtPresentationValidator_new)
+    * [new JwtPresentationValidator(signatureVerifier)](#new_JwtPresentationValidator_new)
     * _instance_
-        * [.validate(presentation_jwt, holder, validation_options)](#JwtPresentationValidator+validate) ⇒ [<code>DecodedJwtPresentation</code>](#DecodedJwtPresentation)
+        * [.validate(presentationJwt, holder, validation_options)](#JwtPresentationValidator+validate) ⇒ [<code>DecodedJwtPresentation</code>](#DecodedJwtPresentation)
     * _static_
         * [.checkStructure(presentation)](#JwtPresentationValidator.checkStructure)
         * [.extractHolder(presentation)](#JwtPresentationValidator.extractHolder) ⇒ [<code>CoreDID</code>](#CoreDID)
 
 <a name="new_JwtPresentationValidator_new"></a>
 
-### new JwtPresentationValidator(signature_verifier)
-Creates a new `JwtPresentationValidator`. If a `signature_verifier` is provided it will be used when
+### new JwtPresentationValidator(signatureVerifier)
+Creates a new [JwtPresentationValidator](#JwtPresentationValidator). If a `signatureVerifier` is provided it will be used when
 verifying decoded JWS signatures, otherwise the default which is only capable of handling the `EdDSA`
 algorithm will be used.
 
 
 | Param | Type |
 | --- | --- |
-| signature_verifier | <code>IJwsVerifier</code> \| <code>undefined</code> | 
+| signatureVerifier | <code>IJwsVerifier</code> \| <code>undefined</code> | 
 
 <a name="JwtPresentationValidator+validate"></a>
 
-### jwtPresentationValidator.validate(presentation_jwt, holder, validation_options) ⇒ [<code>DecodedJwtPresentation</code>](#DecodedJwtPresentation)
-Validates a [`JwtPresentation`].
+### jwtPresentationValidator.validate(presentationJwt, holder, validation_options) ⇒ [<code>DecodedJwtPresentation</code>](#DecodedJwtPresentation)
+Validates a [Presentation](#Presentation) encoded as a [Jwt](#Jwt).
 
 The following properties are validated according to `options`:
 - the JWT can be decoded into a semantically valid presentation.
@@ -3726,7 +3729,7 @@ Validation is done with respect to the properties set in `options`.
 # Warning
 
 * This method does NOT validate the constituent credentials and therefore also not the relationship between the
-credentials' subjects and the presentation holder. This can be done with `JwtCredentialValidationOptions`.
+credentials' subjects and the presentation holder. This can be done with [JwtCredentialValidationOptions](#JwtCredentialValidationOptions).
 * The lack of an error returned from this method is in of itself not enough to conclude that the presentation can
 be trusted. This section contains more information on additional checks that should be carried out before and
 after calling this method.
@@ -3743,14 +3746,14 @@ An error is returned whenever a validated condition is not satisfied or when dec
 
 | Param | Type |
 | --- | --- |
-| presentation_jwt | [<code>Jwt</code>](#Jwt) | 
+| presentationJwt | [<code>Jwt</code>](#Jwt) | 
 | holder | [<code>CoreDocument</code>](#CoreDocument) \| <code>IToCoreDocument</code> | 
 | validation_options | [<code>JwtPresentationValidationOptions</code>](#JwtPresentationValidationOptions) | 
 
 <a name="JwtPresentationValidator.checkStructure"></a>
 
 ### JwtPresentationValidator.checkStructure(presentation)
-Validates the semantic structure of the `JwtPresentation`.
+Validates the semantic structure of the [Presentation](#Presentation).
 
 **Kind**: static method of [<code>JwtPresentationValidator</code>](#JwtPresentationValidator)  
 
@@ -3791,7 +3794,8 @@ Attempt to extract the holder of the presentation.
 <a name="new_LinkedDomainService_new"></a>
 
 ### new LinkedDomainService(options)
-Constructs a new `LinkedDomainService` that wraps a spec compliant [Linked Domain Service Endpoint](https://identity.foundation/.well-known/resources/did-configuration/#linked-domain-service-endpoint)
+Constructs a new [LinkedDomainService](#LinkedDomainService) that wraps a spec compliant [Linked Domain Service Endpoint](https://identity.foundation/.well-known/resources/did-configuration/#linked-domain-service-endpoint).
+
 Domain URLs must include the `https` scheme in order to pass the domain linkage validation.
 
 
@@ -3820,8 +3824,10 @@ Deep clones the object.
 <a name="LinkedDomainService.fromService"></a>
 
 ### LinkedDomainService.fromService(service) ⇒ [<code>LinkedDomainService</code>](#LinkedDomainService)
-Creates a new @link{LinkedDomainService} from a @link{Service}.
+Creates a new [LinkedDomainService](#LinkedDomainService) from a [Service](#Service).
+
 # Error
+
 Errors if `service` is not a valid Linked Domain Service.
 
 **Kind**: static method of [<code>LinkedDomainService</code>](#LinkedDomainService)  
@@ -3833,7 +3839,7 @@ Errors if `service` is not a valid Linked Domain Service.
 <a name="LinkedDomainService.isValid"></a>
 
 ### LinkedDomainService.isValid(service) ⇒ <code>boolean</code>
-Returns `true` if a @link{Service} is a valid Linked Domain Service.
+Returns `true` if a [Service](#Service) is a valid Linked Domain Service.
 
 **Kind**: static method of [<code>LinkedDomainService</code>](#LinkedDomainService)  
 
@@ -3863,19 +3869,19 @@ Supported verification method data formats.
 <a name="MethodData+tryDecode"></a>
 
 ### methodData.tryDecode() ⇒ <code>Uint8Array</code>
-Returns a `Uint8Array` containing the decoded bytes of the `MethodData`.
+Returns a `Uint8Array` containing the decoded bytes of the [MethodData](#MethodData).
 
-This is generally a public key identified by a `MethodData` value.
+This is generally a public key identified by a [MethodData](#MethodData) value.
 
 ### Errors
-Decoding can fail if `MethodData` has invalid content or cannot be
+Decoding can fail if [MethodData](#MethodData) has invalid content or cannot be
 represented as a vector of bytes.
 
 **Kind**: instance method of [<code>MethodData</code>](#MethodData)  
 <a name="MethodData+tryPublicKeyJwk"></a>
 
 ### methodData.tryPublicKeyJwk() ⇒ [<code>Jwk</code>](#Jwk)
-Returns the wrapped `Jwk` if the format is `PublicKeyJwk`.
+Returns the wrapped [Jwk](#Jwk) if the format is `PublicKeyJwk`.
 
 **Kind**: instance method of [<code>MethodData</code>](#MethodData)  
 <a name="MethodData+toJSON"></a>
@@ -3893,7 +3899,7 @@ Deep clones the object.
 <a name="MethodData.newBase58"></a>
 
 ### MethodData.newBase58(data) ⇒ [<code>MethodData</code>](#MethodData)
-Creates a new `MethodData` variant with Base58-BTC encoded content.
+Creates a new [MethodData](#MethodData) variant with Base58-BTC encoded content.
 
 **Kind**: static method of [<code>MethodData</code>](#MethodData)  
 
@@ -3904,7 +3910,7 @@ Creates a new `MethodData` variant with Base58-BTC encoded content.
 <a name="MethodData.newMultibase"></a>
 
 ### MethodData.newMultibase(data) ⇒ [<code>MethodData</code>](#MethodData)
-Creates a new `MethodData` variant with Multibase-encoded content.
+Creates a new [MethodData](#MethodData) variant with Multibase-encoded content.
 
 **Kind**: static method of [<code>MethodData</code>](#MethodData)  
 
@@ -3915,7 +3921,7 @@ Creates a new `MethodData` variant with Multibase-encoded content.
 <a name="MethodData.newJwk"></a>
 
 ### MethodData.newJwk(key) ⇒ [<code>MethodData</code>](#MethodData)
-Creates a new `MethodData` variant consisting of the given `key`.
+Creates a new [MethodData](#MethodData) variant consisting of the given `key`.
 
 ### Errors
 An error is thrown if the given `key` contains any private components.
@@ -3940,7 +3946,7 @@ Deserializes an instance from a JSON object.
 <a name="MethodDigest"></a>
 
 ## MethodDigest
-Unique identifier of a [`VerificationMethod`].
+Unique identifier of a [VerificationMethod](#VerificationMethod).
 
 NOTE:
 This class does not have a JSON representation,
@@ -3967,7 +3973,7 @@ use the methods `pack` and `unpack` instead.
 <a name="MethodDigest+pack"></a>
 
 ### methodDigest.pack() ⇒ <code>Uint8Array</code>
-Packs `MethodDigest` into bytes.
+Packs [MethodDigest](#MethodDigest) into bytes.
 
 **Kind**: instance method of [<code>MethodDigest</code>](#MethodDigest)  
 <a name="MethodDigest+clone"></a>
@@ -3979,7 +3985,7 @@ Deep clones the object.
 <a name="MethodDigest.unpack"></a>
 
 ### MethodDigest.unpack(bytes) ⇒ [<code>MethodDigest</code>](#MethodDigest)
-Unpacks bytes into [`MethodDigest`].
+Unpacks bytes into [MethodDigest](#MethodDigest).
 
 **Kind**: static method of [<code>MethodDigest</code>](#MethodDigest)  
 
@@ -4011,7 +4017,7 @@ Supported verification method types.
 <a name="MethodScope+toString"></a>
 
 ### methodScope.toString() ⇒ <code>string</code>
-Returns the `MethodScope` as a string.
+Returns the [MethodScope](#MethodScope) as a string.
 
 **Kind**: instance method of [<code>MethodScope</code>](#MethodScope)  
 <a name="MethodScope+toJSON"></a>
@@ -4082,7 +4088,7 @@ Supported verification method types.
 <a name="MethodType+toString"></a>
 
 ### methodType.toString() ⇒ <code>string</code>
-Returns the `MethodType` as a string.
+Returns the [MethodType](#MethodType) as a string.
 
 **Kind**: instance method of [<code>MethodType</code>](#MethodType)  
 <a name="MethodType+toJSON"></a>
@@ -4108,7 +4114,7 @@ Deep clones the object.
 <a name="MethodType.JsonWebKey"></a>
 
 ### MethodType.JsonWebKey() ⇒ [<code>MethodType</code>](#MethodType)
-A verification method for use with JWT verification as prescribed by the `Jwk`
+A verification method for use with JWT verification as prescribed by the [Jwk](#Jwk)
 in the `publicKeyJwk` entry.
 
 **Kind**: static method of [<code>MethodType</code>](#MethodType)  
@@ -4138,7 +4144,8 @@ Deserializes an instance from a JSON object.
         * [.holder()](#Presentation+holder) ⇒ <code>string</code>
         * [.refreshService()](#Presentation+refreshService) ⇒ <code>Array.&lt;RefreshService&gt;</code>
         * [.termsOfUse()](#Presentation+termsOfUse) ⇒ <code>Array.&lt;Policy&gt;</code>
-        * [.proof()](#Presentation+proof) ⇒ <code>Map.&lt;string, any&gt;</code> \| <code>undefined</code>
+        * [.proof()](#Presentation+proof) ⇒ [<code>Proof</code>](#Proof) \| <code>undefined</code>
+        * [.setProof(proof)](#Presentation+setProof)
         * [.properties()](#Presentation+properties) ⇒ <code>Map.&lt;string, any&gt;</code>
         * [.toJSON()](#Presentation+toJSON) ⇒ <code>any</code>
         * [.clone()](#Presentation+clone) ⇒ [<code>Presentation</code>](#Presentation)
@@ -4201,10 +4208,23 @@ Returns a copy of the terms-of-use specified by the presentation holder
 **Kind**: instance method of [<code>Presentation</code>](#Presentation)  
 <a name="Presentation+proof"></a>
 
-### presentation.proof() ⇒ <code>Map.&lt;string, any&gt;</code> \| <code>undefined</code>
-Optional proof that can be verified by users in addition to JWS.
+### presentation.proof() ⇒ [<code>Proof</code>](#Proof) \| <code>undefined</code>
+Optional cryptographic proof, unrelated to JWT.
 
 **Kind**: instance method of [<code>Presentation</code>](#Presentation)  
+<a name="Presentation+setProof"></a>
+
+### presentation.setProof(proof)
+Sets the proof property of the [Presentation](#Presentation).
+
+Note that this proof is not related to JWT.
+
+**Kind**: instance method of [<code>Presentation</code>](#Presentation)  
+
+| Param | Type |
+| --- | --- |
+| proof | [<code>Proof</code>](#Proof) \| <code>undefined</code> | 
+
 <a name="Presentation+properties"></a>
 
 ### presentation.properties() ⇒ <code>Map.&lt;string, any&gt;</code>
@@ -4246,15 +4266,85 @@ Deserializes an instance from a JSON object.
 | --- | --- |
 | json | <code>any</code> | 
 
+<a name="Proof"></a>
+
+## Proof
+Represents a cryptographic proof that can be used to validate verifiable credentials and
+presentations.
+
+This representation does not inherently implement any standard; instead, it
+can be utilized to implement standards or user-defined proofs. The presence of the
+`type` field is necessary to accommodate different types of cryptographic proofs.
+
+Note that this proof is not related to JWT and can be used in combination or as an alternative
+to it.
+
+**Kind**: global class  
+
+* [Proof](#Proof)
+    * [new Proof(type_, properties)](#new_Proof_new)
+    * _instance_
+        * [.type()](#Proof+type) ⇒ <code>string</code>
+        * [.properties()](#Proof+properties) ⇒ <code>any</code>
+        * [.toJSON()](#Proof+toJSON) ⇒ <code>any</code>
+        * [.clone()](#Proof+clone) ⇒ [<code>Proof</code>](#Proof)
+    * _static_
+        * [.fromJSON(json)](#Proof.fromJSON) ⇒ [<code>Proof</code>](#Proof)
+
+<a name="new_Proof_new"></a>
+
+### new Proof(type_, properties)
+
+| Param | Type |
+| --- | --- |
+| type_ | <code>string</code> | 
+| properties | <code>any</code> | 
+
+<a name="Proof+type"></a>
+
+### proof.type() ⇒ <code>string</code>
+Returns the type of proof.
+
+**Kind**: instance method of [<code>Proof</code>](#Proof)  
+<a name="Proof+properties"></a>
+
+### proof.properties() ⇒ <code>any</code>
+Returns the properties of the proof.
+
+**Kind**: instance method of [<code>Proof</code>](#Proof)  
+<a name="Proof+toJSON"></a>
+
+### proof.toJSON() ⇒ <code>any</code>
+Serializes this to a JSON object.
+
+**Kind**: instance method of [<code>Proof</code>](#Proof)  
+<a name="Proof+clone"></a>
+
+### proof.clone() ⇒ [<code>Proof</code>](#Proof)
+Deep clones the object.
+
+**Kind**: instance method of [<code>Proof</code>](#Proof)  
+<a name="Proof.fromJSON"></a>
+
+### Proof.fromJSON(json) ⇒ [<code>Proof</code>](#Proof)
+Deserializes an instance from a JSON object.
+
+**Kind**: static method of [<code>Proof</code>](#Proof)  
+
+| Param | Type |
+| --- | --- |
+| json | <code>any</code> | 
+
 <a name="Resolver"></a>
 
 ## Resolver
 Convenience type for resolving DID documents from different DID methods.
 
 Also provides methods for resolving DID Documents associated with
-verifiable `Credentials` and `Presentations`.
+verifiable [Credential](#Credential)s and [Presentation](#Presentation)s.
 
 # Configuration
+
 The resolver will only be able to resolve DID documents for methods it has been configured for in the constructor.
 
 **Kind**: global class  
@@ -4267,7 +4357,7 @@ The resolver will only be able to resolve DID documents for methods it has been 
 <a name="new_Resolver_new"></a>
 
 ### new Resolver(config)
-Constructs a new `Resolver`.
+Constructs a new [Resolver](#Resolver).
 
 # Errors
 If both a `client` is given and the `handlers` map contains the "iota" key the construction process
@@ -4328,15 +4418,15 @@ A compressed bitmap for managing credential revocation.
         * [.revoke(index)](#RevocationBitmap+revoke) ⇒ <code>boolean</code>
         * [.unrevoke(index)](#RevocationBitmap+unrevoke) ⇒ <code>boolean</code>
         * [.len()](#RevocationBitmap+len) ⇒ <code>number</code>
-        * [.toEndpoint()](#RevocationBitmap+toEndpoint) ⇒ <code>string</code> \| <code>Array.&lt;string&gt;</code> \| <code>Map.&lt;string, Array.&lt;string&gt;&gt;</code>
+        * [.toService(serviceId)](#RevocationBitmap+toService) ⇒ [<code>Service</code>](#Service)
     * _static_
         * [.type()](#RevocationBitmap.type) ⇒ <code>string</code>
-        * [.fromEndpoint(endpoint)](#RevocationBitmap.fromEndpoint) ⇒ [<code>RevocationBitmap</code>](#RevocationBitmap)
+        * [.fromEndpoint(service)](#RevocationBitmap.fromEndpoint) ⇒ [<code>RevocationBitmap</code>](#RevocationBitmap)
 
 <a name="new_RevocationBitmap_new"></a>
 
 ### new RevocationBitmap()
-Creates a new `RevocationBitmap` instance.
+Creates a new [RevocationBitmap](#RevocationBitmap) instance.
 
 <a name="RevocationBitmap+isRevoked"></a>
 
@@ -4381,12 +4471,20 @@ Returns true if the index was present in the set.
 Returns the number of revoked credentials.
 
 **Kind**: instance method of [<code>RevocationBitmap</code>](#RevocationBitmap)  
-<a name="RevocationBitmap+toEndpoint"></a>
+<a name="RevocationBitmap+toService"></a>
 
-### revocationBitmap.toEndpoint() ⇒ <code>string</code> \| <code>Array.&lt;string&gt;</code> \| <code>Map.&lt;string, Array.&lt;string&gt;&gt;</code>
-Return the bitmap as a data url embedded in a service endpoint.
+### revocationBitmap.toService(serviceId) ⇒ [<code>Service</code>](#Service)
+Return a `Service` with:
+- the service's id set to `serviceId`,
+- of type `RevocationBitmap2022`,
+- and with the bitmap embedded in a data url in the service's endpoint.
 
 **Kind**: instance method of [<code>RevocationBitmap</code>](#RevocationBitmap)  
+
+| Param | Type |
+| --- | --- |
+| serviceId | [<code>DIDUrl</code>](#DIDUrl) | 
+
 <a name="RevocationBitmap.type"></a>
 
 ### RevocationBitmap.type() ⇒ <code>string</code>
@@ -4395,14 +4493,15 @@ The name of the service type.
 **Kind**: static method of [<code>RevocationBitmap</code>](#RevocationBitmap)  
 <a name="RevocationBitmap.fromEndpoint"></a>
 
-### RevocationBitmap.fromEndpoint(endpoint) ⇒ [<code>RevocationBitmap</code>](#RevocationBitmap)
-Construct a `RevocationBitmap` from a data `url`.
+### RevocationBitmap.fromEndpoint(service) ⇒ [<code>RevocationBitmap</code>](#RevocationBitmap)
+Try to construct a [RevocationBitmap](#RevocationBitmap) from a service
+if it is a valid Revocation Bitmap Service.
 
 **Kind**: static method of [<code>RevocationBitmap</code>](#RevocationBitmap)  
 
 | Param | Type |
 | --- | --- |
-| endpoint | <code>string</code> \| <code>Array.&lt;string&gt;</code> \| <code>Map.&lt;string, Array.&lt;string&gt;&gt;</code> | 
+| service | [<code>Service</code>](#Service) | 
 
 <a name="Service"></a>
 
@@ -4434,25 +4533,25 @@ A DID Document Service used to enable trusted interactions associated with a DID
 <a name="Service+id"></a>
 
 ### service.id() ⇒ [<code>DIDUrl</code>](#DIDUrl)
-Returns a copy of the `Service` id.
+Returns a copy of the [Service](#Service) id.
 
 **Kind**: instance method of [<code>Service</code>](#Service)  
 <a name="Service+type"></a>
 
 ### service.type() ⇒ <code>Array.&lt;string&gt;</code>
-Returns a copy of the `Service` type.
+Returns a copy of the [Service](#Service) type.
 
 **Kind**: instance method of [<code>Service</code>](#Service)  
 <a name="Service+serviceEndpoint"></a>
 
 ### service.serviceEndpoint() ⇒ <code>string</code> \| <code>Array.&lt;string&gt;</code> \| <code>Map.&lt;string, Array.&lt;string&gt;&gt;</code>
-Returns a copy of the `Service` endpoint.
+Returns a copy of the [Service](#Service) endpoint.
 
 **Kind**: instance method of [<code>Service</code>](#Service)  
 <a name="Service+properties"></a>
 
 ### service.properties() ⇒ <code>Map.&lt;string, any&gt;</code>
-Returns a copy of the custom properties on the `Service`.
+Returns a copy of the custom properties on the [Service](#Service).
 
 **Kind**: instance method of [<code>Service</code>](#Service)  
 <a name="Service+toJSON"></a>
@@ -4533,7 +4632,7 @@ Obtain the wrapped `JwkStorage`.
 <a name="Timestamp+toRFC3339"></a>
 
 ### timestamp.toRFC3339() ⇒ <code>string</code>
-Returns the `Timestamp` as an RFC 3339 `String`.
+Returns the [Timestamp](#Timestamp) as an RFC 3339 `String`.
 
 **Kind**: instance method of [<code>Timestamp</code>](#Timestamp)  
 <a name="Timestamp+checkedAdd"></a>
@@ -4571,7 +4670,7 @@ Serializes this to a JSON object.
 <a name="Timestamp.parse"></a>
 
 ### Timestamp.parse(input) ⇒ [<code>Timestamp</code>](#Timestamp)
-Parses a `Timestamp` from the provided input string.
+Parses a [Timestamp](#Timestamp) from the provided input string.
 
 **Kind**: static method of [<code>Timestamp</code>](#Timestamp)  
 
@@ -4582,7 +4681,7 @@ Parses a `Timestamp` from the provided input string.
 <a name="Timestamp.nowUTC"></a>
 
 ### Timestamp.nowUTC() ⇒ [<code>Timestamp</code>](#Timestamp)
-Creates a new `Timestamp` with the current date and time.
+Creates a new [Timestamp](#Timestamp) with the current date and time.
 
 **Kind**: static method of [<code>Timestamp</code>](#Timestamp)  
 <a name="Timestamp.fromJSON"></a>
@@ -4614,19 +4713,19 @@ Deserializes an instance from a JSON object.
 <a name="UnknownCredential+tryIntoJwt"></a>
 
 ### unknownCredential.tryIntoJwt() ⇒ [<code>Jwt</code>](#Jwt) \| <code>undefined</code>
-Returns a `Jwt` if the credential is of type string, `undefined` otherwise.
+Returns a [Jwt](#Jwt) if the credential is of type string, `undefined` otherwise.
 
 **Kind**: instance method of [<code>UnknownCredential</code>](#UnknownCredential)  
 <a name="UnknownCredential+tryIntoCredential"></a>
 
 ### unknownCredential.tryIntoCredential() ⇒ [<code>Credential</code>](#Credential) \| <code>undefined</code>
-Returns a `Credential` if the credential is of said type, `undefined` otherwise.
+Returns a [Credential](#Credential) if the credential is of said type, `undefined` otherwise.
 
 **Kind**: instance method of [<code>UnknownCredential</code>](#UnknownCredential)  
 <a name="UnknownCredential+tryIntoRaw"></a>
 
 ### unknownCredential.tryIntoRaw() ⇒ <code>Record.&lt;string, any&gt;</code> \| <code>undefined</code>
-Returns the contained value as JSON, if it can be converted, `undefined` otherwise.
+Returns the contained value as an Object, if it can be converted, `undefined` otherwise.
 
 **Kind**: instance method of [<code>UnknownCredential</code>](#UnknownCredential)  
 <a name="UnknownCredential+toJSON"></a>
@@ -4680,13 +4779,13 @@ A DID Document Verification Method.
 <a name="VerificationMethod+id"></a>
 
 ### verificationMethod.id() ⇒ [<code>DIDUrl</code>](#DIDUrl)
-Returns a copy of the `DIDUrl` of the `VerificationMethod`'s `id`.
+Returns a copy of the [DIDUrl](#DIDUrl) of the [VerificationMethod](#VerificationMethod)'s `id`.
 
 **Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)  
 <a name="VerificationMethod+setId"></a>
 
 ### verificationMethod.setId(id)
-Sets the id of the `VerificationMethod`.
+Sets the id of the [VerificationMethod](#VerificationMethod).
 
 **Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)  
 
@@ -4697,13 +4796,13 @@ Sets the id of the `VerificationMethod`.
 <a name="VerificationMethod+controller"></a>
 
 ### verificationMethod.controller() ⇒ [<code>CoreDID</code>](#CoreDID)
-Returns a copy of the `controller` `DID` of the `VerificationMethod`.
+Returns a copy of the `controller` `DID` of the [VerificationMethod](#VerificationMethod).
 
 **Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)  
 <a name="VerificationMethod+setController"></a>
 
 ### verificationMethod.setController(did)
-Sets the `controller` `DID` of the `VerificationMethod` object.
+Sets the `controller` `DID` of the [VerificationMethod](#VerificationMethod) object.
 
 **Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)  
 
@@ -4714,13 +4813,13 @@ Sets the `controller` `DID` of the `VerificationMethod` object.
 <a name="VerificationMethod+type"></a>
 
 ### verificationMethod.type() ⇒ [<code>MethodType</code>](#MethodType)
-Returns a copy of the `VerificationMethod` type.
+Returns a copy of the [VerificationMethod](#VerificationMethod) type.
 
 **Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)  
 <a name="VerificationMethod+setType"></a>
 
 ### verificationMethod.setType(type_)
-Sets the `VerificationMethod` type.
+Sets the [VerificationMethod](#VerificationMethod) type.
 
 **Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)  
 
@@ -4731,13 +4830,13 @@ Sets the `VerificationMethod` type.
 <a name="VerificationMethod+data"></a>
 
 ### verificationMethod.data() ⇒ [<code>MethodData</code>](#MethodData)
-Returns a copy of the `VerificationMethod` public key data.
+Returns a copy of the [VerificationMethod](#VerificationMethod) public key data.
 
 **Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)  
 <a name="VerificationMethod+setData"></a>
 
 ### verificationMethod.setData(data)
-Sets `VerificationMethod` public key data.
+Sets [VerificationMethod](#VerificationMethod) public key data.
 
 **Kind**: instance method of [<code>VerificationMethod</code>](#VerificationMethod)  
 
@@ -4783,7 +4882,7 @@ Deep clones the object.
 <a name="VerificationMethod.newFromJwk"></a>
 
 ### VerificationMethod.newFromJwk(did, key, fragment) ⇒ [<code>VerificationMethod</code>](#VerificationMethod)
-Creates a new `VerificationMethod` from the given `did` and `Jwk`. If `fragment` is not given
+Creates a new [VerificationMethod](#VerificationMethod) from the given `did` and [Jwk](#Jwk). If `fragment` is not given
 the `kid` value of the given `key` will be used, if present, otherwise an error is returned.
 
 ### Recommendations
@@ -4791,7 +4890,7 @@ The following recommendations are essentially taken from the `publicKeyJwk` desc
 - It is recommended that verification methods that use `Jwks` to represent their public keys use the value of
   `kid` as their fragment identifier. This is
 done automatically if `None` is passed in as the fragment.
-- It is recommended that `Jwk` kid values are set to the public key fingerprint.
+- It is recommended that [Jwk](#Jwk) kid values are set to the public key fingerprint.
 
 **Kind**: static method of [<code>VerificationMethod</code>](#VerificationMethod)  
 
@@ -4812,6 +4911,14 @@ Deserializes an instance from a JSON object.
 | --- | --- |
 | json | <code>any</code> | 
 
+<a name="StateMetadataEncoding"></a>
+
+## StateMetadataEncoding
+**Kind**: global variable  
+<a name="MethodRelationship"></a>
+
+## MethodRelationship
+**Kind**: global variable  
 <a name="StatusCheck"></a>
 
 ## StatusCheck
@@ -4846,8 +4953,7 @@ Skip all status checks.
 <a name="SubjectHolderRelationship"></a>
 
 ## SubjectHolderRelationship
-Declares how credential subjects must relate to the presentation holder during validation.
-See `PresentationValidationOptions::subject_holder_relationship`.
+Declares how credential subjects must relate to the presentation holder.
 
 See also the [Subject-Holder Relationship](https://www.w3.org/TR/vc-data-model/#subject-holder-relationships) section of the specification.
 
@@ -4856,8 +4962,7 @@ See also the [Subject-Holder Relationship](https://www.w3.org/TR/vc-data-model/#
 
 ## AlwaysSubject
 The holder must always match the subject on all credentials, regardless of their [`nonTransferable`](https://www.w3.org/TR/vc-data-model/#nontransferable-property) property.
-This variant is the default used if no other variant is specified when constructing a new
-`PresentationValidationOptions`.
+This variant is the default.
 
 **Kind**: global variable  
 <a name="SubjectOnNonTransferable"></a>
@@ -4890,20 +4995,6 @@ Return all errors that occur during validation.
 Return after the first error occurs.
 
 **Kind**: global variable  
-<a name="MethodRelationship"></a>
-
-## MethodRelationship
-**Kind**: global variable  
-<a name="StateMetadataEncoding"></a>
-
-## StateMetadataEncoding
-**Kind**: global variable  
-<a name="start"></a>
-
-## start()
-Initializes the console error panic hook for better error messages
-
-**Kind**: global function  
 <a name="encodeB64"></a>
 
 ## encodeB64(data) ⇒ <code>string</code>
@@ -4926,6 +5017,12 @@ Decode the given url-safe base64-encoded slice into its raw bytes.
 | --- | --- |
 | data | <code>Uint8Array</code> | 
 
+<a name="start"></a>
+
+## start()
+Initializes the console error panic hook for better error messages
+
+**Kind**: global function  
 <a name="verifyEdDSA"></a>
 
 ## verifyEdDSA(alg, signingInput, decodedSignature, publicKey)

--- a/bindings/wasm/src/storage/key_id_storage.rs
+++ b/bindings/wasm/src/storage/key_id_storage.rs
@@ -65,7 +65,7 @@ const JWK_STORAGE: &'static str = r#"
  */
 interface KeyIdStorage {
   /**
-   * Insert a key id into the {@link KeyIdStorage} under the given {@link MethodDigest}.
+   * Insert a key id into the `KeyIdStorage` under the given {@link MethodDigest}.
    * 
    * If an entry for `key` already exists in the storage an error must be returned
    * immediately without altering the state of the storage.

--- a/bindings/wasm/src/storage/wasm_storage.rs
+++ b/bindings/wasm/src/storage/wasm_storage.rs
@@ -11,27 +11,27 @@ use wasm_bindgen::prelude::*;
 
 pub(crate) type WasmStorageInner = Storage<WasmJwkStorage, WasmKeyIdStorage>;
 
-/// A type wrapping a {@link JwkStorage} and {@link KeyIdStorage} that should always be used together when
+/// A type wrapping a `JwkStorage` and `KeyIdStorage` that should always be used together when
 /// working with storage backed DID documents.
 #[wasm_bindgen(js_name = Storage)]
 pub struct WasmStorage(pub(crate) Rc<WasmStorageInner>);
 
 #[wasm_bindgen(js_class = Storage)]
 impl WasmStorage {
-  /// Constructs a new {@link Storage}.
+  /// Constructs a new `Storage`.
   #[wasm_bindgen(constructor)]
   #[allow(non_snake_case)]
   pub fn new(jwkStorage: WasmJwkStorage, keyIdStorage: WasmKeyIdStorage) -> WasmStorage {
     WasmStorage(Rc::new(Storage::new(jwkStorage, keyIdStorage)))
   }
 
-  /// Obtain the wrapped {@link KeyIdStorage}.
+  /// Obtain the wrapped `KeyIdStorage`.
   #[wasm_bindgen(js_name = keyIdStorage)]
   pub fn key_id_storage(&self) -> WasmKeyIdStorage {
     JsValue::from(self.0.key_id_storage()).unchecked_into()
   }
 
-  /// Obtain the wrapped {@link JwkStorage}.
+  /// Obtain the wrapped `JwkStorage`.
   #[wasm_bindgen(js_name = keyStorage)]
   pub fn key_storage(&self) -> WasmJwkStorage {
     JsValue::from(self.0.key_storage()).unchecked_into()


### PR DESCRIPTION
The storage classes referenced by the `@link` notations do not exist in the same file which causes broken links in the .md documentation. 
