### PR TITLE
Fix failing DID IOTA tests and add NetworkName alias for well known networks

### DIFF
--- a/identity_iota_core/src/did/iota_did.rs
+++ b/identity_iota_core/src/did/iota_did.rs
@@ -39,6 +39,8 @@ impl IotaDID {
   pub const METHOD: &'static str = "iota";
 
   /// The default network name (`"iota"`).
+  // TODO: replace this with main net chain ID
+  // as soon as IOTA rebased lands on mainnet.
   pub const DEFAULT_NETWORK: &'static str = "iota";
 
   /// The tag of the placeholder DID.
@@ -431,7 +433,16 @@ mod tests {
     let mut check_network_executed: bool = false;
 
     const INVALID_NETWORK_NAMES: [&str; 10] = [
-      "Main", "fOo", "deV", "féta", "", "  ", "foo ", " foo", "1234567", "foobar0",
+      "Main",
+      "fOo",
+      "deV",
+      "féta",
+      "",
+      "  ",
+      "foo ",
+      " foo",
+      "123456789",
+      "foobar123",
     ];
     for network_name in INVALID_NETWORK_NAMES {
       let did_string: String = format!("did:method:{network_name}:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
@@ -559,9 +570,9 @@ mod tests {
         Err(DIDError::InvalidMethodName)
       ));
 
-      // invalid network name (exceeded six characters)
+      // invalid network name (exceeded eight characters)
       assert!(matches!(
-        IotaDID::parse(format!("did:{}:1234567:{}", IotaDID::METHOD, valid_object_id)),
+        IotaDID::parse(format!("did:{}:123456789:{}", IotaDID::METHOD, valid_object_id)),
         Err(DIDError::Other(_))
       ));
 

--- a/identity_iota_core/src/rebased/client/read_only.rs
+++ b/identity_iota_core/src/rebased/client/read_only.rs
@@ -90,6 +90,8 @@ impl IdentityClientReadOnly {
         "unrecognized network \"{network}\". Use `new_with_pkg_id` instead."
       ))
     })?;
+    // If the network has a well known alias use it otherwise default to the network's chain ID.
+    let network = metadata.network_alias().unwrap_or(network);
 
     let pkg_id = metadata.latest_pkg_id();
 

--- a/identity_iota_core/src/rebased/iota/well_known_networks.rs
+++ b/identity_iota_core/src/rebased/iota/well_known_networks.rs
@@ -5,15 +5,17 @@ use iota_sdk::types::base_types::ObjectID;
 use phf::phf_map;
 use phf::Map;
 
+use crate::NetworkName;
+
 /// A Mapping `network_id` -> metadata needed by the library.
 pub(crate) static IOTA_NETWORKS: Map<&str, IdentityNetworkMetadata> = phf_map! {
-  // devnet
   "e678123a" => IdentityNetworkMetadata::new(
+    Some("devnet"),
     &["0x156dfa0c4d4e576f5675de7d4bbe161c767947ffceefd7498cb39c406bc1cb67"],
     "0x0247da7f3b8708fc1d326f70153c01b7caf52a19a6f42dd3b868ac8777486b11",
   ),
-  // testnet
   "2304aa97" => IdentityNetworkMetadata::new(
+    Some("testnet"),
     &["0x7a67dd504eb1291958495c71a07d20985951648dd5ebf01ac921a50257346818"],
     "0xf1e20e6e3fa4de99ca269a0168f431dc459bc3a1ee5b76b426d5cf3094680483",
   ),
@@ -22,6 +24,7 @@ pub(crate) static IOTA_NETWORKS: Map<&str, IdentityNetworkMetadata> = phf_map! {
 /// `iota_identity` package information for a given network.
 #[derive(Debug)]
 pub(crate) struct IdentityNetworkMetadata {
+  pub alias: Option<&'static str>,
   /// `package[0]` is the current version, `package[1]`
   /// is the version before, and so forth.
   pub package: &'static [&'static str],
@@ -34,9 +37,10 @@ pub(crate) fn network_metadata(network_id: &str) -> Option<&'static IdentityNetw
 }
 
 impl IdentityNetworkMetadata {
-  const fn new(pkgs: &'static [&'static str], migration_registry: &'static str) -> Self {
+  const fn new(alias: Option<&'static str>, pkgs: &'static [&'static str], migration_registry: &'static str) -> Self {
     assert!(!pkgs.is_empty());
     Self {
+      alias,
       package: pkgs,
       migration_registry,
     }
@@ -55,6 +59,13 @@ impl IdentityNetworkMetadata {
   /// Returns the ID for the `MigrationRegistry` on this network.
   pub(crate) fn migration_registry(&self) -> ObjectID {
     self.migration_registry.parse().expect("valid ObjectID")
+  }
+
+  /// Returns a [`NetworkName`] if `alias` is set.
+  pub(crate) fn network_alias(&self) -> Option<NetworkName> {
+    self.alias.map(|alias| {
+      NetworkName::try_from(alias).expect("an hardcoded network alias is valid (unless a dev messed it up)")
+    })
   }
 }
 

--- a/identity_iota_core/src/rebased/iota/well_known_networks.rs
+++ b/identity_iota_core/src/rebased/iota/well_known_networks.rs
@@ -77,13 +77,15 @@ mod test {
 
   #[tokio::test]
   async fn identity_client_connection_to_devnet_works() -> anyhow::Result<()> {
-    IdentityClientReadOnly::new(IotaClientBuilder::default().build_devnet().await?).await?;
+    let client = IdentityClientReadOnly::new(IotaClientBuilder::default().build_devnet().await?).await?;
+    assert_eq!(client.network().as_ref(), "devnet");
     Ok(())
   }
 
   #[tokio::test]
   async fn identity_client_connection_to_testnet_works() -> anyhow::Result<()> {
-    IdentityClientReadOnly::new(IotaClientBuilder::default().build_testnet().await?).await?;
+    let client = IdentityClientReadOnly::new(IotaClientBuilder::default().build_testnet().await?).await?;
+    assert_eq!(client.network().as_ref(), "testnet");
     Ok(())
   }
 }


### PR DESCRIPTION
# Description of change
Tests were failing in CI because they weren't updated to support 8 characters long network ids. Fixed that. 
Also added network aliases for well known networks such as "devnet" and "testnet"
