### PR TITLE
Feat/ts move calls ext

### DIFF
--- a/.github/actions/rust/sccache/setup-sccache/action.yml
+++ b/.github/actions/rust/sccache/setup-sccache/action.yml
@@ -12,7 +12,7 @@ runs:
       if: inputs.os == 'macos-latest'
       shell: bash
       run: |
-        brew update --preinstall
+        brew update --auto-update
         brew install sccache
 
     - name: Install sccache (ubuntu-24.04)

--- a/identity_iota_core/src/rebased/proposals/borrow.rs
+++ b/identity_iota_core/src/rebased/proposals/borrow.rs
@@ -37,7 +37,7 @@ use super::UserDrivenTx;
 
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
-      use iota_interaction_ts::NativeTsCodeBindingWrapper as Ptb;
+      use iota_interaction_ts::NativeTsTransactionBuilderBindingWrapper as Ptb;
       use iota_interaction_ts::error::TsSdkError as IotaInteractionError;
       /// Instances of BorrowIntentFnT can be used as user-provided function to describe how
       /// a borrowed assets shall be used.

--- a/identity_iota_core/src/rebased/proposals/controller.rs
+++ b/identity_iota_core/src/rebased/proposals/controller.rs
@@ -38,7 +38,7 @@ use super::UserDrivenTx;
 
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
-      use iota_interaction_ts::NativeTsCodeBindingWrapper as Ptb;
+      use iota_interaction_ts::NativeTsTransactionBuilderBindingWrapper as Ptb;
       /// Instances of ControllerIntentFnT can be used as user-provided function to describe how
       /// a borrowed identity's controller capability will be used.
       pub trait ControllerIntentFnT: FnOnce(&mut Ptb, &Argument) {}


### PR DESCRIPTION
This PR includes:

- Renaming 'brew update' option --preinstall to --auto-update of the 'build-and-test (macos-latest)' action which broke the 'build-and-test (macos-latest)' check.
  Further details:
  - https://docs.brew.sh/Manpage#update-up-options
  - https://github.com/Homebrew/brew/pull/13299
- Revert commit [c465dd2](https://github.com/iotaledger/identity.rs/commit/c465dd27d8473648ed38151a7387afe44729c291) "Update type name of NativeTsCodeBindingWrapper" 
  I've committed this by mistake due to a badly synced branch.