### PR TITLE
Chore: allow large result err variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ homepage = "https://www.iota.org"
 license = "Apache-2.0"
 repository = "https://github.com/iotaledger/identity.rs"
 rust-version = "1.65"
+
+[workspace.lints.clippy]
+result_large_err = "allow"

--- a/identity_core/Cargo.toml
+++ b/identity_core/Cargo.toml
@@ -35,3 +35,6 @@ quickcheck_macros = { version = "1.0" }
 # RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --workspace --open
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/identity_credential/Cargo.toml
+++ b/identity_credential/Cargo.toml
@@ -55,3 +55,6 @@ validator = ["dep:itertools", "dep:serde_repr", "credential", "presentation"]
 domain-linkage = ["validator"]
 domain-linkage-fetch = ["domain-linkage", "dep:reqwest", "dep:futures"]
 sd-jwt = ["credential", "validator", "sd-jwt-payload"]
+
+[lints]
+workspace = true

--- a/identity_did/Cargo.toml
+++ b/identity_did/Cargo.toml
@@ -27,3 +27,6 @@ serde_json.workspace = true
 # RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --workspace --open
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/identity_document/Cargo.toml
+++ b/identity_document/Cargo.toml
@@ -28,3 +28,6 @@ serde_json.workspace = true
 [[bench]]
 name = "deserialize_document"
 harness = false
+
+[lints]
+workspace = true

--- a/identity_eddsa_verifier/Cargo.toml
+++ b/identity_eddsa_verifier/Cargo.toml
@@ -18,3 +18,6 @@ iota-crypto = { version = "0.23", default-features = false, features = ["std"] }
 [features]
 ed25519 = ["iota-crypto/ed25519"]
 default = ["ed25519"]
+
+[lints]
+workspace = true

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -69,3 +69,6 @@ sd-jwt = ["identity_credential/sd-jwt"]
 # RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --workspace --open
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/identity_iota_core/Cargo.toml
+++ b/identity_iota_core/Cargo.toml
@@ -53,3 +53,6 @@ revocation-bitmap = ["identity_credential/revocation-bitmap"]
 send-sync-client-ext = []
 # Disables the blanket implementation of `IotaIdentityClientExt`.
 test = ["client"]
+
+[lints]
+workspace = true

--- a/identity_jose/Cargo.toml
+++ b/identity_jose/Cargo.toml
@@ -29,3 +29,6 @@ signature = { version = "2", default-features = false }
 [[example]]
 name = "jws_encoding_decoding"
 test = true
+
+[lints]
+workspace = true

--- a/identity_resolver/Cargo.toml
+++ b/identity_resolver/Cargo.toml
@@ -40,3 +40,6 @@ default = ["revocation-bitmap", "iota"]
 revocation-bitmap = ["identity_credential/revocation-bitmap", "identity_iota_core?/revocation-bitmap"]
 # Enables the IOTA integration for the resolver.
 iota = ["dep:identity_iota_core"]
+
+[lints]
+workspace = true

--- a/identity_storage/Cargo.toml
+++ b/identity_storage/Cargo.toml
@@ -42,3 +42,6 @@ memstore = ["dep:tokio", "dep:rand", "dep:iota-crypto"]
 send-sync-storage = []
 # Implements the JwkStorageDocumentExt trait for IotaDocument
 iota-document = ["dep:identity_iota_core"]
+
+[lints]
+workspace = true

--- a/identity_stronghold/Cargo.toml
+++ b/identity_stronghold/Cargo.toml
@@ -30,3 +30,6 @@ tokio = { version = "1.29.0", default-features = false, features = ["macros", "s
 default = []
 # Enables `Send` + `Sync` bounds for the trait implementations on `StrongholdStorage`.
 send-sync-storage = ["identity_storage/send-sync-storage"]
+
+[lints]
+workspace = true

--- a/identity_verification/Cargo.toml
+++ b/identity_verification/Cargo.toml
@@ -18,3 +18,6 @@ strum.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+
+[lints]
+workspace = true


### PR DESCRIPTION
# Description of change
Disable a clippy's `result_large_err` lints.