### PR TITLE
Remove "kinesis" wording and switch back to "iota"

### DIFF
--- a/bindings/grpc/Cargo.toml
+++ b/bindings/grpc/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 anyhow = "1.0"
 futures = { version = "0.3" }
 identity_eddsa_verifier = { path = "../../identity_eddsa_verifier" }
-identity_iota = { path = "../../identity_iota", features = ["resolver", "sd-jwt", "domain-linkage", "domain-linkage-fetch", "status-list-2021", "kinesis-client"] }
+identity_iota = { path = "../../identity_iota", features = ["resolver", "sd-jwt", "domain-linkage", "domain-linkage-fetch", "status-list-2021", "iota-client"] }
 identity_jose = { path = "../../identity_jose" }
 identity_storage = { path = "../../identity_storage", features = ["memstore"] }
 identity_stronghold = { path = "../../identity_stronghold", features = ["send-sync-storage"] }

--- a/examples/0_basic/0_create_did.rs
+++ b/examples/0_basic/0_create_did.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use examples::create_kinesis_did_document;
+use examples::create_did_document;
 use examples::get_client_and_create_account;
 
 use examples::get_memstorage;
@@ -20,7 +20,7 @@ async fn main() -> anyhow::Result<()> {
   let identity_client = get_client_and_create_account(&storage).await?;
 
   // create new DID document and publish it
-  let (document, _) = create_kinesis_did_document(&identity_client, &storage).await?;
+  let (document, _) = create_did_document(&identity_client, &storage).await?;
   println!("Published DID document: {document:#}");
 
   // check if we can resolve it via client

--- a/examples/0_basic/1_update_did.rs
+++ b/examples/0_basic/1_update_did.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use examples::create_kinesis_did_document;
+use examples::create_did_document;
 use examples::get_client_and_create_account;
 use examples::get_memstorage;
 use examples::TEST_GAS_BUDGET;
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
   let storage = get_memstorage()?;
   let identity_client = get_client_and_create_account(&storage).await?;
   // create new DID document and publish it
-  let (document, vm_fragment_1) = create_kinesis_did_document(&identity_client, &storage).await?;
+  let (document, vm_fragment_1) = create_did_document(&identity_client, &storage).await?;
   let did: IotaDID = document.id().clone();
 
   // Resolve the latest state of the document.

--- a/examples/0_basic/2_resolve_did.rs
+++ b/examples/0_basic/2_resolve_did.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use examples::create_kinesis_did_document;
+use examples::create_did_document;
 use examples::get_client_and_create_account;
 
 use examples::get_memstorage;
@@ -15,7 +15,7 @@ async fn main() -> anyhow::Result<()> {
   let storage = get_memstorage()?;
   let identity_client = get_client_and_create_account(&storage).await?;
   // create new DID document and publish it
-  let (document, _) = create_kinesis_did_document(&identity_client, &storage).await?;
+  let (document, _) = create_did_document(&identity_client, &storage).await?;
 
   let did = document.id().clone();
 

--- a/examples/0_basic/3_deactivate_did.rs
+++ b/examples/0_basic/3_deactivate_did.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use examples::create_kinesis_did_document;
+use examples::create_did_document;
 use examples::get_client_and_create_account;
 use examples::get_memstorage;
 use examples::TEST_GAS_BUDGET;
@@ -16,7 +16,7 @@ async fn main() -> anyhow::Result<()> {
   let identity_client = get_client_and_create_account(&storage).await?;
 
   // create new DID document and publish it
-  let (document, _) = create_kinesis_did_document(&identity_client, &storage).await?;
+  let (document, _) = create_did_document(&identity_client, &storage).await?;
 
   println!("Published DID document: {document:#}");
 

--- a/examples/0_basic/5_create_vc.rs
+++ b/examples/0_basic/5_create_vc.rs
@@ -9,7 +9,7 @@
 //!
 //! cargo run --release --example 5_create_vc
 
-use examples::create_kinesis_did_document;
+use examples::create_did_document;
 use examples::get_client_and_create_account;
 use examples::get_memstorage;
 use identity_eddsa_verifier::EdDSAJwsVerifier;
@@ -37,12 +37,12 @@ async fn main() -> anyhow::Result<()> {
   let issuer_storage = get_memstorage()?;
   let issuer_identity_client = get_client_and_create_account(&issuer_storage).await?;
   let (issuer_document, issuer_vm_fragment) =
-    create_kinesis_did_document(&issuer_identity_client, &issuer_storage).await?;
+    create_did_document(&issuer_identity_client, &issuer_storage).await?;
 
   // create new holder account with did document
   let holder_storage = get_memstorage()?;
   let holder_identity_client = get_client_and_create_account(&holder_storage).await?;
-  let (holder_document, _) = create_kinesis_did_document(&holder_identity_client, &holder_storage).await?;
+  let (holder_document, _) = create_did_document(&holder_identity_client, &holder_storage).await?;
 
   // Create a credential subject indicating the degree earned by Alice.
   let subject: Subject = Subject::from_json_value(json!({

--- a/examples/0_basic/6_create_vp.rs
+++ b/examples/0_basic/6_create_vp.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use examples::create_kinesis_did_document;
+use examples::create_did_document;
 use examples::get_client_and_create_account;
 use examples::get_memstorage;
 use identity_eddsa_verifier::EdDSAJwsVerifier;
@@ -55,13 +55,13 @@ async fn main() -> anyhow::Result<()> {
   let issuer_storage = get_memstorage()?;
   let issuer_identity_client = get_client_and_create_account(&issuer_storage).await?;
   let (issuer_document, issuer_vm_fragment) =
-    create_kinesis_did_document(&issuer_identity_client, &issuer_storage).await?;
+    create_did_document(&issuer_identity_client, &issuer_storage).await?;
 
   // create new holder account with did document
   let holder_storage = get_memstorage()?;
   let holder_identity_client = get_client_and_create_account(&holder_storage).await?;
   let (holder_document, holder_vm_fragment) =
-    create_kinesis_did_document(&holder_identity_client, &holder_storage).await?;
+    create_did_document(&holder_identity_client, &holder_storage).await?;
 
   // create new client for verifier
   // new client actually not necessary, but shows, that client is independent from issuer and holder

--- a/examples/0_basic/7_revoke_vc.rs
+++ b/examples/0_basic/7_revoke_vc.rs
@@ -11,7 +11,7 @@
 //! cargo run --release --example 7_revoke_vc
 
 use anyhow::anyhow;
-use examples::create_kinesis_did_document;
+use examples::create_did_document;
 use examples::get_client_and_create_account;
 use examples::get_memstorage;
 use examples::TEST_GAS_BUDGET;
@@ -53,12 +53,12 @@ async fn main() -> anyhow::Result<()> {
   let issuer_storage = get_memstorage()?;
   let issuer_identity_client = get_client_and_create_account(&issuer_storage).await?;
   let (mut issuer_document, issuer_vm_fragment) =
-    create_kinesis_did_document(&issuer_identity_client, &issuer_storage).await?;
+    create_did_document(&issuer_identity_client, &issuer_storage).await?;
 
   // create new holder account with did document
   let holder_storage = get_memstorage()?;
   let holder_identity_client = get_client_and_create_account(&holder_storage).await?;
-  let (holder_document, _) = create_kinesis_did_document(&holder_identity_client, &holder_storage).await?;
+  let (holder_document, _) = create_did_document(&holder_identity_client, &holder_storage).await?;
 
   // Create a new empty revocation bitmap. No credential is revoked yet.
   let revocation_bitmap: RevocationBitmap = RevocationBitmap::new();

--- a/examples/0_basic/8_legacy_stronghold.rs
+++ b/examples/0_basic/8_legacy_stronghold.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use examples::create_kinesis_did_document;
+use examples::create_did_document;
 use examples::get_client_and_create_account;
 use examples::get_stronghold_storage;
 use examples::random_stronghold_path;
@@ -27,7 +27,7 @@ async fn main() -> anyhow::Result<()> {
   // use stronghold storage to create new client to interact with chain and get funded account with keys
   let identity_client = get_client_and_create_account(&storage).await?;
   // create and publish document with stronghold storage
-  let (document, vm_fragment) = create_kinesis_did_document(&identity_client, &storage).await?;
+  let (document, vm_fragment) = create_did_document(&identity_client, &storage).await?;
 
   // Resolve the published DID Document.
   let mut resolver = Resolver::<IotaDocument>::new();

--- a/examples/1_advanced/11_linked_verifiable_presentation.rs
+++ b/examples/1_advanced/11_linked_verifiable_presentation.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Context;
 
-use examples::create_kinesis_did_document;
+use examples::create_did_document;
 use examples::get_client_and_create_account;
 use examples::get_memstorage;
 use examples::MemStorage;
@@ -46,7 +46,7 @@ async fn main() -> anyhow::Result<()> {
   let identity_client = get_client_and_create_account(&storage).await?;
 
   // create new DID document and publish it
-  let (mut did_document, fragment) = create_kinesis_did_document(&identity_client, &storage).await?;
+  let (mut did_document, fragment) = create_did_document(&identity_client, &storage).await?;
 
   println!("Published DID document: {did_document:#}");
 

--- a/examples/1_advanced/4_identity_history.rs
+++ b/examples/1_advanced/4_identity_history.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use examples::create_kinesis_did_document;
+use examples::create_did_document;
 use examples::get_client_and_create_account;
 use examples::get_memstorage;
 use examples::TEST_GAS_BUDGET;
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
   let storage = get_memstorage()?;
   let identity_client = get_client_and_create_account(&storage).await?;
   // create new DID document and publish it
-  let (document, vm_fragment_1) = create_kinesis_did_document(&identity_client, &storage).await?;
+  let (document, vm_fragment_1) = create_did_document(&identity_client, &storage).await?;
   let did: IotaDID = document.id().clone();
 
   // Resolve the latest state of the document.

--- a/examples/1_advanced/5_custom_resolution.rs
+++ b/examples/1_advanced/5_custom_resolution.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use examples::create_kinesis_did_document;
+use examples::create_did_document;
 use examples::get_client_and_create_account;
 use examples::get_memstorage;
 use identity_iota::core::FromJson;
@@ -22,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
   let storage = get_memstorage()?;
   let identity_client = get_client_and_create_account(&storage).await?;
   // create new DID document and publish it
-  let (document, _) = create_kinesis_did_document(&identity_client, &storage).await?;
+  let (document, _) = create_did_document(&identity_client, &storage).await?;
 
   // Create a resolver returning an enum of the documents we are interested in and attach handlers for the "foo" and
   // "iota" methods.

--- a/examples/1_advanced/6_domain_linkage.rs
+++ b/examples/1_advanced/6_domain_linkage.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use examples::create_kinesis_did_document;
+use examples::create_did_document;
 use examples::get_client_and_create_account;
 use examples::get_memstorage;
 use examples::TEST_GAS_BUDGET;
@@ -36,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
   let storage = get_memstorage()?;
   let identity_client = get_client_and_create_account(&storage).await?;
   // Create a DID for the entity that will issue the Domain Linkage Credential.
-  let (mut document, vm_fragment_1) = create_kinesis_did_document(&identity_client, &storage).await?;
+  let (mut document, vm_fragment_1) = create_did_document(&identity_client, &storage).await?;
   let did: IotaDID = document.id().clone();
 
   // =====================================================

--- a/examples/1_advanced/7_sd_jwt.rs
+++ b/examples/1_advanced/7_sd_jwt.rs
@@ -6,7 +6,7 @@
 //!
 //! cargo run --release --example 7_sd_jwt
 
-use examples::create_kinesis_did_document;
+use examples::create_did_document;
 use examples::get_client_and_create_account;
 use examples::get_memstorage;
 use examples::pretty_print_json;
@@ -44,13 +44,13 @@ async fn main() -> anyhow::Result<()> {
   let issuer_storage = get_memstorage()?;
   let issuer_identity_client = get_client_and_create_account(&issuer_storage).await?;
   let (issuer_document, issuer_vm_fragment) =
-    create_kinesis_did_document(&issuer_identity_client, &issuer_storage).await?;
+    create_did_document(&issuer_identity_client, &issuer_storage).await?;
 
   // Create an identity for the holder, in this case also the subject.
   let holder_storage = get_memstorage()?;
   let holder_identity_client = get_client_and_create_account(&holder_storage).await?;
   let (holder_document, holder_vm_fragment) =
-    create_kinesis_did_document(&holder_identity_client, &holder_storage).await?;
+    create_did_document(&holder_identity_client, &holder_storage).await?;
 
   // ===========================================================================
   // Step 2: Issuer creates and signs a selectively disclosable JWT verifiable credential.

--- a/examples/1_advanced/8_status_list_2021.rs
+++ b/examples/1_advanced/8_status_list_2021.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use examples::create_kinesis_did_document;
+use examples::create_did_document;
 use examples::get_client_and_create_account;
 use examples::get_memstorage;
 use identity_eddsa_verifier::EdDSAJwsVerifier;
@@ -42,12 +42,12 @@ async fn main() -> anyhow::Result<()> {
   let issuer_storage = get_memstorage()?;
   let issuer_identity_client = get_client_and_create_account(&issuer_storage).await?;
   let (issuer_document, issuer_vm_fragment) =
-    create_kinesis_did_document(&issuer_identity_client, &issuer_storage).await?;
+    create_did_document(&issuer_identity_client, &issuer_storage).await?;
 
   // create new holder account with did document
   let holder_storage = get_memstorage()?;
   let holder_identity_client = get_client_and_create_account(&holder_storage).await?;
-  let (holder_document, _) = create_kinesis_did_document(&holder_identity_client, &holder_storage).await?;
+  let (holder_document, _) = create_did_document(&holder_identity_client, &holder_storage).await?;
 
   // Create a new empty status list. No credentials have been revoked yet.
   let status_list: StatusList2021 = StatusList2021::default();

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -23,11 +23,9 @@ tokio = { version = "1.29", default-features = false, features = ["rt"] }
 path = "../identity_iota"
 default-features = false
 features = [
-  "client",
   "domain-linkage",
-  "iota-client",
   "jpt-bbs-plus",
-  "kinesis-client",
+  "iota-client",
   "memstore",
   "resolver",
   "revocation-bitmap",

--- a/examples/utils/utils.rs
+++ b/examples/utils/utils.rs
@@ -35,7 +35,7 @@ pub const TEST_GAS_BUDGET: u64 = 50_000_000;
 
 pub type MemStorage = Storage<JwkMemStore, KeyIdMemstore>;
 
-pub async fn create_kinesis_did_document<K, I, S>(
+pub async fn create_did_document<K, I, S>(
   identity_client: &IdentityClient<S>,
   storage: &Storage<K, I>,
 ) -> anyhow::Result<(IotaDocument, String)>

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -22,18 +22,12 @@ identity_storage = { version = "=1.4.0", path = "../identity_storage", default-f
 identity_verification = { version = "=1.4.0", path = "../identity_verification", default-features = false }
 
 [features]
-default = ["revocation-bitmap", "client", "iota-client", "kinesis-client", "resolver"]
+default = ["revocation-bitmap", "iota-client", "resolver"]
 
-# Exposes the `IotaIdentityClient` and `IotaIdentityClientExt` traits.
-client = ["identity_iota_core/client"]
-
-# Enables the iota-client integration, the client trait implementations for it, and the `IotaClientExt` trait.
-iota-client = ["identity_iota_core/iota-client", "identity_resolver?/iota"]
-
-# Enables the kinesis client integration.
-kinesis-client = [
-  "identity_iota_core/kinesis-client",
-  "identity_resolver/kinesis",
+# Enables the IOTA client integration, and the `DidResolutionHandler` trait.
+iota-client = [
+  "identity_iota_core/iota-client",
+  "identity_resolver/iota",
   "identity_storage/send-sync-storage",
   "identity_storage/storage-signer",
 ]

--- a/identity_iota_core/Cargo.toml
+++ b/identity_iota_core/Cargo.toml
@@ -30,7 +30,7 @@ serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 
-# for feature `kinesis-client`
+# for feature `iota-client`
 bcs = { version = "0.1.4", optional = true }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597", package = "fastcrypto", optional = true }
 identity_eddsa_verifier = { version = "=1.4.0", path = "../identity_eddsa_verifier", optional = true }
@@ -50,8 +50,8 @@ tokio = { version = "1.29.0", default-features = false, optional = true, feature
 iota-crypto = { version = "0.23", default-features = false, features = ["bip39", "bip39-en"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 
-# for feature kinesis-client tests
-identity_iota_core = { path = ".", features = ["kinesis-client"] } # enable for e2e tests
+# for feature iota-client tests
+identity_iota_core= { path = ".", features = ["iota-client"] } # enable for e2e tests
 identity_storage = { path = "../identity_storage", features = ["send-sync-storage", "storage-signer"] }
 jsonpath-rust = "0.5.1"
 serial_test = "3.1.1"
@@ -63,12 +63,9 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["client", "iota-client", "kinesis-client", "revocation-bitmap", "send-sync-client-ext"]
-# Exposes the IotaIdentityClient and IotaIdentityClientExt traits.
-client = ["dep:async-trait"]
-# client = ["dep:async-trait"]
-# Client for rebased.
-kinesis-client = [
+default = ["iota-client", "revocation-bitmap", "send-sync-client-ext"]
+# Enables the IOTA Client related components, and dependencies.
+iota-client = [
   "dep:async-trait",
   "dep:bcs",
   "dep:fastcrypto",
@@ -85,14 +82,10 @@ kinesis-client = [
   "dep:shared-crypto",
   "dep:tokio",
 ]
-# Enables the IOTA Client related components.
-iota-client = ["client"]
 # Enables revocation with `RevocationBitmap2022`.
 revocation-bitmap = ["identity_credential/revocation-bitmap"]
 # Adds Send bounds on the futures produces by the client extension traits.
 send-sync-client-ext = []
-# Disables the blanket implementation of `IotaIdentityClientExt`.
-test = ["client"]
 
 [lints]
 workspace = true

--- a/identity_iota_core/src/did_resolution/did_resolution_handler.rs
+++ b/identity_iota_core/src/did_resolution/did_resolution_handler.rs
@@ -29,6 +29,9 @@ pub trait DidResolutionHandler {
 #[cfg_attr(not(feature = "send-sync-client-ext"), async_trait::async_trait(?Send))]
 impl DidResolutionHandler for IdentityClientReadOnly {
   async fn resolve_did(&self, did: &IotaDID) -> Result<IotaDocument> {
-    self.resolve_did(did).await.map_err(|err| Error::DIDResolutionError(err.to_string()))
+    self
+      .resolve_did(did)
+      .await
+      .map_err(|err| Error::DIDResolutionError(err.to_string()))
   }
 }

--- a/identity_iota_core/src/document/iota_document.rs
+++ b/identity_iota_core/src/document/iota_document.rs
@@ -394,7 +394,7 @@ impl IotaDocument {
   }
 }
 
-#[cfg(all(feature = "client", feature = "kinesis-client"))]
+#[cfg(feature = "iota-client")]
 pub mod client_document {
   use identity_core::common::Timestamp;
   use iota_sdk::rpc_types::IotaObjectData;
@@ -427,11 +427,14 @@ pub mod client_document {
           None,
         ))
       })?;
-      let Some((_, multi_controller, created, updated)) = unpacked else {
-        return Err(Error::InvalidDoc(identity_document::Error::InvalidDocument(
-          "given IotaObjectData did not contain a document",
-          None,
-        )));
+      let (_, multi_controller, created, updated) = match unpacked {
+        Some(data) => data,
+        None => {
+          return Err(Error::InvalidDoc(identity_document::Error::InvalidDocument(
+            "given IotaObjectData did not contain a document",
+            None,
+          )));
+        }
       };
       let did_doc =
         Self::from_iota_document_data(multi_controller.controlled_value(), allow_empty, &did, created, updated)?;

--- a/identity_iota_core/src/lib.rs
+++ b/identity_iota_core/src/lib.rs
@@ -15,7 +15,7 @@
 #![allow(clippy::upper_case_acronyms)]
 
 pub use did::IotaDID;
-#[cfg(feature = "kinesis-client")]
+#[cfg(feature = "iota-client")]
 pub use did_resolution::DidResolutionHandler;
 pub use document::*;
 pub use network::NetworkName;
@@ -25,11 +25,11 @@ pub use self::error::Error;
 pub use self::error::Result;
 
 mod did;
-#[cfg(feature = "kinesis-client")]
+#[cfg(feature = "iota-client")]
 mod did_resolution;
 mod document;
 mod error;
 mod network;
-#[cfg(feature = "kinesis-client")]
+#[cfg(feature = "iota-client")]
 pub mod rebased;
 mod state_metadata;

--- a/identity_iota_core/src/rebased/migration/identity.rs
+++ b/identity_iota_core/src/rebased/migration/identity.rs
@@ -344,8 +344,11 @@ pub async fn get_identity(
   };
 
   let did = IotaDID::from_alias_id(&object_id.to_string(), client.network());
-  let Some((id, multi_controller, created, updated)) = unpack_identity_data(&did, &data)? else {
-    return Ok(None);
+  let (id, multi_controller, created, updated) = match unpack_identity_data(&did, &data)? {
+    Some(data) => data,
+    None => {
+      return Ok(None);
+    }
   };
 
   let did_doc =

--- a/identity_resolver/Cargo.toml
+++ b/identity_resolver/Cargo.toml
@@ -31,15 +31,13 @@ features = ["send-sync-client-ext", "iota-client"]
 optional = true
 
 [dev-dependencies]
-identity_iota_core = { path = "../identity_iota_core", features = ["test"] }
 tokio = { version = "1.29.0", default-features = false, features = ["rt-multi-thread", "macros"] }
 
 [features]
 default = ["revocation-bitmap", "iota"]
 revocation-bitmap = ["identity_credential/revocation-bitmap", "identity_iota_core?/revocation-bitmap"]
 # Enables the IOTA integration for the resolver.
-iota = ["dep:identity_iota_core"]
-kinesis = ["identity_iota_core/kinesis-client"]
+iota = ["dep:identity_iota_core", "identity_iota_core/iota-client"]
 
 [lints]
 workspace = true

--- a/identity_resolver/src/resolution/resolver.rs
+++ b/identity_resolver/src/resolution/resolver.rs
@@ -264,7 +264,7 @@ impl<DOC: From<CoreDocument> + 'static> Resolver<DOC, SendSyncCommand<DOC>> {
   }
 }
 
-#[cfg(all(feature = "iota", feature = "kinesis"))]
+#[cfg(feature = "iota")]
 mod iota_handler {
   use crate::ErrorCause;
 
@@ -399,7 +399,7 @@ mod tests {
     }
   }
 
-  #[cfg(all(feature = "iota", feature = "kinesis"))]
+  #[cfg(feature = "iota")]
   #[tokio::test]
   async fn test_multiple_handlers() {
     let did1 =

--- a/identity_storage/Cargo.toml
+++ b/identity_storage/Cargo.toml
@@ -22,7 +22,7 @@ identity_did = { version = "=1.4.0", path = "../identity_did", default-features 
 identity_document = { version = "=1.4.0", path = "../identity_document", default-features = false }
 identity_iota_core = { version = "=1.4.0", path = "../identity_iota_core", default-features = false, optional = true }
 identity_verification = { version = "=1.4.0", path = "../identity_verification", default-features = false }
-iota-crypto = { version = "0.23.2", default-features = false, features = ["ed25519"], optional = true }
+iota-crypto = { version = "0.23.2", default-features = false, features = ["ed25519", "random"], optional = true }
 json-proof-token = { workspace = true, optional = true }
 rand = { version = "0.8.5", default-features = false, features = ["std", "std_rng"], optional = true }
 seahash = { version = "4.1.0", default-features = false }
@@ -48,7 +48,7 @@ send-sync-storage = ["identity_iota_core?/send-sync-client-ext"]
 # Implements the JwkStorageDocumentExt trait for IotaDocument
 iota-document = ["dep:identity_iota_core"]
 # enables support to sign via storage
-storage-signer = ["identity_iota_core?/kinesis-client", "dep:secret-storage"]
+storage-signer = ["identity_iota_core?/iota-client", "dep:secret-storage"]
 # Enables JSON Proof Token & BBS+ related features
 jpt-bbs-plus = [
   "identity_credential/jpt-bbs-plus",


### PR DESCRIPTION
# Description of change
During development, the placeholder name "kinesis" was used for IOTA rebased in this project. This PR removes this placeholder name and lets the "iota" based naming take over the role of the "kinesis" based naming.

This is most evident in the feature names, e.g.:
- feature `kinesis-client` -> `iota-client`
- feature `kinesis` -> `iota`

Therefore, the "iota" based names should be responsible for the same things in the rebased code base as they were in the stardust implementation. 

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tested against local tests.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
