### PR TITLE
SD-JWT VC: use latest SD-JWT crate version

### DIFF
--- a/identity_credential/Cargo.toml
+++ b/identity_credential/Cargo.toml
@@ -28,7 +28,7 @@ once_cell = { version = "1.18", default-features = false, features = ["std"] }
 reqwest = { version = "0.11", default-features = false, features = ["default-tls", "json", "stream"], optional = true }
 roaring = { version = "0.10.2", default-features = false, features = ["serde"], optional = true }
 sd-jwt-payload = { version = "0.2.1", default-features = false, features = ["sha"], optional = true }
-sd-jwt-payload-rework = { package = "sd-jwt-payload", git = "https://github.com/iotaledger/sd-jwt-payload.git", branch = "feat/sd-jwt-v11", default-features = false, features = ["sha"], optional = true }
+sd-jwt-payload-rework = { package = "sd-jwt-payload", version = "0.3", features = ["sha"], optional = true }
 serde.workspace = true
 serde-aux = { version = "4.3.1", default-features = false }
 serde_json.workspace = true


### PR DESCRIPTION
# Description of change
Upgrade dependency `sd-jwt-payload` to latest version (v0.3.0).