### PR TITLE
Add support for CI in PRs that target `feat/...` branches

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,6 +14,8 @@ on:
   pull_request:
     branches:
       - main
+      - 'feat/**'
+      - 'support/**'
     paths:
       - "**/Cargo.lock"
       - "**/Cargo.toml"

--- a/.github/workflows/build-and-test-grpc.yml
+++ b/.github/workflows/build-and-test-grpc.yml
@@ -8,7 +8,7 @@ on:
     types: [ opened, synchronize, reopened, ready_for_review ]
     branches:
       - main
-      - 'epic/**'
+      - 'feat/**'
       - 'support/**'
     paths:
       - '.github/workflows/build-and-test.yml'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,7 @@ on:
     types: [ opened, synchronize, reopened, ready_for_review ]
     branches:
       - main
-      - 'epic/**'
+      - 'feat/**'
       - 'support/**'
     paths:
       - '.github/workflows/build-and-test.yml'

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'epic/**'
+      - 'feat/**'
       - 'support/**'
     paths:
       - '.github/workflows/clippy.yml'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'epic/**'
+      - 'feat/**'
       - 'support/**'
     paths:
       - '.github/workflows/format.yml'


### PR DESCRIPTION
# Description of change
Add support for CI in PRs that target `feat/...` branches, and removes CI triggers for `epic/...` branches (currently unused).

The audit workflow has been enabled for `support/...` targeting PRs as well. Summary of changes:

| workflow                  | change                       |
| ------------------------- | ---------------------------- |
| audit                     | + feat/** <br> + support/**  |
| build-and-test-grpc       | * epic/** -> feat/**         |
| build-and-test            | * epic/** -> feat/**         |
| clippy                    | * epic/** -> feat/**         |
| format                    | * epic/** -> feat/**         | 

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix
- [x] CI

## How the change has been tested
Checked format, etc. locally, PR's CI should be triggered when openening this PR.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
