### PR TITLE
Fix compilation error caused by the `roaring` crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-identity_iota = {version = "1.1.0", features = ["memstore"]}
+identity_iota = { version = "1.1.0", features = ["memstore"] }
 iota-sdk = { version = "1.0.2", default-features = true, features = ["tls", "client", "stronghold"] }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1.0.62"

--- a/identity_credential/Cargo.toml
+++ b/identity_credential/Cargo.toml
@@ -22,7 +22,7 @@ indexmap = { version = "2.0", default-features = false, features = ["std", "serd
 itertools = { version = "0.11", default-features = false, features = ["use_std"], optional = true }
 once_cell = { version = "1.18", default-features = false, features = ["std"] }
 reqwest = { version = "0.11", default-features = false, features = ["default-tls", "json", "stream"], optional = true }
-roaring = { version = "0.10", default-features = false, optional = true }
+roaring = { version = "0.10", default-features = false, features = ["std"], optional = true }
 sd-jwt-payload = { version = "0.2.0", default-features = false, features = ["sha"], optional = true }
 serde.workspace = true
 serde-aux = { version = "4.3.1", default-features = false, optional = true }


### PR DESCRIPTION
The `roaring` crate feature gates some functions we use. Add the missing feature to fix compilation. 