### PR TITLE
Mark error enums as non-exhaustive

### DIFF
--- a/bindings/wasm/src/iota/iota_metadata_encoding.rs
+++ b/bindings/wasm/src/iota/iota_metadata_encoding.rs
@@ -13,14 +13,6 @@ pub enum WasmStateMetadataEncoding {
   Json = 0,
 }
 
-impl From<StateMetadataEncoding> for WasmStateMetadataEncoding {
-  fn from(encoding: StateMetadataEncoding) -> Self {
-    match encoding {
-      StateMetadataEncoding::Json => Self::Json,
-    }
-  }
-}
-
 impl From<WasmStateMetadataEncoding> for StateMetadataEncoding {
   fn from(encoding: WasmStateMetadataEncoding) -> Self {
     match encoding {

--- a/identity_core/src/common/one_or_set.rs
+++ b/identity_core/src/common/one_or_set.rs
@@ -167,7 +167,7 @@ where
       OneOrSetInner::One(inner) if inner.key() == item.key() => false,
       OneOrSetInner::One(_) => match replace(&mut self.0, OneOrSetInner::Set(OrderedSet::new())) {
         OneOrSetInner::One(inner) => {
-          self.0 = OneOrSetInner::Set(OrderedSet::from_iter([inner, item].into_iter()));
+          self.0 = OneOrSetInner::Set(OrderedSet::from_iter([inner, item]));
           true
         }
         OneOrSetInner::Set(_) => unreachable!(),
@@ -348,7 +348,7 @@ mod tests {
   #[test]
   fn test_new_set() {
     // VALID: non-empty set.
-    let ordered_set: OrderedSet<MockKeyU8> = OrderedSet::from_iter([1, 2, 3].map(MockKeyU8).into_iter());
+    let ordered_set: OrderedSet<MockKeyU8> = OrderedSet::from_iter([1, 2, 3].map(MockKeyU8));
     let new_set: OneOrSet<MockKeyU8> = OneOrSet::new_set(ordered_set.clone()).unwrap();
     let try_from_set: OneOrSet<MockKeyU8> = OneOrSet::try_from(ordered_set.clone()).unwrap();
     assert_eq!(new_set, try_from_set);

--- a/identity_core/src/convert/base_encoding.rs
+++ b/identity_core/src/convert/base_encoding.rs
@@ -263,7 +263,7 @@ mod tests {
   #[test]
   fn test_multibase() {
     // Encode.
-    let data: &str = r#"Multibase is awesome! \o/"#;
+    let data: &str = r"Multibase is awesome! \o/";
     for (base, expected) in [
       (Base::Base16Upper, "F4D756C74696261736520697320617765736F6D6521205C6F2F"),
       (Base::Base32Upper, "BJV2WY5DJMJQXGZJANFZSAYLXMVZW63LFEEQFY3ZP"),

--- a/identity_credential/src/domain_linkage/error.rs
+++ b/identity_credential/src/domain_linkage/error.rs
@@ -5,8 +5,8 @@ use std::error::Error;
 
 pub(crate) type DomainLinkageValidationResult = Result<(), DomainLinkageValidationError>;
 
-#[derive(Debug, thiserror::Error)]
 /// An error caused by a failure to verify a Domain Linkage configuration or credential.
+#[derive(Debug, thiserror::Error)]
 pub struct DomainLinkageValidationError {
   /// Cause of the error.
   pub cause: DomainLinkageValidationErrorCause,
@@ -27,8 +27,8 @@ impl From<DomainLinkageValidationError> for &str {
 }
 
 /// The causes for why domain linkage validation can fail.
-#[non_exhaustive]
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[non_exhaustive]
 pub enum DomainLinkageValidationErrorCause {
   /// Caused when a Domain Linkage Credential cannot be successfully validated.
   #[error("invalid credential")]

--- a/identity_credential/src/error.rs
+++ b/identity_credential/src/error.rs
@@ -8,6 +8,7 @@ pub type Result<T, E = Error> = ::core::result::Result<T, E>;
 
 /// This type represents errors that can occur when constructing credentials and presentations or their serializations.
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[non_exhaustive]
 pub enum Error {
   /// Caused when constructing a credential or presentation without a valid base context.
   #[error("missing base context")]

--- a/identity_credential/src/revocation/error.rs
+++ b/identity_credential/src/revocation/error.rs
@@ -6,6 +6,7 @@ pub type RevocationResult<T> = std::result::Result<T, RevocationError>;
 
 /// Errors occurring when creating or extracting a Service of type `RevocationBitmap2022`
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[non_exhaustive]
 pub enum RevocationError {
   #[error("revocation bitmap could not be deserialized or decompressed")]
   /// Indicates that the bitmap could not be reconstructed.

--- a/identity_credential/src/validator/vc_jwt_validation/error.rs
+++ b/identity_credential/src/validator/vc_jwt_validation/error.rs
@@ -6,9 +6,9 @@ use std::fmt::Display;
 
 use itertools;
 
+/// An error associated with validating credentials and presentations.
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 #[non_exhaustive]
-/// An error associated with validating credentials and presentations.
 pub enum JwtValidationError {
   /// Indicates that the JWS representation of an issued credential or presentation could not be decoded.
   #[error("could not decode jws")]

--- a/identity_document/src/error.rs
+++ b/identity_document/src/error.rs
@@ -8,6 +8,7 @@ pub type Result<T, E = Error> = ::core::result::Result<T, E>;
 
 /// This type represents all possible errors that can occur in the library.
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[non_exhaustive]
 pub enum Error {
   /// Caused by querying for a method that does not exist.
   #[error("verification method not found")]

--- a/identity_iota_core/src/state_metadata/encoding.rs
+++ b/identity_iota_core/src/state_metadata/encoding.rs
@@ -7,6 +7,7 @@ use crate::Error;
 
 /// Indicates the encoding of a DID document in state metadata.
 #[derive(Copy, Clone, Debug, Default, Ord, PartialOrd, Eq, PartialEq, num_derive::FromPrimitive)]
+#[non_exhaustive]
 pub enum StateMetadataEncoding {
   /// State Metadata encoded as JSON.
   #[default]

--- a/identity_iota_core/src/state_metadata/version.rs
+++ b/identity_iota_core/src/state_metadata/version.rs
@@ -7,6 +7,7 @@ use crate::Error;
 
 /// Indicates the version of a DID document in state metadata.
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, num_derive::FromPrimitive)]
+#[non_exhaustive]
 pub(crate) enum StateMetadataVersion {
   V1 = 1,
 }

--- a/identity_jose/src/error.rs
+++ b/identity_jose/src/error.rs
@@ -8,6 +8,7 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 /// All possible errors that can occur in the library.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
   /// Caused by invalid json serialization or deserialization.
   #[error("invalid json")]

--- a/identity_jose/src/tests/es256.rs
+++ b/identity_jose/src/tests/es256.rs
@@ -29,8 +29,8 @@ pub(crate) fn expand_p256_jwk(jwk: &Jwk) -> (SecretKey, PublicKey) {
   // Transformation according to section 2.3.3 from http://www.secg.org/sec1-v2.pdf.
   let pk_bytes: Vec<u8> = [0x04]
     .into_iter()
-    .chain(jwu::decode_b64(&params.x).unwrap().into_iter())
-    .chain(jwu::decode_b64(&params.y).unwrap().into_iter())
+    .chain(jwu::decode_b64(&params.x).unwrap())
+    .chain(jwu::decode_b64(&params.y).unwrap())
     .collect();
 
   let pk = PublicKey::from_sec1_bytes(&pk_bytes).unwrap();

--- a/identity_storage/src/key_id_storage/method_digest.rs
+++ b/identity_storage/src/key_id_storage/method_digest.rs
@@ -14,6 +14,7 @@ pub type MethodDigestConstructionError = identity_core::common::SingleStructErro
 
 /// Characterization of the underlying cause of a [`MethodDigestConstructionError`].
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum MethodDigestConstructionErrorKind {
   /// Caused by a missing id on a verification method.
   ///

--- a/identity_storage/src/key_storage/ed25519.rs
+++ b/identity_storage/src/key_storage/ed25519.rs
@@ -1,7 +1,6 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crypto::signatures::ed25519::PublicKey;
 use crypto::signatures::ed25519::SecretKey;
 use identity_verification::jose::jwk::EdCurve;
 use identity_verification::jose::jwk::Jwk;
@@ -47,7 +46,8 @@ pub(crate) fn expand_secret_jwk(jwk: &Jwk) -> KeyStorageResult<SecretKey> {
   Ok(SecretKey::from_bytes(&sk))
 }
 
-pub(crate) fn encode_jwk(private_key: &SecretKey, public_key: &PublicKey) -> Jwk {
+#[cfg(any(test, feature = "memstore"))]
+pub(crate) fn encode_jwk(private_key: &SecretKey, public_key: &crypto::signatures::ed25519::PublicKey) -> Jwk {
   let x = jwu::encode_b64(public_key.as_ref());
   let d = jwu::encode_b64(private_key.to_bytes().as_ref());
   let mut params = JwkParamsOkp::new();

--- a/identity_verification/src/error.rs
+++ b/identity_verification/src/error.rs
@@ -8,6 +8,7 @@ pub type Result<T, E = Error> = ::core::result::Result<T, E>;
 
 /// This type represents all possible errors that can occur in the crate.
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[non_exhaustive]
 pub enum Error {
   /// Caused by invalid or missing properties when constructing a
   /// [`VerificationMethod`](crate::VerificationMethod).


### PR DESCRIPTION
# Description of change

Mark error enums and other enums to which it is applicable as non-exhaustive. This is in effort to be more future-proof and be able to add more variants in a non-breaking way.

Also feature-gate the `encode_jwk` function behind flags under which it is actually necessary.

## Links to any relevant issues

n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

`cargo clippy` for the non-exhaustive additions.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
