### PR TITLE
Repair identity-wasm build

### DIFF
--- a/bindings/wasm/identity_wasm/Cargo.toml
+++ b/bindings/wasm/identity_wasm/Cargo.toml
@@ -77,5 +77,5 @@ default = ["dummy-client"]
 dummy-client = ["dep:iota_interaction_ts"]
 # As identity_iota::resolver is currently not available for wasm32 this temporary flag is used
 # to switch of all code depending on identity_iota::resolver
-## TODO: Remove this feature flag after identity_iota::resolver is available for wasm32 platforms
+# TODO: Remove this feature flag after identity_iota::resolver is available for wasm32 platforms
 wasm-resolver = []

--- a/bindings/wasm/identity_wasm/Cargo.toml
+++ b/bindings/wasm/identity_wasm/Cargo.toml
@@ -75,3 +75,7 @@ empty_docs = "allow"
 [features]
 default = ["dummy-client"]
 dummy-client = ["dep:iota_interaction_ts"]
+# As identity_iota::resolver is currently not available for wasm32 this temporary flag is used
+# to switch of all code depending on identity_iota::resolver
+## TODO: Remove this feature flag after identity_iota::resolver is available for wasm32 platforms
+wasm-resolver = []

--- a/bindings/wasm/identity_wasm/src/error.rs
+++ b/bindings/wasm/identity_wasm/src/error.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use identity_iota::credential::CompoundJwtPresentationValidationError;
+#[cfg(feature = "wasm-resolver")]
 use identity_iota::resolver;
 use identity_iota::storage::key_id_storage::KeyIdStorageError;
 use identity_iota::storage::key_id_storage::KeyIdStorageErrorKind;
@@ -158,6 +159,7 @@ impl<'a, E: std::error::Error> Display for ErrorMessage<'a, E> {
   }
 }
 
+#[cfg(feature = "wasm-resolver")]
 impl From<resolver::Error> for WasmError<'_> {
   fn from(error: resolver::Error) -> Self {
     Self {

--- a/bindings/wasm/identity_wasm/src/resolver/mod.rs
+++ b/bindings/wasm/identity_wasm/src/resolver/mod.rs
@@ -3,6 +3,7 @@
 
 mod resolver_config;
 mod resolver_types;
+#[cfg(feature = "wasm-resolver")]
 mod wasm_resolver;
 
 pub use resolver_types::*;


### PR DESCRIPTION
# Description of change
This PR Introduces a new feature flag in crate identity_wasm to control the usage of the dependency identity_iota::resolver, which is currently not available for the wasm32 platform. Without the changes in this PR the identity_wasm crate is not build-able.

## Links to any relevant issues
None

## Type of change
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
In folder `bindings/wasm/identity_wasm`:
`cargo build --lib --target wasm32-unknown-unknown`
