### PR TITLE
Add devnet package information

### DIFF
--- a/examples/utils/utils.rs
+++ b/examples/utils/utils.rs
@@ -104,7 +104,7 @@ where
     })
     .and_then(|pkg_str| pkg_str.parse().context("invalid package id"))?;
 
-  let read_only_client = IdentityClientReadOnly::new(iota_client, package_id).await?;
+  let read_only_client = IdentityClientReadOnly::new_with_pkg_id(iota_client, package_id).await?;
 
   let signer = StorageSigner::new(storage, generate.key_id, public_key_jwk);
 

--- a/identity_iota_core/Cargo.toml
+++ b/identity_iota_core/Cargo.toml
@@ -45,6 +45,7 @@ secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag
 serde-aux = { version = "4.5.0", optional = true }
 shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v0.7.3-rc", optional = true }
 tokio = { version = "1.29.0", default-features = false, optional = true, features = ["macros", "sync", "rt", "process"] }
+phf = { version = "0.11.2", features = ["macros"] }
 
 [dev-dependencies]
 iota-crypto = { version = "0.23", default-features = false, features = ["bip39", "bip39-en"] }

--- a/identity_iota_core/src/network/network_name.rs
+++ b/identity_iota_core/src/network/network_name.rs
@@ -1,13 +1,12 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::borrow::Cow;
-
 use core::convert::TryFrom;
 use core::fmt::Display;
 use core::fmt::Formatter;
 use core::ops::Deref;
 use std::fmt::Debug;
+use std::str::FromStr;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -18,21 +17,11 @@ use crate::error::Result;
 /// Network name compliant with the [`crate::IotaDID`] method specification.
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 #[repr(transparent)]
-pub struct NetworkName(Cow<'static, str>);
+pub struct NetworkName(String);
 
 impl NetworkName {
   /// The maximum length of a network name.
-  pub const MAX_LENGTH: usize = 6;
-
-  /// Creates a new [`NetworkName`] if the name passes validation.
-  pub fn try_from<T>(name: T) -> Result<Self>
-  where
-    T: Into<Cow<'static, str>>,
-  {
-    let name_cow: Cow<'static, str> = name.into();
-    Self::validate_network_name(&name_cow)?;
-    Ok(Self(name_cow))
-  }
+  pub const MAX_LENGTH: usize = 8;
 
   /// Validates whether a string is a spec-compliant IOTA DID [`NetworkName`].
   pub fn validate_network_name(name: &str) -> Result<()> {
@@ -52,33 +41,34 @@ impl AsRef<str> for NetworkName {
   }
 }
 
-impl From<NetworkName> for Cow<'static, str> {
-  fn from(network_name: NetworkName) -> Self {
-    network_name.0
-  }
-}
-
 impl Deref for NetworkName {
-  type Target = Cow<'static, str>;
+  type Target = str;
 
   fn deref(&self) -> &Self::Target {
     &self.0
   }
 }
 
-impl TryFrom<&'static str> for NetworkName {
+impl TryFrom<String> for NetworkName {
   type Error = Error;
-
-  fn try_from(name: &'static str) -> Result<Self, Self::Error> {
-    Self::try_from(Cow::Borrowed(name))
+  fn try_from(value: String) -> Result<Self> {
+    Self::validate_network_name(&value)?;
+    Ok(Self(value))
   }
 }
 
-impl TryFrom<String> for NetworkName {
+impl<'a> TryFrom<&'a str> for NetworkName {
   type Error = Error;
+  fn try_from(value: &'a str) -> Result<Self> {
+    value.to_string().try_into()
+  }
+}
 
-  fn try_from(name: String) -> Result<Self, Self::Error> {
-    Self::try_from(Cow::Owned(name))
+impl FromStr for NetworkName {
+  type Err = Error;
+  fn from_str(name: &str) -> Result<Self> {
+    Self::validate_network_name(name)?;
+    Ok(Self(name.to_string()))
   }
 }
 
@@ -98,15 +88,14 @@ impl Display for NetworkName {
 mod tests {
   use super::*;
 
-  // Rules are: at least one character, at most six characters and may only contain digits and/or lowercase ascii
+  // Rules are: at least one character, at most eight characters and may only contain digits and/or lowercase ascii
   // characters.
-  const VALID_NETWORK_NAMES: [&str; 12] = [
-    "main", "dev", "smr", "rms", "test", "foo", "foobar", "123456", "0", "foo42", "bar123", "42foo",
+  const VALID_NETWORK_NAMES: &[&str] = &[
+    "main", "dev", "smr", "rms", "test", "foo", "foobar", "123456", "0", "foo42", "bar123", "42foo", "1234567",
+    "foobar0",
   ];
 
-  const INVALID_NETWORK_NAMES: [&str; 10] = [
-    "Main", "fOo", "deV", "féta", "", "  ", "foo ", " foo", "1234567", "foobar0",
-  ];
+  const INVALID_NETWORK_NAMES: &[&str] = &["Main", "fOo", "deV", "féta", "", "  ", "foo ", " foo"];
 
   #[test]
   fn valid_validate_network_name() {

--- a/identity_iota_core/src/rebased/client/read_only.rs
+++ b/identity_iota_core/src/rebased/client/read_only.rs
@@ -14,9 +14,9 @@ use anyhow::anyhow;
 use anyhow::Context as _;
 use futures::stream::FuturesUnordered;
 
+use futures::StreamExt as _;
 use identity_core::common::Url;
 use identity_did::DID;
-use futures::StreamExt as _;
 use iota_sdk::rpc_types::EventFilter;
 use iota_sdk::rpc_types::IotaData as _;
 use iota_sdk::rpc_types::IotaObjectData;
@@ -199,8 +199,7 @@ impl IdentityClientReadOnly {
   /// Resolves an [`Identity`] from its ID `object_id`.
   pub async fn get_identity(&self, object_id: ObjectID) -> Result<Identity, Error> {
     // spawn all checks
-    let all_futures =
-      FuturesUnordered::<Pin<Box<dyn Future<Output = Result<Option<Identity>, Error>> + Send>>>::new();
+    let all_futures = FuturesUnordered::<Pin<Box<dyn Future<Output = Result<Option<Identity>, Error>> + Send>>>::new();
     all_futures.push(Box::pin(resolve_new(self, object_id)));
     all_futures.push(Box::pin(resolve_migrated(self, object_id)));
     all_futures.push(Box::pin(resolve_unmigrated(self, object_id)));

--- a/identity_iota_core/src/rebased/iota/mod.rs
+++ b/identity_iota_core/src/rebased/iota/mod.rs
@@ -3,3 +3,4 @@
 
 pub(crate) mod move_calls;
 pub(crate) mod types;
+pub(crate) mod well_known_networks;

--- a/identity_iota_core/src/rebased/iota/well_known_networks.rs
+++ b/identity_iota_core/src/rebased/iota/well_known_networks.rs
@@ -1,7 +1,7 @@
 use iota_sdk::types::base_types::ObjectID;
 use phf::{phf_map, Map};
 
-/// A Mapping `NetworkID` -> metadata needed by the library.
+/// A Mapping `network_id` -> metadata needed by the library.
 pub(crate) static IOTA_NETWORKS: Map<&str, IdentityNetworkMetadata> = phf_map! {
   // devnet
   "e678123a" => IdentityNetworkMetadata::new(

--- a/identity_iota_core/src/rebased/iota/well_known_networks.rs
+++ b/identity_iota_core/src/rebased/iota/well_known_networks.rs
@@ -1,0 +1,73 @@
+use iota_sdk::types::base_types::ObjectID;
+use phf::{phf_map, Map};
+
+/// A Mapping `NetworkID` -> metadata needed by the library.
+pub(crate) static IOTA_NETWORKS: Map<&str, IdentityNetworkMetadata> = phf_map! {
+  // devnet
+  "e678123a" => IdentityNetworkMetadata::new(
+    &["0xf4e01655b0906ecd3d2bbf3dab03a77acdc13662d07edabce502a9087c122a39"],
+    "0x816420bd276f9d89ac77bbefa40ba78552760115f1644d84f870db7612088ca8",
+  ),
+};
+
+/// `iota_identity` package information for a given network.
+#[derive(Debug)]
+pub(crate) struct IdentityNetworkMetadata {
+  /// `package[0]` is the current version, `package[1]`
+  /// is the version before, and so forth.
+  pub package: &'static [&'static str],
+  pub migration_registry: &'static str,
+}
+
+/// Returns the [`IdentityNetworkMetadata`] for a given network, if any.
+pub(crate) fn network_metadata(network_id: &str) -> Option<&'static IdentityNetworkMetadata> {
+  IOTA_NETWORKS.get(network_id)
+}
+
+impl IdentityNetworkMetadata {
+  const fn new(pkgs: &'static [&'static str], migration_registry: &'static str) -> Self {
+    assert!(!pkgs.is_empty());
+    Self {
+      package: pkgs,
+      migration_registry,
+    }
+  }
+
+  /// Returns the latest `IotaIdentity` package ID on this network.
+  pub(crate) fn latest_pkg_id(&self) -> ObjectID {
+    self
+      .package
+      .first()
+      .expect("a package was published")
+      .parse()
+      .expect("valid package ID")
+  }
+
+  /// Returns the ID for the `MigrationRegistry` on this network.
+  pub(crate) fn migration_registry(&self) -> ObjectID {
+    self.migration_registry.parse().expect("valid ObjectID")
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::ops::Deref;
+
+  use crate::rebased::{client::IdentityClientReadOnly, migration::get_identity};
+
+  #[tokio::test]
+  async fn devnet_did_has_right_network_name() -> anyhow::Result<()> {
+    let iota_client = iota_sdk::IotaClientBuilder::default().build_devnet().await?;
+    let identity_client = IdentityClientReadOnly::new(iota_client).await?;
+    let identity = get_identity(
+      &identity_client,
+      "0x867b7b3ff149e78216de81339b4d717696ce3089d22fc58b3eeb3c18f1778dfc".parse()?,
+    )
+    .await?
+    .expect("identity exists on-chain");
+
+    assert_eq!(identity.deref().id().network_str(), identity_client.network().as_ref());
+
+    Ok(())
+  }
+}

--- a/identity_iota_core/src/rebased/iota/well_known_networks.rs
+++ b/identity_iota_core/src/rebased/iota/well_known_networks.rs
@@ -5,8 +5,8 @@ use phf::{phf_map, Map};
 pub(crate) static IOTA_NETWORKS: Map<&str, IdentityNetworkMetadata> = phf_map! {
   // devnet
   "e678123a" => IdentityNetworkMetadata::new(
-    &["0xf4e01655b0906ecd3d2bbf3dab03a77acdc13662d07edabce502a9087c122a39"],
-    "0x816420bd276f9d89ac77bbefa40ba78552760115f1644d84f870db7612088ca8",
+    &["0x156dfa0c4d4e576f5675de7d4bbe161c767947ffceefd7498cb39c406bc1cb67"],
+    "0x0247da7f3b8708fc1d326f70153c01b7caf52a19a6f42dd3b868ac8777486b11",
   ),
 };
 

--- a/identity_iota_core/src/rebased/iota/well_known_networks.rs
+++ b/identity_iota_core/src/rebased/iota/well_known_networks.rs
@@ -48,26 +48,3 @@ impl IdentityNetworkMetadata {
     self.migration_registry.parse().expect("valid ObjectID")
   }
 }
-
-#[cfg(test)]
-mod tests {
-  use std::ops::Deref;
-
-  use crate::rebased::{client::IdentityClientReadOnly, migration::get_identity};
-
-  #[tokio::test]
-  async fn devnet_did_has_right_network_name() -> anyhow::Result<()> {
-    let iota_client = iota_sdk::IotaClientBuilder::default().build_devnet().await?;
-    let identity_client = IdentityClientReadOnly::new(iota_client).await?;
-    let identity = get_identity(
-      &identity_client,
-      "0x867b7b3ff149e78216de81339b4d717696ce3089d22fc58b3eeb3c18f1778dfc".parse()?,
-    )
-    .await?
-    .expect("identity exists on-chain");
-
-    assert_eq!(identity.deref().id().network_str(), identity_client.network().as_ref());
-
-    Ok(())
-  }
-}

--- a/identity_iota_core/src/rebased/iota/well_known_networks.rs
+++ b/identity_iota_core/src/rebased/iota/well_known_networks.rs
@@ -48,3 +48,16 @@ impl IdentityNetworkMetadata {
     self.migration_registry.parse().expect("valid ObjectID")
   }
 }
+
+#[cfg(test)]
+mod test {
+  use iota_sdk::IotaClientBuilder;
+
+  use crate::rebased::client::IdentityClientReadOnly;
+
+  #[tokio::test]
+  async fn identity_client_connection_to_devnet_works() -> anyhow::Result<()> {
+    IdentityClientReadOnly::new(IotaClientBuilder::default().build_devnet().await?).await?;
+    Ok(())
+  }
+}

--- a/identity_iota_core/src/rebased/migration/identity.rs
+++ b/identity_iota_core/src/rebased/migration/identity.rs
@@ -533,7 +533,9 @@ impl Transaction for CreateIdentityTx {
       threshold,
       controllers,
     } = self.0;
-    let did_doc = StateMetadataDocument::from(did_doc).pack(StateMetadataEncoding::default()).map_err(|e| Error::DidDocSerialization(e.to_string()))?;
+    let did_doc = StateMetadataDocument::from(did_doc)
+      .pack(StateMetadataEncoding::default())
+      .map_err(|e| Error::DidDocSerialization(e.to_string()))?;
     let programmable_transaction = if controllers.is_empty() {
       move_calls::identity::new(&did_doc, client.package_id())?
     } else {

--- a/identity_iota_core/tests/e2e/client.rs
+++ b/identity_iota_core/tests/e2e/client.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Deref;
+
 use crate::common::get_client as get_test_client;
 use crate::common::TEST_DOC;
 use identity_iota_core::rebased::migration;
@@ -11,11 +13,15 @@ async fn can_create_an_identity() -> anyhow::Result<()> {
   let test_client = get_test_client().await?;
   let identity_client = test_client.new_user_client().await?;
 
-  let _identity = identity_client
+  let identity = identity_client
     .create_identity(TEST_DOC)
     .finish()
     .execute(&identity_client)
-    .await?;
+    .await?
+    .output;
+
+  let did = identity.deref().id();
+  assert_eq!(did.network_str(), identity_client.network().as_ref());
 
   Ok(())
 }

--- a/identity_iota_core/tests/e2e/common.rs
+++ b/identity_iota_core/tests/e2e/common.rs
@@ -82,7 +82,7 @@ pub async fn get_client() -> anyhow::Result<TestClient> {
   request_funds(&address).await?;
 
   let storage = Arc::new(Storage::new(JwkMemStore::new(), KeyIdMemstore::new()));
-  let identity_client = IdentityClientReadOnly::new(client, package_id).await?;
+  let identity_client = IdentityClientReadOnly::new_with_pkg_id(client, package_id).await?;
 
   Ok(TestClient {
     client: identity_client,


### PR DESCRIPTION
# Description of change
Embed devnet's `IotaIdentity` package metadata into the library and adapt `NetworkName` to work with `ChainIdentifiers` instead of HRP.


