### PR TITLE
Replace private tangle links

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To try out the [examples](https://github.com/iotaledger/identity.rs/blob/HEAD/ex
 ## Example: Creating an Identity
 
 The following code creates and publishes a new IOTA DID Document to a locally running private network.
-See the [instructions](https://wiki.iota.org/hornet/develop/how_tos/private_tangle) on running your own private network.
+See the [instructions](https://github.com/iotaledger/hornet/tree/develop/private_tangle) on running your own private network.
 
 _Cargo.toml_
 

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -49,7 +49,7 @@ The minimum supported version for node is: `v16`
 ## NodeJS Usage
 
 The following code creates a new IOTA DID Document suitable for publishing to a locally running private network.
-See the [instructions](https://wiki.iota.org/hornet/develop/how_tos/private_tangle) on running your own private network.
+See the [instructions](https://github.com/iotaledger/hornet/tree/develop/private_tangle) on running your own private network.
 
 <!--
 Test this example using https://github.com/anko/txm: `txm README.md`

--- a/examples/0_basic/0_create_did.rs
+++ b/examples/0_basic/0_create_did.rs
@@ -26,7 +26,7 @@ use iota_sdk::types::block::output::AliasOutput;
 /// to run on any IOTA node by setting the network and faucet endpoints.
 ///
 /// See the following instructions on running your own private network
-/// https://wiki.iota.org/hornet/develop/how_tos/private_tangle
+/// https://github.com/iotaledger/hornet/tree/develop/private_tangle
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
   // The API endpoint of an IOTA node, e.g. Hornet.

--- a/identity_iota/README.md
+++ b/identity_iota/README.md
@@ -63,7 +63,7 @@ To try out the [examples](https://github.com/iotaledger/identity.rs/blob/HEAD/ex
 ## Example: Creating an Identity
 
 The following code creates and publishes a new IOTA DID Document to a locally running private network.
-See the [instructions](https://wiki.iota.org/hornet/develop/how_tos/private_tangle) on running your own private network.
+See the [instructions](https://github.com/iotaledger/hornet/tree/develop/private_tangle) on running your own private network.
 
 _Cargo.toml_
 


### PR DESCRIPTION
# Description of change
Replace Wiki links with direct GitHub links to the private tangle setup. 

## Links to any relevant issues
https://github.com/iotaledger/iota-wiki/pull/1281

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation Fix

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
