### PR TITLE
Refactor StatusList2021 to use String for credential index

### DIFF
--- a/bindings/wasm/src/credential/revocation/status_list_2021/credential.rs
+++ b/bindings/wasm/src/credential/revocation/status_list_2021/credential.rs
@@ -127,7 +127,7 @@ impl WasmStatusList2021Credential {
   pub fn set_credential_status(
     &mut self,
     credential: &mut WasmCredential,
-    index: &str,
+    index: usize,
     revoked_or_suspended: bool,
   ) -> Result<WasmStatusList2021Entry> {
     let entry = self

--- a/bindings/wasm/src/credential/revocation/status_list_2021/entry.rs
+++ b/bindings/wasm/src/credential/revocation/status_list_2021/entry.rs
@@ -21,7 +21,7 @@ impl WasmStatusList2021Entry {
   pub fn new(
     status_list: &str,
     purpose: WasmStatusPurpose,
-    index: &str,
+    index: usize,
     id: Option<String>,
   ) -> Result<WasmStatusList2021Entry> {
     let status_list = Url::parse(status_list).map_err(|e| JsError::new(&e.to_string()))?;

--- a/examples/1_advanced/8_status_list_2021.rs
+++ b/examples/1_advanced/8_status_list_2021.rs
@@ -100,7 +100,7 @@ async fn main() -> anyhow::Result<()> {
 
   // Create an unsigned `UniversityDegree` credential for Alice.
   // The issuer also chooses a unique `StatusList2021` index to be able to revoke it later.
-  let credential_index: &str = "420";
+  let credential_index: usize = 420;
   let status: Status = StatusList2021Entry::new(
     status_list_credential.id().cloned().unwrap(),
     status_list_credential.purpose(),

--- a/identity_credential/src/revocation/status_list_2021/credential.rs
+++ b/identity_credential/src/revocation/status_list_2021/credential.rs
@@ -128,17 +128,17 @@ impl StatusList2021Credential {
   pub fn set_credential_status(
     &mut self,
     credential: &mut Credential,
-    index: &str,
+    index: usize,
     revoked_or_suspended: bool,
   ) -> Result<StatusList2021Entry, StatusList2021CredentialError> {
     let id = self
       .id()
       .cloned()
       .ok_or(StatusList2021CredentialError::Unreferenceable)?;
-    let entry = StatusList2021Entry::new(id, self.purpose(), index, None);
-    let index_int = index.parse::<usize>().expect("should be integer serialized as string");
 
-    self.set_entry(index_int, revoked_or_suspended)?;
+    let entry = StatusList2021Entry::new(id, self.purpose(), index, None);
+
+    self.set_entry(index, revoked_or_suspended)?;
     credential.credential_status = Some(entry.clone().into());
 
     Ok(entry)

--- a/identity_credential/src/revocation/status_list_2021/entry.rs
+++ b/identity_credential/src/revocation/status_list_2021/entry.rs
@@ -66,7 +66,7 @@ impl From<StatusList2021Entry> for Status {
 
 impl StatusList2021Entry {
   /// Creates a new [`StatusList2021Entry`].
-  pub fn new(status_list: Url, purpose: StatusPurpose, index: impl Into<String>, id: Option<Url>) -> Self {
+  pub fn new(status_list: Url, purpose: StatusPurpose, index: usize, id: Option<Url>) -> Self {
     let id = id.unwrap_or_else(|| {
       let mut id = status_list.clone();
       id.set_fragment(None);
@@ -78,7 +78,7 @@ impl StatusList2021Entry {
       type_: CREDENTIAL_STATUS_TYPE.to_owned(),
       status_purpose: purpose,
       status_list_credential: status_list,
-      status_list_index: index.into(),
+      status_list_index: index.to_string(),
     }
   }
 
@@ -123,7 +123,7 @@ mod tests {
     let status = StatusList2021Entry::new(
       Url::parse("https://example.com/credentials/status/3").unwrap(),
       StatusPurpose::Revocation,
-      "94567",
+      94567,
       Url::parse("https://example.com/credentials/status/3#94567").ok(),
     );
     assert_eq!(status, deserialized);


### PR DESCRIPTION
# Description of change
This PR refactors the `StatusList2021` to use `String` for the credential index instead of `usize`. The internal index remains a usize to the compatibility with existing internal logic. Since we know the type is always an integer, we can parse the string to usize and use in the internal logic.

If required, I can also change the internal types to String instead of `usize`

## Links to any relevant issues
Fixes the wrong index type in the source code; Link [here](https://www.w3.org/TR/2023/WD-vc-status-list-20230427/#statuslist2021entry)

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
