### PR TITLE
Reenable legacy Firefox CDP support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -253,7 +253,7 @@ jobs:
           load: true
 
       - name: Run cypress
-        run: docker run --network host cypress-test test:browser:firefox
+        run: docker run --network host cypress-test test:browser:parallel:firefox
 
       - name: Tear down iota sandbox
         if: always()

--- a/bindings/wasm/cypress.config.ts
+++ b/bindings/wasm/cypress.config.ts
@@ -10,14 +10,17 @@ export default defineConfig({
     },
     e2e: {
         supportFile: false,
-        // Fix to make subtle crypto work in cypress firefox
-        // https://github.com/cypress-io/cypress/issues/18217
         setupNodeEvents(on, config) {
             on("before:browser:launch", (browser, launchOptions) => {
                 if (browser.family === "firefox") {
+                    // Fix to make subtle crypto work in cypress firefox
+                    // https://github.com/cypress-io/cypress/issues/18217
                     launchOptions.preferences[
                         "network.proxy.testing_localhost_is_secure_when_hijacked"
                     ] = true;
+                    // Temporary fix to allow cypress to control Firefox via CDP
+                    // https://github.com/cypress-io/cypress/issues/29713
+                    // https://fxdx.dev/deprecating-cdp-support-in-firefox-embracing-the-future-with-webdriver-bidi/
                     launchOptions.preferences[
                         "remote.active-protocols"
                     ] = 3;

--- a/bindings/wasm/cypress.config.ts
+++ b/bindings/wasm/cypress.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
                     launchOptions.preferences[
                         "network.proxy.testing_localhost_is_secure_when_hijacked"
                     ] = true;
+                    launchOptions.preferences[
+                        "remote.active-protocols"
+                    ] = 3;
                 }
                 return launchOptions;
             });


### PR DESCRIPTION
# Description of change
Reenable Firefox CDP to allow cypress control

## Links to any relevant issues
- https://github.com/cypress-io/cypress/issues/29713
- https://github.com/cypress-io/cypress/issues/29714

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
CI passing

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
