### PR TITLE
Add `get_public_key` for `StrongholdStorage`

### DIFF
--- a/identity_stronghold/src/stronghold_jwk_storage.rs
+++ b/identity_stronghold/src/stronghold_jwk_storage.rs
@@ -66,6 +66,7 @@ impl StrongholdStorage {
     }
   }
 
+  /// Retrieve the public key corresponding to `key_id`.
   pub async fn get_public_key(&self, key_id: &KeyId) -> KeyStorageResult<Jwk> {
     let stronghold = self.get_stronghold().await;
     let client = get_client(&stronghold)?;

--- a/identity_stronghold/src/stronghold_jwk_storage.rs
+++ b/identity_stronghold/src/stronghold_jwk_storage.rs
@@ -62,7 +62,7 @@ impl StrongholdStorage {
   pub(crate) async fn get_stronghold(&self) -> MutexGuard<'_, Stronghold> {
     match *self.0 {
       SecretManager::Stronghold(ref stronghold) => stronghold.inner().await,
-      _ => unreachable!("secret manager can be only constrcuted from stronghold"),
+      _ => unreachable!("secret manager can be only constructed from stronghold"),
     }
   }
 

--- a/identity_stronghold/src/stronghold_jwk_storage.rs
+++ b/identity_stronghold/src/stronghold_jwk_storage.rs
@@ -65,6 +65,36 @@ impl StrongholdStorage {
       _ => unreachable!("secret manager can be only constrcuted from stronghold"),
     }
   }
+
+  pub async fn get_public_key(&self, key_id: &KeyId) -> KeyStorageResult<Jwk> {
+    let stronghold = self.get_stronghold().await;
+    let client = get_client(&stronghold)?;
+
+    let location = Location::generic(
+      IDENTITY_VAULT_PATH.as_bytes().to_vec(),
+      key_id.to_string().as_bytes().to_vec(),
+    );
+
+    let public_key_procedure = iota_stronghold::procedures::PublicKey {
+      ty: ProceduresKeyType::Ed25519,
+      private_key: location,
+    };
+
+    let procedure_result = client
+      .execute_procedure(StrongholdProcedure::PublicKey(public_key_procedure))
+      .map_err(|err| KeyStorageError::new(KeyStorageErrorKind::KeyNotFound).with_source(err))?;
+
+    let public_key: Vec<u8> = procedure_result.into();
+
+    let mut params = JwkParamsOkp::new();
+    params.x = jwu::encode_b64(public_key);
+    params.crv = EdCurve::Ed25519.name().to_owned();
+    let mut jwk: Jwk = Jwk::from_params(params);
+    jwk.set_alg(JwsAlgorithm::EdDSA.name());
+    jwk.set_kid(jwk.thumbprint_sha256_b64());
+
+    Ok(jwk)
+  }
 }
 
 #[cfg_attr(not(feature = "send-sync-storage"), async_trait(?Send))]

--- a/identity_stronghold/src/tests/test_jwk_storage.rs
+++ b/identity_stronghold/src/tests/test_jwk_storage.rs
@@ -23,6 +23,21 @@ async fn insert() {
 }
 
 #[tokio::test]
+async fn retrieve() {
+  let stronghold_secret_manager = create_stronghold_secret_manager();
+  let stronghold_storage = StrongholdStorage::new(stronghold_secret_manager);
+
+  let generate = stronghold_storage
+    .generate(KeyType::new("Ed25519"), JwsAlgorithm::EdDSA)
+    .await
+    .unwrap();
+  let key_id = &generate.key_id;
+
+  let pub_key: Jwk = stronghold_storage.get_public_key(key_id).await.unwrap();
+  assert_eq!(generate.jwk, pub_key);
+}
+
+#[tokio::test]
 async fn incompatible_key_alg() {
   let stronghold_secret_manager = create_stronghold_secret_manager();
   let stronghold_storage = StrongholdStorage::new(stronghold_secret_manager);

--- a/identity_stronghold/src/tests/test_jwk_storage.rs
+++ b/identity_stronghold/src/tests/test_jwk_storage.rs
@@ -68,6 +68,7 @@ async fn key_exists() {
 // Tests the cases that require persisting to disk, generate, insert and delete.
 #[tokio::test]
 async fn write_to_disk() {
+  iota_stronghold::engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
   const PASS: &str = "secure_password";
   let file: PathBuf = create_temp_file();
   let secret_manager = StrongholdSecretManager::builder()


### PR DESCRIPTION
Retrieve public keys from `StrongholdStorage` by `KeyId`.

closes https://github.com/iotaledger/identity.rs/issues/1302

This function can't be added to the trait since that would be a breaking change and it doesn't seem necessary to force other implementations to add this function.