### PR TITLE
Fix wasm panic caused by a race condition in `IotaDocument` and `CoreDocument`

### DIFF
--- a/bindings/wasm/src/common/imported_document_lock.rs
+++ b/bindings/wasm/src/common/imported_document_lock.rs
@@ -11,6 +11,7 @@ use crate::did::ArrayIToCoreDocument;
 use crate::did::CoreDocumentLock;
 use crate::did::IToCoreDocument;
 use crate::did::WasmCoreDocument;
+use crate::error::Result;
 use crate::iota::IotaDocumentLock;
 use crate::iota::WasmIotaDocument;
 
@@ -27,13 +28,13 @@ pub(crate) enum ImportedDocumentLock {
 
 impl ImportedDocumentLock {
   /// Obtain a read guard which implements `AsRef<CoreDocument>`.
-  pub(crate) fn blocking_read(&self) -> ImportedDocumentReadGuard<'_> {
+  pub(crate) fn try_read(&self) -> Result<ImportedDocumentReadGuard<'_>> {
     match self {
-      Self::Iota(lock) => ImportedDocumentReadGuard(tokio::sync::RwLockReadGuard::map(
-        lock.blocking_read(),
+      Self::Iota(lock) => Ok(ImportedDocumentReadGuard(tokio::sync::RwLockReadGuard::map(
+        lock.try_read()?,
         IotaDocument::core_document,
-      )),
-      Self::Core(lock) => ImportedDocumentReadGuard(lock.blocking_read()),
+      ))),
+      Self::Core(lock) => Ok(ImportedDocumentReadGuard(lock.try_read()?)),
     }
   }
   /// Must only be called on values implementing `IToCoreDocument`.

--- a/bindings/wasm/src/credential/domain_linkage_validator.rs
+++ b/bindings/wasm/src/credential/domain_linkage_validator.rs
@@ -60,7 +60,7 @@ impl WasmJwtDomainLinkageValidator {
   ) -> Result<()> {
     let domain = Url::parse(domain).wasm_result()?;
     let doc = ImportedDocumentLock::from(issuer);
-    let doc_guard = doc.blocking_read();
+    let doc_guard = doc.try_read()?;
     self
       .validator
       .validate_linkage(&doc_guard, &configuration.0, &domain, &options.0)
@@ -81,7 +81,7 @@ impl WasmJwtDomainLinkageValidator {
   ) -> Result<()> {
     let domain = Url::parse(domain).wasm_result()?;
     let doc = ImportedDocumentLock::from(issuer);
-    let doc_guard = doc.blocking_read();
+    let doc_guard = doc.try_read()?;
     self
       .validator
       .validate_credential(&doc_guard, &credentialJwt.0, &domain, &options.0)

--- a/bindings/wasm/src/credential/jwt_credential_validation/jwt_credential_validator.rs
+++ b/bindings/wasm/src/credential/jwt_credential_validation/jwt_credential_validator.rs
@@ -114,7 +114,7 @@ impl WasmJwtCredentialValidator {
     let issuer_locks: Vec<ImportedDocumentLock> = trustedIssuers.into();
     let trusted_issuers: Vec<ImportedDocumentReadGuard<'_>> = issuer_locks
       .iter()
-      .map(|iss| ImportedDocumentLock::try_read(iss))
+      .map(ImportedDocumentLock::try_read)
       .collect::<Result<Vec<ImportedDocumentReadGuard<'_>>>>()?;
 
     self

--- a/bindings/wasm/src/credential/jwt_credential_validation/jwt_credential_validator.rs
+++ b/bindings/wasm/src/credential/jwt_credential_validation/jwt_credential_validator.rs
@@ -78,7 +78,7 @@ impl WasmJwtCredentialValidator {
     fail_fast: WasmFailFast,
   ) -> Result<WasmDecodedJwtCredential> {
     let issuer_lock = ImportedDocumentLock::from(issuer);
-    let issuer_guard = issuer_lock.blocking_read();
+    let issuer_guard = issuer_lock.try_read()?;
 
     self
       .0
@@ -112,8 +112,11 @@ impl WasmJwtCredentialValidator {
     options: &WasmJwsVerificationOptions,
   ) -> Result<WasmDecodedJwtCredential> {
     let issuer_locks: Vec<ImportedDocumentLock> = trustedIssuers.into();
-    let trusted_issuers: Vec<ImportedDocumentReadGuard<'_>> =
-      issuer_locks.iter().map(ImportedDocumentLock::blocking_read).collect();
+    let trusted_issuers: Vec<ImportedDocumentReadGuard<'_>> = issuer_locks
+      .iter()
+      .map(|iss| ImportedDocumentLock::try_read(iss))
+      .collect::<Result<Vec<ImportedDocumentReadGuard<'_>>>>()?;
+
     self
       .0
       .verify_signature(&credential.0, &trusted_issuers, &options.0)
@@ -157,8 +160,11 @@ impl WasmJwtCredentialValidator {
     statusCheck: WasmStatusCheck,
   ) -> Result<()> {
     let issuer_locks: Vec<ImportedDocumentLock> = trustedIssuers.into();
-    let trusted_issuers: Vec<ImportedDocumentReadGuard<'_>> =
-      issuer_locks.iter().map(ImportedDocumentLock::blocking_read).collect();
+    let trusted_issuers: Vec<ImportedDocumentReadGuard<'_>> = issuer_locks
+      .iter()
+      .map(ImportedDocumentLock::try_read)
+      .collect::<Result<Vec<ImportedDocumentReadGuard<'_>>>>(
+    )?;
     let status_check: StatusCheck = statusCheck.into();
     JwtCredentialValidatorUtils::check_status(&credential.0, &trusted_issuers, status_check).wasm_result()
   }

--- a/bindings/wasm/src/credential/jwt_credential_validation/jwt_credential_validator.rs
+++ b/bindings/wasm/src/credential/jwt_credential_validation/jwt_credential_validator.rs
@@ -115,7 +115,8 @@ impl WasmJwtCredentialValidator {
     let trusted_issuers: Vec<ImportedDocumentReadGuard<'_>> = issuer_locks
       .iter()
       .map(ImportedDocumentLock::try_read)
-      .collect::<Result<Vec<ImportedDocumentReadGuard<'_>>>>()?;
+      .collect::<Result<Vec<ImportedDocumentReadGuard<'_>>>>(
+    )?;
 
     self
       .0

--- a/bindings/wasm/src/credential/jwt_presentation_validation/jwt_presentation_validator.rs
+++ b/bindings/wasm/src/credential/jwt_presentation_validation/jwt_presentation_validator.rs
@@ -65,7 +65,7 @@ impl WasmJwtPresentationValidator {
     validation_options: &WasmJwtPresentationValidationOptions,
   ) -> Result<WasmDecodedJwtPresentation> {
     let holder_lock = ImportedDocumentLock::from(holder);
-    let holder_guard = holder_lock.blocking_read();
+    let holder_guard = holder_lock.try_read()?;
 
     self
       .0

--- a/bindings/wasm/src/did/wasm_core_document.rs
+++ b/bindings/wasm/src/did/wasm_core_document.rs
@@ -72,12 +72,12 @@ impl CoreDocumentLock {
     Self(tokio::sync::RwLock::new(input))
   }
 
-  pub(crate) fn blocking_read(&self) -> tokio::sync::RwLockReadGuard<'_, CoreDocument> {
-    self.0.blocking_read()
+  pub(crate) fn try_read(&self) -> Result<tokio::sync::RwLockReadGuard<'_, CoreDocument>> {
+    self.0.try_read().wasm_result()
   }
 
-  pub(crate) fn blocking_write(&self) -> tokio::sync::RwLockWriteGuard<'_, CoreDocument> {
-    self.0.blocking_write()
+  pub(crate) fn try_write(&self) -> Result<tokio::sync::RwLockWriteGuard<'_, CoreDocument>> {
+    self.0.try_write().wasm_result()
   }
 
   pub(crate) async fn read(&self) -> tokio::sync::RwLockReadGuard<'_, CoreDocument> {
@@ -90,6 +90,9 @@ impl CoreDocumentLock {
 }
 
 /// A method-agnostic DID Document.
+///
+/// Note: All methods that involve reading from this class may potentially raise an error
+/// if the object is being concurrently modified.
 #[wasm_bindgen(js_name = CoreDocument, inspectable)]
 pub struct WasmCoreDocument(pub(crate) Rc<CoreDocumentLock>);
 
@@ -104,8 +107,8 @@ impl WasmCoreDocument {
 
   /// Returns a copy of the DID Document `id`.
   #[wasm_bindgen]
-  pub fn id(&self) -> WasmCoreDID {
-    WasmCoreDID::from(self.0.blocking_read().id().clone())
+  pub fn id(&self) -> Result<WasmCoreDID> {
+    Ok(WasmCoreDID::from(self.0.try_read()?.id().clone()))
   }
 
   /// Sets the DID of the document.
@@ -116,14 +119,15 @@ impl WasmCoreDocument {
   /// `resolve_method`, `resolve_service` and the related
   /// [DID URL dereferencing](https://w3c-ccg.github.io/did-resolution/#dereferencing) algorithm.
   #[wasm_bindgen(js_name = setId)]
-  pub fn set_id(&mut self, id: &WasmCoreDID) {
-    *self.0.blocking_write().id_mut_unchecked() = id.0.clone();
+  pub fn set_id(&mut self, id: &WasmCoreDID) -> Result<()> {
+    *self.0.try_write()?.id_mut_unchecked() = id.0.clone();
+    Ok(())
   }
 
   /// Returns a copy of the document controllers.
   #[wasm_bindgen]
-  pub fn controller(&self) -> ArrayCoreDID {
-    match self.0.blocking_read().controller() {
+  pub fn controller(&self) -> Result<ArrayCoreDID> {
+    let controller = match self.0.try_read()?.controller() {
       Some(controllers) => controllers
         .iter()
         .cloned()
@@ -132,7 +136,8 @@ impl WasmCoreDocument {
         .collect::<js_sys::Array>()
         .unchecked_into::<ArrayCoreDID>(),
       None => js_sys::Array::new().unchecked_into::<ArrayCoreDID>(),
-    }
+    };
+    Ok(controller)
   }
 
   /// Sets the controllers of the DID Document.
@@ -151,22 +156,24 @@ impl WasmCoreDocument {
     } else {
       None
     };
-    *self.0.blocking_write().controller_mut() = controller_set;
+    *self.0.try_write()?.controller_mut() = controller_set;
     Ok(())
   }
 
   /// Returns a copy of the document's `alsoKnownAs` set.
   #[wasm_bindgen(js_name = alsoKnownAs)]
-  pub fn also_known_as(&self) -> ArrayString {
-    self
-      .0
-      .blocking_read()
-      .also_known_as()
-      .iter()
-      .map(|url| url.to_string())
-      .map(JsValue::from)
-      .collect::<js_sys::Array>()
-      .unchecked_into::<ArrayString>()
+  pub fn also_known_as(&self) -> Result<ArrayString> {
+    Ok(
+      self
+        .0
+        .try_read()?
+        .also_known_as()
+        .iter()
+        .map(|url| url.to_string())
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<ArrayString>(),
+    )
   }
 
   /// Sets the `alsoKnownAs` property in the DID document.
@@ -179,114 +186,126 @@ impl WasmCoreDocument {
         urls_set.append(Url::parse(url).wasm_result()?);
       }
     }
-    *self.0.blocking_write().also_known_as_mut() = urls_set;
+    *self.0.try_write()?.also_known_as_mut() = urls_set;
     Ok(())
   }
 
   /// Returns a copy of the document's `verificationMethod` set.
   #[wasm_bindgen(js_name = verificationMethod)]
-  pub fn verification_method(&self) -> ArrayVerificationMethod {
-    self
-      .0
-      .blocking_read()
-      .verification_method()
-      .iter()
-      .cloned()
-      .map(WasmVerificationMethod::from)
-      .map(JsValue::from)
-      .collect::<js_sys::Array>()
-      .unchecked_into::<ArrayVerificationMethod>()
+  pub fn verification_method(&self) -> Result<ArrayVerificationMethod> {
+    Ok(
+      self
+        .0
+        .try_read()?
+        .verification_method()
+        .iter()
+        .cloned()
+        .map(WasmVerificationMethod::from)
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<ArrayVerificationMethod>(),
+    )
   }
 
   /// Returns a copy of the document's `authentication` set.
   #[wasm_bindgen]
-  pub fn authentication(&self) -> ArrayCoreMethodRef {
-    self
-      .0
-      .blocking_read()
-      .authentication()
-      .iter()
-      .cloned()
-      .map(|method_ref| match method_ref {
-        MethodRef::Embed(verification_method) => JsValue::from(WasmVerificationMethod(verification_method)),
-        MethodRef::Refer(did_url) => JsValue::from(WasmDIDUrl(did_url)),
-      })
-      .collect::<js_sys::Array>()
-      .unchecked_into::<ArrayCoreMethodRef>()
+  pub fn authentication(&self) -> Result<ArrayCoreMethodRef> {
+    Ok(
+      self
+        .0
+        .try_read()?
+        .authentication()
+        .iter()
+        .cloned()
+        .map(|method_ref| match method_ref {
+          MethodRef::Embed(verification_method) => JsValue::from(WasmVerificationMethod(verification_method)),
+          MethodRef::Refer(did_url) => JsValue::from(WasmDIDUrl(did_url)),
+        })
+        .collect::<js_sys::Array>()
+        .unchecked_into::<ArrayCoreMethodRef>(),
+    )
   }
 
   /// Returns a copy of the document's `assertionMethod` set.
   #[wasm_bindgen(js_name = assertionMethod)]
-  pub fn assertion_method(&self) -> ArrayCoreMethodRef {
-    self
-      .0
-      .blocking_read()
-      .assertion_method()
-      .iter()
-      .cloned()
-      .map(|method_ref| match method_ref {
-        MethodRef::Embed(verification_method) => JsValue::from(WasmVerificationMethod(verification_method)),
-        MethodRef::Refer(did_url) => JsValue::from(WasmDIDUrl(did_url)),
-      })
-      .collect::<js_sys::Array>()
-      .unchecked_into::<ArrayCoreMethodRef>()
+  pub fn assertion_method(&self) -> Result<ArrayCoreMethodRef> {
+    Ok(
+      self
+        .0
+        .try_read()?
+        .assertion_method()
+        .iter()
+        .cloned()
+        .map(|method_ref| match method_ref {
+          MethodRef::Embed(verification_method) => JsValue::from(WasmVerificationMethod(verification_method)),
+          MethodRef::Refer(did_url) => JsValue::from(WasmDIDUrl(did_url)),
+        })
+        .collect::<js_sys::Array>()
+        .unchecked_into::<ArrayCoreMethodRef>(),
+    )
   }
 
   /// Returns a copy of the document's `keyAgreement` set.
   #[wasm_bindgen(js_name = keyAgreement)]
-  pub fn key_agreement(&self) -> ArrayCoreMethodRef {
-    self
-      .0
-      .blocking_read()
-      .key_agreement()
-      .iter()
-      .cloned()
-      .map(|method_ref| match method_ref {
-        MethodRef::Embed(verification_method) => JsValue::from(WasmVerificationMethod(verification_method)),
-        MethodRef::Refer(did_url) => JsValue::from(WasmDIDUrl(did_url)),
-      })
-      .collect::<js_sys::Array>()
-      .unchecked_into::<ArrayCoreMethodRef>()
+  pub fn key_agreement(&self) -> Result<ArrayCoreMethodRef> {
+    Ok(
+      self
+        .0
+        .try_read()?
+        .key_agreement()
+        .iter()
+        .cloned()
+        .map(|method_ref| match method_ref {
+          MethodRef::Embed(verification_method) => JsValue::from(WasmVerificationMethod(verification_method)),
+          MethodRef::Refer(did_url) => JsValue::from(WasmDIDUrl(did_url)),
+        })
+        .collect::<js_sys::Array>()
+        .unchecked_into::<ArrayCoreMethodRef>(),
+    )
   }
 
   /// Returns a copy of the document's `capabilityDelegation` set.
   #[wasm_bindgen(js_name = capabilityDelegation)]
-  pub fn capability_delegation(&self) -> ArrayCoreMethodRef {
-    self
-      .0
-      .blocking_read()
-      .capability_delegation()
-      .iter()
-      .cloned()
-      .map(|method_ref| match method_ref {
-        MethodRef::Embed(verification_method) => JsValue::from(WasmVerificationMethod(verification_method)),
-        MethodRef::Refer(did_url) => JsValue::from(WasmDIDUrl(did_url)),
-      })
-      .collect::<js_sys::Array>()
-      .unchecked_into::<ArrayCoreMethodRef>()
+  pub fn capability_delegation(&self) -> Result<ArrayCoreMethodRef> {
+    Ok(
+      self
+        .0
+        .try_read()?
+        .capability_delegation()
+        .iter()
+        .cloned()
+        .map(|method_ref| match method_ref {
+          MethodRef::Embed(verification_method) => JsValue::from(WasmVerificationMethod(verification_method)),
+          MethodRef::Refer(did_url) => JsValue::from(WasmDIDUrl(did_url)),
+        })
+        .collect::<js_sys::Array>()
+        .unchecked_into::<ArrayCoreMethodRef>(),
+    )
   }
 
   /// Returns a copy of the document's `capabilityInvocation` set.
   #[wasm_bindgen(js_name = capabilityInvocation)]
-  pub fn capability_invocation(&self) -> ArrayCoreMethodRef {
-    self
-      .0
-      .blocking_read()
-      .capability_invocation()
-      .iter()
-      .cloned()
-      .map(|method_ref| match method_ref {
-        MethodRef::Embed(verification_method) => JsValue::from(WasmVerificationMethod(verification_method)),
-        MethodRef::Refer(did_url) => JsValue::from(WasmDIDUrl(did_url)),
-      })
-      .collect::<js_sys::Array>()
-      .unchecked_into::<ArrayCoreMethodRef>()
+  pub fn capability_invocation(&self) -> Result<ArrayCoreMethodRef> {
+    Ok(
+      self
+        .0
+        .try_read()?
+        .capability_invocation()
+        .iter()
+        .cloned()
+        .map(|method_ref| match method_ref {
+          MethodRef::Embed(verification_method) => JsValue::from(WasmVerificationMethod(verification_method)),
+          MethodRef::Refer(did_url) => JsValue::from(WasmDIDUrl(did_url)),
+        })
+        .collect::<js_sys::Array>()
+        .unchecked_into::<ArrayCoreMethodRef>(),
+    )
   }
 
   /// Returns a copy of the custom DID Document properties.
   #[wasm_bindgen]
   pub fn properties(&self) -> Result<MapStringAny> {
-    MapStringAny::try_from(self.0.blocking_read().properties())
+    MapStringAny::try_from(self.0.try_read()?.properties())
   }
 
   /// Sets a custom property in the DID Document.
@@ -300,10 +319,10 @@ impl WasmCoreDocument {
     let value: Option<serde_json::Value> = value.into_serde().wasm_result()?;
     match value {
       Some(value) => {
-        self.0.blocking_write().properties_mut_unchecked().insert(key, value);
+        self.0.try_write()?.properties_mut_unchecked().insert(key, value);
       }
       None => {
-        self.0.blocking_write().properties_mut_unchecked().remove(&key);
+        self.0.try_write()?.properties_mut_unchecked().remove(&key);
       }
     }
     Ok(())
@@ -315,17 +334,19 @@ impl WasmCoreDocument {
 
   /// Returns a set of all {@link Service} in the document.
   #[wasm_bindgen]
-  pub fn service(&self) -> ArrayService {
-    self
-      .0
-      .blocking_read()
-      .service()
-      .iter()
-      .cloned()
-      .map(WasmService)
-      .map(JsValue::from)
-      .collect::<js_sys::Array>()
-      .unchecked_into::<ArrayService>()
+  pub fn service(&self) -> Result<ArrayService> {
+    Ok(
+      self
+        .0
+        .try_read()?
+        .service()
+        .iter()
+        .cloned()
+        .map(WasmService)
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<ArrayService>(),
+    )
   }
 
   /// Add a new {@link Service} to the document.
@@ -333,7 +354,7 @@ impl WasmCoreDocument {
   /// Errors if there already exists a service or verification method with the same id.
   #[wasm_bindgen(js_name = insertService)]
   pub fn insert_service(&mut self, service: &WasmService) -> Result<()> {
-    self.0.blocking_write().insert_service(service.0.clone()).wasm_result()
+    self.0.try_write()?.insert_service(service.0.clone()).wasm_result()
   }
 
   /// Remove a {@link Service} identified by the given {@link DIDUrl} from the document.
@@ -341,25 +362,23 @@ impl WasmCoreDocument {
   /// Returns `true` if the service was removed.
   #[wasm_bindgen(js_name = removeService)]
   #[allow(non_snake_case)]
-  pub fn remove_service(&mut self, didUrl: &WasmDIDUrl) -> Option<WasmService> {
-    self
-      .0
-      .blocking_write()
-      .remove_service(&didUrl.0.clone())
-      .map(Into::into)
+  pub fn remove_service(&mut self, didUrl: &WasmDIDUrl) -> Result<Option<WasmService>> {
+    Ok(self.0.try_write()?.remove_service(&didUrl.0.clone()).map(Into::into))
   }
 
   /// Returns the first {@link Service} with an `id` property matching the provided `query`,
   /// if present.
   #[wasm_bindgen(js_name = resolveService)]
-  pub fn resolve_service(&self, query: &UDIDUrlQuery) -> Option<WasmService> {
-    let service_query: String = query.into_serde().ok()?;
-    self
-      .0
-      .blocking_read()
-      .resolve_service(&service_query)
-      .cloned()
-      .map(WasmService::from)
+  pub fn resolve_service(&self, query: &UDIDUrlQuery) -> Result<Option<WasmService>> {
+    let service_query: String = query.into_serde().wasm_result()?;
+    Ok(
+      self
+        .0
+        .try_read()?
+        .resolve_service(&service_query)
+        .cloned()
+        .map(WasmService::from),
+    )
   }
 
   // ===========================================================================
@@ -375,7 +394,7 @@ impl WasmCoreDocument {
     let scope: Option<MethodScope> = scope.map(|js| js.into_serde().wasm_result()).transpose()?;
     let methods = self
       .0
-      .blocking_read()
+      .try_read()?
       .methods(scope)
       .into_iter()
       .cloned()
@@ -388,18 +407,20 @@ impl WasmCoreDocument {
 
   /// Returns an array of all verification relationships.
   #[wasm_bindgen(js_name = verificationRelationships)]
-  pub fn verification_relationships(&self) -> ArrayCoreMethodRef {
-    self
-      .0
-      .blocking_read()
-      .verification_relationships()
-      .cloned()
-      .map(|method_ref| match method_ref {
-        MethodRef::Embed(verification_method) => JsValue::from(WasmVerificationMethod(verification_method)),
-        MethodRef::Refer(did_url) => JsValue::from(WasmDIDUrl(did_url)),
-      })
-      .collect::<js_sys::Array>()
-      .unchecked_into::<ArrayCoreMethodRef>()
+  pub fn verification_relationships(&self) -> Result<ArrayCoreMethodRef> {
+    Ok(
+      self
+        .0
+        .try_read()?
+        .verification_relationships()
+        .cloned()
+        .map(|method_ref| match method_ref {
+          MethodRef::Embed(verification_method) => JsValue::from(WasmVerificationMethod(verification_method)),
+          MethodRef::Refer(did_url) => JsValue::from(WasmDIDUrl(did_url)),
+        })
+        .collect::<js_sys::Array>()
+        .unchecked_into::<ArrayCoreMethodRef>(),
+    )
   }
 
   /// Adds a new `method` to the document in the given `scope`.
@@ -407,15 +428,15 @@ impl WasmCoreDocument {
   pub fn insert_method(&mut self, method: &WasmVerificationMethod, scope: &WasmMethodScope) -> Result<()> {
     self
       .0
-      .blocking_write()
+      .try_write()?
       .insert_method(method.0.clone(), scope.0)
       .wasm_result()
   }
 
   /// Removes all references to the specified Verification Method.
   #[wasm_bindgen(js_name = removeMethod)]
-  pub fn remove_method(&mut self, did: &WasmDIDUrl) -> Option<WasmVerificationMethod> {
-    self.0.blocking_write().remove_method(&did.0).map(Into::into)
+  pub fn remove_method(&mut self, did: &WasmDIDUrl) -> Result<Option<WasmVerificationMethod>> {
+    Ok(self.0.try_write()?.remove_method(&did.0).map(Into::into))
   }
 
   /// Returns a copy of the first verification method with an `id` property
@@ -430,7 +451,7 @@ impl WasmCoreDocument {
     let method_query: String = query.into_serde().wasm_result()?;
     let method_scope: Option<MethodScope> = scope.map(|js| js.into_serde().wasm_result()).transpose()?;
 
-    let guard = self.0.blocking_read();
+    let guard = self.0.try_read()?;
     let method: Option<&VerificationMethod> = guard.resolve_method(&method_query, method_scope);
     Ok(method.cloned().map(WasmVerificationMethod))
   }
@@ -448,7 +469,7 @@ impl WasmCoreDocument {
   ) -> Result<bool> {
     self
       .0
-      .blocking_write()
+      .try_write()?
       .attach_method_relationship(&didUrl.0, relationship.into())
       .wasm_result()
   }
@@ -463,7 +484,7 @@ impl WasmCoreDocument {
   ) -> Result<bool> {
     self
       .0
-      .blocking_write()
+      .try_write()?
       .detach_method_relationship(&didUrl.0, relationship.into())
       .wasm_result()
   }
@@ -493,7 +514,7 @@ impl WasmCoreDocument {
     let jws_verifier = WasmJwsVerifier::new(signatureVerifier);
     self
       .0
-      .blocking_read()
+      .try_read()?
       .verify_jws(
         jws.0.as_str(),
         detachedPayload.as_deref().map(|detached| detached.as_bytes()),
@@ -518,7 +539,7 @@ impl WasmCoreDocument {
 
     self
       .0
-      .blocking_write()
+      .try_write()?
       .revoke_credentials(&query, indices.as_slice())
       .wasm_result()
   }
@@ -533,7 +554,7 @@ impl WasmCoreDocument {
 
     self
       .0
-      .blocking_write()
+      .try_write()?
       .unrevoke_credentials(&query, indices.as_slice())
       .wasm_result()
   }
@@ -544,8 +565,10 @@ impl WasmCoreDocument {
 
   /// Deep clones the {@link CoreDocument}.
   #[wasm_bindgen(js_name = clone)]
-  pub fn deep_clone(&self) -> WasmCoreDocument {
-    WasmCoreDocument(Rc::new(CoreDocumentLock::new(self.0.blocking_read().clone())))
+  pub fn deep_clone(&self) -> Result<WasmCoreDocument> {
+    Ok(WasmCoreDocument(Rc::new(CoreDocumentLock::new(
+      self.0.try_read()?.clone(),
+    ))))
   }
 
   /// ### Warning
@@ -569,7 +592,7 @@ impl WasmCoreDocument {
   /// Serializes to a plain JS representation.
   #[wasm_bindgen(js_name = toJSON)]
   pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0.blocking_read().as_ref()).wasm_result()
+    JsValue::from_serde(&self.0.try_read()?.as_ref()).wasm_result()
   }
 
   /// Deserializes an instance from a plain JS representation.

--- a/bindings/wasm/src/error.rs
+++ b/bindings/wasm/src/error.rs
@@ -13,6 +13,7 @@ use std::borrow::Cow;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::result::Result as StdResult;
+use tokio::sync::TryLockError;
 use wasm_bindgen::JsValue;
 
 /// Convenience wrapper for `Result<T, JsValue>`.
@@ -244,6 +245,15 @@ impl From<CompoundJwtPresentationValidationError> for WasmError<'_> {
   fn from(error: CompoundJwtPresentationValidationError) -> Self {
     Self {
       name: Cow::Borrowed("CompoundJwtPresentationValidationError"),
+      message: Cow::Owned(ErrorMessage(&error).to_string()),
+    }
+  }
+}
+
+impl From<TryLockError> for WasmError<'_> {
+  fn from(error: TryLockError) -> Self {
+    Self {
+      name: Cow::Borrowed("TryLockError"),
       message: Cow::Owned(ErrorMessage(&error).to_string()),
     }
   }

--- a/bindings/wasm/src/iota/identity_client_ext.rs
+++ b/bindings/wasm/src/iota/identity_client_ext.rs
@@ -72,7 +72,7 @@ impl WasmIotaIdentityClientExt {
         identity_iota::iota::Error::JsError(format!("newDidOutput failed to decode Address: {err}: {address_dto:?}"))
       })
       .wasm_result()?;
-    let doc: IotaDocument = document.0.blocking_read().clone();
+    let doc: IotaDocument = document.0.try_read()?.clone();
 
     let promise: Promise = future_to_promise(async move {
       let rent_structure: Option<RentStructure> = rentStructure
@@ -102,7 +102,7 @@ impl WasmIotaIdentityClientExt {
     client: WasmIotaIdentityClient,
     document: &WasmIotaDocument,
   ) -> Result<PromiseAliasOutputBuilderParams> {
-    let document: IotaDocument = document.0.blocking_read().clone();
+    let document: IotaDocument = document.0.try_read()?.clone();
     let promise: Promise = future_to_promise(async move {
       let output: AliasOutput = IotaIdentityClientExt::update_did_output(&client, document)
         .await

--- a/bindings/wasm/src/iota/iota_document.rs
+++ b/bindings/wasm/src/iota/iota_document.rs
@@ -80,12 +80,12 @@ impl IotaDocumentLock {
     Self(tokio::sync::RwLock::new(value))
   }
 
-  pub(crate) fn blocking_read(&self) -> tokio::sync::RwLockReadGuard<'_, IotaDocument> {
-    self.0.blocking_read()
+  pub(crate) fn try_read(&self) -> Result<tokio::sync::RwLockReadGuard<'_, IotaDocument>> {
+    self.0.try_read().wasm_result()
   }
 
-  pub(crate) fn blocking_write(&self) -> tokio::sync::RwLockWriteGuard<'_, IotaDocument> {
-    self.0.blocking_write()
+  pub(crate) fn try_write(&self) -> Result<tokio::sync::RwLockWriteGuard<'_, IotaDocument>> {
+    self.0.try_write().wasm_result()
   }
 
   pub(crate) async fn read(&self) -> tokio::sync::RwLockReadGuard<'_, IotaDocument> {
@@ -99,6 +99,10 @@ impl IotaDocumentLock {
 // =============================================================================
 // =============================================================================
 
+/// A DID Document adhering to the IOTA DID method specification.
+///
+/// Note: All methods that involve reading from this class may potentially raise an error
+/// if the object is being concurrently modified.
 #[wasm_bindgen(js_name = IotaDocument, inspectable)]
 pub struct WasmIotaDocument(pub(crate) Rc<IotaDocumentLock>);
 
@@ -129,8 +133,8 @@ impl WasmIotaDocument {
 
   /// Returns a copy of the DID Document `id`.
   #[wasm_bindgen]
-  pub fn id(&self) -> WasmIotaDID {
-    WasmIotaDID::from(self.0.blocking_read().id().clone())
+  pub fn id(&self) -> Result<WasmIotaDID> {
+    Ok(WasmIotaDID::from(self.0.try_read()?.id().clone()))
   }
 
   /// Returns a copy of the list of document controllers.
@@ -138,30 +142,34 @@ impl WasmIotaDocument {
   /// NOTE: controllers are determined by the `state_controller` unlock condition of the output
   /// during resolution and are omitted when publishing.
   #[wasm_bindgen]
-  pub fn controller(&self) -> ArrayIotaDID {
-    self
-      .0
-      .blocking_read()
-      .controller()
-      .cloned()
-      .map(WasmIotaDID::from)
-      .map(JsValue::from)
-      .collect::<js_sys::Array>()
-      .unchecked_into::<ArrayIotaDID>()
+  pub fn controller(&self) -> Result<ArrayIotaDID> {
+    Ok(
+      self
+        .0
+        .try_read()?
+        .controller()
+        .cloned()
+        .map(WasmIotaDID::from)
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<ArrayIotaDID>(),
+    )
   }
 
   /// Returns a copy of the document's `alsoKnownAs` set.
   #[wasm_bindgen(js_name = alsoKnownAs)]
-  pub fn also_known_as(&self) -> ArrayString {
-    self
-      .0
-      .blocking_read()
-      .also_known_as()
-      .iter()
-      .map(|url| url.to_string())
-      .map(JsValue::from)
-      .collect::<js_sys::Array>()
-      .unchecked_into::<ArrayString>()
+  pub fn also_known_as(&self) -> Result<ArrayString> {
+    Ok(
+      self
+        .0
+        .try_read()?
+        .also_known_as()
+        .iter()
+        .map(|url| url.to_string())
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<ArrayString>(),
+    )
   }
 
   /// Sets the `alsoKnownAs` property in the DID document.
@@ -174,14 +182,14 @@ impl WasmIotaDocument {
         urls_set.append(Url::parse(url).wasm_result()?);
       }
     }
-    *self.0.blocking_write().also_known_as_mut() = urls_set;
+    *self.0.try_write()?.also_known_as_mut() = urls_set;
     Ok(())
   }
 
   /// Returns a copy of the custom DID Document properties.
   #[wasm_bindgen]
   pub fn properties(&self) -> Result<MapStringAny> {
-    MapStringAny::try_from(self.0.blocking_read().properties())
+    MapStringAny::try_from(self.0.try_read()?.properties())
   }
 
   /// Sets a custom property in the DID Document.
@@ -195,10 +203,10 @@ impl WasmIotaDocument {
     let value: Option<serde_json::Value> = value.into_serde().wasm_result()?;
     match value {
       Some(value) => {
-        self.0.blocking_write().properties_mut_unchecked().insert(key, value);
+        self.0.try_write()?.properties_mut_unchecked().insert(key, value);
       }
       None => {
-        self.0.blocking_write().properties_mut_unchecked().remove(&key);
+        self.0.try_write()?.properties_mut_unchecked().remove(&key);
       }
     }
     Ok(())
@@ -210,17 +218,19 @@ impl WasmIotaDocument {
 
   /// Return a set of all {@link Service} in the document.
   #[wasm_bindgen]
-  pub fn service(&self) -> ArrayService {
-    self
-      .0
-      .blocking_read()
-      .service()
-      .iter()
-      .cloned()
-      .map(WasmService)
-      .map(JsValue::from)
-      .collect::<js_sys::Array>()
-      .unchecked_into::<ArrayService>()
+  pub fn service(&self) -> Result<ArrayService> {
+    Ok(
+      self
+        .0
+        .try_read()?
+        .service()
+        .iter()
+        .cloned()
+        .map(WasmService)
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<ArrayService>(),
+    )
   }
 
   /// Add a new {@link Service} to the document.
@@ -228,28 +238,30 @@ impl WasmIotaDocument {
   /// Returns `true` if the service was added.
   #[wasm_bindgen(js_name = insertService)]
   pub fn insert_service(&mut self, service: &WasmService) -> Result<()> {
-    self.0.blocking_write().insert_service(service.0.clone()).wasm_result()
+    self.0.try_write()?.insert_service(service.0.clone()).wasm_result()
   }
 
   /// Remove a {@link Service} identified by the given {@link DIDUrl} from the document.
   ///
   /// Returns `true` if a service was removed.
   #[wasm_bindgen(js_name = removeService)]
-  pub fn remove_service(&mut self, did: &WasmDIDUrl) -> Option<WasmService> {
-    self.0.blocking_write().remove_service(&did.0).map(Into::into)
+  pub fn remove_service(&mut self, did: &WasmDIDUrl) -> Result<Option<WasmService>> {
+    Ok(self.0.try_write()?.remove_service(&did.0).map(Into::into))
   }
 
   /// Returns the first {@link Service} with an `id` property matching the provided `query`,
   /// if present.
   #[wasm_bindgen(js_name = resolveService)]
-  pub fn resolve_service(&self, query: &UDIDUrlQuery) -> Option<WasmService> {
-    let service_query: String = query.into_serde().ok()?;
-    self
-      .0
-      .blocking_read()
-      .resolve_service(&service_query)
-      .cloned()
-      .map(WasmService::from)
+  pub fn resolve_service(&self, query: &UDIDUrlQuery) -> Result<Option<WasmService>> {
+    let service_query: String = query.into_serde().wasm_result()?;
+    Ok(
+      self
+        .0
+        .try_read()?
+        .resolve_service(&service_query)
+        .cloned()
+        .map(WasmService::from),
+    )
   }
 
   // ===========================================================================
@@ -265,7 +277,7 @@ impl WasmIotaDocument {
     let scope: Option<MethodScope> = scope.map(|js| js.into_serde().wasm_result()).transpose()?;
     let methods = self
       .0
-      .blocking_read()
+      .try_read()?
       .methods(scope)
       .into_iter()
       .cloned()
@@ -281,7 +293,7 @@ impl WasmIotaDocument {
   pub fn insert_method(&mut self, method: &WasmVerificationMethod, scope: &WasmMethodScope) -> Result<()> {
     self
       .0
-      .blocking_write()
+      .try_write()?
       .insert_method(method.0.clone(), scope.0)
       .wasm_result()?;
     Ok(())
@@ -289,8 +301,8 @@ impl WasmIotaDocument {
 
   /// Removes all references to the specified Verification Method.
   #[wasm_bindgen(js_name = removeMethod)]
-  pub fn remove_method(&mut self, did: &WasmDIDUrl) -> Option<WasmVerificationMethod> {
-    self.0.blocking_write().remove_method(&did.0).map(Into::into)
+  pub fn remove_method(&mut self, did: &WasmDIDUrl) -> Result<Option<WasmVerificationMethod>> {
+    Ok(self.0.try_write()?.remove_method(&did.0).map(Into::into))
   }
 
   /// Returns a copy of the first verification method with an `id` property
@@ -305,7 +317,7 @@ impl WasmIotaDocument {
     let method_query: String = query.into_serde().wasm_result()?;
     let method_scope: Option<MethodScope> = scope.map(|js| js.into_serde().wasm_result()).transpose()?;
 
-    let guard = self.0.blocking_read();
+    let guard = self.0.try_read()?;
     let method: Option<&VerificationMethod> = guard.resolve_method(&method_query, method_scope);
     Ok(method.cloned().map(WasmVerificationMethod))
   }
@@ -323,7 +335,7 @@ impl WasmIotaDocument {
   ) -> Result<bool> {
     self
       .0
-      .blocking_write()
+      .try_write()?
       .attach_method_relationship(&didUrl.0, relationship.into())
       .wasm_result()
   }
@@ -338,7 +350,7 @@ impl WasmIotaDocument {
   ) -> Result<bool> {
     self
       .0
-      .blocking_write()
+      .try_write()?
       .detach_method_relationship(&didUrl.0, relationship.into())
       .wasm_result()
   }
@@ -367,7 +379,7 @@ impl WasmIotaDocument {
     let jws_verifier = WasmJwsVerifier::new(signatureVerifier);
     self
       .0
-      .blocking_read()
+      .try_read()?
       .verify_jws(
         &jws.0,
         detachedPayload.as_deref().map(|detached| detached.as_bytes()),
@@ -386,7 +398,7 @@ impl WasmIotaDocument {
   /// with the default {@link StateMetadataEncoding}.
   #[wasm_bindgen]
   pub fn pack(&self) -> Result<Vec<u8>> {
-    self.0.blocking_read().clone().pack().wasm_result()
+    self.0.try_read()?.clone().pack().wasm_result()
   }
 
   /// Serializes the document for inclusion in an Alias Output's state metadata.
@@ -394,7 +406,7 @@ impl WasmIotaDocument {
   pub fn pack_with_encoding(&self, encoding: WasmStateMetadataEncoding) -> Result<Vec<u8>> {
     self
       .0
-      .blocking_read()
+      .try_read()?
       .clone()
       .pack_with_encoding(StateMetadataEncoding::from(encoding))
       .wasm_result()
@@ -467,60 +479,61 @@ impl WasmIotaDocument {
   /// NOTE: Copies all the metadata. See also `metadataCreated`, `metadataUpdated`,
   /// `metadataPreviousMessageId`, `metadataProof` if only a subset of the metadata required.
   #[wasm_bindgen]
-  pub fn metadata(&self) -> WasmIotaDocumentMetadata {
-    WasmIotaDocumentMetadata::from(self.0.blocking_read().metadata.clone())
+  pub fn metadata(&self) -> Result<WasmIotaDocumentMetadata> {
+    Ok(WasmIotaDocumentMetadata::from(self.0.try_read()?.metadata.clone()))
   }
 
   /// Returns a copy of the timestamp of when the DID document was created.
   #[wasm_bindgen(js_name = metadataCreated)]
-  pub fn metadata_created(&self) -> Option<WasmTimestamp> {
-    self.0.blocking_read().metadata.created.map(WasmTimestamp::from)
+  pub fn metadata_created(&self) -> Result<Option<WasmTimestamp>> {
+    Ok(self.0.try_read()?.metadata.created.map(WasmTimestamp::from))
   }
 
   /// Sets the timestamp of when the DID document was created.
   #[wasm_bindgen(js_name = setMetadataCreated)]
   pub fn set_metadata_created(&mut self, timestamp: OptionTimestamp) -> Result<()> {
     let timestamp: Option<Timestamp> = timestamp.into_serde().wasm_result()?;
-    self.0.blocking_write().metadata.created = timestamp;
+    self.0.try_write()?.metadata.created = timestamp;
     Ok(())
   }
 
   /// Returns a copy of the timestamp of the last DID document update.
   #[wasm_bindgen(js_name = metadataUpdated)]
-  pub fn metadata_updated(&self) -> Option<WasmTimestamp> {
-    self.0.blocking_read().metadata.updated.map(WasmTimestamp::from)
+  pub fn metadata_updated(&self) -> Result<Option<WasmTimestamp>> {
+    Ok(self.0.try_read()?.metadata.updated.map(WasmTimestamp::from))
   }
 
   /// Sets the timestamp of the last DID document update.
   #[wasm_bindgen(js_name = setMetadataUpdated)]
   pub fn set_metadata_updated(&mut self, timestamp: OptionTimestamp) -> Result<()> {
     let timestamp: Option<Timestamp> = timestamp.into_serde().wasm_result()?;
-    self.0.blocking_write().metadata.updated = timestamp;
+    self.0.try_write()?.metadata.updated = timestamp;
     Ok(())
   }
 
   /// Returns a copy of the deactivated status of the DID document.
   #[wasm_bindgen(js_name = metadataDeactivated)]
-  pub fn metadata_deactivated(&self) -> Option<bool> {
-    self.0.blocking_read().metadata.deactivated
+  pub fn metadata_deactivated(&self) -> Result<Option<bool>> {
+    Ok(self.0.try_read()?.metadata.deactivated)
   }
 
   /// Sets the deactivated status of the DID document.
   #[wasm_bindgen(js_name = setMetadataDeactivated)]
-  pub fn set_metadata_deactivated(&mut self, deactivated: Option<bool>) {
-    self.0.blocking_write().metadata.deactivated = deactivated;
+  pub fn set_metadata_deactivated(&mut self, deactivated: Option<bool>) -> Result<()> {
+    self.0.try_write()?.metadata.deactivated = deactivated;
+    Ok(())
   }
 
   /// Returns a copy of the Bech32-encoded state controller address, if present.
   #[wasm_bindgen(js_name = metadataStateControllerAddress)]
-  pub fn metadata_state_controller_address(&self) -> Option<String> {
-    self.0.blocking_read().metadata.state_controller_address.clone()
+  pub fn metadata_state_controller_address(&self) -> Result<Option<String>> {
+    Ok(self.0.try_read()?.metadata.state_controller_address.clone())
   }
 
   /// Returns a copy of the Bech32-encoded governor address, if present.
   #[wasm_bindgen(js_name = metadataGovernorAddress)]
-  pub fn metadata_governor_address(&self) -> Option<String> {
-    self.0.blocking_read().metadata.governor_address.clone()
+  pub fn metadata_governor_address(&self) -> Result<Option<String>> {
+    Ok(self.0.try_read()?.metadata.governor_address.clone())
   }
 
   /// Sets a custom property in the document metadata.
@@ -530,10 +543,10 @@ impl WasmIotaDocument {
     let value: Option<serde_json::Value> = value.into_serde().wasm_result()?;
     match value {
       Some(value) => {
-        self.0.blocking_write().metadata.properties_mut().insert(key, value);
+        self.0.try_write()?.metadata.properties_mut().insert(key, value);
       }
       None => {
-        self.0.blocking_write().metadata.properties_mut().remove(&key);
+        self.0.try_write()?.metadata.properties_mut().remove(&key);
       }
     }
     Ok(())
@@ -553,7 +566,7 @@ impl WasmIotaDocument {
 
     self
       .0
-      .blocking_write()
+      .try_write()?
       .revoke_credentials(&query, indices.as_slice())
       .wasm_result()
   }
@@ -568,7 +581,7 @@ impl WasmIotaDocument {
 
     self
       .0
-      .blocking_write()
+      .try_write()?
       .unrevoke_credentials(&query, indices.as_slice())
       .wasm_result()
   }
@@ -579,8 +592,10 @@ impl WasmIotaDocument {
 
   #[wasm_bindgen(js_name = clone)]
   /// Returns a deep clone of the {@link IotaDocument}.
-  pub fn deep_clone(&self) -> WasmIotaDocument {
-    WasmIotaDocument(Rc::new(IotaDocumentLock::new(self.0.blocking_read().clone())))
+  pub fn deep_clone(&self) -> Result<WasmIotaDocument> {
+    Ok(WasmIotaDocument(Rc::new(IotaDocumentLock::new(
+      self.0.try_read()?.clone(),
+    ))))
   }
 
   /// ### Warning
@@ -604,7 +619,7 @@ impl WasmIotaDocument {
   /// Serializes to a plain JS representation.
   #[wasm_bindgen(js_name = toJSON)]
   pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0.blocking_read().as_ref()).wasm_result()
+    JsValue::from_serde(&self.0.try_read()?.as_ref()).wasm_result()
   }
 
   /// Deserializes an instance from a plain JS representation.
@@ -621,10 +636,10 @@ impl WasmIotaDocument {
   // ===========================================================================
   /// Transforms the {@link IotaDocument} to its {@link CoreDocument} representation.
   #[wasm_bindgen(js_name = toCoreDocument)]
-  pub fn as_core_document(&self) -> WasmCoreDocument {
-    WasmCoreDocument(Rc::new(CoreDocumentLock::new(
-      self.0.blocking_read().core_document().clone(),
-    )))
+  pub fn as_core_document(&self) -> Result<WasmCoreDocument> {
+    Ok(WasmCoreDocument(Rc::new(CoreDocumentLock::new(
+      self.0.try_read()?.core_document().clone(),
+    ))))
   }
 
   // ===========================================================================

--- a/bindings/wasm/tests/storage.ts
+++ b/bindings/wasm/tests/storage.ts
@@ -473,7 +473,7 @@ describe("#OptionParsing", function() {
         });
 });
 
-describe("#documents throw error on concurrent access", async function() {
+describe("#Documents throw error on concurrent synchronous access", async function() {
     const wait: any = (ms: any) => new Promise(r => setTimeout(r, ms));
 
     class MyJwkStore extends JwkMemStore {
@@ -501,11 +501,14 @@ describe("#documents throw error on concurrent access", async function() {
             return document.id();
         });
 
+        let resolvedToError = false;
         try {
             await Promise.all([insertPromise, idPromise]);
         } catch (e: any) {
+            resolvedToError = true;
             assert.equal(e.name, "TryLockError");
         }
+        assert.ok(resolvedToError, "Promise.all did not throw an error");
     });
 
     it("IotaDocument", async () => {
@@ -522,11 +525,13 @@ describe("#documents throw error on concurrent access", async function() {
         const idPromise = wait(10).then((_value: any) => {
             return document.id();
         });
-
+        let resolvedToError = false;
         try {
             await Promise.all([insertPromise, idPromise]);
         } catch (e: any) {
+            resolvedToError = true;
             assert.equal(e.name, "TryLockError");
         }
+        assert.ok(resolvedToError, "Promise.all did not throw an error");
     });
 });


### PR DESCRIPTION
# Description of change

fixes #https://github.com/iotaledger/identity.rs/issues/1150

This PR change the methods requiring read/write to be fallible if the lock is acquired to prevent uncontrolled crashes, since blocking is not supported for `RwLock` in wasm. 