### PR TITLE
chore(cargo): inherit `repository` in identity_verification

### DIFF
--- a/identity_verification/Cargo.toml
+++ b/identity_verification/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+repository.workspace = true
 rust-version.workspace = true
 description = "Verification data types and functionality for identity.rs"
 


### PR DESCRIPTION
# Description of change
Inherit [repository](https://rust-digger.code-maven.com/about-repository) key for correctly labeling/pointing to the GitHub repo.

This makes location of the source code easier to see Crates.io. 🙂

This change only affects `identity_verification` crate. All other modules already correctly inherit repository.

## Links to any relevant issues
*None*

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Fix

## How the change has been tested
*None*

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
