### PR TITLE
Support %-encoded characters in DID URL

### DIFF
--- a/bindings/wasm/src/common/imported_document_lock.rs
+++ b/bindings/wasm/src/common/imported_document_lock.rs
@@ -79,7 +79,7 @@ impl From<&ArrayIToCoreDocument> for Vec<ImportedDocumentLock> {
 
 pub(crate) struct ImportedDocumentReadGuard<'a>(tokio::sync::RwLockReadGuard<'a, CoreDocument>);
 
-impl<'a> AsRef<CoreDocument> for ImportedDocumentReadGuard<'a> {
+impl AsRef<CoreDocument> for ImportedDocumentReadGuard<'_> {
   fn as_ref(&self) -> &CoreDocument {
     self.0.as_ref()
   }

--- a/bindings/wasm/src/error.rs
+++ b/bindings/wasm/src/error.rs
@@ -151,7 +151,7 @@ fn error_chain_fmt(e: &impl std::error::Error, f: &mut std::fmt::Formatter<'_>) 
 
 struct ErrorMessage<'a, E: std::error::Error>(&'a E);
 
-impl<'a, E: std::error::Error> Display for ErrorMessage<'a, E> {
+impl<E: std::error::Error> Display for ErrorMessage<'_, E> {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     error_chain_fmt(self.0, f)
   }

--- a/identity_credential/src/credential/jwt_serialization.rs
+++ b/identity_credential/src/credential/jwt_serialization.rs
@@ -118,7 +118,7 @@ where
 }
 
 #[cfg(feature = "validator")]
-impl<'credential, T> CredentialJwtClaims<'credential, T>
+impl<T> CredentialJwtClaims<'_, T>
 where
   T: ToOwned<Owned = T> + Serialize + DeserializeOwned,
 {

--- a/identity_credential/src/domain_linkage/domain_linkage_validator.rs
+++ b/identity_credential/src/domain_linkage/domain_linkage_validator.rs
@@ -21,7 +21,6 @@ use super::DomainLinkageValidationResult;
 use crate::utils::url_only_includes_origin;
 
 /// A validator for a Domain Linkage Configuration and Credentials.
-
 pub struct JwtDomainLinkageValidator<V: JwsVerifier> {
   validator: JwtCredentialValidator<V>,
 }

--- a/identity_credential/src/presentation/jwt_serialization.rs
+++ b/identity_credential/src/presentation/jwt_serialization.rs
@@ -136,7 +136,7 @@ where
 }
 
 #[cfg(feature = "validator")]
-impl<'presentation, CRED, T> PresentationJwtClaims<'presentation, CRED, T>
+impl<CRED, T> PresentationJwtClaims<'_, CRED, T>
 where
   CRED: ToOwned<Owned = CRED> + Serialize + DeserializeOwned + Clone,
   T: ToOwned<Owned = T> + Serialize + DeserializeOwned,

--- a/identity_credential/src/revocation/status_list_2021/entry.rs
+++ b/identity_credential/src/revocation/status_list_2021/entry.rs
@@ -18,7 +18,7 @@ where
   D: serde::Deserializer<'de>,
 {
   struct ExactStrVisitor(&'static str);
-  impl<'a> Visitor<'a> for ExactStrVisitor {
+  impl Visitor<'_> for ExactStrVisitor {
     type Value = &'static str;
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
       write!(formatter, "the exact string \"{}\"", self.0)

--- a/identity_credential/src/revocation/validity_timeframe_2024/revocation_timeframe_status.rs
+++ b/identity_credential/src/revocation/validity_timeframe_2024/revocation_timeframe_status.rs
@@ -18,7 +18,7 @@ where
   D: serde::Deserializer<'de>,
 {
   struct ExactStrVisitor(&'static str);
-  impl<'a> Visitor<'a> for ExactStrVisitor {
+  impl Visitor<'_> for ExactStrVisitor {
     type Value = &'static str;
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
       write!(formatter, "the exact string \"{}\"", self.0)

--- a/identity_did/Cargo.toml
+++ b/identity_did/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 description = "Agnostic implementation of the Decentralized Identifiers (DID) standard."
 
 [dependencies]
-did_url_parser = { version = "0.2.0", features = ["std", "serde"] }
+did_url_parser = { version = "0.3.0", features = ["std", "serde"] }
 form_urlencoded = { version = "1.2.0", default-features = false, features = ["alloc"] }
 identity_core = { version = "=1.4.0", path = "../identity_core", default-features = false }
 identity_jose = { version = "=1.4.0", path = "../identity_jose" }

--- a/identity_did/src/did_url.rs
+++ b/identity_did/src/did_url.rs
@@ -537,7 +537,7 @@ pub(crate) const fn is_char_fragment(ch: char) -> bool {
 pub(crate) fn is_valid_percent_encoded_char(s: &str) -> bool {
   let mut chars = s.chars();
   let Some('%') = chars.next() else { return false };
-  chars.take(2).all(|c| c.is_ascii_hexdigit() && !c.is_ascii_lowercase())
+  s.len() == 3 && chars.take(2).all(|c| c.is_ascii_hexdigit())
 }
 
 pub(crate) fn is_valid_url_segment<F>(segment: &str, char_predicate: F) -> bool

--- a/identity_did/src/did_url.rs
+++ b/identity_did/src/did_url.rs
@@ -537,7 +537,7 @@ pub(crate) const fn is_char_fragment(ch: char) -> bool {
 pub(crate) fn is_valid_percent_encoded_char(s: &str) -> bool {
   let mut chars = s.chars();
   let Some('%') = chars.next() else { return false };
-  s.len() == 3 && chars.take(2).all(|c| c.is_ascii_hexdigit())
+  s.len() >= 3 && chars.take(2).all(|c| c.is_ascii_hexdigit())
 }
 
 pub(crate) fn is_valid_url_segment<F>(segment: &str, char_predicate: F) -> bool

--- a/identity_did/src/did_url.rs
+++ b/identity_did/src/did_url.rs
@@ -96,7 +96,7 @@ impl RelativeDIDUrl {
     self.path = value
       .filter(|s| !s.is_empty())
       .map(|s| {
-        if s.starts_with('/') && s.chars().all(is_char_path) {
+        if s.starts_with('/') && is_valid_url_segment(s, is_char_path) {
           Ok(s.to_owned())
         } else {
           Err(Error::InvalidPath)
@@ -138,7 +138,7 @@ impl RelativeDIDUrl {
       .map(|mut s| {
         // Ignore leading '?' during validation.
         s = s.strip_prefix('?').unwrap_or(s);
-        if s.is_empty() || !s.chars().all(is_char_query) {
+        if s.is_empty() || !is_valid_url_segment(s, is_char_query) {
           return Err(Error::InvalidQuery);
         }
         Ok(format!("?{s}"))
@@ -188,7 +188,7 @@ impl RelativeDIDUrl {
       .map(|mut s| {
         // Ignore leading '#' during validation.
         s = s.strip_prefix('#').unwrap_or(s);
-        if s.is_empty() || !s.chars().all(is_char_fragment) {
+        if s.is_empty() || !is_valid_url_segment(s, is_char_fragment) {
           return Err(Error::InvalidFragment);
         }
         Ok(format!("#{s}"))
@@ -519,8 +519,7 @@ impl KeyComparable for DIDUrl {
 #[inline(always)]
 #[rustfmt::skip]
 pub(crate) const fn is_char_path(ch: char) -> bool {
-  // Allow percent encoding or not?
-  is_char_method_id(ch) || matches!(ch, '~' | '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '@' | '/' /* | '%' */)
+  is_char_method_id(ch) || matches!(ch, '~' | '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '@' | '/')
 }
 
 /// Checks whether a character satisfies DID Url query constraints.
@@ -533,6 +532,33 @@ pub(crate) const fn is_char_query(ch: char) -> bool {
 #[inline(always)]
 pub(crate) const fn is_char_fragment(ch: char) -> bool {
   is_char_path(ch) || ch == '?'
+}
+
+pub(crate) fn is_valid_percent_encoded_char(s: &str) -> bool {
+  let mut chars = s.chars();
+  let Some('%') = chars.next() else { return false };
+  chars.take(2).all(|c| c.is_ascii_hexdigit() && !c.is_ascii_lowercase())
+}
+
+pub(crate) fn is_valid_url_segment<F>(segment: &str, char_predicate: F) -> bool
+where
+  F: Fn(char) -> bool,
+{
+  let mut chars = segment.char_indices();
+  while let Some((i, c)) = chars.next() {
+    if c == '%' {
+      if !is_valid_percent_encoded_char(&segment[i..]) {
+        return false;
+      }
+      // skip the two HEX digits
+      chars.next();
+      chars.next();
+    } else if !char_predicate(c) {
+      return false;
+    }
+  }
+
+  true
 }
 
 #[cfg(test)]
@@ -639,6 +665,10 @@ mod tests {
     assert!(relative_url.path().is_none());
     assert!(relative_url.set_path(None).is_ok());
     assert!(relative_url.path().is_none());
+
+    // Percent encoded path.
+    assert!(relative_url.set_path(Some("/p%AAth")).is_ok());
+    assert_eq!(relative_url.path().unwrap(), "/p%AAth");
   }
 
   #[rustfmt::skip]
@@ -697,6 +727,10 @@ mod tests {
     assert_eq!(relative_url.query().unwrap(), "query");
     assert!(relative_url.set_query(Some("name=value&name2=value2&3=true")).is_ok());
     assert_eq!(relative_url.query().unwrap(), "name=value&name2=value2&3=true");
+
+    // With percent encoded char.
+    assert!(relative_url.set_query(Some("qu%EEry")).is_ok());
+    assert_eq!(relative_url.query().unwrap(), "qu%EEry");
   }
 
   #[rustfmt::skip]
@@ -745,6 +779,10 @@ mod tests {
     assert!(relative_url.fragment().is_none());
     assert!(relative_url.set_fragment(None).is_ok());
     assert!(relative_url.fragment().is_none());
+
+    // Percent encoded fragment.
+    assert!(relative_url.set_fragment(Some("fr%AAgm%EEnt")).is_ok());
+    assert_eq!(relative_url.fragment().unwrap(), "fr%AAgm%EEnt");
   }
 
   #[rustfmt::skip]

--- a/identity_document/benches/deserialize_document.rs
+++ b/identity_document/benches/deserialize_document.rs
@@ -220,9 +220,9 @@ fn deserialize_json_document(c: &mut Criterion) {
     (JSON_DOC_DID_KEY, "did:key document"),
     (JSON_DOCUMENT_LARGE, "large document"),
   ] {
-    group.throughput(Throughput::Bytes(json.as_bytes().len() as u64));
+    group.throughput(Throughput::Bytes(json.len() as u64));
     group.bench_with_input(
-      BenchmarkId::from_parameter(format!("{name}, document size: {} bytes", json.as_bytes().len())),
+      BenchmarkId::from_parameter(format!("{name}, document size: {} bytes", json.len())),
       json,
       |b, json| {
         b.iter(|| {

--- a/identity_document/src/document/core_document.rs
+++ b/identity_document/src/document/core_document.rs
@@ -690,7 +690,7 @@ impl CoreDocument {
     &'me self,
     method_query: Q,
     scope: Option<MethodScope>,
-  ) -> Option<&VerificationMethod>
+  ) -> Option<&'me VerificationMethod>
   where
     Q: Into<DIDUrlQuery<'query>>,
   {
@@ -773,7 +773,7 @@ impl CoreDocument {
   /// Returns the first [`Service`] with an `id` property matching the provided `service_query`, if present.
   // NOTE: This method demonstrates unexpected behavior in the edge cases where the document contains
   // services whose ids are of the form <did different from this document's>#<fragment>.
-  pub fn resolve_service<'query, 'me, Q>(&'me self, service_query: Q) -> Option<&Service>
+  pub fn resolve_service<'query, 'me, Q>(&'me self, service_query: Q) -> Option<&'me Service>
   where
     Q: Into<DIDUrlQuery<'query>>,
   {

--- a/identity_document/src/utils/did_url_query.rs
+++ b/identity_document/src/utils/did_url_query.rs
@@ -13,7 +13,7 @@ use identity_did::DID;
 #[repr(transparent)]
 pub struct DIDUrlQuery<'query>(Cow<'query, str>);
 
-impl<'query> DIDUrlQuery<'query> {
+impl DIDUrlQuery<'_> {
   /// Returns whether this query matches the given DIDUrl.
   pub(crate) fn matches(&self, did_url: &DIDUrl) -> bool {
     // Ensure the DID matches if included in the query.
@@ -81,7 +81,7 @@ impl<'query> From<&'query DIDUrl> for DIDUrlQuery<'query> {
   }
 }
 
-impl<'query> From<DIDUrl> for DIDUrlQuery<'query> {
+impl From<DIDUrl> for DIDUrlQuery<'_> {
   fn from(other: DIDUrl) -> Self {
     Self(Cow::Owned(other.to_string()))
   }

--- a/identity_iota_core/src/document/iota_document.rs
+++ b/identity_iota_core/src/document/iota_document.rs
@@ -332,7 +332,7 @@ impl IotaDocument {
   /// Returns the first [`Service`] with an `id` property matching the provided `service_query`, if present.
   // NOTE: This method demonstrates unexpected behaviour in the edge cases where the document contains
   // services whose ids are of the form <did different from this document's>#<fragment>.
-  pub fn resolve_service<'query, 'me, Q>(&'me self, service_query: Q) -> Option<&Service>
+  pub fn resolve_service<'query, 'me, Q>(&'me self, service_query: Q) -> Option<&'me Service>
   where
     Q: Into<DIDUrlQuery<'query>>,
   {
@@ -347,7 +347,7 @@ impl IotaDocument {
     &'me self,
     method_query: Q,
     scope: Option<MethodScope>,
-  ) -> Option<&VerificationMethod>
+  ) -> Option<&'me VerificationMethod>
   where
     Q: Into<DIDUrlQuery<'query>>,
   {

--- a/identity_iota_core/src/state_metadata/document.rs
+++ b/identity_iota_core/src/state_metadata/document.rs
@@ -424,10 +424,7 @@ mod tests {
     // Encoding.
     assert_eq!(packed[4], StateMetadataEncoding::Json as u8);
     // JSON length.
-    assert_eq!(
-      &packed[5..=6],
-      (expected_payload.as_bytes().len() as u16).to_le_bytes().as_ref()
-    );
+    assert_eq!(&packed[5..=6], (expected_payload.len() as u16).to_le_bytes().as_ref());
     // JSON payload.
     assert_eq!(&packed[7..], expected_payload.as_bytes());
   }

--- a/identity_jose/src/jws/decoder.rs
+++ b/identity_jose/src/jws/decoder.rs
@@ -322,7 +322,7 @@ pub struct JwsValidationIter<'decoder, 'payload, 'signatures> {
   payload: &'payload [u8],
 }
 
-impl<'decoder, 'payload, 'signatures> Iterator for JwsValidationIter<'decoder, 'payload, 'signatures> {
+impl<'payload> Iterator for JwsValidationIter<'_, 'payload, '_> {
   type Item = Result<JwsValidationItem<'payload>>;
 
   fn next(&mut self) -> Option<Self::Item> {

--- a/identity_jose/src/jws/encoding/utils.rs
+++ b/identity_jose/src/jws/encoding/utils.rs
@@ -86,7 +86,7 @@ pub(super) struct Flatten<'payload, 'unprotected> {
   pub(super) signature: JwsSignature<'unprotected>,
 }
 
-impl<'payload, 'unprotected> Flatten<'payload, 'unprotected> {
+impl Flatten<'_, '_> {
   pub(super) fn to_json(&self) -> Result<String> {
     serde_json::to_string(&self).map_err(Error::InvalidJson)
   }
@@ -99,7 +99,7 @@ pub(super) struct General<'payload, 'unprotected> {
   pub(super) signatures: Vec<JwsSignature<'unprotected>>,
 }
 
-impl<'payload, 'unprotected> General<'payload, 'unprotected> {
+impl General<'_, '_> {
   pub(super) fn to_json(&self) -> Result<String> {
     serde_json::to_string(&self).map_err(Error::InvalidJson)
   }

--- a/identity_jose/src/jws/recipient.rs
+++ b/identity_jose/src/jws/recipient.rs
@@ -15,7 +15,7 @@ pub struct Recipient<'a> {
   pub unprotected: Option<&'a JwsHeader>,
 }
 
-impl<'a> Default for Recipient<'a> {
+impl Default for Recipient<'_> {
   fn default() -> Self {
     Self::new()
   }


### PR DESCRIPTION
# Description of change
Allow the use of %-encoded characters in DID URLs.

## Links to any relevant issues
Closes #1492 

## Type of change
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Updated unit tests.
