### PR TITLE
Remove dependency on `identity_core` default features

### DIFF
--- a/identity_did/Cargo.toml
+++ b/identity_did/Cargo.toml
@@ -13,7 +13,7 @@ description = "Agnostic implementation of the Decentralized Identifiers (DID) st
 [dependencies]
 did_url_parser = { version = "0.2.0", features = ["std", "serde"] }
 form_urlencoded = { version = "1.2.0", default-features = false, features = ["alloc"] }
-identity_core = { version = "=1.3.1", path = "../identity_core" }
+identity_core = { version = "=1.3.1", path = "../identity_core", default-features = false }
 serde.workspace = true
 strum.workspace = true
 thiserror.workspace = true

--- a/identity_document/Cargo.toml
+++ b/identity_document/Cargo.toml
@@ -13,7 +13,7 @@ description = "Method-agnostic implementation of the Decentralized Identifiers (
 
 [dependencies]
 did_url_parser = { version = "0.2.0", features = ["std", "serde"] }
-identity_core = { version = "=1.3.1", path = "../identity_core" }
+identity_core = { version = "=1.3.1", path = "../identity_core", default-features = false }
 identity_did = { version = "=1.3.1", path = "../identity_did" }
 identity_verification = { version = "=1.3.1", path = "../identity_verification", default-features = false }
 indexmap = { version = "2.0", default-features = false, features = ["std", "serde"] }


### PR DESCRIPTION
# Description of change
`identity_did` and `identity_document` depend on `identity_core` but do not turn off default features. This means that these crates cannot be compiled for `wasm32-unknown-unknown` without a dependency on `js-sys`.

Given the default features are not required, removing them makes these crates compatible across a wider range of compilation targets.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Existing test suite.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
