### PR TITLE
Support for specification-compliant verification method type `JsonWebKey2020`

### DIFF
--- a/bindings/wasm/src/verification/wasm_method_type.rs
+++ b/bindings/wasm/src/verification/wasm_method_type.rs
@@ -20,11 +20,17 @@ impl WasmMethodType {
     WasmMethodType(MethodType::X25519_KEY_AGREEMENT_KEY_2019)
   }
 
-  /// A verification method for use with JWT verification as prescribed by the {@link Jwk}
-  /// in the `publicKeyJwk` entry.
-  #[wasm_bindgen(js_name = JsonWebKey)]
+  /// @deprecated Use {@link JsonWebKey2020} instead.
+  #[wasm_bindgen(js_name = JsonWebKey, skip_jsdoc)]
   pub fn json_web_key() -> WasmMethodType {
     WasmMethodType(MethodType::JSON_WEB_KEY)
+  }
+
+  /// A verification method for use with JWT verification as prescribed by the {@link Jwk}
+  /// in the `publicKeyJwk` entry.
+  #[wasm_bindgen(js_name = JsonWebKey2020)]
+  pub fn json_web_key_2020() -> WasmMethodType {
+    WasmMethodType(MethodType::JSON_WEB_KEY_2020)
   }
 
   /// A custom method.

--- a/bindings/wasm/tests/core.ts
+++ b/bindings/wasm/tests/core.ts
@@ -225,7 +225,7 @@ describe("CoreDocument", function() {
             // Resolve.
             const resolved = doc.resolveMethod(fragment, scope)!;
             assert.deepStrictEqual(resolved.id().fragment(), fragment);
-            assert.deepStrictEqual(resolved.type().toString(), MethodType.JsonWebKey().toString());
+            assert.deepStrictEqual(resolved.type().toString(), MethodType.JsonWebKey2020().toString());
             assert.deepStrictEqual(resolved.controller().toString(), doc.id().toString());
             assert.deepStrictEqual(resolved.data().tryPublicKeyJwk().toJSON(), JWK.toJSON());
             assert.deepStrictEqual(resolved.toJSON(), method.toJSON());

--- a/bindings/wasm/tests/iota.ts
+++ b/bindings/wasm/tests/iota.ts
@@ -100,7 +100,7 @@ describe("IotaDocument", function() {
             // Resolve.
             const resolved = doc.resolveMethod(fragment, scope)!;
             assert.deepStrictEqual(resolved.id().fragment(), fragment);
-            assert.deepStrictEqual(resolved.type().toString(), MethodType.JsonWebKey().toString());
+            assert.deepStrictEqual(resolved.type().toString(), MethodType.JsonWebKey2020().toString());
             assert.deepStrictEqual(resolved.controller().toString(), doc.id().toString());
             assert.deepStrictEqual(resolved.data().tryPublicKeyJwk().toJSON(), JWK.toJSON());
             assert.deepStrictEqual(resolved.toJSON(), method.toJSON());

--- a/identity_verification/src/verification_method/method.rs
+++ b/identity_verification/src/verification_method/method.rs
@@ -220,7 +220,7 @@ impl VerificationMethod {
     MethodBuilder::default()
       .id(id)
       .controller(did.into())
-      .type_(MethodType::JSON_WEB_KEY)
+      .type_(MethodType::JSON_WEB_KEY_2020)
       .data(MethodData::PublicKeyJwk(key))
       .build()
   }

--- a/identity_verification/src/verification_method/method_type.rs
+++ b/identity_verification/src/verification_method/method_type.rs
@@ -12,6 +12,7 @@ use crate::error::Result;
 const ED25519_VERIFICATION_KEY_2018_STR: &str = "Ed25519VerificationKey2018";
 const X25519_KEY_AGREEMENT_KEY_2019_STR: &str = "X25519KeyAgreementKey2019";
 const JSON_WEB_KEY_METHOD_TYPE: &str = "JsonWebKey";
+const JSON_WEB_KEY_2020_STR: &str = "JsonWebKey2020";
 
 /// verification method types.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
@@ -24,7 +25,11 @@ impl MethodType {
   pub const X25519_KEY_AGREEMENT_KEY_2019: Self = Self(Cow::Borrowed(X25519_KEY_AGREEMENT_KEY_2019_STR));
   /// A verification method for use with JWT verification as prescribed by the [`Jwk`](::identity_jose::jwk::Jwk)
   /// in the [`publicKeyJwk`](crate::MethodData::PublicKeyJwk) entry.
+  #[deprecated(since = "1.3.0", note = "use JSON_WEB_KEY_2020 instead")]
   pub const JSON_WEB_KEY: Self = Self(Cow::Borrowed(JSON_WEB_KEY_METHOD_TYPE));
+  /// A verification method for use with JWT verification as prescribed by the [`Jwk`](::identity_jose::jwk::Jwk)
+  /// in the [`publicKeyJwk`](crate::MethodData::PublicKeyJwk) entry.
+  pub const JSON_WEB_KEY_2020: Self = Self(Cow::Borrowed(JSON_WEB_KEY_2020_STR));
   /// Construct a custom method type.
   pub fn custom(type_: impl AsRef<str>) -> Self {
     Self(Cow::Owned(type_.as_ref().to_owned()))
@@ -57,7 +62,11 @@ impl FromStr for MethodType {
     match string {
       ED25519_VERIFICATION_KEY_2018_STR => Ok(Self::ED25519_VERIFICATION_KEY_2018),
       X25519_KEY_AGREEMENT_KEY_2019_STR => Ok(Self::X25519_KEY_AGREEMENT_KEY_2019),
-      JSON_WEB_KEY_METHOD_TYPE => Ok(Self::JSON_WEB_KEY),
+      JSON_WEB_KEY_METHOD_TYPE => Ok(
+        #[allow(deprecated)]
+        Self::JSON_WEB_KEY,
+      ),
+      JSON_WEB_KEY_2020_STR => Ok(Self::JSON_WEB_KEY_2020),
       _ => Ok(Self(Cow::Owned(string.to_owned()))),
     }
   }
@@ -74,6 +83,7 @@ mod tests {
     for method_type in [
       MethodType::ED25519_VERIFICATION_KEY_2018,
       MethodType::X25519_KEY_AGREEMENT_KEY_2019,
+      MethodType::JSON_WEB_KEY_2020,
     ] {
       let ser: Value = serde_json::to_value(method_type.clone()).unwrap();
       assert_eq!(ser.as_str().unwrap(), method_type.as_str());


### PR DESCRIPTION
# Description of change
Support for JWK-based verification has long been added to the library but under a non-standardized type - i.e. `JsonWebKey`. This PR solves this issue by making the already implemented method spec-compliant by changing the method's type to `JsonWebKey2020` and deprecating the previous type.

## Links to any relevant issues
Closes #1366

## Type of change
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Ran linter and all tests.

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
