### PR TITLE
Use `JWT Data Model v1.1` spec instead of `VC-JWT`

### DIFF
--- a/bindings/wasm/src/did/wasm_core_document.rs
+++ b/bindings/wasm/src/did/wasm_core_document.rs
@@ -666,7 +666,7 @@ impl WasmCoreDocument {
   }
 
   /// Produces a JWT where the payload is produced from the given `credential`
-  /// in accordance with [VC-JWT version 1.1](https://w3c.github.io/vc-jwt/#version-1.1).
+  /// in accordance with [VC Data Model v1.1](https://www.w3.org/TR/vc-data-model/#json-web-token).
   ///
   /// The `kid` in the protected header is the `id` of the method identified by `fragment` and the JWS signature will be
   /// produced by the corresponding private key backed by the `storage` in accordance with the passed `options`.
@@ -696,7 +696,7 @@ impl WasmCoreDocument {
   }
 
   /// Produces a JWT where the payload is produced from the given presentation.
-  /// in accordance with [VC-JWT version 1.1](https://w3c.github.io/vc-jwt/#version-1.1).
+  /// in accordance with [VC Data Model v1.1](https://www.w3.org/TR/vc-data-model/#json-web-token).
   ///
   /// The `kid` in the protected header is the `id` of the method identified by `fragment` and the JWS signature will be
   /// produced by the corresponding private key backed by the `storage` in accordance with the passed `options`.

--- a/bindings/wasm/src/iota/iota_document.rs
+++ b/bindings/wasm/src/iota/iota_document.rs
@@ -712,7 +712,7 @@ impl WasmIotaDocument {
   }
 
   /// Produces a JWS where the payload is produced from the given `credential`
-  /// in accordance with [VC-JWT version 1.1](https://w3c.github.io/vc-jwt/#version-1.1).
+  /// in accordance with [VC Data Model v1.1](https://www.w3.org/TR/vc-data-model/#json-web-token).
   ///
   /// The `kid` in the protected header is the `id` of the method identified by `fragment` and the JWS signature will be
   /// produced by the corresponding private key backed by the `storage` in accordance with the passed `options`.
@@ -742,7 +742,7 @@ impl WasmIotaDocument {
   }
 
   /// Produces a JWT where the payload is produced from the given presentation.
-  /// in accordance with [VC-JWT version 1.1](https://w3c.github.io/vc-jwt/#version-1.1).
+  /// in accordance with [VC Data Model v1.1](https://www.w3.org/TR/vc-data-model/#json-web-token).
   ///
   /// The `kid` in the protected header is the `id` of the method identified by `fragment` and the JWS signature will be
   /// produced by the corresponding private key backed by the `storage` in accordance with the passed `options`.

--- a/identity_credential/src/credential/credential.rs
+++ b/identity_credential/src/credential/credential.rs
@@ -162,7 +162,7 @@ impl<T> Credential<T> {
   }
 
   /// Serializes the [`Credential`] as a JWT claims set
-  /// in accordance with [VC-JWT version 1.1](https://w3c.github.io/vc-jwt/#version-1.1).
+  /// in accordance with [VC Data Model v1.1](https://www.w3.org/TR/vc-data-model/#json-web-token).
   ///
   /// The resulting string can be used as the payload of a JWS when issuing the credential.  
   pub fn serialize_jwt(&self) -> Result<String>

--- a/identity_credential/src/credential/jwt_serialization.rs
+++ b/identity_credential/src/credential/jwt_serialization.rs
@@ -25,7 +25,7 @@ use crate::credential::Subject;
 use crate::Error;
 use crate::Result;
 
-/// Implementation of JWT Encoding/Decoding according to https://w3c.github.io/vc-jwt/#version-1.1.
+/// Implementation of JWT Encoding/Decoding according to [VC Data Model v1.1](https://www.w3.org/TR/vc-data-model/#json-web-token).
 ///
 /// This type is opinionated in the following ways:
 /// 1. Serialization tries to duplicate as little as possible between the required registered claims and the `vc` entry.
@@ -228,9 +228,9 @@ where
   }
 }
 
-/// The VC-JWT spec states that issuanceDate corresponds to the registered `nbf` claim,
-/// but `iat` is also used in the ecosystem. This type aims to take care of this discrepancy on
-/// a best effort basis.
+/// The [VC Data Model v1.1](https://www.w3.org/TR/vc-data-model/#json-web-token) states that issuanceDate
+/// corresponds to the registered `nbf` claim, but `iat` is also used in the ecosystem.
+/// This type aims to take care of this discrepancy on a best effort basis.
 #[derive(Serialize, Deserialize, Clone, Copy)]
 pub(crate) struct IssuanceDateClaims {
   #[serde(skip_serializing_if = "Option::is_none")]

--- a/identity_credential/src/presentation/presentation.rs
+++ b/identity_credential/src/presentation/presentation.rs
@@ -127,7 +127,7 @@ impl<CRED, T> Presentation<CRED, T> {
   }
 
   /// Serializes the [`Presentation`] as a JWT claims set
-  /// in accordance with [VC-JWT version 1.1](https://w3c.github.io/vc-jwt/#version-1.1).
+  /// in accordance with [VC Data Model v1.1](https://www.w3.org/TR/vc-data-model/#json-web-token).
   ///
   /// The resulting string can be used as the payload of a JWS when issuing the credential.  
   pub fn serialize_jwt(&self, options: &JwtPresentationOptions) -> Result<String>

--- a/identity_storage/src/storage/jwk_document_ext.rs
+++ b/identity_storage/src/storage/jwk_document_ext.rs
@@ -95,7 +95,7 @@ pub trait JwkDocumentExt: private::Sealed {
     I: KeyIdStorage;
 
   /// Produces a JWT where the payload is produced from the given `credential`
-  /// in accordance with [VC-JWT version 1.1](https://w3c.github.io/vc-jwt/#version-1.1).
+  /// in accordance with [VC Data Model v1.1](https://www.w3.org/TR/vc-data-model/#json-web-token).
   ///
   /// The `kid` in the protected header is the `id` of the method identified by `fragment` and the JWS signature will be
   /// produced by the corresponding private key backed by the `storage` in accordance with the passed `options`.
@@ -112,7 +112,7 @@ pub trait JwkDocumentExt: private::Sealed {
     T: ToOwned<Owned = T> + Serialize + DeserializeOwned + Sync;
 
   /// Produces a JWT where the payload is produced from the given `presentation`
-  /// in accordance with [VC-JWT version 1.1](https://w3c.github.io/vc-jwt/#version-1.1).
+  /// in accordance with [VC Data Model v1.1](https://www.w3.org/TR/vc-data-model/#json-web-token).
   ///
   /// The `kid` in the protected header is the `id` of the method identified by `fragment` and the JWS signature will be
   /// produced by the corresponding private key backed by the `storage` in accordance with the passed `options`.
@@ -373,7 +373,10 @@ impl JwkDocumentExt for CoreDocument {
 
       if let Some(typ) = &options.typ {
         header.set_typ(typ.clone())
-      };
+      } else {
+        // https://www.w3.org/TR/vc-data-model/#jwt-encoding
+        header.set_typ("JWT")
+      }
 
       if let Some(cty) = &options.cty {
         header.set_cty(cty.clone())

--- a/identity_storage/src/storage/tests/api.rs
+++ b/identity_storage/src/storage/tests/api.rs
@@ -117,8 +117,9 @@ async fn create_jws() {
     .await
     .unwrap();
 
-  let decoded_jws = document.verify_jws(jws.as_str(), None, &EdDSAJwsVerifier::default(), &verification_options);
-  assert!(decoded_jws.is_ok());
+  assert!(document
+    .verify_jws(jws.as_str(), None, &EdDSAJwsVerifier::default(), &verification_options)
+    .is_ok());
 }
 
 #[tokio::test]

--- a/identity_storage/src/storage/tests/api.rs
+++ b/identity_storage/src/storage/tests/api.rs
@@ -5,7 +5,6 @@ use identity_core::common::Object;
 use identity_core::common::Url;
 use identity_core::convert::FromJson;
 use identity_credential::credential::Credential;
-
 use identity_credential::credential::Jws;
 use identity_credential::validator::JwtCredentialValidationOptions;
 use identity_did::DIDUrl;
@@ -106,7 +105,7 @@ async fn generation() {
 }
 
 #[tokio::test]
-async fn sign_bytes() {
+async fn create_jws() {
   let (document, storage, fragment) = setup_with_method().await;
 
   let payload: &[u8] = b"test";
@@ -118,13 +117,40 @@ async fn sign_bytes() {
     .await
     .unwrap();
 
-  assert!(document
-    .verify_jws(jws.as_str(), None, &EdDSAJwsVerifier::default(), &verification_options)
-    .is_ok());
+  let decoded_jws = document.verify_jws(jws.as_str(), None, &EdDSAJwsVerifier::default(), &verification_options);
+  assert!(decoded_jws.is_ok());
 }
 
 #[tokio::test]
-async fn sign_bytes_with_nonce() {
+async fn create_jws_typ() {
+  // Default `typ` is "JWT".
+  let (document, storage, fragment) = setup_with_method().await;
+  let payload: &[u8] = b"test";
+  let signature_options: JwsSignatureOptions = JwsSignatureOptions::new();
+  let verification_options: JwsVerificationOptions = JwsVerificationOptions::new();
+
+  let jws: Jws = document
+    .create_jws(&storage, &fragment, payload, &signature_options)
+    .await
+    .unwrap();
+
+  let decoded_jws = document.verify_jws(jws.as_str(), None, &EdDSAJwsVerifier::default(), &verification_options);
+  assert_eq!(decoded_jws.unwrap().protected.typ().unwrap(), "JWT");
+
+  // Custom `typ`.
+  let signature_options: JwsSignatureOptions = JwsSignatureOptions::new().typ("test-typ");
+
+  let jws: Jws = document
+    .create_jws(&storage, &fragment, payload, &signature_options)
+    .await
+    .unwrap();
+
+  let decoded_jws = document.verify_jws(jws.as_str(), None, &EdDSAJwsVerifier::default(), &verification_options);
+  assert_eq!(decoded_jws.unwrap().protected.typ().unwrap(), "test-typ");
+}
+
+#[tokio::test]
+async fn create_jws_with_nonce() {
   let (document, storage, fragment) = setup_with_method().await;
 
   let payload: &[u8] = b"test";
@@ -161,7 +187,7 @@ async fn sign_bytes_with_nonce() {
 }
 
 #[tokio::test]
-async fn sign_bytes_with_header_copy_options() {
+async fn create_jws_with_header_copy_options() {
   let (document, storage, fragment) = setup_with_method().await;
 
   let payload: &[u8] = b"test";
@@ -200,7 +226,7 @@ async fn sign_bytes_with_header_copy_options() {
 }
 
 #[tokio::test]
-async fn sign_bytes_detached() {
+async fn create_jws_detached() {
   let (document, storage, fragment) = setup_with_method().await;
 
   // =====================


### PR DESCRIPTION
# Description of change
Since [VC-JWT](https://w3c.github.io/vc-jwt/#version-1.1) is now outdated, we will use the JWT spec defined in the [Data Model spec v1.1](https://www.w3.org/TR/vc-data-model/#json-web-token).

The only difference between the two specs that I see is the `typ` property. (this needs to be double-checked in reviews). 

