### PR TITLE
Prepare public Identity interface for future wasm-bindings

### DIFF
--- a/identity_iota_core/src/rebased/assets/asset.rs
+++ b/identity_iota_core/src/rebased/assets/asset.rs
@@ -24,7 +24,6 @@ use iota_sdk::types::base_types::SequenceNumber;
 use iota_sdk::types::id::UID;
 use iota_sdk::types::object::Owner;
 use iota_sdk::types::TypeTag;
-use iota_sdk::IotaClient;
 use move_core_types::ident_str;
 use move_core_types::language_storage::StructTag;
 use secret_storage::Signer;
@@ -69,7 +68,7 @@ where
   T: DeserializeOwned,
 {
   /// Resolves an [`AuthenticatedAsset`] by its ID `id`.
-  pub async fn get_by_id(id: ObjectID, client: &IotaClient) -> Result<Self, Error> {
+  pub async fn get_by_id<S>(id: ObjectID, client: &IdentityClient<S>) -> Result<Self, Error> {
     let res = client
       .read_api()
       .get_object_with_options(id, IotaObjectDataOptions::new().with_content())
@@ -89,7 +88,7 @@ where
 }
 
 impl<T> AuthenticatedAsset<T> {
-  async fn object_ref(&self, client: &IotaClient) -> Result<ObjectRef, Error> {
+  async fn object_ref<S>(&self, client: &IdentityClient<S>) -> Result<ObjectRef, Error> {
     client
       .read_api()
       .get_object_with_options(self.id(), IotaObjectDataOptions::default())
@@ -259,7 +258,7 @@ impl MoveType for TransferProposal {
 
 impl TransferProposal {
   /// Resolves a [`TransferProposal`] by its ID `id`.
-  pub async fn get_by_id(id: ObjectID, client: &IotaClient) -> Result<Self, Error> {
+  pub async fn get_by_id<S>(id: ObjectID, client: &IdentityClient<S>) -> Result<Self, Error> {
     let res = client
       .read_api()
       .get_object_with_options(id, IotaObjectDataOptions::new().with_content())
@@ -294,7 +293,7 @@ impl TransferProposal {
       })
   }
 
-  async fn asset_metadata(&self, client: &IotaClient) -> anyhow::Result<(ObjectRef, TypeTag)> {
+  async fn asset_metadata<S>(&self, client: &IdentityClient<S>) -> anyhow::Result<(ObjectRef, TypeTag)> {
     let res = client
       .read_api()
       .get_object_with_options(self.asset_id, IotaObjectDataOptions::default().with_type())
@@ -318,7 +317,7 @@ impl TransferProposal {
     Ok((asset_ref, param_type))
   }
 
-  async fn initial_shared_version(&self, client: &IotaClient) -> anyhow::Result<SequenceNumber> {
+  async fn initial_shared_version<S>(&self, client: &IdentityClient<S>) -> anyhow::Result<SequenceNumber> {
     let owner = client
       .read_api()
       .get_object_with_options(*self.id.object_id(), IotaObjectDataOptions::default().with_owner())

--- a/identity_iota_core/src/rebased/client/full_client.rs
+++ b/identity_iota_core/src/rebased/client/full_client.rs
@@ -102,7 +102,7 @@ impl<S> Deref for IdentityClient<S> {
 
 impl<S> IdentityClient<S>
 where
-  S: Signer<IotaKeySignature>,
+  S: Signer<IotaKeySignature> + Sync,
 {
   pub async fn new(client: IdentityClientReadOnly, signer: S) -> Result<Self, Error> {
     let public_key = signer

--- a/identity_iota_core/src/rebased/error.rs
+++ b/identity_iota_core/src/rebased/error.rs
@@ -65,4 +65,7 @@ pub enum Error {
   /// An error caused by either a connection issue or an invalid RPC call.
   #[error("RPC error: {0}")]
   RpcError(String),
+  /// An error caused by a bcs serialization or deserialization.
+  #[error("BCS error: {0}")]
+  BcsError(#[from] bcs::Error),
 }


### PR DESCRIPTION
This PR introduces minor changes to prepare the public Identity interface for future wasm-bindings.

Important questions:

* All uses of ProgrammableTransaction in our public interface needs to be avoided.
  * identity_iota_core/src/rebased/transaction.rs
    * `impl Transaction for ProgrammableTransaction`
      Will be replaced with 
      `impl Transaction for ProgrammableTransactionBcs`
      **Can this cause any Problems?**
  * identity_iota_core/src/rebased/proposals/mod.rs
     * pub trait ProposalT
      `fn parse_tx_effects(tx_response: &IotaTransactionBlockResponse)`
      `IotaTransactionBlockResponse` will be replaced with `dyn IotaTransactionBlockResponseT object`
      **Can this cause any Problems?**
      If yes see below (_IotaTransactionBlockResponse_)
* As the following public usages of rust sdk types can not be avoided anymore:
  **Do we need to warn library users in the documentation?**
  Are these types/functions only used internal but can not be made `pup(crate) `?
  * ProgrammableTransactionBuilder
    * identity_iota_core/src/rebased/proposals/borrow.rs
      * BorrowActionWithIntent<F> where
        `F: FnOnce(&mut Ptb, &HashMap<ObjectID, (Argument, IotaObjectData)>)`
      * Proposal<BorrowAction>::with_intent<F> where
        `F: FnOnce(&mut Ptb, &HashMap<ObjectID, (Argument, IotaObjectData)>) + Send + 'static`
      * ExecuteBorrowTx<'i, BorrowAction>::with_intent<F> where
        `F: FnOnce(&mut Ptb, &HashMap<ObjectID, (Argument, IotaObjectData)>)`
      * impl<'i, F> Transaction for ExecuteBorrowTx<'i, BorrowActionWithIntent<F>> where
        `F: FnOnce(&mut Ptb, &HashMap<ObjectID, (Argument, IotaObjectData)>) + Send`
      * `pub(crate) IntentFn = Box<dyn FnOnce(&mut Ptb, &HashMap<ObjectID, (Argument, IotaObjectData)>) + Send>`
        `Ptb` needds to be replaced with `ProgrammableTransactionBcs`
        Effects for library users is unclear
* IotaTransactionBlockResponse
     This type will be replaced internaly with a `dyn IotaTransactionBlockResponseT` object. As the library users should not be aware of our internal type, we could use a BCS serealization here. The users would need to de-serialize the IotaTransactionBlockResponseBcs in their code. 
  * identity_iota_core/src/rebased/transaction.rs
    * TransactionOutput
        `pub response: IotaTransactionBlockResponse`

Other Questions:

* identity_iota_core::rebased::client::IdentityClient
  * Following functions will be moved into the IotaClientAdapter.
     As they are are `pub(crate)` this will not effect our library users, right?
    * pub(crate) async fn execute_transaction()
    * pub(crate) async fn default_gas_budget()
* Is this needed anymore?
  * identity_iota_core::rebased::utils - fn get_client()
* Do our users also implement these traits (could be `pub(crate)` otherwise?):
  * identity_iota_core::rebased::transaction
    * pub trait Transaction
      * Type 'Output' could be incompatible
      * FYI: Migrated in earlier version in asset::asset.rs
         No changes in Trait definition needed but implementation changed
    * pub trait ProtoTransaction
      * Type 'Input' could be incompatible
  * identity_iota_core::rebased::proposals
    * pub trait ProposalT
      * Types 'Action' and 'Output' could be incompatible
      * FYI: Migrated in earlier version in proposals::config_change.rs, 
        * Trait Return value had to be changed:
          dyn TxBuilder object instead of ProgrammableTransactionBuilder
          but this is not needed anymore
  * identity_iota_core::rebased::utils
    * pub trait MoveType
      * Default function try_to_argument() is moved to asset_move_calls.rs
      * FYI: Migrated in earlier version in proposals::config_change.rs, 

Informational:

* Constructor functions for IdentityClientReadOnly:
   There will be target compile switches for IdentityClientReadOnly constructors:
  * identity_iota_core::rebased::client::IdentityClientReadOnly
    * Existing constructors (new() and new_with_network_name()) will be renamed,
      become non public and are called by target switched new constructor functions
    * Target switches for new public constructor functions
* Our identity_iota_core/src/rebased/sui/move_calls module and all fn definitions are pub(crate).
  There are no "pub fun" in the move_calls folder, so our library users can not use
  them (there are no public re-exports through a pub use directive). 