### PR TITLE
Bring `JwkDocumentExt` names in line with Wasm

### DIFF
--- a/bindings/wasm/src/did/wasm_core_document.rs
+++ b/bindings/wasm/src/did/wasm_core_document.rs
@@ -656,7 +656,7 @@ impl WasmCoreDocument {
       document_lock_clone
         .read()
         .await
-        .sign_bytes(&storage_clone, &fragment, payload.as_bytes(), &options_clone)
+        .create_jws(&storage_clone, &fragment, payload.as_bytes(), &options_clone)
         .await
         .wasm_result()
         .map(WasmJws::new)
@@ -686,7 +686,7 @@ impl WasmCoreDocument {
       document_lock_clone
         .read()
         .await
-        .sign_credential(&credential_clone, &storage_clone, &fragment, &options_clone)
+        .create_credential_jwt(&credential_clone, &storage_clone, &fragment, &options_clone)
         .await
         .wasm_result()
         .map(WasmJwt::new)
@@ -718,7 +718,7 @@ impl WasmCoreDocument {
       document_lock_clone
         .read()
         .await
-        .sign_presentation(
+        .create_presentation_jwt(
           &presentation_clone,
           &storage_clone,
           &fragment,

--- a/bindings/wasm/src/iota/iota_document.rs
+++ b/bindings/wasm/src/iota/iota_document.rs
@@ -702,7 +702,7 @@ impl WasmIotaDocument {
       document_lock_clone
         .read()
         .await
-        .sign_bytes(&storage_clone, &fragment, payload.as_bytes(), &options_clone)
+        .create_jws(&storage_clone, &fragment, payload.as_bytes(), &options_clone)
         .await
         .wasm_result()
         .map(WasmJws::new)
@@ -732,7 +732,7 @@ impl WasmIotaDocument {
       document_lock_clone
         .read()
         .await
-        .sign_credential(&credential_clone, &storage_clone, &fragment, &options_clone)
+        .create_credential_jwt(&credential_clone, &storage_clone, &fragment, &options_clone)
         .await
         .wasm_result()
         .map(WasmJwt::new)
@@ -764,7 +764,7 @@ impl WasmIotaDocument {
       document_lock_clone
         .read()
         .await
-        .sign_presentation(
+        .create_presentation_jwt(
           &presentation_clone,
           &storage_clone,
           &fragment,

--- a/examples/0_basic/5_create_vc.rs
+++ b/examples/0_basic/5_create_vc.rs
@@ -86,7 +86,7 @@ async fn main() -> anyhow::Result<()> {
     .build()?;
 
   let credential_jwt: Jwt = issuer_document
-    .sign_credential(&credential, &issuer_storage, &fragment, &JwsSignatureOptions::default())
+    .create_credential_jwt(&credential, &issuer_storage, &fragment, &JwsSignatureOptions::default())
     .await?;
 
   // Before sending this credential to the holder the issuer wants to validate that some properties

--- a/examples/0_basic/6_create_vp.rs
+++ b/examples/0_basic/6_create_vp.rs
@@ -107,7 +107,7 @@ async fn main() -> anyhow::Result<()> {
     .build()?;
 
   let credential_jwt: Jwt = issuer_document
-    .sign_credential(
+    .create_credential_jwt(
       &credential,
       &storage_issuer,
       &fragment_issuer,
@@ -160,7 +160,7 @@ async fn main() -> anyhow::Result<()> {
   // Create a JWT verifiable presentation using the holder's verification method
   // and include the requested challenge and expiry timestamp.
   let presentation_jwt: Jwt = alice_document
-    .sign_presentation(
+    .create_presentation_jwt(
       &presentation,
       &storage_alice,
       &fragment_alice,

--- a/examples/0_basic/7_revoke_vc.rs
+++ b/examples/0_basic/7_revoke_vc.rs
@@ -137,7 +137,7 @@ async fn main() -> anyhow::Result<()> {
   println!("Credential JSON > {credential:#}");
 
   let credential_jwt: Jwt = issuer_document
-    .sign_credential(
+    .create_credential_jwt(
       &credential,
       &storage_issuer,
       &fragment_issuer,

--- a/examples/0_basic/8_stronghold.rs
+++ b/examples/0_basic/8_stronghold.rs
@@ -105,7 +105,7 @@ async fn main() -> anyhow::Result<()> {
   // Sign data with the created verification method.
   let data = b"test_data";
   let jws: Jws = resolved_document
-    .sign_bytes(&storage, &fragment, data, &JwsSignatureOptions::default())
+    .create_jws(&storage, &fragment, data, &JwsSignatureOptions::default())
     .await?;
 
   // Verify Signature.

--- a/examples/1_advanced/6_domain_linkage.rs
+++ b/examples/1_advanced/6_domain_linkage.rs
@@ -106,7 +106,7 @@ async fn main() -> anyhow::Result<()> {
     .build()?;
 
   let jwt: Jwt = updated_did_document
-    .sign_credential(
+    .create_credential_jwt(
       &domain_linkage_credential,
       &storage,
       &fragment,

--- a/identity_storage/src/storage/jwk_document_ext.rs
+++ b/identity_storage/src/storage/jwk_document_ext.rs
@@ -82,8 +82,8 @@ pub trait JwkDocumentExt: private::Sealed {
   /// public key material in the verification method identified by the given `fragment.
   ///
   /// Upon success a string representing a JWS encoded according to the Compact JWS Serialization format is returned.
-  /// See [RFC7515 section 3.1](https://www.rfc-editor.org/rfc/rfc7515#section-3.1).   
-  async fn sign_bytes<K, I>(
+  /// See [RFC7515 section 3.1](https://www.rfc-editor.org/rfc/rfc7515#section-3.1).
+  async fn create_jws<K, I>(
     &self,
     storage: &Storage<K, I>,
     fragment: &str,
@@ -99,7 +99,7 @@ pub trait JwkDocumentExt: private::Sealed {
   ///
   /// The `kid` in the protected header is the `id` of the method identified by `fragment` and the JWS signature will be
   /// produced by the corresponding private key backed by the `storage` in accordance with the passed `options`.
-  async fn sign_credential<K, I, T>(
+  async fn create_credential_jwt<K, I, T>(
     &self,
     credential: &Credential<T>,
     storage: &Storage<K, I>,
@@ -116,7 +116,7 @@ pub trait JwkDocumentExt: private::Sealed {
   ///
   /// The `kid` in the protected header is the `id` of the method identified by `fragment` and the JWS signature will be
   /// produced by the corresponding private key backed by the `storage` in accordance with the passed `options`.
-  async fn sign_presentation<K, I, CRED, T>(
+  async fn create_presentation_jwt<K, I, CRED, T>(
     &self,
     presentation: &Presentation<CRED, T>,
     storage: &Storage<K, I>,
@@ -327,7 +327,7 @@ impl JwkDocumentExt for CoreDocument {
     purge_method_core_document(self, storage, id).await
   }
 
-  async fn sign_bytes<K, I>(
+  async fn create_jws<K, I>(
     &self,
     storage: &Storage<K, I>,
     fragment: &str,
@@ -414,7 +414,7 @@ impl JwkDocumentExt for CoreDocument {
     Ok(Jws::new(jws_encoder.into_jws(&signature)))
   }
 
-  async fn sign_credential<K, I, T>(
+  async fn create_credential_jwt<K, I, T>(
     &self,
     credential: &Credential<T>,
     storage: &Storage<K, I>,
@@ -441,12 +441,12 @@ impl JwkDocumentExt for CoreDocument {
 
     let payload = credential.serialize_jwt().map_err(Error::ClaimsSerializationError)?;
     self
-      .sign_bytes(storage, fragment, payload.as_bytes(), options)
+      .create_jws(storage, fragment, payload.as_bytes(), options)
       .await
       .map(|jws| Jwt::new(jws.into()))
   }
 
-  async fn sign_presentation<K, I, CRED, T>(
+  async fn create_presentation_jwt<K, I, CRED, T>(
     &self,
     presentation: &Presentation<CRED, T>,
     storage: &Storage<K, I>,
@@ -476,7 +476,7 @@ impl JwkDocumentExt for CoreDocument {
       .serialize_jwt(jwt_options)
       .map_err(Error::ClaimsSerializationError)?;
     self
-      .sign_bytes(storage, fragment, payload.as_bytes(), jws_options)
+      .create_jws(storage, fragment, payload.as_bytes(), jws_options)
       .await
       .map(|jws| Jwt::new(jws.into()))
   }
@@ -540,7 +540,7 @@ mod iota_document {
       purge_method_iota_document(self, storage, id).await
     }
 
-    async fn sign_bytes<K, I>(
+    async fn create_jws<K, I>(
       &self,
       storage: &Storage<K, I>,
       fragment: &str,
@@ -553,11 +553,11 @@ mod iota_document {
     {
       self
         .core_document()
-        .sign_bytes(storage, fragment, payload, options)
+        .create_jws(storage, fragment, payload, options)
         .await
     }
 
-    async fn sign_credential<K, I, T>(
+    async fn create_credential_jwt<K, I, T>(
       &self,
       credential: &Credential<T>,
       storage: &Storage<K, I>,
@@ -571,10 +571,10 @@ mod iota_document {
     {
       self
         .core_document()
-        .sign_credential(credential, storage, fragment, options)
+        .create_credential_jwt(credential, storage, fragment, options)
         .await
     }
-    async fn sign_presentation<K, I, CRED, T>(
+    async fn create_presentation_jwt<K, I, CRED, T>(
       &self,
       presentation: &Presentation<CRED, T>,
       storage: &Storage<K, I>,
@@ -590,7 +590,7 @@ mod iota_document {
     {
       self
         .core_document()
-        .sign_presentation(presentation, storage, fragment, options, jwt_options)
+        .create_presentation_jwt(presentation, storage, fragment, options, jwt_options)
         .await
     }
   }

--- a/identity_storage/src/storage/tests/api.rs
+++ b/identity_storage/src/storage/tests/api.rs
@@ -114,7 +114,7 @@ async fn sign_bytes() {
   let verification_options: JwsVerificationOptions = JwsVerificationOptions::new();
 
   let jws: Jws = document
-    .sign_bytes(&storage, &fragment, payload, &signature_options)
+    .create_jws(&storage, &fragment, payload, &signature_options)
     .await
     .unwrap();
 
@@ -133,7 +133,7 @@ async fn sign_bytes_with_nonce() {
   let verification_options: JwsVerificationOptions = JwsVerificationOptions::new().nonce(nonce);
 
   let jws: Jws = document
-    .sign_bytes(&storage, &fragment, payload, &signature_options)
+    .create_jws(&storage, &fragment, payload, &signature_options)
     .await
     .unwrap();
 
@@ -178,7 +178,7 @@ async fn sign_bytes_with_header_copy_options() {
   let verification_options: JwsVerificationOptions = JwsVerificationOptions::new();
 
   let jws: Jws = document
-    .sign_bytes(&storage, &fragment, payload, &signature_options)
+    .create_jws(&storage, &fragment, payload, &signature_options)
     .await
     .unwrap();
 
@@ -212,7 +212,7 @@ async fn sign_bytes_detached() {
   let verification_options: JwsVerificationOptions = JwsVerificationOptions::new();
 
   let jws: Jws = document
-    .sign_bytes(&storage, fragment.as_ref(), payload, &signature_options)
+    .create_jws(&storage, fragment.as_ref(), payload, &signature_options)
     .await
     .unwrap();
 
@@ -232,7 +232,7 @@ async fn sign_bytes_detached() {
   let signature_options: JwsSignatureOptions = JwsSignatureOptions::new().b64(true).detached_payload(true);
 
   let jws: Jws = document
-    .sign_bytes(&storage, fragment.as_ref(), payload, &signature_options)
+    .create_jws(&storage, fragment.as_ref(), payload, &signature_options)
     .await
     .unwrap();
   let payload_b64: String = encode_b64(payload);
@@ -284,7 +284,7 @@ async fn signing_credential() {
 
   let credential: Credential = Credential::from_json(credential_json).unwrap();
   let jws = document
-    .sign_credential(&credential, &storage, &method_fragment, &JwsSignatureOptions::default())
+    .create_credential_jwt(&credential, &storage, &method_fragment, &JwsSignatureOptions::default())
     .await
     .unwrap();
   // Verify the credential
@@ -366,7 +366,7 @@ mod iota_document_tests {
 
     // Sign the test string
     let jws = iota_document
-      .sign_bytes(&storage, fragment, b"test", &JwsSignatureOptions::new())
+      .create_jws(&storage, fragment, b"test", &JwsSignatureOptions::new())
       .await
       .unwrap();
 

--- a/identity_storage/src/storage/tests/credential_jws.rs
+++ b/identity_storage/src/storage/tests/credential_jws.rs
@@ -78,7 +78,7 @@ async fn signing_credential_with_detached_option_fails() {
   let (document, storage, kid, credential) = setup().await;
 
   assert!(document
-    .sign_credential(
+    .create_credential_jwt(
       &credential,
       &storage,
       kid.as_ref(),
@@ -94,7 +94,7 @@ async fn signing_credential_with_nonce_and_scope() {
   let nonce: &str = "0xaabbccddeeff";
 
   let jws = document
-    .sign_credential(
+    .create_credential_jwt(
       &credential,
       &storage,
       kid.as_ref(),
@@ -151,7 +151,7 @@ async fn signing_credential_with_b64() {
   let (document, storage, kid, credential) = setup().await;
 
   let jws = document
-    .sign_credential(
+    .create_credential_jwt(
       &credential,
       &storage,
       kid.as_ref(),
@@ -177,7 +177,7 @@ async fn signing_credential_with_b64() {
 
   // JWTs should not have `b64` set per https://datatracker.ietf.org/doc/html/rfc7797#section-7.
   assert!(document
-    .sign_credential(
+    .create_credential_jwt(
       &credential,
       &storage,
       kid.as_ref(),

--- a/identity_storage/src/storage/tests/credential_validation.rs
+++ b/identity_storage/src/storage/tests/credential_validation.rs
@@ -46,7 +46,7 @@ where
   } = test_utils::generate_credential(&issuer_doc, &[&subject_doc], None, None);
 
   let jws = issuer_doc
-    .sign_credential(
+    .create_credential_jwt(
       &credential,
       &storage,
       method_fragment.as_ref(),
@@ -128,7 +128,7 @@ where
   } = test_utils::generate_credential(&issuer_doc, &[&subject_doc], None, None);
 
   let jwt: Jwt = issuer_doc
-    .sign_credential(
+    .create_credential_jwt(
       &credential,
       &storage,
       method_fragment.as_ref(),
@@ -169,7 +169,7 @@ where
   let CredentialSetup { credential, .. } = test_utils::generate_credential(&issuer_doc, &[&subject_doc], None, None);
 
   let jwt: Jwt = issuer_doc
-    .sign_credential(
+    .create_credential_jwt(
       &credential,
       &storage,
       method_fragment.as_ref(),
@@ -233,7 +233,7 @@ where
 
   // Sign the credential with the *other* issuer.
   let jwt: Jwt = other_issuer_doc
-    .sign_credential(&credential, &other_storage, fragment, &JwsSignatureOptions::default())
+    .create_credential_jwt(&credential, &other_storage, fragment, &JwsSignatureOptions::default())
     .await
     .unwrap();
 
@@ -392,7 +392,7 @@ where
   } = test_utils::generate_credential(&issuer_doc, &[&subject_doc], None, None);
 
   let jws = issuer_doc
-    .sign_credential(
+    .create_credential_jwt(
       &credential,
       &storage,
       method_fragment.as_ref(),

--- a/identity_storage/src/storage/tests/presentation_validation.rs
+++ b/identity_storage/src/storage/tests/presentation_validation.rs
@@ -57,7 +57,7 @@ where
 
   let presentation_jwt = setup
     .subject_doc
-    .sign_presentation(
+    .create_presentation_jwt(
       &presentation,
       &setup.subject_storage,
       &setup.subject_method_fragment,
@@ -115,7 +115,7 @@ where
 
   let presentation_jwt = setup
     .subject_doc
-    .sign_presentation(
+    .create_presentation_jwt(
       &presentation,
       &setup.subject_storage,
       &setup.subject_method_fragment,
@@ -172,7 +172,7 @@ where
 
   let presentation_jwt = setup
     .subject_doc
-    .sign_presentation(
+    .create_presentation_jwt(
       &presentation,
       &setup.subject_storage,
       &setup.subject_method_fragment,
@@ -254,7 +254,7 @@ where
 
   let presentation_jwt = setup
     .subject_doc
-    .sign_presentation(
+    .create_presentation_jwt(
       &presentation,
       &setup.subject_storage,
       &setup.subject_method_fragment,
@@ -319,7 +319,7 @@ where
 
   let presentation_jwt = setup
     .subject_doc
-    .sign_presentation(
+    .create_presentation_jwt(
       &presentation,
       &setup.subject_storage,
       &setup.subject_method_fragment,
@@ -380,7 +380,7 @@ where
 
   let presentation_jwt = setup
     .issuer_doc
-    .sign_presentation(
+    .create_presentation_jwt(
       &presentation,
       &setup.issuer_storage,
       &setup.issuer_method_fragment,
@@ -416,7 +416,7 @@ where
 {
   setup
     .issuer_doc
-    .sign_credential(
+    .create_credential_jwt(
       credential,
       &setup.issuer_storage,
       &setup.issuer_method_fragment,


### PR DESCRIPTION
# Description of change

Bring `JwkDocumentExt` names in line with Wasm, since we agreed they are better.

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

n/a

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
