### PR TITLE
Support for %-encoded characters in did_url

### DIFF
--- a/identity_did/Cargo.toml
+++ b/identity_did/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 description = "Agnostic implementation of the Decentralized Identifiers (DID) standard."
 
 [dependencies]
-did_url = { version = "0.1", default-features = false, features = ["std", "serde"] }
+did_url = { git = "https://github.com/iotaledger/did_url.git", features = ["std", "serde"] }
 form_urlencoded = { version = "1.2.0", default-features = false, features = ["alloc"] }
 identity_core = { version = "=1.1.0", path = "../identity_core" }
 serde.workspace = true

--- a/identity_document/Cargo.toml
+++ b/identity_document/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 description = "Method-agnostic implementation of the Decentralized Identifiers (DID) standard."
 
 [dependencies]
-did_url = { version = "0.1", default-features = false, features = ["std", "serde"] }
+did_url = { git = "https://github.com/iotaledger/did_url.git", features = ["std", "serde"] }
 identity_core = { version = "=1.1.0", path = "../identity_core" }
 identity_did = { version = "=1.1.0", path = "../identity_did" }
 identity_verification = { version = "=1.1.0", path = "../identity_verification", default-features = false }


### PR DESCRIPTION
# Description of change
The `did_url` crate doesn't support `%`-encoded characters. We add this functionality through our [fork](https://github.com/iotaledger/did_url).

## Links to any relevant issues
Fixes issue #1299.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Ran all tests and examples to assure they still work.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
