### PR TITLE
Make base64 encoding target independent in `KeyIdMemStore` in wasm bindings

### DIFF
--- a/bindings/wasm/lib/key_id_storage.ts
+++ b/bindings/wasm/lib/key_id_storage.ts
@@ -1,4 +1,4 @@
-import {encode as base64Encode} from 'base64-arraybuffer';
+import { encode as base64Encode } from 'base64-arraybuffer';
 import type { KeyIdStorage, MethodDigest } from "~identity_wasm";
 
 export class KeyIdMemStore implements KeyIdStorage {

--- a/bindings/wasm/lib/key_id_storage.ts
+++ b/bindings/wasm/lib/key_id_storage.ts
@@ -1,3 +1,4 @@
+import {encode as base64Encode} from 'base64-arraybuffer';
 import type { KeyIdStorage, MethodDigest } from "~identity_wasm";
 
 export class KeyIdMemStore implements KeyIdStorage {
@@ -48,6 +49,5 @@ export class KeyIdMemStore implements KeyIdStorage {
  */
 function methodDigestToString(methodDigest: MethodDigest): string {
     let arrayBuffer = methodDigest.pack().buffer;
-    let buffer = Buffer.from(arrayBuffer);
-    return buffer.toString("base64");
+    return base64Encode(arrayBuffer);
 }

--- a/bindings/wasm/lib/key_id_storage.ts
+++ b/bindings/wasm/lib/key_id_storage.ts
@@ -1,4 +1,4 @@
-import { encode as base64Encode } from 'base64-arraybuffer';
+import { encode as base64Encode } from "base64-arraybuffer";
 import type { KeyIdStorage, MethodDigest } from "~identity_wasm";
 
 export class KeyIdMemStore implements KeyIdStorage {

--- a/bindings/wasm/package-lock.json
+++ b/bindings/wasm/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@noble/ed25519": "^1.7.3",
         "@types/node-fetch": "^2.6.2",
+        "base64-arraybuffer": "^1.0.2",
         "node-fetch": "^2.6.7"
       },
       "devDependencies": {
@@ -1115,6 +1116,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -7720,6 +7729,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="
     },
     "base64-js": {
       "version": "1.5.1",

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -75,6 +75,7 @@
   "dependencies": {
     "@noble/ed25519": "^1.7.3",
     "@types/node-fetch": "^2.6.2",
+    "base64-arraybuffer": "^1.0.2",
     "node-fetch": "^2.6.7"
   },
   "peerDependencies": {

--- a/identity_storage/src/key_id_storage/key_id_storage_error.rs
+++ b/identity_storage/src/key_id_storage/key_id_storage_error.rs
@@ -52,7 +52,7 @@ impl KeyIdStorageErrorKind {
       Self::KeyIdNotFound => "key id not found in storage",
       Self::Unavailable => "key id storage unavailable",
       Self::Unauthenticated => "authentication with the key id storage failed",
-      Self::Unspecified => "key storage operation failed",
+      Self::Unspecified => "key id storage operation failed",
       Self::RetryableIOFailure => "key id storage was unsuccessful because of an I/O failure",
       Self::SerializationError => "(de)serialization error",
     }

--- a/identity_storage/src/storage/error.rs
+++ b/identity_storage/src/storage/error.rs
@@ -13,7 +13,7 @@ pub enum JwkStorageDocumentError {
   #[error("storage operation failed: key storage error")]
   KeyStorageError(KeyStorageError),
   /// Caused by a failure in the key id storage.
-  #[error("storage operation failed: key id storage error")]
+  #[error("storage operation failed: key id storage error: {0}")]
   KeyIdStorageError(KeyIdStorageError),
   /// Caused by an attempt to add a method with a fragment that already exists.
   #[error("could not add method: the fragment already exists")]


### PR DESCRIPTION
# Description of change
Makes base64 encoding in `KeyIdMemStore`, `methodDigestToString` work for node and web targets. By using new dependency `base64-arraybuffer`.

Also adds smaller improvements for storage related errors.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tested in browser and against local wasm tests.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
