### PR TITLE
Change `verifiable_credential` to type `Vec<CRED>` in `Presentation`

### DIFF
--- a/examples/0_basic/6_create_vp.rs
+++ b/examples/0_basic/6_create_vp.rs
@@ -12,7 +12,6 @@ use std::collections::HashMap;
 use examples::create_did;
 use examples::MemStorage;
 use identity_iota::core::Object;
-use identity_iota::core::OneOrMany;
 use identity_iota::credential::DecodedJwtCredential;
 use identity_iota::credential::DecodedJwtPresentation;
 use identity_iota::credential::Jwt;
@@ -201,7 +200,7 @@ async fn main() -> anyhow::Result<()> {
     JwtPresentationValidator::new().validate(&presentation_jwt, &holder, &presentation_validation_options)?;
 
   // Concurrently resolve the issuers' documents.
-  let jwt_credentials: &OneOrMany<Jwt> = &presentation.presentation.verifiable_credential;
+  let jwt_credentials: &Vec<Jwt> = &presentation.presentation.verifiable_credential;
   let issuers: Vec<CoreDID> = jwt_credentials
     .iter()
     .map(JwtCredentialValidator::extract_issuer_from_jwt)

--- a/identity_credential/src/error.rs
+++ b/identity_credential/src/error.rs
@@ -45,6 +45,11 @@ pub enum Error {
   #[error("could not convert JWT to the VC data model: {0}")]
   InconsistentCredentialJwtClaims(&'static str),
 
+  /// Caused when deserializing a Presentation with an empty array for the
+  /// `verifiableCredential` property.
+  #[error("empty verifiableCredential array")]
+  EmptyVerifiableCredentialsArray,
+
   /// Caused when attempting to convert a JWT to a `Presentation` that has conflicting values
   /// between the registered claims and those in the `vp` object.
   #[error("could not convert JWT to the VP data model: {0}")]

--- a/identity_credential/src/error.rs
+++ b/identity_credential/src/error.rs
@@ -47,8 +47,8 @@ pub enum Error {
 
   /// Caused when deserializing a Presentation with an empty array for the
   /// `verifiableCredential` property.
-  #[error("empty verifiableCredential array")]
-  EmptyVerifiableCredentialsArray,
+  #[error("empty verifiableCredential array in presentation")]
+  EmptyVerifiableCredentialArray,
 
   /// Caused when attempting to convert a JWT to a `Presentation` that has conflicting values
   /// between the registered claims and those in the `vp` object.

--- a/identity_credential/src/presentation/jwt_serialization.rs
+++ b/identity_credential/src/presentation/jwt_serialization.rs
@@ -112,7 +112,7 @@ where
   types: Cow<'presentation, OneOrMany<String>>,
   /// Credential(s) expressing the claims of the `Presentation`.
   #[serde(default = "Default::default", rename = "verifiableCredential")]
-  pub(crate) verifiable_credential: Cow<'presentation, OneOrMany<CRED>>,
+  pub(crate) verifiable_credential: Cow<'presentation, Vec<CRED>>,
   /// Service(s) used to refresh an expired [`Credential`] in the `Presentation`.
   #[serde(default, rename = "refreshService", skip_serializing_if = "OneOrMany::is_empty")]
   refresh_service: Cow<'presentation, OneOrMany<RefreshService>>,

--- a/identity_credential/src/presentation/presentation.rs
+++ b/identity_credential/src/presentation/presentation.rs
@@ -39,7 +39,7 @@ pub struct Presentation<CRED, T = Object> {
   pub types: OneOrMany<String>,
   /// Credential(s) expressing the claims of the `Presentation`.
   #[serde(default = "Default::default", rename = "verifiableCredential")]
-  pub verifiable_credential: OneOrMany<CRED>,
+  pub verifiable_credential: Vec<CRED>,
   /// The entity that generated the `Presentation`.
   pub holder: Url,
   /// Service(s) used to refresh an expired [`Credential`] in the `Presentation`.

--- a/identity_credential/src/presentation/presentation.rs
+++ b/identity_credential/src/presentation/presentation.rs
@@ -38,6 +38,7 @@ pub struct Presentation<CRED, T = Object> {
   #[serde(rename = "type")]
   pub types: OneOrMany<String>,
   /// Credential(s) expressing the claims of the `Presentation`.
+  #[rustfmt::skip]
   #[serde(default = "Default::default", rename = "verifiableCredential", skip_serializing_if = "Vec::is_empty")]
   pub verifiable_credential: Vec<CRED>,
   /// The entity that generated the `Presentation`.

--- a/identity_credential/src/presentation/presentation.rs
+++ b/identity_credential/src/presentation/presentation.rs
@@ -244,7 +244,7 @@ mod tests {
       .source()
       .unwrap()
       .to_string(),
-      "empty verifiableCredential array in presentation"
+      crate::error::Error::EmptyVerifiableCredentialArray.to_string()
     );
   }
 }

--- a/identity_credential/src/presentation/presentation.rs
+++ b/identity_credential/src/presentation/presentation.rs
@@ -66,7 +66,7 @@ where
   let verifiable_credentials = Vec::<T>::deserialize(deserializer)?;
 
   (!verifiable_credentials.is_empty())
-    .then(|| verifiable_credentials)
+    .then_some(verifiable_credentials)
     .ok_or_else(|| de::Error::custom(Error::EmptyVerifiableCredentialsArray))
 }
 

--- a/identity_credential/src/presentation/presentation.rs
+++ b/identity_credential/src/presentation/presentation.rs
@@ -38,7 +38,7 @@ pub struct Presentation<CRED, T = Object> {
   #[serde(rename = "type")]
   pub types: OneOrMany<String>,
   /// Credential(s) expressing the claims of the `Presentation`.
-  #[serde(default, rename = "verifiableCredential", skip_serializing_if = "Vec::is_empty")]
+  #[serde(default = "Default::default", rename = "verifiableCredential", skip_serializing_if = "Vec::is_empty")]
   pub verifiable_credential: Vec<CRED>,
   /// The entity that generated the `Presentation`.
   pub holder: Url,

--- a/identity_credential/src/presentation/presentation.rs
+++ b/identity_credential/src/presentation/presentation.rs
@@ -80,7 +80,7 @@ impl<CRED, T> Presentation<CRED, T> {
       context: builder.context.into(),
       id: builder.id,
       types: builder.types.into(),
-      verifiable_credential: builder.credentials.into(),
+      verifiable_credential: builder.credentials,
       holder: builder.holder,
       refresh_service: builder.refresh_service.into(),
       terms_of_use: builder.terms_of_use.into(),

--- a/identity_credential/src/presentation/presentation.rs
+++ b/identity_credential/src/presentation/presentation.rs
@@ -161,6 +161,7 @@ where
 #[cfg(test)]
 mod tests {
   use serde_json::json;
+  use std::error::Error;
 
   use identity_core::common::Object;
   use identity_core::convert::FromJson;
@@ -228,17 +229,22 @@ mod tests {
   }
 
   #[test]
-  fn test_presentation_deserialization_with_empty_credentials_array() {
-    // Deserializing a Presentation with an empty `verifiableCredential' property is not allowed.
-    assert!(Presentation::<()>::from_json_value(json!({
-      "@context": [
-        "https://www.w3.org/2018/credentials/v1",
-        "https://www.w3.org/2018/credentials/examples/v1"
-      ],
-      "holder": "did:test:abc1",
-      "type": "VerifiablePresentation",
-      "verifiableCredential": []
-    }))
-    .is_err());
+  fn test_presentation_deserialization_with_empty_credential_array() {
+    assert_eq!(
+      Presentation::<()>::from_json_value(json!({
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://www.w3.org/2018/credentials/examples/v1"
+        ],
+        "holder": "did:test:abc1",
+        "type": "VerifiablePresentation",
+        "verifiableCredential": []
+      }))
+      .unwrap_err()
+      .source()
+      .unwrap()
+      .to_string(),
+      "empty verifiableCredential array in presentation"
+    );
   }
 }

--- a/identity_credential/src/presentation/presentation.rs
+++ b/identity_credential/src/presentation/presentation.rs
@@ -67,7 +67,7 @@ where
 
   (!verifiable_credentials.is_empty())
     .then_some(verifiable_credentials)
-    .ok_or_else(|| de::Error::custom(Error::EmptyVerifiableCredentialsArray))
+    .ok_or_else(|| de::Error::custom(Error::EmptyVerifiableCredentialArray))
 }
 
 impl<CRED, T> Presentation<CRED, T> {

--- a/identity_credential/src/presentation/presentation_builder.rs
+++ b/identity_credential/src/presentation/presentation_builder.rs
@@ -174,4 +174,22 @@ mod tests {
     assert_eq!(presentation.types.get(1).unwrap(), "ExamplePresentation");
     assert_eq!(presentation.verifiable_credential.len(), 1);
   }
+
+  #[test]
+  fn test_presentation_builder_valid_without_credentials() {
+    let presentation: Presentation<Jwt> = PresentationBuilder::new(Url::parse("did:test:abc1").unwrap(), Object::new())
+      .type_("ExamplePresentation")
+      .build()
+      .unwrap();
+
+    assert_eq!(presentation.context.len(), 1);
+    assert_eq!(
+      presentation.context.get(0).unwrap(),
+      Presentation::<Object>::base_context()
+    );
+    assert_eq!(presentation.types.len(), 2);
+    assert_eq!(presentation.types.get(0).unwrap(), Presentation::<Object>::base_type());
+    assert_eq!(presentation.types.get(1).unwrap(), "ExamplePresentation");
+    assert_eq!(presentation.verifiable_credential.len(), 0);
+  }
 }


### PR DESCRIPTION
# Description of change
This change ensures that `verifiable_credential` in `Presentation` will serialize into a `[T]` instead of a `T`, which was previously the case when `verifiable_credential` would only hold one single credential.

This previous serialization is in line with how `credentialSubject` can be serialized: https://www.w3.org/TR/vc-data-model/#credential-subject, however this is not explicitly stated for `verifiableCredential`: https://www.w3.org/TR/vc-data-model/#presentations-0.
The following examples that are used in the specification seem to imply that 'single credentials' should be serialized as `[<credential>]`:
* https://www.w3.org/TR/vc-data-model/#example-a-simple-example-of-a-verifiable-presentation
* https://www.w3.org/TR/vc-data-model/#example-usage-of-the-termsofuse-property-by-a-holder
* https://www.w3.org/TR/vc-data-model/#example-a-verifiable-presentation-that-supports-cl-signatures

The W3C VC Data Model 2.0 specification fortunately is more specific in this regard: https://www.w3.org/TR/vc-data-model-2.0/#presentations-0:
> **verifiableCredential**
    The verifiableCredential [property](https://www.w3.org/TR/vc-data-model-2.0/#dfn-property) MAY be present. The value MUST be an array of one or more [verifiable credentials](https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential), or of data derived from [verifiable credentials](https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-credential) in a cryptographically [verifiable](https://www.w3.org/TR/vc-data-model-2.0/#dfn-verify) format.

Therefore the introduction of the change in this PR.

Important detail: 
Both W3C VC Data Model versions state that: `MAY be present` and `**If** present...`, which imply that `verifiableCredential` is an optional property. I fail to think of any use case where one would have a presentation without any credentials included but this optional status of `verifiableCredential` is included in this PR as well.

## Links to any relevant issues
n/a

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
* Added unit test: `test_presentation_deserialization` which tests deserializing from an example verifiable presentation (with some minor adjustments): https://www.w3.org/TR/vc-data-model/#example-a-simple-example-of-a-verifiable-presentation
* Added unit test: `test_presentation_deserialization_without_credentials` which tests deserializing a verifiable presentation as well, but one without any `verifiableCredential`.
* Added unit test: `test_presentation_builder_valid_without_credentials` which tests building a Presentation without any credentials set.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
