### PR TITLE
Allow arbitrary JWS header parameters

### DIFF
--- a/bindings/wasm/src/jose/jws_header.rs
+++ b/bindings/wasm/src/jose/jws_header.rs
@@ -12,6 +12,7 @@ use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
 use crate::common::ArrayString;
+use crate::common::RecordStringAny;
 use crate::error::Result;
 use crate::error::WasmResult;
 use crate::jose::WasmJwk;
@@ -57,6 +58,17 @@ impl WasmJwsHeader {
   #[wasm_bindgen(js_name = setB64)]
   pub fn set_b64(&mut self, value: bool) {
     self.0.set_b64(value);
+  }
+
+  /// Additional header parameters.
+  #[wasm_bindgen(js_name = custom)]
+  pub fn custom(&self) -> Option<RecordStringAny> {
+    match self.0.custom() {
+      Some(claims) => JsValue::from_serde(claims)
+        .map(|js_val| js_val.unchecked_into::<RecordStringAny>())
+        .ok(),
+      None => None,
+    }
   }
 
   // ===========================================================================

--- a/bindings/wasm/src/storage/signature_options.rs
+++ b/bindings/wasm/src/storage/signature_options.rs
@@ -72,7 +72,7 @@ impl WasmJwsSignatureOptions {
     self.0.detached_payload = value;
   }
 
-  /// Replace the value of the `detached_payload` field.
+  /// Add additional header parameters.
   #[wasm_bindgen(js_name = setCustomHeaderParameters)]
   pub fn set_custom_header_parameters(&mut self, value: RecordStringAny) -> Result<()> {
     self.0.custom_header_parameters = Some(value.into_serde().wasm_result()?);

--- a/bindings/wasm/src/storage/signature_options.rs
+++ b/bindings/wasm/src/storage/signature_options.rs
@@ -1,6 +1,7 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::common::RecordStringAny;
 use crate::error::Result;
 use crate::error::WasmResult;
 use identity_iota::core::Url;
@@ -70,6 +71,13 @@ impl WasmJwsSignatureOptions {
   pub fn set_detached_payload(&mut self, value: bool) {
     self.0.detached_payload = value;
   }
+
+  /// Replace the value of the `detached_payload` field.
+  #[wasm_bindgen(js_name = setCustomHeaderParameters)]
+  pub fn set_custom_header_parameters(&mut self, value: RecordStringAny) -> Result<()> {
+    self.0.custom_header_parameters = Some(value.into_serde().wasm_result()?);
+    Ok(())
+  }
 }
 
 impl_wasm_json!(WasmJwsSignatureOptions, JwsSignatureOptions);
@@ -94,15 +102,15 @@ interface IJwsSignatureOptions {
     readonly attachJwk?: boolean;
 
     /** Whether to Base64url encode the payload or not.
-    *
-    * [More Info](https://tools.ietf.org/html/rfc7797#section-3)
-    */
+     *
+     * [More Info](https://tools.ietf.org/html/rfc7797#section-3)
+     */
     readonly b64?: boolean;
 
     /** The Type value to be placed in the protected header.
      * 
      * [More Info](https://tools.ietf.org/html/rfc7515#section-4.1.9)
-    */
+     */
     readonly typ?: string;
 
     /** Content Type to be placed in the protected header.
@@ -135,4 +143,9 @@ interface IJwsSignatureOptions {
      * [More Info](https://www.rfc-editor.org/rfc/rfc7515#appendix-F).
      */
     readonly detachedPayload?: boolean
+
+    /**
+     * Additional header parameters.
+     */
+    readonly customHeaderParameters?: Record<string, any>;
 }"#;

--- a/bindings/wasm/tests/storage.ts
+++ b/bindings/wasm/tests/storage.ts
@@ -89,16 +89,24 @@ describe("#JwkStorageDocument", function() {
 
         // Check that signing works
         let testString = "test";
+        let options = new JwsSignatureOptions({
+            customHeaderParameters: {
+                testKey: "testValue"
+            }
+        });
         const jws = await doc.createJws(
             storage,
             fragment,
             testString,
-            new JwsSignatureOptions(),
+            options
         );
 
         // Verify the signature and obtain a decoded token.
         const token = doc.verifyJws(jws, new JwsVerificationOptions(), new EdDSAJwsVerifier());
         assert.deepStrictEqual(testString, token.claims());
+
+        // Verify custom header parameters.
+        assert.deepStrictEqual(token.protectedHeader().custom(), { testKey: "testValue" })
 
         // Check that we can also verify it using a custom verifier
         let customVerifier = new CustomVerifier();

--- a/bindings/wasm/tests/storage.ts
+++ b/bindings/wasm/tests/storage.ts
@@ -91,14 +91,14 @@ describe("#JwkStorageDocument", function() {
         let testString = "test";
         let options = new JwsSignatureOptions({
             customHeaderParameters: {
-                testKey: "testValue"
-            }
+                testKey: "testValue",
+            },
         });
         const jws = await doc.createJws(
             storage,
             fragment,
             testString,
-            options
+            options,
         );
 
         // Verify the signature and obtain a decoded token.
@@ -106,7 +106,7 @@ describe("#JwkStorageDocument", function() {
         assert.deepStrictEqual(testString, token.claims());
 
         // Verify custom header parameters.
-        assert.deepStrictEqual(token.protectedHeader().custom(), { testKey: "testValue" })
+        assert.deepStrictEqual(token.protectedHeader().custom(), { testKey: "testValue" });
 
         // Check that we can also verify it using a custom verifier
         let customVerifier = new CustomVerifier();

--- a/identity_jose/src/jws/header.rs
+++ b/identity_jose/src/jws/header.rs
@@ -185,10 +185,7 @@ mod tests {
       "tst-value".to_owned()
     );
 
-    assert_eq!(
-      header1.custom().unwrap().get("test-bool").unwrap().as_bool().unwrap(),
-      false
-    );
+    assert!(!header1.custom().unwrap().get("test-bool").unwrap().as_bool().unwrap());
     assert!(header1.has("test"));
     assert!(!header1.has("invalid"));
   }

--- a/identity_jose/src/jws/header.rs
+++ b/identity_jose/src/jws/header.rs
@@ -132,7 +132,6 @@ impl JwsHeader {
       _ => true,
     }
   }
-  }
 }
 
 impl Deref for JwsHeader {

--- a/identity_jose/src/jws/header.rs
+++ b/identity_jose/src/jws/header.rs
@@ -118,21 +118,20 @@ impl JwsHeader {
     !has_duplicate && self.common.is_disjoint(other.common()) && self.is_custom_disjoint(other)
   }
 
+  /// Returns `true` if none of the fields are set in both `self.custom` and `other.custom`.
   fn is_custom_disjoint(&self, other: &JwsHeader) -> bool {
-    if let Some(custom) = self.custom() {
-      for key in custom.keys() {
-        if let Some(custom) = other.custom() {
-          if custom.contains_key(key) {
+    match (&self.custom, &other.custom) {
+      (Some(self_custom), Some(other_custom)) => {
+        for self_key in self_custom.keys() {
+          if other_custom.contains_key(self_key) {
             return false;
           }
-        } else {
-          return true;
         }
+        true
       }
-    } else {
-      return true;
+      _ => true,
     }
-    true
+  }
   }
 }
 

--- a/identity_storage/src/storage/jwk_document_ext.rs
+++ b/identity_storage/src/storage/jwk_document_ext.rs
@@ -362,6 +362,9 @@ impl JwkDocumentExt for CoreDocument {
       let mut header = JwsHeader::new();
 
       header.set_alg(alg);
+      if let Some(custom) = &options.custom_header_parameters {
+        header.set_custom(custom.clone())
+      }
 
       if let Some(ref kid) = options.kid {
         header.set_kid(kid.clone());
@@ -399,6 +402,7 @@ impl JwkDocumentExt for CoreDocument {
       if let Some(nonce) = &options.nonce {
         header.set_nonce(nonce.clone())
       };
+
       header
     };
 

--- a/identity_storage/src/storage/signature_options.rs
+++ b/identity_storage/src/storage/signature_options.rs
@@ -1,7 +1,8 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use identity_core::common::{Object, Url};
+use identity_core::common::Object;
+use identity_core::common::Url;
 
 /// Options for creating a JSON Web Signature.
 #[non_exhaustive]

--- a/identity_storage/src/storage/signature_options.rs
+++ b/identity_storage/src/storage/signature_options.rs
@@ -58,6 +58,7 @@ pub struct JwsSignatureOptions {
   pub detached_payload: bool,
 
   /// Additional header parameters.
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub custom_header_parameters: Option<Object>,
 }
 

--- a/identity_storage/src/storage/signature_options.rs
+++ b/identity_storage/src/storage/signature_options.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use identity_core::common::Url;
+use identity_core::common::{Object, Url};
 
 /// Options for creating a JSON Web Signature.
 #[non_exhaustive]
@@ -55,6 +55,9 @@ pub struct JwsSignatureOptions {
   ///
   /// [More Info](https://www.rfc-editor.org/rfc/rfc7515#appendix-F).
   pub detached_payload: bool,
+
+  /// Additional header parameters.
+  pub custom_header_parameters: Option<Object>,
 }
 
 impl JwsSignatureOptions {
@@ -108,6 +111,12 @@ impl JwsSignatureOptions {
   /// Replace the value of the `detached_payload` field.
   pub fn detached_payload(mut self, value: bool) -> Self {
     self.detached_payload = value;
+    self
+  }
+
+  /// Adds additional header parameters.
+  pub fn custom_header_parameters(mut self, value: Object) -> Self {
+    self.custom_header_parameters = Some(value);
     self
   }
 }


### PR DESCRIPTION
# Description of change
Now `JwsSignatureOptions` has the option to set arbitrary header parameters https://datatracker.ietf.org/doc/html/rfc7519#section-5
