### PR TITLE
Fix RevocationBitmap2022 encoding bug

### DIFF
--- a/identity_credential/Cargo.toml
+++ b/identity_credential/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 description = "An implementation of the Verifiable Credentials standard."
 
 [dependencies]
-dataurl = { version = "0.1.2", default-features = false, optional = true }
+data-url = { version = "0.3.1", optional = true }
 flate2 = { version = "1.0.28", default-features = false, features = ["rust_backend"], optional = true }
 futures = { version = "0.3", default-features = false, optional = true }
 identity_core = { version = "=1.1.0-alpha.1", path = "../identity_core", default-features = false }
@@ -50,7 +50,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["revocation-bitmap", "validator", "credential", "presentation", "domain-linkage-fetch", "sd-jwt"]
 credential = []
 presentation = ["credential"]
-revocation-bitmap = ["dep:dataurl", "dep:flate2", "dep:roaring"]
+revocation-bitmap = ["dep:data-url", "dep:flate2", "dep:roaring"]
 status-list-2021 = ["revocation-bitmap", "dep:serde-aux"]
 validator = ["dep:itertools", "dep:serde_repr", "credential", "presentation"]
 domain-linkage = ["validator"]

--- a/identity_credential/Cargo.toml
+++ b/identity_credential/Cargo.toml
@@ -12,7 +12,6 @@ rust-version.workspace = true
 description = "An implementation of the Verifiable Credentials standard."
 
 [dependencies]
-data-url = { version = "0.3.1", optional = true }
 flate2 = { version = "1.0.28", default-features = false, features = ["rust_backend"], optional = true }
 futures = { version = "0.3", default-features = false, optional = true }
 identity_core = { version = "=1.1.0-alpha.1", path = "../identity_core", default-features = false }
@@ -50,7 +49,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["revocation-bitmap", "validator", "credential", "presentation", "domain-linkage-fetch", "sd-jwt"]
 credential = []
 presentation = ["credential"]
-revocation-bitmap = ["dep:data-url", "dep:flate2", "dep:roaring"]
+revocation-bitmap = ["dep:flate2", "dep:roaring"]
 status-list-2021 = ["revocation-bitmap", "dep:serde-aux"]
 validator = ["dep:itertools", "dep:serde_repr", "credential", "presentation"]
 domain-linkage = ["validator"]


### PR DESCRIPTION
# Description of change
Fixes an encoding error in `RevocationBitmap2022`.

## Links to any relevant issues
Fixes issue #1291.
Our implementation of `RevocationBitmap2022` had a bug in the code that takes care of encoding the bitmap into a credential service URL. This bug caused a double base64 encoding for the binary list which this PR fixes.
All revocation bitmaps encoded as credential's services before this PR will still be properly decoded and any update on them will fix their encoding.

## Type of change
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Added unit tests for both encoding and decoding functions.

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
