### PR TITLE
fix: add delegation token id

### DIFF
--- a/identity_iota_core/packages/iota_identity/sources/controller.move
+++ b/identity_iota_core/packages/iota_identity/sources/controller.move
@@ -71,6 +71,11 @@ module iota_identity::controller {
     self.permissions
   }
 
+  /// Returns the ID of this `DelegationToken`.
+  public fun delegation_token_id(self: &DelegationToken): &UID {
+    &self.id
+  }
+
   /// Returns true if this `DelegationToken` has permission `permission`.
   public fun has_permission(self: &DelegationToken, permission: u32): bool {
     self.permissions & permission != 0

--- a/identity_iota_core/packages/iota_identity/sources/identity.move
+++ b/identity_iota_core/packages/iota_identity/sources/identity.move
@@ -181,7 +181,7 @@ module iota_identity::identity {
             self.execute_deactivation(cap, proposal_id, clock, ctx);
             option::none()
         } else {
-            emit_proposal_event(self.id().to_inner(), cap.id().to_inner(), proposal_id, false);
+            emit_proposal_event(self.id().to_inner(), cap.delegation_token_id().to_inner(), proposal_id, false);
             option::some(proposal_id)
         }
     }
@@ -202,7 +202,7 @@ module iota_identity::identity {
         self.did_doc.set_controlled_value(vector[]);
         self.updated = clock.timestamp_ms();
 
-        emit_proposal_event(self.id().to_inner(), cap.id().to_inner(), proposal_id, true);
+        emit_proposal_event(self.id().to_inner(), cap.delegation_token_id().to_inner(), proposal_id, true);
     }
 
     /// Proposes an update to the DID Document contained in this `Identity`.
@@ -232,7 +232,7 @@ module iota_identity::identity {
             self.execute_update(cap, proposal_id, clock, ctx);
             option::none()
         } else {
-            emit_proposal_event(self.id().to_inner(), cap.id().to_inner(), proposal_id, false);
+            emit_proposal_event(self.id().to_inner(), cap.delegation_token_id().to_inner(), proposal_id, false);
             option::some(proposal_id)
         }
     }
@@ -253,7 +253,7 @@ module iota_identity::identity {
         );
 
         self.updated = clock.timestamp_ms();
-        emit_proposal_event(self.id().to_inner(), cap.id().to_inner(), proposal_id, true);
+        emit_proposal_event(self.id().to_inner(), cap.delegation_token_id().to_inner(), proposal_id, true);
     }
 
     /// Proposes to update this `Identity`'s AC.
@@ -287,7 +287,7 @@ module iota_identity::identity {
             self.execute_config_change(cap, proposal_id, ctx);
             option::none()
         } else {
-            emit_proposal_event(self.id().to_inner(), cap.id().to_inner(), proposal_id, false);
+            emit_proposal_event(self.id().to_inner(), cap.delegation_token_id().to_inner(), proposal_id, false);
             option::some(proposal_id)
         }
     }
@@ -305,7 +305,7 @@ module iota_identity::identity {
             proposal_id,
             ctx,
         );
-        emit_proposal_event(self.id().to_inner(), cap.id().to_inner(), proposal_id, true);
+        emit_proposal_event(self.id().to_inner(), cap.delegation_token_id().to_inner(), proposal_id, true);
     }
 
     /// Proposes the transfer of a set of objects owned by this `Identity`.
@@ -325,7 +325,7 @@ module iota_identity::identity {
             recipients,
             ctx
         );
-        emit_proposal_event(self.id().to_inner(), cap.id().to_inner(), proposal_id, false);
+        emit_proposal_event(self.id().to_inner(), cap.delegation_token_id().to_inner(), proposal_id, false);
     }
 
     /// Sends one object among the one specified in a `Send` proposal.
@@ -355,7 +355,7 @@ module iota_identity::identity {
             identity_address,
             ctx,
         );
-        emit_proposal_event(self.id().to_inner(), cap.id().to_inner(), proposal_id, false);
+        emit_proposal_event(self.id().to_inner(), cap.delegation_token_id().to_inner(), proposal_id, false);
     }
 
     /// Takes one of the borrowed assets.
@@ -375,7 +375,7 @@ module iota_identity::identity {
         expiration: Option<u64>,
         new_controller_addr: address,
         voting_power: u64,
-        ctx: &mut TxContext, 
+        ctx: &mut TxContext,
     ): Option<ID> {
         let mut new_controllers = vec_map::empty();
         new_controllers.insert(new_controller_addr, voting_power);
@@ -390,7 +390,7 @@ module iota_identity::identity {
         proposal_id: ID,
         ctx: &mut TxContext,
     ): Action<T> {
-        emit_proposal_event(self.id().to_inner(), cap.id().to_inner(), proposal_id, true);
+        emit_proposal_event(self.id().to_inner(), cap.delegation_token_id().to_inner(), proposal_id, true);
         self.did_doc.execute_proposal(cap, proposal_id, ctx)
     }
 


### PR DESCRIPTION
# Description of change
A quick for the identity move package; currently the build fails because the `DelegationToken` doesn't have `id` function.

I opted to use `delegation_token_id` as a function name as Move doesn't allow using `id` twice in the same namespace level.
## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
