### PR TITLE
Enhance coin retrieval logic in Iota client

### DIFF
--- a/identity_iota_core/src/rebased/client/full_client.rs
+++ b/identity_iota_core/src/rebased/client/full_client.rs
@@ -263,7 +263,6 @@ impl<S> IdentityClient<S> {
     const LIMIT: usize = 10;
     let mut cursor = None;
 
-    // Keep track of the highest balance coin found
     let mut best_coin: Option<Coin> = None;
 
     loop {
@@ -280,7 +279,6 @@ impl<S> IdentityClient<S> {
         };
       }
 
-      // Find the coin with the highest balance in this page
       let page_best_coin = coins.data.into_iter().max_by_key(|coin| coin.balance);
 
       if let Some(coin) = page_best_coin {
@@ -288,7 +286,6 @@ impl<S> IdentityClient<S> {
           return Ok(coin);
         }
 
-        // Update best_coin if this coin has a higher balance
         if best_coin.as_ref().map_or(true, |best| coin.balance > best.balance) {
           best_coin = Some(coin);
         }
@@ -301,7 +298,6 @@ impl<S> IdentityClient<S> {
       cursor = coins.next_cursor;
     }
 
-    // We've searched all pages and found no coin with sufficient balance
     Err(Error::GasIssue(format!(
       "no coin found with minimum required balance of {}",
       MINIMUM_BALANCE

--- a/identity_iota_core/src/rebased/client/full_client.rs
+++ b/identity_iota_core/src/rebased/client/full_client.rs
@@ -49,9 +49,7 @@ use super::get_object_id_from_did;
 use super::IdentityClientReadOnly;
 
 /// The minimum balance required to execute a transaction.
-///
-/// TBD: A temporary value,
-pub(crate) const MINIMUM_BALANCE: u64 = 100_000_000;
+pub(crate) const MINIMUM_BALANCE: u64 = 1_000_000_000;
 
 /// A signature which is used to sign transactions.
 pub struct IotaKeySignature {
@@ -275,7 +273,7 @@ impl<S> IdentityClient<S> {
           self.sender_address()
         )));
       };
-      
+
       if coin.balance >= MINIMUM_BALANCE {
         return Ok(coin);
       }

--- a/identity_iota_core/src/rebased/client/full_client.rs
+++ b/identity_iota_core/src/rebased/client/full_client.rs
@@ -269,17 +269,15 @@ impl<S> IdentityClient<S> {
         .get_coins(self.sender_address(), None, cursor, Some(LIMIT))
         .await?;
 
-      if coins.data.is_empty() {
+      let Some(coin) = coins.data.into_iter().max_by_key(|coin| coin.balance) else {
         return Err(Error::GasIssue(format!(
           "no coins found for address {}",
           self.sender_address()
         )));
-      }
-
-      if let Some(coin) = coins.data.into_iter().max_by_key(|coin| coin.balance) {
-        if coin.balance >= MINIMUM_BALANCE {
-          return Ok(coin);
-        }
+      };
+      
+      if coin.balance >= MINIMUM_BALANCE {
+        return Ok(coin);
       }
 
       if !coins.has_next_page {

--- a/identity_iota_core/src/rebased/client/full_client.rs
+++ b/identity_iota_core/src/rebased/client/full_client.rs
@@ -270,18 +270,16 @@ impl<S> IdentityClient<S> {
         .await?;
 
       if coins.data.is_empty() {
-        return Err(Error::GasIssue("no coins found for address".to_string()));
+        return Err(Error::GasIssue(format!(
+          "no coins found for address {}",
+          self.sender_address()
+        )));
       }
 
       if let Some(coin) = coins.data.into_iter().max_by_key(|coin| coin.balance) {
         if coin.balance >= MINIMUM_BALANCE {
           return Ok(coin);
         }
-
-        return Err(Error::GasIssue(format!(
-          "highest balance coin ({}) is below minimum required balance of {}",
-          coin.balance, MINIMUM_BALANCE
-        )));
       }
 
       if !coins.has_next_page {
@@ -292,8 +290,9 @@ impl<S> IdentityClient<S> {
     }
 
     Err(Error::GasIssue(format!(
-      "no coin found with minimum required balance of {}",
-      MINIMUM_BALANCE
+      "no coin found with minimum required balance of {} for address {}",
+      MINIMUM_BALANCE,
+      self.sender_address()
     )))
   }
 


### PR DESCRIPTION
# Description of change

- Introduced a constant `MINIMUM_BALANCE` to define the minimum balance required for transactions.
- Updated `get_coin_for_transaction` method to iterate through paginated coin data, selecting the coin with the highest balance that meets the minimum requirement.
- Improved error handling to provide clearer messages when no suitable coins are found.



## Links to any relevant issues
fixes issue #1470 

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
