### PR TITLE
Onchain identity controller delegation

### DIFF
--- a/identity_iota_core/packages/iota_identity/sources/asset.move
+++ b/identity_iota_core/packages/iota_identity/sources/asset.move
@@ -124,7 +124,7 @@ module iota_identity::asset {
         transfer::share_object(proposal);
     }
 
-    /// Strucure that encodes the logic required to transfer an `AuthenticatedAsset`
+    /// Structure that encodes the logic required to transfer an `AuthenticatedAsset`
     /// from one address to another. The transfer can be refused by the recipient.
     public struct TransferProposal has key {
         id: UID,

--- a/identity_iota_core/packages/iota_identity/sources/controller.move
+++ b/identity_iota_core/packages/iota_identity/sources/controller.move
@@ -1,0 +1,144 @@
+module iota_identity::controller {
+  use iota::transfer::Receiving;
+  use iota::borrow::{Self, Referent, Borrow};
+  use iota_identity::permissions;  
+
+  public use fun delete_controller_cap as ControllerCap.delete;
+  public use fun delete_delegation_token as DelegationToken.delete;
+
+  /// This `ControllerCap` cannot delegate access.
+  const ECannotDelegate: u64 = 0;
+  // The permission of the provided `DelegationToken` are not
+  // valid to perform this operation.
+  const EInvalidPermissions: u64 = 1;
+
+  /// Event that is created when a new `DelegationToken` is minted.
+  public struct NewDelegationTokenEvent has copy, drop {
+    controller: ID,
+    token: ID,
+    permissions: u32,
+  }
+
+  /// Capability that allows to access mutative APIs of a `Multicontroller`.
+  public struct ControllerCap has key {
+    id: UID,
+    can_delegate: bool,
+    access_token: Referent<DelegationToken>,
+  }
+
+  public fun id(self: &ControllerCap): &UID {
+    &self.id
+  }
+
+  /// Borrows this `ControllerCap`'s access token.
+  public fun borrow(self: &mut ControllerCap): (DelegationToken, Borrow) {
+    self.access_token.borrow()
+  }
+
+  /// Returns the borrowed access token together with the hot potato.
+  public fun put_back(self: &mut ControllerCap, token: DelegationToken, borrow: Borrow) {
+    self.access_token.put_back(token, borrow);
+  }
+
+  /// Creates a delegation token for this controller. The created `DelegationToken`
+  /// will have full permissions. Use `delegate_with_permissions` to set or unset
+  /// specific permissions.
+  public fun delegate(self: &ControllerCap, ctx: &mut TxContext): DelegationToken {
+    assert!(self.can_delegate, ECannotDelegate);
+    new_delegation_token(self.id.to_inner(), permissions::all(), ctx)
+  }
+
+  /// Creates a delegation token for this controller, specifying the delegate's permissions.
+  public fun delegate_with_permissions(self: &ControllerCap, permissions: u32, ctx: &mut TxContext): DelegationToken {
+    assert!(self.can_delegate, ECannotDelegate);
+    new_delegation_token(self.id.to_inner(), permissions, ctx)
+  }
+
+  /// A token that allows an entity to act in a Controller's stead.
+  public struct DelegationToken has key, store {
+    id: UID,
+    permissions: u32,
+    controller: ID,
+  }
+
+  /// Returns the controller's ID of this `DelegationToken`.
+  public fun controller(self: &DelegationToken): ID {
+    self.controller
+  }
+
+  /// Returns the permissions of this `DelegationToken`.
+  public fun permissions(self: &DelegationToken): u32 {
+    self.permissions
+  }
+
+  /// Returns true if this `DelegationToken` has permission `permission`.
+  public fun has_permission(self: &DelegationToken, permission: u32): bool {
+    self.permissions & permission != 0
+  }
+
+  /// Aborts if this `DelegationToken` doesn't have permission `permission`.
+  public fun assert_has_permission(self: &DelegationToken, permission: u32) {
+    assert!(self.has_permission(permission), EInvalidPermissions)
+  }
+
+  /// Creates a new `ControllerCap`.
+  public(package) fun new(can_delegate: bool, ctx: &mut TxContext): ControllerCap {
+    let id = object::new(ctx);
+    let access_token = borrow::new(new_delegation_token(id.to_inner(), permissions::all(), ctx), ctx);
+
+    ControllerCap {
+      id,
+      access_token,
+      can_delegate,
+    }
+  }
+
+  /// Transfer a `ControllerCap`.
+  public(package) fun transfer(cap: ControllerCap, recipient: address) {
+    transfer::transfer(cap, recipient)
+  }
+
+  /// Receives a `ControllerCap`.
+  public(package) fun receive(owner: &mut UID, cap: Receiving<ControllerCap>): ControllerCap {
+    transfer::receive(owner, cap)
+  }
+
+  public(package) fun new_delegation_token(
+    controller: ID,
+    permissions: u32,
+    ctx: &mut TxContext
+  ): DelegationToken {
+    let id = object::new(ctx);
+
+    iota::event::emit(NewDelegationTokenEvent {
+      controller,
+      token: id.to_inner(),
+      permissions,
+    });
+
+    DelegationToken {
+      id,
+      controller,
+      permissions,
+    }
+  }
+
+  public(package) fun delete_controller_cap(cap: ControllerCap) {
+    let ControllerCap {
+      access_token,
+      id,
+      ..
+    } = cap;
+
+    delete_delegation_token(access_token.destroy());
+    object::delete(id);
+  }
+
+  public(package) fun delete_delegation_token(token: DelegationToken) {
+    let DelegationToken {
+      id,
+      ..
+    } = token;
+    object::delete(id);
+  }
+}

--- a/identity_iota_core/packages/iota_identity/sources/permissions.move
+++ b/identity_iota_core/packages/iota_identity/sources/permissions.move
@@ -1,0 +1,20 @@
+module iota_identity::permissions {
+  /// Permission that enables a controller's delegate to create proposals.
+  const CAN_CREATE_PROPOSAL: u32 = 0x1;  
+  /// Permission that enables a controller's delegate to approve proposals.
+  const CAN_APPROVE_PROPOSAL: u32 = 0x1 << 1;
+  /// Permission that enables a controller's delegate to execute proposals.
+  const CAN_EXECUTE_PROPOSAL: u32 = 0x1 << 2;
+  /// Permission that enables a controller's delegate to delete proposals.
+  const CAN_DELETE_PROPOSAL: u32 = 0x1 << 3;
+  /// Permission that enables a controller's delegate to remove a proposal's approval.
+  const CAN_REMOVE_APPROVAL: u32 = 0x1 << 4;
+  const ALL_PERMISSIONS: u32 = 0xFFFFFFFF;
+
+  public fun can_create_proposal(): u32 { CAN_CREATE_PROPOSAL }
+  public fun can_approve_proposal(): u32 { CAN_APPROVE_PROPOSAL }
+  public fun can_execute_proposal(): u32 { CAN_EXECUTE_PROPOSAL }
+  public fun can_delete_proposal(): u32 { CAN_DELETE_PROPOSAL }
+  public fun can_remove_approval(): u32 { CAN_REMOVE_APPROVAL }
+  public fun all(): u32 { ALL_PERMISSIONS }
+}

--- a/identity_iota_core/packages/iota_identity/sources/proposals/borrow.move
+++ b/identity_iota_core/packages/iota_identity/sources/proposals/borrow.move
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module iota_identity::borrow_proposal {
-  use iota_identity::{multicontroller::{Multicontroller, Action, ControllerCap}};
+  use iota_identity::multicontroller::{Multicontroller, Action};
+  use iota_identity::controller::DelegationToken;
   use iota::transfer::Receiving;
 
   const EInvalidObject: u64 = 0;
@@ -19,7 +20,7 @@ module iota_identity::borrow_proposal {
   /// Propose the borrowing of a set of assets owned by this multicontroller.
   public fun propose_borrow<V>(
     multi: &mut Multicontroller<V>,
-    cap: &ControllerCap,
+    cap: &DelegationToken,
     expiration: Option<u64>,
     objects: vector<ID>,
     owner: address,

--- a/identity_iota_core/packages/iota_identity/sources/proposals/config.move
+++ b/identity_iota_core/packages/iota_identity/sources/proposals/config.move
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module iota_identity::config_proposal {
-    use iota_identity::multicontroller::{ControllerCap, Multicontroller};
+    use iota_identity::multicontroller::Multicontroller;
+    use iota_identity::controller::DelegationToken;
     use iota::vec_map::VecMap;
 
     const ENotMember: u64 = 0;
@@ -17,7 +18,7 @@ module iota_identity::config_proposal {
 
     public fun propose_modify<V>(
         multi: &mut Multicontroller<V>,
-        cap: &ControllerCap,
+        cap: &DelegationToken,
         expiration: Option<u64>,
         mut threshold: Option<u64>,
         controllers_to_add: VecMap<address, u64>,
@@ -87,7 +88,7 @@ module iota_identity::config_proposal {
 
     public fun execute_modify<V>(
         multi: &mut Multicontroller<V>,
-        cap: &ControllerCap,
+        cap: &DelegationToken,
         proposal_id: ID,
         ctx: &mut TxContext,
     ) {

--- a/identity_iota_core/packages/iota_identity/sources/proposals/transfer.move
+++ b/identity_iota_core/packages/iota_identity/sources/proposals/transfer.move
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module iota_identity::transfer_proposal {
-    use iota_identity::{multicontroller::{Multicontroller, Action, ControllerCap}};
+    use iota_identity::multicontroller::{Multicontroller, Action};
+    use iota_identity::controller::DelegationToken;
     use iota::transfer::Receiving;
 
     const EDifferentLength: u64 = 0;
@@ -16,7 +17,7 @@ module iota_identity::transfer_proposal {
 
     public fun propose_send<V>(
         multi: &mut Multicontroller<V>,
-        cap: &ControllerCap,
+        cap: &DelegationToken,
         expiration: Option<u64>,
         objects: vector<ID>,
         recipients: vector<address>,

--- a/identity_iota_core/packages/iota_identity/sources/proposals/value.move
+++ b/identity_iota_core/packages/iota_identity/sources/proposals/value.move
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module iota_identity::update_value_proposal {
-    use iota_identity::multicontroller::{Multicontroller, ControllerCap};
+    use iota_identity::multicontroller::Multicontroller;
+    use iota_identity::controller::DelegationToken;
 
     public struct UpdateValue<V: store> has store {
         new_value: V,
@@ -10,7 +11,7 @@ module iota_identity::update_value_proposal {
 
     public fun propose_update<V: store>(
         multi: &mut Multicontroller<V>,
-        cap: &ControllerCap,
+        cap: &DelegationToken,
         new_value: V,
         expiration: Option<u64>,
         ctx: &mut TxContext,
@@ -21,10 +22,12 @@ module iota_identity::update_value_proposal {
 
     public fun execute_update<V: store + drop>(
         multi: &mut Multicontroller<V>,
-        cap: &ControllerCap,
+        cap: &DelegationToken,
         proposal_id: ID,
         ctx: &mut TxContext,
     ) {
+
+
         let action = multi.execute_proposal(cap, proposal_id, ctx);
         let UpdateValue { new_value } = action.unpack_action();
 

--- a/identity_iota_core/src/rebased/migration/identity.rs
+++ b/identity_iota_core/src/rebased/migration/identity.rs
@@ -144,7 +144,7 @@ impl OnChainIdentity {
   }
 
   pub(crate) async fn get_controller_cap<S>(&self, client: &IdentityClient<S>) -> Result<ObjectRef, Error> {
-    let controller_cap_tag = StructTag::from_str(&format!("{}::multicontroller::ControllerCap", client.package_id()))
+    let controller_cap_tag = StructTag::from_str(&format!("{}::controller::ControllerCap", client.package_id()))
       .map_err(|e| Error::TransactionBuildingFailed(e.to_string()))?;
     client
       .find_owned_ref(controller_cap_tag, |obj_data| {
@@ -170,7 +170,7 @@ impl OnChainIdentity {
   }
 
   /// Sends assets owned by this [`OnChainIdentity`] to other addresses.
-  pub fn send_assets(&mut self) -> ProposalBuilder<SendAction> {
+  pub fn send_assets(&mut self) -> ProposalBuilder<'_, SendAction> {
     ProposalBuilder::new(self, SendAction::default())
   }
 
@@ -178,7 +178,7 @@ impl OnChainIdentity {
   /// # Notes
   /// Make sure to call [`super::Proposal::with_intent`] before executing the proposal.
   /// Failing to do so will make [`crate::proposals::ProposalT::execute`] return an error.
-  pub fn borrow_assets(&mut self) -> ProposalBuilder<BorrowAction> {
+  pub fn borrow_assets(&mut self) -> ProposalBuilder<'_, BorrowAction> {
     ProposalBuilder::new(self, BorrowAction::default())
   }
 

--- a/identity_iota_core/src/rebased/proposals/borrow.rs
+++ b/identity_iota_core/src/rebased/proposals/borrow.rs
@@ -36,8 +36,6 @@ pub(crate) type IntentFn = Box<dyn FnOnce(&mut Ptb, &HashMap<ObjectID, (Argument
 #[derive(Default, Deserialize, Serialize)]
 pub struct BorrowAction {
   objects: Vec<ObjectID>,
-  #[serde(skip)]
-  intent: Option<IntentFn>,
 }
 
 /// A [`BorrowAction`] coupled with a user-provided function to describe how
@@ -86,17 +84,6 @@ impl<'i> ProposalBuilder<'i, BorrowAction> {
     I: IntoIterator<Item = ObjectID>,
   {
     objects.into_iter().fold(self, |builder, obj| builder.borrow(obj))
-  }
-}
-
-impl Proposal<BorrowAction> {
-  /// Defines how the borrowed assets should be used.
-  pub fn with_intent<F>(mut self, intent_fn: F) -> Self
-  where
-    F: FnOnce(&mut Ptb, &HashMap<ObjectID, (Argument, IotaObjectData)>) + Send + 'static,
-  {
-    self.action.intent = Some(Box::new(intent_fn));
-    self
   }
 }
 

--- a/identity_iota_core/src/rebased/sui/move_calls/identity/create.rs
+++ b/identity_iota_core/src/rebased/sui/move_calls/identity/create.rs
@@ -67,6 +67,14 @@ where
       vec![ids, vps],
     )
   };
+  
+  let controllers_that_can_delegate = ptb.programmable_move_call(
+    IOTA_FRAMEWORK_PACKAGE_ID,
+    ident_str!("vec_map").into(),
+    ident_str!("empty").into(),
+    vec![TypeTag::Address, TypeTag::U64],
+    vec![],
+  );
   let doc_arg = ptb.pure(did_doc).map_err(|e| Error::InvalidArgument(e.to_string()))?;
   let threshold_arg = ptb.pure(threshold).map_err(|e| Error::InvalidArgument(e.to_string()))?;
   let clock = utils::get_clock_ref(&mut ptb);
@@ -77,7 +85,7 @@ where
     module: ident_str!("identity").into(),
     function: ident_str!("new_with_controllers").into(),
     type_arguments: vec![],
-    arguments: vec![doc_arg, controllers, threshold_arg, clock],
+    arguments: vec![doc_arg, controllers, controllers_that_can_delegate, threshold_arg, clock],
   })));
 
   // Share the resulting identity.

--- a/identity_iota_core/src/rebased/sui/move_calls/identity/proposal.rs
+++ b/identity_iota_core/src/rebased/sui/move_calls/identity/proposal.rs
@@ -1,12 +1,12 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::rebased::sui::move_calls::utils;
 use crate::rebased::utils::MoveType;
 use crate::rebased::Error;
 use iota_sdk::rpc_types::OwnedObjectRef;
 use iota_sdk::types::base_types::ObjectID;
 use iota_sdk::types::base_types::ObjectRef;
-use iota_sdk::types::object::Owner;
 use iota_sdk::types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use iota_sdk::types::transaction::ObjectArg;
 use iota_sdk::types::transaction::ProgrammableTransaction;
@@ -19,22 +19,12 @@ pub(crate) fn approve<T: MoveType>(
   package: ObjectID,
 ) -> Result<ProgrammableTransaction, Error> {
   let mut ptb = ProgrammableTransactionBuilder::new();
-  let Owner::Shared { initial_shared_version } = identity.owner else {
-    return Err(Error::TransactionBuildingFailed(format!(
-      "Identity \"{}\" is not a shared object",
-      identity.object_id()
-    )));
-  };
-  let identity = ptb
-    .obj(ObjectArg::SharedObject {
-      id: identity.object_id(),
-      initial_shared_version,
-      mutable: true,
-    })
-    .map_err(|e| Error::InvalidArgument(e.to_string()))?;
+  let identity = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true)
+    .map_err(|e| Error::TransactionBuildingFailed(e.to_string()))?;
   let controller_cap = ptb
     .obj(ObjectArg::ImmOrOwnedObject(controller_cap))
     .map_err(|e| Error::InvalidArgument(e.to_string()))?;
+  let (delegation_token, borrow)  = utils::get_controller_delegation(&mut ptb, controller_cap, package);
   let proposal_id = ptb
     .pure(proposal_id)
     .map_err(|e| Error::InvalidArgument(e.to_string()))?;
@@ -44,8 +34,10 @@ pub(crate) fn approve<T: MoveType>(
     ident_str!("identity").into(),
     ident_str!("approve_proposal").into(),
     vec![T::move_type(package)],
-    vec![identity, controller_cap, proposal_id],
+    vec![identity, delegation_token, proposal_id],
   );
+
+  utils::put_back_delegation_token(&mut ptb, controller_cap, delegation_token, borrow, package);
 
   Ok(ptb.finish())
 }

--- a/identity_iota_core/src/rebased/sui/move_calls/identity/send_asset.rs
+++ b/identity_iota_core/src/rebased/sui/move_calls/identity/send_asset.rs
@@ -15,6 +15,8 @@ use crate::rebased::proposals::SendAction;
 use crate::rebased::sui::move_calls;
 use crate::rebased::utils::MoveType;
 
+use self::move_calls::utils;
+
 pub(crate) fn propose_send(
   identity: OwnedObjectRef,
   capability: ObjectRef,
@@ -24,6 +26,7 @@ pub(crate) fn propose_send(
 ) -> Result<ProgrammableTransaction, anyhow::Error> {
   let mut ptb = ProgrammableTransactionBuilder::new();
   let cap_arg = ptb.obj(ObjectArg::ImmOrOwnedObject(capability))?;
+  let (delegation_token, borrow) = move_calls::utils::get_controller_delegation(&mut ptb, cap_arg, package_id);
   let identity_arg = move_calls::utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true)?;
   let exp_arg = move_calls::utils::option_to_move(expiration, &mut ptb, package_id)?;
   let (objects, recipients) = {
@@ -39,8 +42,10 @@ pub(crate) fn propose_send(
     ident_str!("identity").into(),
     ident_str!("propose_send").into(),
     vec![],
-    vec![identity_arg, cap_arg, exp_arg, objects, recipients],
+    vec![identity_arg, delegation_token, exp_arg, objects, recipients],
   );
+
+  utils::put_back_delegation_token(&mut ptb, cap_arg, delegation_token, borrow, package_id);
 
   Ok(ptb.finish())
 }
@@ -55,6 +60,7 @@ pub(crate) fn execute_send(
   let mut ptb = ProgrammableTransactionBuilder::new();
   let identity = move_calls::utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true)?;
   let controller_cap = ptb.obj(ObjectArg::ImmOrOwnedObject(capability))?;
+  let (delegation_token, borrow) = move_calls::utils::get_controller_delegation(&mut ptb, controller_cap, package);
   let proposal_id = ptb.pure(proposal_id)?;
 
   // Get the proposal's action as argument.
@@ -63,8 +69,10 @@ pub(crate) fn execute_send(
     ident_str!("identity").into(),
     ident_str!("execute_proposal").into(),
     vec![SendAction::move_type(package)],
-    vec![identity, controller_cap, proposal_id],
+    vec![identity, delegation_token, proposal_id],
   );
+
+  utils::put_back_delegation_token(&mut ptb, controller_cap, delegation_token, borrow, package);
 
   // Send each object in this send action.
   // Traversing the map in reverse reduces the number of operations on the move side.

--- a/identity_iota_core/src/rebased/sui/move_calls/utils.rs
+++ b/identity_iota_core/src/rebased/sui/move_calls/utils.rs
@@ -27,6 +27,36 @@ pub(crate) fn get_clock_ref(ptb: &mut Ptb) -> Argument {
     .expect("network has a singleton clock instantiated")
 }
 
+pub(crate) fn get_controller_delegation(ptb: &mut Ptb, controller_cap: Argument, package: ObjectID) -> (Argument, Argument) {
+  let Argument::Result(idx) = ptb.programmable_move_call(
+    package,
+    ident_str!("controller").into(),
+    ident_str!("borrow").into(),
+    vec![],
+    vec![controller_cap],
+  ) else {
+    unreachable!("making move calls always return a result variant");
+  };
+
+  (Argument::NestedResult(idx, 0), Argument::NestedResult(idx, 1))
+}
+
+pub(crate) fn put_back_delegation_token(
+  ptb: &mut Ptb,
+  controller_cap: Argument,
+  delegation_token: Argument,
+  borrow: Argument,
+  package: ObjectID,
+) {
+  ptb.programmable_move_call(
+    package,
+    ident_str!("controller").into(),
+    ident_str!("put_back").into(),
+    vec![],
+    vec![controller_cap, delegation_token, borrow]
+  );
+}
+
 pub(crate) fn owned_ref_to_shared_object_arg(
   owned_ref: OwnedObjectRef,
   ptb: &mut Ptb,

--- a/identity_iota_core/tests/e2e/identity.rs
+++ b/identity_iota_core/tests/e2e/identity.rs
@@ -158,7 +158,7 @@ async fn adding_controller_works() -> anyhow::Result<()> {
 
   let cap = bob_client
     .find_owned_ref(
-      StructTag::from_str(&format!("{}::multicontroller::ControllerCap", test_client.package_id())).unwrap(),
+      StructTag::from_str(&format!("{}::controller::ControllerCap", test_client.package_id())).unwrap(),
       |_| true,
     )
     .await?;


### PR DESCRIPTION
# Description of change
Introduces a new `store` token used for Identity's AC. When a controller is created the committee can choose whether to allow it to delegate its access through the `can_delegate` flag. If a controller can delegate its access it can mint `DelegationTokens` a blind token that can be freely traded and allows whatever entity it presents it to act in the stead of the controller that minted it.

`DelegationTokens` can be revoked and unrevoked by any controller.
 