### PR TITLE
Mark `js-sys` as optional for identity_core

### DIFF
--- a/identity_core/Cargo.toml
+++ b/identity_core/Cargo.toml
@@ -21,8 +21,8 @@ time = { version = "0.3.23", default-features = false, features = ["std", "serde
 url = { version = "2.4", default-features = false, features = ["serde"] }
 zeroize = { version = "1.6", default-features = false }
 
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(feature = "custom_time")))'.dependencies]
-js-sys = { version = "0.3.55", default-features = false }
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
+js-sys = { version = "0.3.55", default-features = false, optional = true }
 
 [dev-dependencies]
 proptest = { version = "1.0.0" }


### PR DESCRIPTION
# Description of change
In #1397 my intention was to make the `js-sys` dependency mutually exclusive with the feature `custom_time`. As it turns out, it's not that simple and mixing target specific dependencies with feature specific dependencies does not actually work. See [here](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies) and [here](https://doc.rust-lang.org/cargo/reference/features.html#mutually-exclusive-features).

So this removes the broken feature reference in the dependency declaration and instead marks it as `optional`. Also, the feature `custom_time` takes precedence over `js-sys` so these do not actually conflict and one _could_ enable both.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Existing tests

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
