### PR TITLE
Some feat/ts-move-calls extensions

### DIFF
--- a/bindings/wasm/identity_wasm/Cargo.toml
+++ b/bindings/wasm/identity_wasm/Cargo.toml
@@ -75,3 +75,7 @@ empty_docs = "allow"
 [features]
 default = ["dummy-client"]
 dummy-client = ["dep:iota_interaction_ts"]
+# As identity_iota::resolver is currently not available for wasm32 this temporary flag is used
+# to switch of all code depending on identity_iota::resolver
+# TODO: Remove this feature flag after identity_iota::resolver is available for wasm32 platforms
+wasm-resolver = []

--- a/bindings/wasm/identity_wasm/src/error.rs
+++ b/bindings/wasm/identity_wasm/src/error.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use identity_iota::credential::CompoundJwtPresentationValidationError;
+#[cfg(feature = "wasm-resolver")]
 use identity_iota::resolver;
 use identity_iota::storage::key_id_storage::KeyIdStorageError;
 use identity_iota::storage::key_id_storage::KeyIdStorageErrorKind;
@@ -158,6 +159,7 @@ impl<'a, E: std::error::Error> Display for ErrorMessage<'a, E> {
   }
 }
 
+#[cfg(feature = "wasm-resolver")]
 impl From<resolver::Error> for WasmError<'_> {
   fn from(error: resolver::Error) -> Self {
     Self {

--- a/bindings/wasm/identity_wasm/src/resolver/mod.rs
+++ b/bindings/wasm/identity_wasm/src/resolver/mod.rs
@@ -3,6 +3,7 @@
 
 mod resolver_config;
 mod resolver_types;
+#[cfg(feature = "wasm-resolver")]
 mod wasm_resolver;
 
 pub use resolver_types::*;

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/asset/create.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/asset/create.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { Transaction } from "@iota/iota-sdk/transactions";
+import { Transaction } from "@iota/iota.js/transactions";
 
 export function create(
     inner_bytes: Uint8Array,

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/asset/delete.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/asset/delete.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { ObjectRef, Transaction } from "@iota/iota-sdk/transactions";
+import { ObjectRef, Transaction } from "@iota/iota.js/transactions";
 
 export function remove(
     asset: ObjectRef,

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/asset/transfer.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/asset/transfer.ts
@@ -1,8 +1,8 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
-import { ObjectRef, Transaction } from "@iota/iota-sdk/transactions";
+import { SharedObjectRef } from "@iota/iota.js/dist/cjs/bcs/types";
+import { ObjectRef, Transaction } from "@iota/iota.js/transactions";
 
 export function transfer(
     asset: ObjectRef,

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/asset/update.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/asset/update.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { ObjectRef, Transaction } from "@iota/iota-sdk/transactions";
+import { ObjectRef, Transaction } from "@iota/iota.js/transactions";
 
 export function update(
     asset: ObjectRef,

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/borrow_asset.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/borrow_asset.ts
@@ -1,9 +1,9 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
-import { IotaObjectData } from "@iota/iota-sdk/dist/cjs/client";
-import { ObjectRef, Transaction, TransactionArgument } from "@iota/iota-sdk/transactions";
+import { SharedObjectRef } from "@iota/iota.js/dist/cjs/bcs/types";
+import { IotaObjectData } from "@iota/iota.js/dist/cjs/client";
+import { ObjectRef, Transaction, TransactionArgument } from "@iota/iota.js/transactions";
 import { getControllerDelegation, putBackDelegationToken } from "../utils";
 
 export function proposeBorrow(

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/config.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/config.ts
@@ -1,8 +1,8 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
-import { ObjectRef, Transaction } from "@iota/iota-sdk/transactions";
+import { SharedObjectRef } from "@iota/iota.js/dist/cjs/bcs/types";
+import { ObjectRef, Transaction } from "@iota/iota.js/transactions";
 import { getControllerDelegation, putBackDelegationToken } from "../utils";
 
 export function proposeConfigChange(

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/controller_execution.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/controller_execution.ts
@@ -1,8 +1,8 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
-import { ObjectRef, Transaction, TransactionArgument } from "@iota/iota-sdk/transactions";
+import { SharedObjectRef } from "@iota/iota.js/dist/cjs/bcs/types";
+import { ObjectRef, Transaction, TransactionArgument } from "@iota/iota.js/transactions";
 import { getControllerDelegation, putBackDelegationToken } from "../utils";
 
 export function proposeControllerExecution(

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/create.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/create.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { Transaction } from "@iota/iota-sdk/transactions";
+import { Transaction } from "@iota/iota.js/transactions";
 import { getClockRef } from "../utils";
 
 export function create(didDoc: Uint8Array, packageId: string): Promise<Uint8Array> {

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/deactivate.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/deactivate.ts
@@ -1,8 +1,8 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
-import { ObjectRef, Transaction } from "@iota/iota-sdk/transactions";
+import { SharedObjectRef } from "@iota/iota.js/dist/cjs/bcs/types";
+import { ObjectRef, Transaction } from "@iota/iota.js/transactions";
 import { getClockRef, getControllerDelegation, putBackDelegationToken } from "../utils";
 
 export function proposeDeactivation(

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/proposal.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/proposal.ts
@@ -1,8 +1,8 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
-import { ObjectRef, Transaction } from "@iota/iota-sdk/transactions";
+import { SharedObjectRef } from "@iota/iota.js/dist/cjs/bcs/types";
+import { ObjectRef, Transaction } from "@iota/iota.js/transactions";
 import { getControllerDelegation, putBackDelegationToken } from "../utils";
 
 export function approve(

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/send_asset.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/send_asset.ts
@@ -1,8 +1,8 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
-import { ObjectRef, Transaction } from "@iota/iota-sdk/transactions";
+import { SharedObjectRef } from "@iota/iota.js/dist/cjs/bcs/types";
+import { ObjectRef, Transaction } from "@iota/iota.js/transactions";
 import { getControllerDelegation, putBackDelegationToken } from "../utils";
 
 export function proposeSend(

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/update.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/update.ts
@@ -1,8 +1,8 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
-import { ObjectRef, Transaction } from "@iota/iota-sdk/transactions";
+import { SharedObjectRef } from "@iota/iota.js/dist/cjs/bcs/types";
+import { ObjectRef, Transaction } from "@iota/iota.js/transactions";
 import { getClockRef, getControllerDelegation, putBackDelegationToken } from "../utils";
 
 export function proposeUpdate(

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/upgrade.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/upgrade.ts
@@ -1,8 +1,8 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
-import { ObjectRef, Transaction } from "@iota/iota-sdk/transactions";
+import { SharedObjectRef } from "@iota/iota.js/dist/cjs/bcs/types";
+import { ObjectRef, Transaction } from "@iota/iota.js/transactions";
 
 export function proposeUpgrade(
     identity: SharedObjectRef,

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/migration.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/migration.ts
@@ -1,8 +1,8 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
-import { ObjectRef, Transaction } from "@iota/iota-sdk/transactions";
+import { SharedObjectRef } from "@iota/iota.js/dist/cjs/bcs/types";
+import { ObjectRef, Transaction } from "@iota/iota.js/transactions";
 import { getClockRef } from "./utils";
 
 export function migrateDidOutput(

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/utils.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/utils.ts
@@ -1,5 +1,5 @@
-import { Transaction, TransactionArgument, TransactionResult } from "@iota/iota-sdk/transactions";
-import { IOTA_CLOCK_OBJECT_ID } from "@iota/iota-sdk/utils";
+import { Transaction, TransactionArgument, TransactionResult } from "@iota/iota.js/transactions";
+import { IOTA_CLOCK_OBJECT_ID } from "@iota/iota.js/utils";
 
 export function getClockRef(tx: Transaction): TransactionArgument {
     return tx.sharedObjectRef({ objectId: IOTA_CLOCK_OBJECT_ID, initialSharedVersion: 1, mutable: false });

--- a/bindings/wasm/iota_interaction_ts/package-lock.json
+++ b/bindings/wasm/iota_interaction_ts/package-lock.json
@@ -6930,6 +6930,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/bindings/wasm/iota_interaction_ts/package.json
+++ b/bindings/wasm/iota_interaction_ts/package.json
@@ -74,7 +74,6 @@
   },
   "dependencies": {
     "@iota/iota.js": "file:../../../../iota/sdk/typescript",
-    "@iota/iota-sdk": "^0.4.0",
     "@noble/ed25519": "^1.7.3",
     "@noble/hashes": "^1.4.0",
     "@types/node-fetch": "^2.6.2",

--- a/bindings/wasm/iota_interaction_ts/src/identity_move_calls.rs
+++ b/bindings/wasm/iota_interaction_ts/src/identity_move_calls.rs
@@ -21,6 +21,8 @@ use identity_iota_interaction::rpc_types::OwnedObjectRef;
 use identity_iota_interaction::types::base_types::IotaAddress;
 use identity_iota_interaction::types::base_types::ObjectID;
 use identity_iota_interaction::types::base_types::ObjectRef;
+use identity_iota_interaction::types::base_types::SequenceNumber;
+use identity_iota_interaction::types::transaction::Argument;
 use identity_iota_interaction::types::TypeTag;
 use identity_iota_interaction::BorrowIntentFnInternalT;
 use identity_iota_interaction::ControllerIntentFnInternalT;

--- a/bindings/wasm/iota_interaction_ts/src/migration_move_calls.rs
+++ b/bindings/wasm/iota_interaction_ts/src/migration_move_calls.rs
@@ -5,6 +5,8 @@ use identity_iota_interaction::ident_str;
 use identity_iota_interaction::rpc_types::OwnedObjectRef;
 use identity_iota_interaction::types::base_types::ObjectID;
 use identity_iota_interaction::types::base_types::ObjectRef;
+use identity_iota_interaction::types::transaction::ObjectArg;
+use identity_iota_interaction::types::IOTA_FRAMEWORK_PACKAGE_ID;
 use identity_iota_interaction::MigrationMoveCalls;
 use identity_iota_interaction::ProgrammableTransactionBcs;
 use js_sys::Uint8Array;

--- a/identity_iota_core/src/rebased/proposals/borrow.rs
+++ b/identity_iota_core/src/rebased/proposals/borrow.rs
@@ -37,7 +37,7 @@ use super::UserDrivenTx;
 
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
-      use iota_interaction_ts::NativeTsTransactionBuilderBindingWrapper as Ptb;
+      use iota_interaction_ts::NativeTsCodeBindingWrapper as Ptb;
       use iota_interaction_ts::error::TsSdkError as IotaInteractionError;
       /// Instances of BorrowIntentFnT can be used as user-provided function to describe how
       /// a borrowed assets shall be used.

--- a/identity_iota_core/src/rebased/proposals/controller.rs
+++ b/identity_iota_core/src/rebased/proposals/controller.rs
@@ -38,7 +38,7 @@ use super::UserDrivenTx;
 
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
-      use iota_interaction_ts::NativeTsTransactionBuilderBindingWrapper as Ptb;
+      use iota_interaction_ts::NativeTsCodeBindingWrapper as Ptb;
       /// Instances of ControllerIntentFnT can be used as user-provided function to describe how
       /// a borrowed identity's controller capability will be used.
       pub trait ControllerIntentFnT: FnOnce(&mut Ptb, &Argument) {}


### PR DESCRIPTION
This PR provides changes needed to build the two wasm-bindgen crates/packages iota_interaction_ts and identity_wasm in the `feat/ts-move-calls` branch.

The latest state of `identity-rebased-alpha `has also been merged into this branch, so that there are few changes resulting from there.