### PR TITLE
Signer: support for keys other than ED25519

### DIFF
--- a/bindings/wasm/iota_interaction_ts/Cargo.toml
+++ b/bindings/wasm/iota_interaction_ts/Cargo.toml
@@ -25,7 +25,7 @@ console_error_panic_hook = { version = "0.1" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597", package = "fastcrypto" }
 futures = { version = "0.3" }
 js-sys = { version = "0.3.61" }
-secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.1.0" }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.2.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 serde_json.workspace = true

--- a/bindings/wasm/iota_interaction_ts/src/iota_client_ts_sdk.rs
+++ b/bindings/wasm/iota_interaction_ts/src/iota_client_ts_sdk.rs
@@ -325,8 +325,6 @@ impl IotaClientTrait for IotaClientTsSdk {
 
   async fn execute_transaction<S: Signer<IotaKeySignature>>(
     &self,
-    sender_address: IotaAddress,
-    sender_public_key: &[u8],
     tx_bcs: ProgrammableTransactionBcs,
     gas_budget: Option<u64>,
     signer: &S,

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ iota-sdk-legacy = { package = "iota-sdk", version = "1.0", default-features = fa
 json-proof-token.workspace = true
 rand = "0.8.5"
 sd-jwt-payload = { version = "0.2.1", default-features = false, features = ["sha"] }
-secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.1.0" }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.2.0" }
 serde_json = { version = "1.0", default-features = false }
 tokio = { version = "1.29", default-features = false, features = ["rt", "macros"] }
 

--- a/examples/utils/utils.rs
+++ b/examples/utils/utils.rs
@@ -12,8 +12,6 @@ use identity_iota::storage::Storage;
 use identity_iota::verification::jws::JwsAlgorithm;
 use identity_iota::verification::MethodScope;
 
-use identity_iota::iota::rebased::client::convert_to_address;
-use identity_iota::iota::rebased::client::get_sender_public_key;
 use identity_iota::iota::rebased::client::IdentityClient;
 use identity_iota::iota::rebased::client::IdentityClientReadOnly;
 use identity_iota::iota::rebased::client::IotaKeySignature;
@@ -24,6 +22,7 @@ use identity_storage::KeyIdStorage;
 use identity_storage::KeyType;
 use identity_storage::StorageSigner;
 use identity_stronghold::StrongholdStorage;
+use iota_sdk::types::base_types::IotaAddress;
 use iota_sdk::IotaClientBuilder;
 use iota_sdk::IOTA_LOCAL_NETWORK_URL;
 use iota_sdk_legacy::client::secret::stronghold::StrongholdSecretManager;
@@ -94,8 +93,9 @@ where
     .generate(KeyType::new("Ed25519"), JwsAlgorithm::EdDSA)
     .await?;
   let public_key_jwk = generate.jwk.to_public().expect("public components should be derivable");
-  let public_key_bytes = get_sender_public_key(&public_key_jwk)?;
-  let sender_address = convert_to_address(&public_key_bytes)?;
+  let signer = StorageSigner::new(storage, generate.key_id, public_key_jwk);
+  let sender_address = IotaAddress::from(&Signer::public_key(&signer).await?);
+
   request_funds(&sender_address).await?;
   let package_id = std::env::var("IOTA_IDENTITY_PKG_ID")
     .map_err(|e| {
@@ -104,8 +104,6 @@ where
     .and_then(|pkg_str| pkg_str.parse().context("invalid package id"))?;
 
   let read_only_client = IdentityClientReadOnly::new_with_pkg_id(iota_client, package_id).await?;
-
-  let signer = StorageSigner::new(storage, generate.key_id, public_key_jwk);
 
   let identity_client = IdentityClient::new(read_only_client, signer).await?;
 

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -33,8 +33,8 @@ anyhow = "1.0.64"
 identity_iota = { version = "=1.4.0", path = "./", features = ["memstore"] }
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.8.1-rc" }
 rand = "0.8.5"
-tokio = { version = "1.29.0", features = ["full"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.1.0" }
+tokio = { version = "1.29.0", features = ["full"] }
 
 [features]
 default = ["revocation-bitmap", "iota-client", "send-sync", "resolver"]

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -34,6 +34,7 @@ identity_iota = { version = "=1.4.0", path = "./", features = ["memstore"] }
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.8.1-rc" }
 rand = "0.8.5"
 tokio = { version = "1.29.0", features = ["full"] }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.1.0" }
 
 [features]
 default = ["revocation-bitmap", "iota-client", "send-sync", "resolver"]

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -33,7 +33,7 @@ anyhow = "1.0.64"
 identity_iota = { version = "=1.4.0", path = "./", features = ["memstore"] }
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.8.1-rc" }
 rand = "0.8.5"
-secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.1.0" }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.2.0" }
 tokio = { version = "1.29.0", features = ["full"] }
 
 [features]

--- a/identity_iota/README.md
+++ b/identity_iota/README.md
@@ -97,7 +97,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.62"
 identity_iota = { git = "https://github.com/iotaledger/identity.rs.git", tag = "v1.6.0-alpha", features = ["memstore"] }
-secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.1.0" }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.2.0" }
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.8.1-rc" }
 rand = "0.8.5"
 tokio = { version = "1", features = ["full"] }

--- a/identity_iota/README.md
+++ b/identity_iota/README.md
@@ -97,6 +97,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.62"
 identity_iota = { git = "https://github.com/iotaledger/identity.rs.git", tag = "v1.6.0-alpha", features = ["memstore"] }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.1.0" }
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.8.1-rc" }
 rand = "0.8.5"
 tokio = { version = "1", features = ["full"] }
@@ -119,8 +120,6 @@ timeout 360 cargo build || (echo "Process timed out after 360 seconds" && exit 1
 ```rust,no_run
 use anyhow::Context;
 use identity_iota::iota::IotaDocument;
-use identity_iota::iota::rebased::client::convert_to_address;
-use identity_iota::iota::rebased::client::get_sender_public_key;
 use identity_iota::iota::rebased::client::IdentityClient;
 use identity_iota::iota::rebased::client::IdentityClientReadOnly;
 use identity_iota::iota::rebased::transaction::Transaction;
@@ -134,6 +133,8 @@ use identity_iota::storage::StorageSigner;
 use identity_iota::verification::jws::JwsAlgorithm;
 use identity_iota::verification::MethodScope;
 use iota_sdk::IotaClientBuilder;
+use iota_sdk::types::base_types::IotaAddress;
+use secret_storage::Signer;
 use tokio::io::AsyncReadExt;
 
 /// Demonstrates how to create a DID Document and publish it in a new identity.
@@ -152,8 +153,11 @@ async fn main() -> anyhow::Result<()> {
     .generate(KeyType::new("Ed25519"), JwsAlgorithm::EdDSA)
     .await?;
   let public_key_jwk = generate.jwk.to_public().expect("public components should be derivable");
-  let public_key_bytes = get_sender_public_key(&public_key_jwk)?;
-  let sender_address = convert_to_address(&public_key_bytes)?;
+  let signer = StorageSigner::new(&storage, generate.key_id, public_key_jwk);
+  let sender_address = {
+    let public_key = Signer::public_key(&signer).await?;
+    IotaAddress::from(&public_key)
+  };
   let package_id = std::env::var("IOTA_IDENTITY_PKG_ID")
     .map_err(|e| {
       anyhow::anyhow!("env variable IOTA_IDENTITY_PKG_ID must be set in order to run the examples").context(e)
@@ -162,7 +166,6 @@ async fn main() -> anyhow::Result<()> {
 
   // Create identity client with signing capabilities.
   let read_only_client = IdentityClientReadOnly::new_with_pkg_id(iota_client, package_id).await?;
-  let signer = StorageSigner::new(&storage, generate.key_id, public_key_jwk);
   let identity_client = IdentityClient::new(read_only_client, signer).await?;
 
   println!("Your wallet address is: {}", sender_address);

--- a/identity_iota_core/Cargo.toml
+++ b/identity_iota_core/Cargo.toml
@@ -40,7 +40,7 @@ iota-crypto = { version = "0.23", optional = true }
 itertools = { version = "0.13.0", optional = true }
 phf = { version = "0.11.2", features = ["macros"] }
 rand = { version = "0.8.5", optional = true }
-secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.1.0", default-features = false, optional = true }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.2.0", default-features = false, optional = true }
 serde-aux = { version = "4.5.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/identity_iota_core/src/iota_interaction_rust/iota_client_rust_sdk.rs
+++ b/identity_iota_core/src/iota_interaction_rust/iota_client_rust_sdk.rs
@@ -547,7 +547,7 @@ impl IotaClientRustSdk {
     tx_data: &TransactionData,
   ) -> Result<Signature, Error> {
     signer
-      .sign(tx_data)
+      .sign(&bcs::to_bytes(tx_data)?)
       .await
       .map_err(|err| Error::TransactionSigningFailed(format!("could not sign transaction message; {err}")))
   }

--- a/identity_iota_core/src/iota_interaction_rust/iota_client_rust_sdk.rs
+++ b/identity_iota_core/src/iota_interaction_rust/iota_client_rust_sdk.rs
@@ -7,8 +7,6 @@ use std::marker::Send;
 use std::option::Option;
 use std::result::Result;
 
-use fastcrypto::hash::Blake2b256;
-use fastcrypto::traits::ToFromBytes;
 use secret_storage::Signer;
 
 use crate::rebased::Error;
@@ -35,13 +33,10 @@ use identity_iota_interaction::rpc_types::IotaTransactionBlockResponseOptions;
 use identity_iota_interaction::rpc_types::ObjectChange;
 use identity_iota_interaction::rpc_types::ObjectsPage;
 use identity_iota_interaction::rpc_types::OwnedObjectRef;
-use identity_iota_interaction::shared_crypto::intent::Intent;
-use identity_iota_interaction::shared_crypto::intent::IntentMessage;
 use identity_iota_interaction::types::base_types::IotaAddress;
 use identity_iota_interaction::types::base_types::ObjectID;
 use identity_iota_interaction::types::base_types::SequenceNumber;
 use identity_iota_interaction::types::crypto::Signature;
-use identity_iota_interaction::types::crypto::SignatureScheme;
 use identity_iota_interaction::types::digests::TransactionDigest;
 use identity_iota_interaction::types::dynamic_field::DynamicFieldName;
 use identity_iota_interaction::types::event::EventID;
@@ -342,14 +337,7 @@ impl IotaClientTrait for IotaClientRustSdk {
     S: Signer<IotaKeySignature> + Sync,
   {
     let tx = bcs::from_bytes::<ProgrammableTransaction>(tx_bcs.as_slice())?;
-    let public_key = signer
-      .public_key()
-      .await
-      .map_err(|e| Error::TransactionSigningFailed(e.to_string()))?;
-    let address = IotaAddress::from(&public_key);
-    let response = self
-      .sdk_execute_transaction(address, public_key.as_ref(), tx, gas_budget, signer)
-      .await?;
+    let response = self.sdk_execute_transaction(tx, gas_budget, signer).await?;
     Ok(Box::new(IotaTransactionBlockResponseProvider::new(response)))
   }
 
@@ -451,18 +439,21 @@ impl IotaClientRustSdk {
 
   async fn sdk_execute_transaction<S: Signer<IotaKeySignature>>(
     &self,
-    sender_address: IotaAddress,
-    sender_public_key: &[u8],
     tx: ProgrammableTransaction,
     gas_budget: Option<u64>,
     signer: &S,
   ) -> Result<IotaTransactionBlockResponse, Error> {
+    let public_key = signer
+      .public_key()
+      .await
+      .map_err(|e| Error::TransactionSigningFailed(e.to_string()))?;
+    let sender_address = IotaAddress::from(&public_key);
     let gas_budget = match gas_budget {
       Some(gas) => gas,
       None => self.sdk_default_gas_budget(sender_address, &tx).await?,
     };
     let tx_data = self.get_transaction_data(tx, gas_budget, sender_address).await?;
-    let signature = Self::sign_transaction_data(signer, &tx_data, sender_public_key).await?;
+    let signature = Self::sign_transaction_data(signer, &tx_data).await?;
 
     // execute tx
     let response = self
@@ -554,34 +545,11 @@ impl IotaClientRustSdk {
   async fn sign_transaction_data<S: Signer<IotaKeySignature>>(
     signer: &S,
     tx_data: &TransactionData,
-    sender_public_key: &[u8],
   ) -> Result<Signature, Error> {
-    use fastcrypto::hash::HashFunction;
-
-    let intent = Intent::iota_transaction();
-    let intent_msg = IntentMessage::new(intent, tx_data);
-    let mut hasher = Blake2b256::default();
-    let bcs_bytes = bcs::to_bytes(&intent_msg).map_err(|err| {
-      Error::TransactionSigningFailed(format!("could not serialize transaction message to bcs; {err}"))
-    })?;
-    hasher.update(bcs_bytes);
-    let digest = hasher.finalize().digest;
-
-    let raw_signature = signer
-      .sign(&digest)
+    signer
+      .sign(tx_data)
       .await
-      .map_err(|err| Error::TransactionSigningFailed(format!("could not sign transaction message; {err}")))?;
-
-    let binding = [
-      [SignatureScheme::ED25519.flag()].as_slice(),
-      &raw_signature,
-      sender_public_key,
-    ]
-    .concat();
-    let signature_bytes: &[u8] = binding.as_slice();
-
-    Signature::from_bytes(signature_bytes)
-      .map_err(|err| Error::TransactionSigningFailed(format!("could not parse signature to IOTA signature; {err}")))
+      .map_err(|err| Error::TransactionSigningFailed(format!("could not sign transaction message; {err}")))
   }
 
   async fn get_coin_for_transaction(&self, sender_address: IotaAddress) -> Result<Coin, Error> {

--- a/identity_iota_interaction/Cargo.toml
+++ b/identity_iota_interaction/Cargo.toml
@@ -45,6 +45,7 @@ strum.workspace = true
 thiserror.workspace = true
 tracing = { version = "0.1" }
 uint = { version = "0.9" }
+phf = { version = "0.11.2", features = ["macros"] }
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/identity_iota_interaction/Cargo.toml
+++ b/identity_iota_interaction/Cargo.toml
@@ -45,7 +45,6 @@ strum.workspace = true
 thiserror.workspace = true
 tracing = { version = "0.1" }
 uint = { version = "0.9" }
-phf = { version = "0.11.2", features = ["macros"] }
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/identity_iota_interaction/Cargo.toml
+++ b/identity_iota_interaction/Cargo.toml
@@ -45,6 +45,9 @@ strum.workspace = true
 thiserror.workspace = true
 tracing = { version = "0.1" }
 uint = { version = "0.9" }
+derive_more = "0.99.18"
+enum_dispatch = "0.3.13"
+schemars = "0.8.21"
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/identity_iota_interaction/Cargo.toml
+++ b/identity_iota_interaction/Cargo.toml
@@ -15,7 +15,7 @@ description = "Trait definitions and a wasm32 compatible subset of code, copied 
 anyhow = "1.0.75"
 async-trait = { version = "0.1.81", default-features = false }
 cfg-if = "1.0.0"
-secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.1.0" }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.2.0" }
 serde.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/identity_iota_interaction/src/iota_client_trait.rs
+++ b/identity_iota_interaction/src/iota_client_trait.rs
@@ -23,7 +23,6 @@ use crate::types::digests::TransactionDigest;
 use crate::types::dynamic_field::DynamicFieldName;
 use crate::types::event::EventID;
 use crate::types::quorum_driver_types::ExecuteTransactionRequestType;
-use crate::types::transaction::TransactionData;
 use crate::OptionalSend;
 use crate::ProgrammableTransactionBcs;
 use crate::SignatureBcs;
@@ -46,7 +45,7 @@ pub struct IotaKeySignature {
 impl SignatureScheme for IotaKeySignature {
   type PublicKey = PublicKey;
   type Signature = Signature;
-  type Input = TransactionData;
+  type Input = TransactionDataBcs;
 }
 
 //********************************************************************

--- a/identity_iota_interaction/src/iota_client_trait.rs
+++ b/identity_iota_interaction/src/iota_client_trait.rs
@@ -17,6 +17,7 @@ use crate::rpc_types::OwnedObjectRef;
 use crate::types::base_types::IotaAddress;
 use crate::types::base_types::ObjectID;
 use crate::types::base_types::SequenceNumber;
+use crate::types::crypto::PublicKey;
 use crate::types::digests::TransactionDigest;
 use crate::types::dynamic_field::DynamicFieldName;
 use crate::types::event::EventID;
@@ -36,12 +37,12 @@ use std::result::Result;
 use std::marker::Send;
 
 pub struct IotaKeySignature {
-  pub public_key: Vec<u8>,
+  pub public_key: PublicKey,
   pub signature: Vec<u8>,
 }
 
 impl SignatureScheme for IotaKeySignature {
-  type PublicKey = Vec<u8>;
+  type PublicKey = PublicKey;
   type Signature = Vec<u8>;
 }
 
@@ -229,8 +230,6 @@ pub trait IotaClientTrait {
   #[cfg(not(feature = "send-sync-transaction"))]
   async fn execute_transaction<S: Signer<IotaKeySignature>>(
     &self,
-    sender_address: IotaAddress,
-    sender_public_key: &[u8],
     tx_bcs: ProgrammableTransactionBcs,
     gas_budget: Option<u64>,
     signer: &S,
@@ -241,8 +240,6 @@ pub trait IotaClientTrait {
   #[cfg(feature = "send-sync-transaction")]
   async fn execute_transaction<S: Signer<IotaKeySignature> + Sync>(
     &self,
-    sender_address: IotaAddress,
-    sender_public_key: &[u8],
     tx_bcs: ProgrammableTransactionBcs,
     gas_budget: Option<u64>,
     signer: &S,

--- a/identity_iota_interaction/src/iota_client_trait.rs
+++ b/identity_iota_interaction/src/iota_client_trait.rs
@@ -18,10 +18,12 @@ use crate::types::base_types::IotaAddress;
 use crate::types::base_types::ObjectID;
 use crate::types::base_types::SequenceNumber;
 use crate::types::crypto::PublicKey;
+use crate::types::crypto::Signature;
 use crate::types::digests::TransactionDigest;
 use crate::types::dynamic_field::DynamicFieldName;
 use crate::types::event::EventID;
 use crate::types::quorum_driver_types::ExecuteTransactionRequestType;
+use crate::types::transaction::TransactionData;
 use crate::OptionalSend;
 use crate::ProgrammableTransactionBcs;
 use crate::SignatureBcs;
@@ -38,12 +40,13 @@ use std::marker::Send;
 
 pub struct IotaKeySignature {
   pub public_key: PublicKey,
-  pub signature: Vec<u8>,
+  pub signature: Signature,
 }
 
 impl SignatureScheme for IotaKeySignature {
   type PublicKey = PublicKey;
-  type Signature = Vec<u8>;
+  type Signature = Signature;
+  type Input = TransactionData;
 }
 
 //********************************************************************

--- a/identity_iota_interaction/src/sdk_types/iota_types/crypto.rs
+++ b/identity_iota_interaction/src/sdk_types/iota_types/crypto.rs
@@ -1,37 +1,32 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+use std::hash::Hash;
 
+use enum_dispatch::enum_dispatch;
 use strum::EnumString;
+use schemars::JsonSchema;
+use derive_more::{AsRef, AsMut};
 
 use fastcrypto::{
     bls12381::min_sig::{
         BLS12381AggregateSignature, BLS12381AggregateSignatureAsBytes, BLS12381KeyPair,
         BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature,
-    },
-    ed25519::{
+    }, ed25519::{
         Ed25519KeyPair, Ed25519PrivateKey, Ed25519PublicKey, Ed25519PublicKeyAsBytes,
         Ed25519Signature
-    },
-    hash::{Blake2b256, HashFunction},
-    traits::{VerifyingKey, Authenticator},
-    encoding::{Base64},
-    secp256k1::{
-        Secp256k1PublicKeyAsBytes
-    },
-    secp256r1::{
-        Secp256r1PublicKeyAsBytes
-    }
+    }, encoding::{Base64, Encoding}, error::FastCryptoError, hash::{Blake2b256, HashFunction}, secp256k1::{Secp256k1KeyPair, Secp256k1PublicKey, Secp256k1PublicKeyAsBytes, Secp256k1Signature}, secp256r1::{Secp256r1KeyPair, Secp256r1PublicKey, Secp256r1PublicKeyAsBytes, Secp256r1Signature}, traits::{Authenticator, KeyPair as KeypairTraits, Signer, ToFromBytes, VerifyingKey}
 };
-use fastcrypto_zkp::{zk_login_utils::Bn254FrElement};
+use fastcrypto_zkp::zk_login_utils::Bn254FrElement;
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer, Serializer};
 use serde::Serialize;
 use serde_with::{serde_as, Bytes};
 
+use crate::shared_crypto::intent::IntentMessage;
+
 use super::{
-    iota_serde::{Readable},
-    error::{IotaResult, IotaError},
+    base_types::IotaAddress, error::{IotaError, IotaResult}, iota_serde::Readable
 };
 
 // Authority Objects
@@ -104,6 +99,48 @@ impl PublicKey {
     }
 }
 
+pub trait IotaPublicKey: VerifyingKey {
+    const SIGNATURE_SCHEME: SignatureScheme;
+}
+
+// This struct exists due to the limitations of the `enum_dispatch` library.
+//
+pub trait IotaSignatureInner: Sized + ToFromBytes + PartialEq + Eq + Hash {
+    type Sig: Authenticator<PubKey = Self::PubKey>;
+    type PubKey: VerifyingKey<Sig = Self::Sig> + IotaPublicKey;
+    type KeyPair: KeypairTraits<PubKey = Self::PubKey, Sig = Self::Sig>;
+
+    const LENGTH: usize = Self::Sig::LENGTH + Self::PubKey::LENGTH + 1;
+    const SCHEME: SignatureScheme = Self::PubKey::SIGNATURE_SCHEME;
+
+    /// Returns the deserialized signature and deserialized pubkey.
+    fn get_verification_inputs(&self) -> IotaResult<(Self::Sig, Self::PubKey)> {
+        let pk = Self::PubKey::from_bytes(self.public_key_bytes())
+            .map_err(|_| IotaError::KeyConversion("Invalid public key".to_string()))?;
+
+        // deserialize the signature
+        let signature = Self::Sig::from_bytes(self.signature_bytes()).map_err(|_| {
+            IotaError::InvalidSignature {
+                error: "Fail to get pubkey and sig".to_string(),
+            }
+        })?;
+
+        Ok((signature, pk))
+    }
+
+    fn new(kp: &Self::KeyPair, message: &[u8]) -> Self {
+        let sig = Signer::sign(kp, message);
+
+        let mut signature_bytes: Vec<u8> = Vec::new();
+        signature_bytes
+            .extend_from_slice(&[<Self::PubKey as IotaPublicKey>::SIGNATURE_SCHEME.flag()]);
+        signature_bytes.extend_from_slice(sig.as_ref());
+        signature_bytes.extend_from_slice(kp.public().as_ref());
+        Self::from_bytes(&signature_bytes[..])
+            .expect("Serialized signature did not have expected size")
+    }
+}
+
 /// Defines the compressed version of the public key that we pass around
 /// in Iota
 #[serde_as]
@@ -123,38 +160,6 @@ pub struct AuthorityPublicKeyBytes(
     #[serde_as(as = "Readable<Base64, Bytes>")]
     pub [u8; AuthorityPublicKey::LENGTH],
 );
-
-// BLS Port
-//
-
-impl IotaPublicKey for BLS12381PublicKey {
-    const SIGNATURE_SCHEME: SignatureScheme = SignatureScheme::BLS12381;
-}
-
-// Ed25519 Iota Signature port
-//
-
-#[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub struct Ed25519IotaSignature(
-    #[serde_as(as = "Readable<Base64, Bytes>")]
-    [u8; Ed25519PublicKey::LENGTH + Ed25519Signature::LENGTH + 1],
-);
-
-// Implementation useful for simplify testing when mock signature is needed
-impl Default for Ed25519IotaSignature {
-    fn default() -> Self {
-        Self([0; Ed25519PublicKey::LENGTH + Ed25519Signature::LENGTH + 1])
-    }
-}
-
-impl IotaPublicKey for Ed25519PublicKey {
-    const SIGNATURE_SCHEME: SignatureScheme = SignatureScheme::ED25519;
-}
-
-pub trait IotaPublicKey: VerifyingKey {
-    const SIGNATURE_SCHEME: SignatureScheme;
-}
 
 
 #[derive(Clone, Copy, Deserialize, Serialize, Debug, EnumString, strum::Display)]
@@ -210,5 +215,267 @@ impl SignatureScheme {
             0x06 => Ok(SignatureScheme::PasskeyAuthenticator),
             _ => Err(IotaError::KeyConversion("Invalid key scheme".to_string())),
         }
+    }
+}
+
+// Enums for signature scheme signatures
+#[enum_dispatch]
+#[derive(Clone, JsonSchema, Debug, PartialEq, Eq, Hash)]
+pub enum Signature {
+    Ed25519IotaSignature,
+    Secp256k1IotaSignature,
+    Secp256r1IotaSignature,
+}
+
+impl Serialize for Signature {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let bytes = self.as_ref();
+
+        if serializer.is_human_readable() {
+            let s = Base64::encode(bytes);
+            serializer.serialize_str(&s)
+        } else {
+            serializer.serialize_bytes(bytes)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Signature {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        let bytes = if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            Base64::decode(&s).map_err(|e| Error::custom(e.to_string()))?
+        } else {
+            let data: Vec<u8> = Vec::deserialize(deserializer)?;
+            data
+        };
+
+        Self::from_bytes(&bytes).map_err(|e| Error::custom(e.to_string()))
+    }
+}
+
+impl AsRef<[u8]> for Signature {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Signature::Ed25519IotaSignature(sig) => sig.as_ref(),
+            Signature::Secp256k1IotaSignature(sig) => sig.as_ref(),
+            Signature::Secp256r1IotaSignature(sig) => sig.as_ref(),
+        }
+    }
+}
+impl AsMut<[u8]> for Signature {
+    fn as_mut(&mut self) -> &mut [u8] {
+        match self {
+            Signature::Ed25519IotaSignature(sig) => sig.as_mut(),
+            Signature::Secp256k1IotaSignature(sig) => sig.as_mut(),
+            Signature::Secp256r1IotaSignature(sig) => sig.as_mut(),
+        }
+    }
+}
+
+impl ToFromBytes for Signature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        match bytes.first() {
+            Some(x) => {
+                if x == &Ed25519IotaSignature::SCHEME.flag() {
+                    Ok(<Ed25519IotaSignature as ToFromBytes>::from_bytes(bytes)?.into())
+                } else if x == &Secp256k1IotaSignature::SCHEME.flag() {
+                    Ok(<Secp256k1IotaSignature as ToFromBytes>::from_bytes(bytes)?.into())
+                } else if x == &Secp256r1IotaSignature::SCHEME.flag() {
+                    Ok(<Secp256r1IotaSignature as ToFromBytes>::from_bytes(bytes)?.into())
+                } else {
+                    Err(FastCryptoError::InvalidInput)
+                }
+            }
+            _ => Err(FastCryptoError::InvalidInput),
+        }
+    }
+}
+
+// Ed25519 Iota Signature port
+//
+
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash, AsRef, AsMut)]
+#[as_ref(forward)]
+#[as_mut(forward)]
+pub struct Ed25519IotaSignature(
+    #[schemars(with = "Base64")]
+    #[serde_as(as = "Readable<Base64, Bytes>")]
+    [u8; Ed25519PublicKey::LENGTH + Ed25519Signature::LENGTH + 1],
+);
+
+// Implementation useful for simplify testing when mock signature is needed
+impl Default for Ed25519IotaSignature {
+    fn default() -> Self {
+        Self([0; Ed25519PublicKey::LENGTH + Ed25519Signature::LENGTH + 1])
+    }
+}
+
+impl ToFromBytes for Ed25519IotaSignature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        if bytes.len() != Self::LENGTH {
+            return Err(FastCryptoError::InputLengthWrong(Self::LENGTH));
+        }
+        let mut sig_bytes = [0; Self::LENGTH];
+        sig_bytes.copy_from_slice(bytes);
+        Ok(Self(sig_bytes))
+    }
+}
+
+impl IotaSignatureInner for Ed25519IotaSignature {
+    type Sig = Ed25519Signature;
+    type PubKey = Ed25519PublicKey;
+    type KeyPair = Ed25519KeyPair;
+    const LENGTH: usize = Ed25519PublicKey::LENGTH + Ed25519Signature::LENGTH + 1;
+}
+
+impl IotaPublicKey for Ed25519PublicKey {
+    const SIGNATURE_SCHEME: SignatureScheme = SignatureScheme::ED25519;
+}
+
+// Secp256k1 Iota Signature port
+//
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash, AsRef, AsMut)]
+#[as_ref(forward)]
+#[as_mut(forward)]
+pub struct Secp256k1IotaSignature(
+    #[schemars(with = "Base64")]
+    #[serde_as(as = "Readable<Base64, Bytes>")]
+    [u8; Secp256k1PublicKey::LENGTH + Secp256k1Signature::LENGTH + 1],
+);
+
+impl ToFromBytes for Secp256k1IotaSignature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        if bytes.len() != Self::LENGTH {
+            return Err(FastCryptoError::InputLengthWrong(Self::LENGTH));
+        }
+        let mut sig_bytes = [0; Self::LENGTH];
+        sig_bytes.copy_from_slice(bytes);
+        Ok(Self(sig_bytes))
+    }
+}
+
+impl IotaSignatureInner for Secp256k1IotaSignature {
+    type Sig = Secp256k1Signature;
+    type PubKey = Secp256k1PublicKey;
+    type KeyPair = Secp256k1KeyPair;
+    const LENGTH: usize = Secp256k1PublicKey::LENGTH + Secp256k1Signature::LENGTH + 1;
+}
+
+impl IotaPublicKey for Secp256k1PublicKey {
+    const SIGNATURE_SCHEME: SignatureScheme = SignatureScheme::Secp256k1;
+}
+
+// Secp256r1 Iota Signature port
+//
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash, AsRef, AsMut)]
+#[as_ref(forward)]
+#[as_mut(forward)]
+pub struct Secp256r1IotaSignature(
+    #[schemars(with = "Base64")]
+    #[serde_as(as = "Readable<Base64, Bytes>")]
+    [u8; Secp256r1PublicKey::LENGTH + Secp256r1Signature::LENGTH + 1],
+);
+
+impl ToFromBytes for Secp256r1IotaSignature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        if bytes.len() != Self::LENGTH {
+            return Err(FastCryptoError::InputLengthWrong(Self::LENGTH));
+        }
+        let mut sig_bytes = [0; Self::LENGTH];
+        sig_bytes.copy_from_slice(bytes);
+        Ok(Self(sig_bytes))
+    }
+}
+
+impl IotaSignatureInner for Secp256r1IotaSignature {
+    type Sig = Secp256r1Signature;
+    type PubKey = Secp256r1PublicKey;
+    type KeyPair = Secp256r1KeyPair;
+    const LENGTH: usize = Secp256r1PublicKey::LENGTH + Secp256r1Signature::LENGTH + 1;
+}
+
+impl IotaPublicKey for Secp256r1PublicKey {
+    const SIGNATURE_SCHEME: SignatureScheme = SignatureScheme::Secp256r1;
+}
+
+#[enum_dispatch(Signature)]
+pub trait IotaSignature: Sized + ToFromBytes {
+    fn signature_bytes(&self) -> &[u8];
+    fn public_key_bytes(&self) -> &[u8];
+    fn scheme(&self) -> SignatureScheme;
+
+    fn verify_secure<T>(
+        &self,
+        value: &IntentMessage<T>,
+        author: IotaAddress,
+        scheme: SignatureScheme,
+    ) -> IotaResult<()>
+    where
+        T: Serialize;
+}
+
+impl<S: IotaSignatureInner + Sized> IotaSignature for S {
+    fn signature_bytes(&self) -> &[u8] {
+        // Access array slice is safe because the array bytes is initialized as
+        // flag || signature || pubkey with its defined length.
+        &self.as_ref()[1..1 + S::Sig::LENGTH]
+    }
+
+    fn public_key_bytes(&self) -> &[u8] {
+        // Access array slice is safe because the array bytes is initialized as
+        // flag || signature || pubkey with its defined length.
+        &self.as_ref()[S::Sig::LENGTH + 1..]
+    }
+
+    fn scheme(&self) -> SignatureScheme {
+        S::PubKey::SIGNATURE_SCHEME
+    }
+
+    fn verify_secure<T>(
+        &self,
+        value: &IntentMessage<T>,
+        author: IotaAddress,
+        scheme: SignatureScheme,
+    ) -> Result<(), IotaError>
+    where
+        T: Serialize,
+    {
+        let mut hasher = DefaultHash::default();
+        hasher.update(bcs::to_bytes(&value).expect("Message serialization should not fail"));
+        let digest = hasher.finalize().digest;
+
+        let (sig, pk) = &self.get_verification_inputs()?;
+        match scheme {
+            SignatureScheme::ZkLoginAuthenticator => {} // Pass this check because zk login does
+            // not derive address from pubkey.
+            _ => {
+                let address = IotaAddress::from(pk);
+                if author != address {
+                    return Err(IotaError::IncorrectSigner {
+                        error: format!(
+                            "Incorrect signer, expected {:?}, got {:?}",
+                            author, address
+                        ),
+                    });
+                }
+            }
+        }
+
+        pk.verify(&digest, sig)
+            .map_err(|e| IotaError::InvalidSignature {
+                error: format!("Fail to verify user sig {}", e),
+            })
     }
 }

--- a/identity_storage/Cargo.toml
+++ b/identity_storage/Cargo.toml
@@ -14,7 +14,9 @@ description = "Abstractions over storage for cryptographic keys used in DID Docu
 [dependencies]
 anyhow = { version = "1.0.82" }
 async-trait = { version = "0.1.64", default-features = false }
+bcs = { version = "0.1.4", optional = true }
 bls12_381_plus = { workspace = true, optional = true }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597", package = "fastcrypto", optional = true }
 futures = { version = "0.3.27", default-features = false, features = ["async-await"] }
 identity_core = { version = "=1.4.0", path = "../identity_core", default-features = false }
 identity_credential = { version = "=1.4.0", path = "../identity_credential", default-features = false, features = ["credential", "presentation"] }
@@ -27,7 +29,7 @@ iota-crypto = { version = "0.23.2", default-features = false, features = ["ed255
 json-proof-token = { workspace = true, optional = true }
 rand = { version = "0.8.5", default-features = false, features = ["std", "std_rng"], optional = true }
 seahash = { version = "4.1.0", default-features = false }
-secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.1.0", optional = true }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.2.0", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
@@ -49,7 +51,13 @@ send-sync-storage = ["identity_iota_core?/send-sync-client-ext", "secret-storage
 # Implements the JwkStorageDocumentExt trait for IotaDocument
 iota-document = ["dep:identity_iota_core"]
 # enables support to sign via storage
-storage-signer = ["identity_iota_core?/iota-client", "dep:secret-storage", "dep:identity_iota_interaction"]
+storage-signer = [
+  "identity_iota_core?/iota-client",
+  "dep:secret-storage",
+  "dep:identity_iota_interaction",
+  "dep:fastcrypto",
+  "dep:bcs",
+]
 # Enables JSON Proof Token & BBS+ related features
 jpt-bbs-plus = [
   "identity_credential/jpt-bbs-plus",

--- a/identity_storage/src/storage/storage_signer.rs
+++ b/identity_storage/src/storage/storage_signer.rs
@@ -1,10 +1,15 @@
 // Copyright 2020-2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::anyhow;
+use anyhow::Context as _;
 use async_trait::async_trait;
+use identity_iota_interaction::types::crypto::PublicKey;
+use identity_iota_interaction::types::crypto::SignatureScheme as IotaSignatureScheme;
 use identity_iota_interaction::IotaKeySignature;
 use identity_verification::jwk::Jwk;
 use identity_verification::jwk::JwkParams;
+use identity_verification::jwk::JwkParamsEc;
 use identity_verification::jwu;
 use secret_storage::Error as SecretStorageError;
 use secret_storage::SignatureScheme;
@@ -71,11 +76,45 @@ where
   fn key_id(&self) -> &KeyId {
     &self.key_id
   }
-  async fn public_key(&self) -> Result<<IotaKeySignature as SignatureScheme>::PublicKey, SecretStorageError> {
+  async fn public_key(&self) -> Result<PublicKey, SecretStorageError> {
     match self.public_key.params() {
-      JwkParams::Okp(params) => jwu::decode_b64(&params.x)
-        .map_err(|e| SecretStorageError::Other(anyhow::anyhow!("could not base64 decode key {}; {e}", self.key_id()))),
-      _ => todo!("add support for other key types"),
+      JwkParams::Okp(params) => {
+        if params.crv != "Ed25519" {
+          return Err(SecretStorageError::Other(anyhow!(
+            "unsupported key type {}",
+            params.crv
+          )));
+        }
+
+        jwu::decode_b64(&params.x)
+          .context("failed to base64 decode key")
+          .and_then(|pk_bytes| {
+            PublicKey::try_from_bytes(IotaSignatureScheme::ED25519, &pk_bytes).map_err(|e| anyhow!("{e}"))
+          })
+          .map_err(SecretStorageError::Other)
+      }
+      JwkParams::Ec(JwkParamsEc { crv, x, y, .. }) => {
+        let pk_bytes = {
+          let mut decoded_x_bytes = jwu::decode_b64(x)
+            .map_err(|e| SecretStorageError::Other(anyhow!("failed to decode b64 x parameter: {e}")))?;
+          let mut decoded_y_bytes = jwu::decode_b64(y)
+            .map_err(|e| SecretStorageError::Other(anyhow!("failed to decode b64 y parameter: {e}")))?;
+          decoded_x_bytes.append(&mut decoded_y_bytes);
+
+          decoded_x_bytes
+        };
+
+        if self.public_key.alg() == Some("ES256") || crv == "P-256" {
+          PublicKey::try_from_bytes(IotaSignatureScheme::Secp256r1, &pk_bytes)
+            .map_err(|e| SecretStorageError::Other(anyhow!("not a secp256r1 key: {e}")))
+        } else if self.public_key.alg() == Some("ES256K") || crv == "K-256" {
+          PublicKey::try_from_bytes(IotaSignatureScheme::Secp256k1, &pk_bytes)
+            .map_err(|e| SecretStorageError::Other(anyhow!("not a secp256k1 key: {e}")))
+        } else {
+          Err(SecretStorageError::Other(anyhow!("invalid EC key")))
+        }
+      }
+      _ => Err(SecretStorageError::Other(anyhow!("unsupported key"))),
     }
   }
   async fn sign(&self, data: &[u8]) -> Result<<IotaKeySignature as SignatureScheme>::Signature, SecretStorageError> {


### PR DESCRIPTION
# Description of change
Add support for non-Ed25519 keys when using signer.

## Links to any relevant issues
Closes issue #1467.

## Type of change
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Run tests.
