### PR TITLE
Pin `cargo-release` version to `0.21.1`

### DIFF
--- a/.github/actions/publish/publish-rust/action.yml
+++ b/.github/actions/publish/publish-rust/action.yml
@@ -21,7 +21,7 @@ runs:
 
     - name: Install cargo-release
       shell: bash
-      run: cargo install --version ^0.21 cargo-release
+      run: cargo install --version =0.21.1 cargo-release
 
     - name: Publish library to crates.io
       shell: bash


### PR DESCRIPTION
To solve dependency tree issue

See https://github.com/crate-ci/cargo-release/issues/605#issuecomment-1331359921