### PR TITLE
Re-add Resolver API for WASM builds

### DIFF
--- a/.github/actions/rust/rust-setup/action.yml
+++ b/.github/actions/rust/rust-setup/action.yml
@@ -90,7 +90,7 @@ runs:
         rustup show
 
     - name: Cache cargo
-      uses: actions/cache@v2.1.7
+      uses: actions/cache@v4
       if: inputs.cargo-cache-enabled == 'true'
       with:
         # https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
@@ -115,7 +115,7 @@ runs:
       shell: bash
 
     - name: Cache build target
-      uses: actions/cache@v2.1.7
+      uses: actions/cache@v4
       if: inputs.target-cache-enabled == 'true'
       with:
         path: ${{ inputs.target-cache-path }}
@@ -127,7 +127,7 @@ runs:
           ${{ inputs.os }}-target-
 
     - name: Cache sccache
-      uses: actions/cache@v2.1.7
+      uses: actions/cache@v4
       if: inputs.sccache-enabled == 'true'
       with:
           path: ${{ inputs.sccache-path }}

--- a/bindings/wasm/identity_wasm/Cargo.toml
+++ b/bindings/wasm/identity_wasm/Cargo.toml
@@ -76,7 +76,3 @@ empty_docs = "allow"
 [features]
 default = ["dummy-client"]
 dummy-client = ["dep:iota_interaction_ts"]
-# As identity_iota::resolver is currently not available for wasm32 this temporary flag is used
-# to switch of all code depending on identity_iota::resolver
-# TODO: Remove this feature flag after identity_iota::resolver is available for wasm32 platforms
-wasm-resolver = []

--- a/bindings/wasm/identity_wasm/examples/src/0_basic/0_create_did.ts
+++ b/bindings/wasm/identity_wasm/examples/src/0_basic/0_create_did.ts
@@ -16,13 +16,12 @@ export async function createIdentity(): Promise<void>  {
     const iotaClient = new IotaClient({ url: NETWORK_URL });
     const network = await iotaClient.getChainIdentifier();
 
-    const storage = getMemstorage();
-    // TODO: check if we can update storage implementation to a non-owning variant
-    // order is important here as wrapped storage will be set to a null pointer after passing it to a client
-    const [unpublished] = await createDocumentForNetwork(storage, network);
     // create new client that offers identity related functions
+    const storage = getMemstorage();
     const identityClient = await getClientAndCreateAccount(storage);
 
+    // create new unpublished document 
+    const [unpublished] = await createDocumentForNetwork(storage, network);
     console.log(`Unpublished DID document: ${JSON.stringify(unpublished, null, 2)}`); 
     let did: IotaDID;
 

--- a/bindings/wasm/identity_wasm/examples/src/0_basic/1_update_did.ts
+++ b/bindings/wasm/identity_wasm/examples/src/0_basic/1_update_did.ts
@@ -26,8 +26,8 @@ export async function updateIdentity() {
     const iotaClient = new IotaClient({ url: NETWORK_URL });
     const network = await iotaClient.getChainIdentifier();
     const storage = getMemstorage();
-    const [unpublished, vmFragment1] = await createDocumentForNetwork(storage, network);
     const identityClient = await getClientAndCreateAccount(storage);
+    const [unpublished, vmFragment1] = await createDocumentForNetwork(storage, network);
 
     // create new identity for this account and publish document for it
     const { output: identity } = await identityClient

--- a/bindings/wasm/identity_wasm/examples/src/0_basic/2_resolve_did.ts
+++ b/bindings/wasm/identity_wasm/examples/src/0_basic/2_resolve_did.ts
@@ -25,8 +25,8 @@ export async function resolveIdentity() {
     const iotaClient = new IotaClient({ url: NETWORK_URL });
     const network = await iotaClient.getChainIdentifier();
     const storage = getMemstorage();
-    const [unpublished, vmFragment1] = await createDocumentForNetwork(storage, network);
     const identityClient = await getClientAndCreateAccount(storage);
+    const [unpublished] = await createDocumentForNetwork(storage, network);
 
     // create new identity for this account and publish document for it
     const { output: identity } = await identityClient

--- a/bindings/wasm/identity_wasm/examples/src/0_basic/2_resolve_did.ts
+++ b/bindings/wasm/identity_wasm/examples/src/0_basic/2_resolve_did.ts
@@ -1,51 +1,63 @@
 // Copyright 2020-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO:
-// - [ ] clarify if we need/want a resolver example
-// - [ ] clarify if we need/want the AliasOutput -> ObjectID example
-
-
 import {
     CoreDocument,
     DIDJwk,
-    IotaDocument,
-    IotaIdentityClient,
+    IotaDID,
     IToCoreDocument,
-    JwkMemStore,
-    KeyIdMemStore,
     Resolver,
-    Storage,
 } from "@iota/identity-wasm/node";
-import { AliasOutput,  } from "@iota/sdk-wasm/node";
-import { API_ENDPOINT, createDid } from "../util";
-import { createDidDocument, getClientAndCreateAccount, getMemstorage } from "../utils_alpha";
+import { IotaClient as KinesisClient } from "@iota/iota-sdk/client";
+import {
+    createDocumentForNetwork,
+    getClientAndCreateAccount,
+    getMemstorage,
+    NETWORK_URL,
+} from '../utils_alpha';
 
 const DID_JWK: string =
     "did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9";
 
 /** Demonstrates how to resolve an existing DID in an Alias Output. */
 export async function resolveIdentity() {
-    // create new client to interact with chain and get funded account with keys
+    // create new clients and create new account
+    const kinesisClient = new KinesisClient({ url: NETWORK_URL });
+    const network = await kinesisClient.getChainIdentifier();
     const storage = getMemstorage();
+    const [unpublished, vmFragment1] = await createDocumentForNetwork(storage, network);
     const identityClient = await getClientAndCreateAccount(storage);
-  
-    // create new DID document and publish it
-    let [document] = await createDidDocument(identityClient, storage);
-    let did = document.id();
+
+    // create new identity for this account and publish document for it
+    const { output: identity } = await identityClient
+        .createIdentity(unpublished)
+        .finish()
+        .execute(identityClient);
+    const did = IotaDID.fromAliasId(identity.id(), identityClient.network());
 
     // Resolve the associated Alias Output and extract the DID document from it.
-    const resolved: IotaDocument = await identityClient.resolveDid(did);
+    const resolved = await identityClient.resolveDid(did);
     console.log("Resolved DID document:", JSON.stringify(resolved, null, 2));
 
-    // We can also resolve the Object ID reictly
-    const aliasOutput: AliasOutput = await identityClient.resolveDidOutput(did);
-    console.log("The Alias Output holds " + aliasOutput.getAmount() + " tokens");
+    // We can resolve the Object ID directly
+    const resolvedIdentity = await identityClient.getIdentity(identity.id());
+    console.dir(resolvedIdentity);
+    console.log(`Resolved identity has object ID ${resolvedIdentity.toFullFledged()?.id()}`);
 
-    // did:jwk can be resolved as well.
+    // Or we can resolve it via the `Resolver` api:
+
+    // While at it, also define a custom resolver for jwk:
     const handlers = new Map<string, (did: string) => Promise<CoreDocument | IToCoreDocument>>();
     handlers.set("jwk", didJwkHandler);
-    const resolver = new Resolver({ handlers });
+
+    // Create new `Resolver` instance
+    const resolver = new Resolver({ client: identityClient, handlers });
+
+    // and resolve DID with it.
+    const resolverResolved = await resolver.resolve(did.toString());
+    console.log(`resolverResolved ${DID_JWK} resolves to:\n ${JSON.stringify(resolverResolved, null, 2)}`);
+
+    // We can also resolve via the custom resolver defined before:
     const did_jwk_resolved_doc = await resolver.resolve(DID_JWK);
     console.log(`DID ${DID_JWK} resolves to:\n ${JSON.stringify(did_jwk_resolved_doc, null, 2)}`);
 }

--- a/bindings/wasm/identity_wasm/examples/src/0_basic/2_resolve_did.ts
+++ b/bindings/wasm/identity_wasm/examples/src/0_basic/2_resolve_did.ts
@@ -46,14 +46,14 @@ export async function resolveIdentity() {
 
     // Or we can resolve it via the `Resolver` api:
 
-    // While at it, also define a custom resolver for jwk:
+    // While at it, define a custom resolver for jwk DIDs as well.
     const handlers = new Map<string, (did: string) => Promise<CoreDocument | IToCoreDocument>>();
     handlers.set("jwk", didJwkHandler);
 
     // Create new `Resolver` instance
     const resolver = new Resolver({ client: identityClient, handlers });
 
-    // and resolve DID with it.
+    // and resolve identity DID with it.
     const resolverResolved = await resolver.resolve(did.toString());
     console.log(`resolverResolved ${DID_JWK} resolves to:\n ${JSON.stringify(resolverResolved, null, 2)}`);
 

--- a/bindings/wasm/identity_wasm/examples/src/0_basic/2_resolve_did.ts
+++ b/bindings/wasm/identity_wasm/examples/src/0_basic/2_resolve_did.ts
@@ -8,7 +8,7 @@ import {
     IToCoreDocument,
     Resolver,
 } from "@iota/identity-wasm/node";
-import { IotaClient as KinesisClient } from "@iota/iota-sdk/client";
+import { IotaClient } from "@iota/iota-sdk/client";
 import {
     createDocumentForNetwork,
     getClientAndCreateAccount,
@@ -22,8 +22,8 @@ const DID_JWK: string =
 /** Demonstrates how to resolve an existing DID in an Alias Output. */
 export async function resolveIdentity() {
     // create new clients and create new account
-    const kinesisClient = new KinesisClient({ url: NETWORK_URL });
-    const network = await kinesisClient.getChainIdentifier();
+    const iotaClient = new IotaClient({ url: NETWORK_URL });
+    const network = await iotaClient.getChainIdentifier();
     const storage = getMemstorage();
     const [unpublished, vmFragment1] = await createDocumentForNetwork(storage, network);
     const identityClient = await getClientAndCreateAccount(storage);

--- a/bindings/wasm/identity_wasm/examples/src/0_basic/2_resolve_did.ts
+++ b/bindings/wasm/identity_wasm/examples/src/0_basic/2_resolve_did.ts
@@ -4,7 +4,9 @@
 import {
     CoreDocument,
     DIDJwk,
+    IdentityClientReadOnly,
     IotaDID,
+    IotaDocument,
     IToCoreDocument,
     Resolver,
 } from "@iota/identity-wasm/node";
@@ -13,6 +15,7 @@ import {
     createDocumentForNetwork,
     getClientAndCreateAccount,
     getMemstorage,
+    IDENTITY_IOTA_PACKAGE_ID,
     NETWORK_URL,
 } from '../utils_alpha';
 
@@ -50,16 +53,29 @@ export async function resolveIdentity() {
     const handlers = new Map<string, (did: string) => Promise<CoreDocument | IToCoreDocument>>();
     handlers.set("jwk", didJwkHandler);
 
-    // Create new `Resolver` instance
+    // Create new `Resolver` instance with the client with write capabilities we already have at hand
     const resolver = new Resolver({ client: identityClient, handlers });
 
     // and resolve identity DID with it.
     const resolverResolved = await resolver.resolve(did.toString());
-    console.log(`resolverResolved ${DID_JWK} resolves to:\n ${JSON.stringify(resolverResolved, null, 2)}`);
+    console.log(`resolverResolved ${did.toString()} resolves to:\n ${JSON.stringify(resolverResolved, null, 2)}`);
 
     // We can also resolve via the custom resolver defined before:
     const did_jwk_resolved_doc = await resolver.resolve(DID_JWK);
     console.log(`DID ${DID_JWK} resolves to:\n ${JSON.stringify(did_jwk_resolved_doc, null, 2)}`);
+
+    // We can also create a resolver with a read-only client
+    const identityClientReadOnly = await IdentityClientReadOnly.createWithPkgId(iotaClient, IDENTITY_IOTA_PACKAGE_ID);
+    // In this case we will only be resolving `IotaDocument` instances, as we don't pass a `handler` configuration.
+    // Therefore we can limit the type of the resolved documents to `IotaDocument` when creating the new resolver as well.
+    const resolverWithReadOnlyClient = new Resolver<IotaDocument>({ client: identityClientReadOnly });
+
+    // And resolve as before.
+    const resolvedViaReadOnly = await resolverWithReadOnlyClient.resolve(did.toString());
+    console.log(`resolverWithReadOnlyClient ${did.toString()} resolves to:\n ${JSON.stringify(resolvedViaReadOnly, null, 2)}`);
+
+    // As our `Resolver<IotaDocument>` instance will only return `IotaDocument` instances, we can directly work with them, w.g.
+    console.log(`${did.toString()}'s metadata is ${resolvedViaReadOnly.metadata()}`);
 }
 
 const didJwkHandler = async (did: string) => {

--- a/bindings/wasm/identity_wasm/examples/src/0_basic/2_resolve_did.ts
+++ b/bindings/wasm/identity_wasm/examples/src/0_basic/2_resolve_did.ts
@@ -74,7 +74,7 @@ export async function resolveIdentity() {
     const resolvedViaReadOnly = await resolverWithReadOnlyClient.resolve(did.toString());
     console.log(`resolverWithReadOnlyClient ${did.toString()} resolves to:\n ${JSON.stringify(resolvedViaReadOnly, null, 2)}`);
 
-    // As our `Resolver<IotaDocument>` instance will only return `IotaDocument` instances, we can directly work with them, w.g.
+    // As our `Resolver<IotaDocument>` instance will only return `IotaDocument` instances, we can directly work with them, e.g.
     console.log(`${did.toString()}'s metadata is ${resolvedViaReadOnly.metadata()}`);
 }
 

--- a/bindings/wasm/identity_wasm/examples/src/0_basic/3_deactivate_did.ts
+++ b/bindings/wasm/identity_wasm/examples/src/0_basic/3_deactivate_did.ts
@@ -17,8 +17,8 @@ export async function deactivateIdentity() {
     const iotaClient = new IotaClient({ url: NETWORK_URL });
     const network = await iotaClient.getChainIdentifier();
     const storage = getMemstorage();
-    const [unpublished, vmFragment1] = await createDocumentForNetwork(storage, network);
     const identityClient = await getClientAndCreateAccount(storage);
+    const [unpublished] = await createDocumentForNetwork(storage, network);
 
     // create new identity for this account and publish document for it
     const { output: identity } = await identityClient

--- a/bindings/wasm/identity_wasm/examples/src/1_advanced/4_custom_resolution.ts
+++ b/bindings/wasm/identity_wasm/examples/src/1_advanced/4_custom_resolution.ts
@@ -4,7 +4,7 @@ import {
     IotaDocument,
     Resolver,
 } from "@iota/identity-wasm/node";
-import { IotaClient as KinesisClient } from "@iota/iota-sdk/client";
+import { IotaClient } from "@iota/iota-sdk/client";
 import {
     createDocumentForNetwork,
     getClientAndCreateAccount,
@@ -28,8 +28,8 @@ export async function customResolution() {
     };
 
     // create new clients and create new account
-    const kinesisClient = new KinesisClient({ url: NETWORK_URL });
-    const network = await kinesisClient.getChainIdentifier();
+    const iotaClient = new IotaClient({ url: NETWORK_URL });
+    const network = await iotaClient.getChainIdentifier();
     const storage = getMemstorage();
     const [unpublished, vmFragment1] = await createDocumentForNetwork(storage, network);
     const identityClient = await getClientAndCreateAccount(storage);

--- a/bindings/wasm/identity_wasm/examples/src/1_advanced/4_custom_resolution.ts
+++ b/bindings/wasm/identity_wasm/examples/src/1_advanced/4_custom_resolution.ts
@@ -31,8 +31,8 @@ export async function customResolution() {
     const iotaClient = new IotaClient({ url: NETWORK_URL });
     const network = await iotaClient.getChainIdentifier();
     const storage = getMemstorage();
-    const [unpublished, vmFragment1] = await createDocumentForNetwork(storage, network);
     const identityClient = await getClientAndCreateAccount(storage);
+    const [unpublished] = await createDocumentForNetwork(storage, network);
     
     // create new identity for this account and publish document for it, DID of it will be resolved later on
     const { output: identity } = await identityClient

--- a/bindings/wasm/identity_wasm/examples/src/1_advanced/4_custom_resolution.ts
+++ b/bindings/wasm/identity_wasm/examples/src/1_advanced/4_custom_resolution.ts
@@ -15,16 +15,27 @@ import {
 // Use this external package to avoid implementing the entire did:key method in this example.
 import * as ed25519 from "@transmute/did-key-ed25519";
 
+type KeyDocument = { customProperty: String } & CoreDocument;
+
+function isKeyDocument(doc: object): doc is KeyDocument {
+    return 'customProperty' in doc;
+}
+
 /** Demonstrates how to set up a resolver using custom handlers.
  */
 export async function customResolution() {
     // Set up a handler for resolving Ed25519 did:key
-    const keyHandler = async function(didKey: string): Promise<CoreDocument> {
+    const keyHandler = async function(didKey: string): Promise<KeyDocument> {
         let document = await ed25519.resolve(
             didKey,
             { accept: "application/did+ld+json" },
         );
-        return CoreDocument.fromJSON(document.didDocument);
+
+        // for demo purposes we'll just inject the custom property into a core document
+        // instead of creating a proper instance
+        let coreDocument = CoreDocument.fromJSON(document.didDocument);
+        (coreDocument as unknown as KeyDocument).customProperty = "foobar";
+        return coreDocument as unknown as KeyDocument;
     };
 
     // create new clients and create new account
@@ -42,10 +53,10 @@ export async function customResolution() {
     const did = IotaDID.fromAliasId(identity.id(), identityClient.network());
 
     // Construct a Resolver capable of resolving the did:key and iota methods.
-    let handlerMap: Map<string, (did: string) => Promise<IotaDocument | CoreDocument>> = new Map();
+    let handlerMap: Map<string, (did: string) => Promise<IotaDocument | KeyDocument>> = new Map();
     handlerMap.set("key", keyHandler);
 
-    const resolver = new Resolver(
+    const resolver = new Resolver<IotaDocument | KeyDocument>(
         {
             client: identityClient,
             handlers: handlerMap,
@@ -63,8 +74,9 @@ export async function customResolution() {
 
     // Check that the types of the resolved documents match our expectations:
 
-    if (didKeyDoc instanceof CoreDocument) {
+    if (isKeyDocument(didKeyDoc)) {
         console.log("Resolved DID Key document:", JSON.stringify(didKeyDoc, null, 2));
+        console.log(`Resolved DID Key document has a custom property with the value '${didKeyDoc.customProperty}'`);
     } else {
         throw new Error(
             "the resolved document type should match the output type of keyHandler",

--- a/bindings/wasm/identity_wasm/examples/src/1_advanced/4_custom_resolution.ts
+++ b/bindings/wasm/identity_wasm/examples/src/1_advanced/4_custom_resolution.ts
@@ -1,14 +1,16 @@
 import {
     CoreDocument,
+    IotaDID,
     IotaDocument,
-    IotaIdentityClient,
-    JwkMemStore,
-    KeyIdMemStore,
     Resolver,
-    Storage,
 } from "@iota/identity-wasm/node";
-import { Client, MnemonicSecretManager, Utils } from "@iota/sdk-wasm/node";
-import { API_ENDPOINT, createDid } from "../util";
+import { IotaClient as KinesisClient } from "@iota/iota-sdk/client";
+import {
+    createDocumentForNetwork,
+    getClientAndCreateAccount,
+    getMemstorage,
+    NETWORK_URL,
+} from '../utils_alpha';
 
 // Use this external package to avoid implementing the entire did:key method in this example.
 import * as ed25519 from "@transmute/did-key-ed25519";
@@ -25,12 +27,19 @@ export async function customResolution() {
         return CoreDocument.fromJSON(document.didDocument);
     };
 
-    // Create a new Client to interact with the IOTA ledger.
-    const client = new Client({
-        primaryNode: API_ENDPOINT,
-        localPow: true,
-    });
-    const didClient = new IotaIdentityClient(client);
+    // create new clients and create new account
+    const kinesisClient = new KinesisClient({ url: NETWORK_URL });
+    const network = await kinesisClient.getChainIdentifier();
+    const storage = getMemstorage();
+    const [unpublished, vmFragment1] = await createDocumentForNetwork(storage, network);
+    const identityClient = await getClientAndCreateAccount(storage);
+    
+    // create new identity for this account and publish document for it, DID of it will be resolved later on
+    const { output: identity } = await identityClient
+        .createIdentity(unpublished)
+        .finish()
+        .execute(identityClient);
+    const did = IotaDID.fromAliasId(identity.id(), identityClient.network());
 
     // Construct a Resolver capable of resolving the did:key and iota methods.
     let handlerMap: Map<string, (did: string) => Promise<IotaDocument | CoreDocument>> = new Map();
@@ -38,7 +47,7 @@ export async function customResolution() {
 
     const resolver = new Resolver(
         {
-            client: didClient,
+            client: identityClient,
             handlers: handlerMap,
         },
     );
@@ -46,24 +55,10 @@ export async function customResolution() {
     // A valid Ed25519 did:key value taken from https://w3c-ccg.github.io/did-method-key/#example-1-a-simple-ed25519-did-key-value.
     const didKey = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
 
-    // Generate a random mnemonic for our wallet.
-    const secretManager: MnemonicSecretManager = {
-        mnemonic: Utils.generateMnemonic(),
-    };
-
-    // Creates a new wallet and identity for us to resolve (see "0_create_did" example).
-    const storage: Storage = new Storage(new JwkMemStore(), new KeyIdMemStore());
-    let { document } = await createDid(
-        client,
-        secretManager,
-        storage,
-    );
-    const did = document.id();
-
     // Resolve didKey into a DID document.
     const didKeyDoc = await resolver.resolve(didKey);
 
-    // Resolve the DID we created on the IOTA ledger.
+    // Resolve the DID we created on the IOTA network.
     const didIotaDoc = await resolver.resolve(did.toString());
 
     // Check that the types of the resolved documents match our expectations:

--- a/bindings/wasm/identity_wasm/examples/src/main.ts
+++ b/bindings/wasm/identity_wasm/examples/src/main.ts
@@ -14,7 +14,7 @@ import { deactivateIdentity } from "./0_basic/3_deactivate_did";
 // import { didIssuesNft } from "./1_advanced/1_did_issues_nft";
 // import { nftOwnsDid } from "./1_advanced/2_nft_owns_did";
 // import { didIssuesTokens } from "./1_advanced/3_did_issues_tokens";
-// import { customResolution } from "./1_advanced/4_custom_resolution";
+import { customResolution } from "./1_advanced/4_custom_resolution";
 // import { domainLinkage } from "./1_advanced/5_domain_linkage";
 // import { sdJwt } from "./1_advanced/6_sd_jwt";
 // import { statusList2021 } from "./1_advanced/7_status_list_2021";
@@ -55,8 +55,8 @@ async function main() {
         //     return await nftOwnsDid();
         // case "3_did_issues_tokens":
         //     return await didIssuesTokens();
-        // case "4_custom_resolution":
-        //     return await customResolution();
+        case "4_custom_resolution":
+            return await customResolution();
         // case "5_domain_linkage":
         //     return await domainLinkage();
         // case "6_sd_jwt":

--- a/bindings/wasm/identity_wasm/examples/src/main.ts
+++ b/bindings/wasm/identity_wasm/examples/src/main.ts
@@ -4,7 +4,7 @@
 import { testApiCall } from "./0_basic/-1_test_api_call";
 import { createIdentity } from "./0_basic/0_create_did";
 import { updateIdentity } from "./0_basic/1_update_did";
-// import { resolveIdentity } from "./0_basic/2_resolve_did";
+import { resolveIdentity } from "./0_basic/2_resolve_did";
 import { deactivateIdentity } from "./0_basic/3_deactivate_did";
 // import { deleteIdentity } from "./0_basic/4_delete_did";
 // import { createVC } from "./0_basic/5_create_vc";
@@ -35,8 +35,8 @@ async function main() {
             return await createIdentity();
         case "1_update_did":
             return await updateIdentity();
-        // case "2_resolve_did":
-        //     return await resolveIdentity();
+        case "2_resolve_did":
+            return await resolveIdentity();
         case "3_deactivate_did":
             return await deactivateIdentity();
         // case "4_delete_did":

--- a/bindings/wasm/identity_wasm/lib/index.ts
+++ b/bindings/wasm/identity_wasm/lib/index.ts
@@ -9,3 +9,6 @@ export * from "./jwk_storage";
 export * from "./key_id_storage";
 
 export * from "~identity_wasm";
+
+// keep this export last to override the original `Resolver` from `identity_wasm` in the exports
+export { Resolver } from "./resolver";

--- a/bindings/wasm/identity_wasm/lib/resolver.ts
+++ b/bindings/wasm/identity_wasm/lib/resolver.ts
@@ -1,0 +1,37 @@
+// Copyright 2021-2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { CoreDocument, IToCoreDocument, Resolver as ResolverInner } from "~identity_wasm";
+
+// `Resolver` type below acts the same as the "normal" resolver from `~identity_wasm`
+// with the difference being that the `Resolver` here allows to pass generic type params to
+// the constructor to specify the types expected to be returned by the `resolve` function.
+
+/**
+* Convenience type for resolving DID documents from different DID methods.
+* 
+* DID documents resolved with `resolve` will have the type specified as generic type parameter T.
+* With the default being `CoreDocument | IToCoreDocument`.
+*  
+* Also provides methods for resolving DID Documents associated with
+* verifiable {@link Credential}s and {@link Presentation}s.
+*
+* # Configuration
+*
+* The resolver will only be able to resolve DID documents for methods it has been configured for in the constructor.
+*/
+export class Resolver<T extends (CoreDocument | IToCoreDocument)> extends ResolverInner {
+    /**
+    * Fetches the DID Document of the given DID.
+    *
+    * ### Errors
+    *
+    * Errors if the resolver has not been configured to handle the method
+    * corresponding to the given DID or the resolution process itself fails.
+    * @param {string} did
+    * @returns {Promise<T>}
+    */
+    async resolve(did: string): Promise<T> {
+      return super.resolve(did) as unknown as T;
+    }
+  } 

--- a/bindings/wasm/identity_wasm/src/error.rs
+++ b/bindings/wasm/identity_wasm/src/error.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use identity_iota::credential::CompoundJwtPresentationValidationError;
-#[cfg(feature = "wasm-resolver")]
 use identity_iota::resolver;
 use identity_iota::storage::key_id_storage::KeyIdStorageError;
 use identity_iota::storage::key_id_storage::KeyIdStorageErrorKind;
@@ -159,7 +158,6 @@ impl<'a, E: std::error::Error> Display for ErrorMessage<'a, E> {
   }
 }
 
-#[cfg(feature = "wasm-resolver")]
 impl From<resolver::Error> for WasmError<'_> {
   fn from(error: resolver::Error) -> Self {
     Self {

--- a/bindings/wasm/identity_wasm/src/iota/iota_document.rs
+++ b/bindings/wasm/identity_wasm/src/iota/iota_document.rs
@@ -648,7 +648,9 @@ impl WasmIotaDocument {
   /// Serializes to a plain JS representation.
   #[wasm_bindgen(js_name = toJSON)]
   pub fn to_json(&self) -> Result<JsValue> {
-    JsValue::from_serde(&self.0.try_read()?.as_ref()).wasm_result()
+    let read_guard = self.0.try_read()?;
+    let iota_document: &IotaDocument = &read_guard;
+    JsValue::from_serde(&iota_document).wasm_result()
   }
 
   /// Deserializes an instance from a plain JS representation.

--- a/bindings/wasm/identity_wasm/src/resolver/mod.rs
+++ b/bindings/wasm/identity_wasm/src/resolver/mod.rs
@@ -3,6 +3,8 @@
 
 mod resolver_config;
 mod resolver_types;
+mod wasm_did_resolution_handler;
 mod wasm_resolver;
 
 pub use resolver_types::*;
+pub use wasm_did_resolution_handler::WasmDidDidResolutionHandler;

--- a/bindings/wasm/identity_wasm/src/resolver/mod.rs
+++ b/bindings/wasm/identity_wasm/src/resolver/mod.rs
@@ -7,4 +7,4 @@ mod wasm_did_resolution_handler;
 mod wasm_resolver;
 
 pub use resolver_types::*;
-pub use wasm_did_resolution_handler::WasmDidDidResolutionHandler;
+pub use wasm_did_resolution_handler::WasmDidResolutionHandler;

--- a/bindings/wasm/identity_wasm/src/resolver/mod.rs
+++ b/bindings/wasm/identity_wasm/src/resolver/mod.rs
@@ -3,7 +3,6 @@
 
 mod resolver_config;
 mod resolver_types;
-#[cfg(feature = "wasm-resolver")]
 mod wasm_resolver;
 
 pub use resolver_types::*;

--- a/bindings/wasm/identity_wasm/src/resolver/resolver_config.rs
+++ b/bindings/wasm/identity_wasm/src/resolver/resolver_config.rs
@@ -3,7 +3,7 @@
 
 use wasm_bindgen::prelude::*;
 
-use super::WasmDidDidResolutionHandler;
+use super::WasmDidResolutionHandler;
 
 #[wasm_bindgen]
 extern "C" {
@@ -14,7 +14,7 @@ extern "C" {
   pub type ResolverConfig;
 
   #[wasm_bindgen(method, getter)]
-  pub(crate) fn client(this: &ResolverConfig) -> Option<WasmDidDidResolutionHandler>;
+  pub(crate) fn client(this: &ResolverConfig) -> Option<WasmDidResolutionHandler>;
 
   #[wasm_bindgen(method, getter)]
   pub(crate) fn handlers(this: &ResolverConfig) -> Option<MapResolutionHandler>;
@@ -35,7 +35,7 @@ export type ResolverConfig = {
     /**
      * Client for resolving DIDs of the iota method, usually an {@link IdentityClient} or an {@link IdentityClientReadOnly}
      */
-    client?: WasmDidDidResolutionHandler,
+    client?: WasmDidResolutionHandler,
 
     /**
      * Handlers for resolving DIDs from arbitrary DID methods. 

--- a/bindings/wasm/identity_wasm/src/resolver/resolver_config.rs
+++ b/bindings/wasm/identity_wasm/src/resolver/resolver_config.rs
@@ -3,7 +3,7 @@
 
 use wasm_bindgen::prelude::*;
 
-use crate::rebased::WasmIdentityClient;
+use super::WasmDidDidResolutionHandler;
 
 #[wasm_bindgen]
 extern "C" {
@@ -14,7 +14,7 @@ extern "C" {
   pub type ResolverConfig;
 
   #[wasm_bindgen(method, getter)]
-  pub(crate) fn client(this: &ResolverConfig) -> Option<WasmIdentityClient>;
+  pub(crate) fn client(this: &ResolverConfig) -> Option<WasmDidDidResolutionHandler>;
 
   #[wasm_bindgen(method, getter)]
   pub(crate) fn handlers(this: &ResolverConfig) -> Option<MapResolutionHandler>;
@@ -33,9 +33,9 @@ const TS_RESOLVER_CONFIG: &'static str = r#"
  */
 export type ResolverConfig = {
     /**
-     * Client for resolving DIDs of the iota method. 
+     * Client for resolving DIDs of the iota method, usually an {@link IdentityClient} or an {@link IdentityClientReadOnly}
      */
-    client?: IdentityClient,
+    client?: WasmDidDidResolutionHandler,
 
     /**
      * Handlers for resolving DIDs from arbitrary DID methods. 

--- a/bindings/wasm/identity_wasm/src/resolver/resolver_config.rs
+++ b/bindings/wasm/identity_wasm/src/resolver/resolver_config.rs
@@ -3,7 +3,7 @@
 
 use wasm_bindgen::prelude::*;
 
-use crate::iota::WasmIotaIdentityClient;
+use crate::rebased::WasmIdentityClient;
 
 #[wasm_bindgen]
 extern "C" {
@@ -14,7 +14,7 @@ extern "C" {
   pub type ResolverConfig;
 
   #[wasm_bindgen(method, getter)]
-  pub(crate) fn client(this: &ResolverConfig) -> Option<WasmIotaIdentityClient>;
+  pub(crate) fn client(this: &ResolverConfig) -> Option<WasmIdentityClient>;
 
   #[wasm_bindgen(method, getter)]
   pub(crate) fn handlers(this: &ResolverConfig) -> Option<MapResolutionHandler>;
@@ -35,7 +35,7 @@ export type ResolverConfig = {
     /**
      * Client for resolving DIDs of the iota method. 
      */
-    client?: IIotaIdentityClient,
+    client?: IdentityClient,
 
     /**
      * Handlers for resolving DIDs from arbitrary DID methods. 

--- a/bindings/wasm/identity_wasm/src/resolver/wasm_did_resolution_handler.rs
+++ b/bindings/wasm/identity_wasm/src/resolver/wasm_did_resolution_handler.rs
@@ -1,0 +1,45 @@
+// Copyright 2020-2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use identity_iota::iota::DidResolutionHandler;
+use identity_iota::iota::IotaDID;
+use identity_iota::iota::IotaDocument;
+use js_sys::Promise;
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::JsValue;
+use wasm_bindgen_futures::JsFuture;
+
+use crate::error::JsValueResult;
+use crate::iota::PromiseIotaDocument;
+use crate::iota::WasmIotaDID;
+
+#[wasm_bindgen(typescript_custom_section)]
+const WASM_DID_DID_RESOLUTION_HANDLER: &str = r#"
+interface WasmDidDidResolutionHandler {
+  resolveDid: (did: IotaDID) => Promise<IotaDocument>;
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+  #[wasm_bindgen(typescript_type = "WasmDidDidResolutionHandler")]
+  pub type WasmDidDidResolutionHandler;
+
+  #[wasm_bindgen(js_name = "resolveDid", method)]
+  pub fn resolve_did(this: &WasmDidDidResolutionHandler, did: WasmIotaDID) -> PromiseIotaDocument;
+}
+
+#[async_trait::async_trait(?Send)]
+impl DidResolutionHandler for WasmDidDidResolutionHandler {
+  async fn resolve_did(&self, did: &IotaDID) -> Result<IotaDocument, identity_iota::iota::Error> {
+    let promise: Promise = Promise::resolve(&self.resolve_did(WasmIotaDID(did.clone())));
+    let result: JsValueResult = JsFuture::from(promise).await.into();
+    let js_value: JsValue = result.to_iota_core_error()?;
+
+    js_value.into_serde().map_err(|err| {
+      identity_iota::iota::Error::JsError(format!(
+        "failed to parse resolved DID document to `IotaDocument`: {err}"
+      ))
+    })
+  }
+}

--- a/bindings/wasm/identity_wasm/src/resolver/wasm_did_resolution_handler.rs
+++ b/bindings/wasm/identity_wasm/src/resolver/wasm_did_resolution_handler.rs
@@ -14,23 +14,23 @@ use crate::iota::PromiseIotaDocument;
 use crate::iota::WasmIotaDID;
 
 #[wasm_bindgen(typescript_custom_section)]
-const WASM_DID_DID_RESOLUTION_HANDLER: &str = r#"
-interface WasmDidDidResolutionHandler {
+const WASM_DID_RESOLUTION_HANDLER: &str = r#"
+interface WasmDidResolutionHandler {
   resolveDid: (did: IotaDID) => Promise<IotaDocument>;
 }
 "#;
 
 #[wasm_bindgen]
 extern "C" {
-  #[wasm_bindgen(typescript_type = "WasmDidDidResolutionHandler")]
-  pub type WasmDidDidResolutionHandler;
+  #[wasm_bindgen(typescript_type = "WasmDidResolutionHandler")]
+  pub type WasmDidResolutionHandler;
 
   #[wasm_bindgen(js_name = "resolveDid", method)]
-  pub fn resolve_did(this: &WasmDidDidResolutionHandler, did: WasmIotaDID) -> PromiseIotaDocument;
+  pub fn resolve_did(this: &WasmDidResolutionHandler, did: WasmIotaDID) -> PromiseIotaDocument;
 }
 
 #[async_trait::async_trait(?Send)]
-impl DidResolutionHandler for WasmDidDidResolutionHandler {
+impl DidResolutionHandler for WasmDidResolutionHandler {
   async fn resolve_did(&self, did: &IotaDID) -> Result<IotaDocument, identity_iota::iota::Error> {
     let promise: Promise = Promise::resolve(&self.resolve_did(WasmIotaDID(did.clone())));
     let result: JsValueResult = JsFuture::from(promise).await.into();

--- a/bindings/wasm/identity_wasm/src/resolver/wasm_resolver.rs
+++ b/bindings/wasm/identity_wasm/src/resolver/wasm_resolver.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 
 use identity_iota::did::CoreDID;
 use identity_iota::did::DID;
+use identity_iota::iota::DidResolutionHandler;
 use identity_iota::iota::IotaDID;
 use identity_iota::resolver::SingleThreadedResolver;
 use js_sys::Array;
@@ -24,6 +25,7 @@ use crate::rebased::WasmIdentityClient;
 use crate::resolver::resolver_config::MapResolutionHandler;
 use crate::resolver::resolver_config::ResolverConfig;
 use crate::resolver::PromiseArrayIToCoreDocument;
+use crate::resolver::WasmDidDidResolutionHandler;
 
 use super::resolver_types::PromiseIToCoreDocument;
 use crate::error::Result;
@@ -33,6 +35,7 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::future_to_promise;
 
 type JsDocumentResolver = SingleThreadedResolver<JsValue>;
+
 /// Convenience type for resolving DID documents from different DID methods.   
 ///  
 /// Also provides methods for resolving DID Documents associated with
@@ -57,7 +60,7 @@ impl WasmResolver {
 
     let mut attached_iota_method = false;
     let resolution_handlers: Option<MapResolutionHandler> = config.handlers();
-    let client: Option<WasmIdentityClient> = config.client();
+    let client: Option<WasmDidDidResolutionHandler> = config.client();
 
     if let Some(handlers) = resolution_handlers {
       let map: &Map = handlers.dyn_ref::<js_sys::Map>().ok_or_else(|| {
@@ -80,11 +83,11 @@ impl WasmResolver {
         ))?;
       }
 
-      let rc_client: Rc<WasmIdentityClient> = Rc::new(wasm_client);
+      let rc_client: Rc<WasmDidDidResolutionHandler> = Rc::new(wasm_client);
       // Take CoreDID (instead of IotaDID) to avoid inconsistent error messages between the
       // cases when the iota handler is attached by passing a client or directly as a handler.
       let handler = move |did: CoreDID| {
-        let rc_client_clone: Rc<WasmIdentityClient> = rc_client.clone();
+        let rc_client_clone: Rc<WasmDidDidResolutionHandler> = rc_client.clone();
         async move {
           let iota_did: IotaDID = IotaDID::parse(did).map_err(identity_iota::iota::Error::DIDSyntaxError)?;
           Self::client_as_handler(rc_client_clone.as_ref(), iota_did.into()).await
@@ -96,18 +99,14 @@ impl WasmResolver {
     Ok(Self(Rc::new(resolver)))
   }
 
-  pub(crate) async fn client_as_handler(
-    client: &WasmIdentityClient,
+  pub(crate) async fn client_as_handler<H>(
+    client: &H,
     did: WasmIotaDID,
-  ) -> std::result::Result<WasmIotaDocument, identity_iota::iota::Error> {
-    Ok(WasmIotaDocument(
-      client
-        .resolve_did(&did)
-        .await
-        .map_err(JsValue::from)
-        .map_err(|err| identity_iota::iota::Error::JsError(format!("failed to resolve DID; {:?}", &err)))?
-        .0,
-    ))
+  ) -> std::result::Result<WasmIotaDocument, identity_iota::iota::Error>
+  where
+    H: DidResolutionHandler,
+  {
+    Ok(WasmIotaDocument::from(client.resolve_did(&did.0).await?))
   }
 
   /// attempts to extract (method, handler) pairs from the entries of a map and attaches them to the resolver.

--- a/bindings/wasm/identity_wasm/src/resolver/wasm_resolver.rs
+++ b/bindings/wasm/identity_wasm/src/resolver/wasm_resolver.rs
@@ -21,11 +21,10 @@ use crate::error::JsValueResult;
 use crate::error::WasmError;
 use crate::iota::WasmIotaDID;
 use crate::iota::WasmIotaDocument;
-use crate::rebased::WasmIdentityClient;
 use crate::resolver::resolver_config::MapResolutionHandler;
 use crate::resolver::resolver_config::ResolverConfig;
 use crate::resolver::PromiseArrayIToCoreDocument;
-use crate::resolver::WasmDidDidResolutionHandler;
+use crate::resolver::WasmDidResolutionHandler;
 
 use super::resolver_types::PromiseIToCoreDocument;
 use crate::error::Result;
@@ -60,7 +59,7 @@ impl WasmResolver {
 
     let mut attached_iota_method = false;
     let resolution_handlers: Option<MapResolutionHandler> = config.handlers();
-    let client: Option<WasmDidDidResolutionHandler> = config.client();
+    let client: Option<WasmDidResolutionHandler> = config.client();
 
     if let Some(handlers) = resolution_handlers {
       let map: &Map = handlers.dyn_ref::<js_sys::Map>().ok_or_else(|| {
@@ -83,11 +82,11 @@ impl WasmResolver {
         ))?;
       }
 
-      let rc_client: Rc<WasmDidDidResolutionHandler> = Rc::new(wasm_client);
+      let rc_client: Rc<WasmDidResolutionHandler> = Rc::new(wasm_client);
       // Take CoreDID (instead of IotaDID) to avoid inconsistent error messages between the
       // cases when the iota handler is attached by passing a client or directly as a handler.
       let handler = move |did: CoreDID| {
-        let rc_client_clone: Rc<WasmDidDidResolutionHandler> = rc_client.clone();
+        let rc_client_clone: Rc<WasmDidResolutionHandler> = rc_client.clone();
         async move {
           let iota_did: IotaDID = IotaDID::parse(did).map_err(identity_iota::iota::Error::DIDSyntaxError)?;
           Self::client_as_handler(rc_client_clone.as_ref(), iota_did.into()).await

--- a/examples/1_advanced/10_zkp_revocation.rs
+++ b/examples/1_advanced/10_zkp_revocation.rs
@@ -51,6 +51,7 @@ use identity_iota::iota::rebased::transaction::Transaction;
 use identity_iota::iota::rebased::transaction::TransactionOutput;
 use identity_iota::iota::IotaDocument;
 use identity_iota::iota::NetworkName;
+use identity_iota::iota_interaction::OptionalSync;
 use identity_iota::resolver::Resolver;
 use identity_iota::storage::JwkDocumentExt;
 use identity_iota::storage::JwkMemStore;

--- a/examples/1_advanced/9_zkp.rs
+++ b/examples/1_advanced/9_zkp.rs
@@ -25,6 +25,7 @@ use identity_iota::credential::SelectiveDisclosurePresentation;
 use identity_iota::credential::Subject;
 use identity_iota::did::CoreDID;
 use identity_iota::did::DID;
+use identity_iota::iota_interaction::OptionalSync;
 
 use identity_iota::iota::rebased::transaction::TransactionOutput;
 use identity_iota::iota::IotaDocument;

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -17,12 +17,12 @@ identity_credential = { version = "=1.4.0", path = "../identity_credential", fea
 identity_did = { version = "=1.4.0", path = "../identity_did", default-features = false }
 identity_document = { version = "=1.4.0", path = "../identity_document", default-features = false }
 identity_iota_core = { version = "=1.4.0", path = "../identity_iota_core", default-features = false }
+identity_resolver = { version = "=1.4.0", path = "../identity_resolver", default-features = false, optional = true }
 identity_storage = { version = "=1.4.0", path = "../identity_storage", default-features = false, features = ["iota-document"] }
 identity_verification = { version = "=1.4.0", path = "../identity_verification", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 identity_iota_interaction = { version = "=1.4.0", path = "../identity_iota_interaction" }
-identity_resolver = { version = "=1.4.0", path = "../identity_resolver", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 identity_iota_interaction = { version = "=1.4.0", path = "../identity_iota_interaction", default-features = false }

--- a/identity_iota/src/lib.rs
+++ b/identity_iota/src/lib.rs
@@ -78,15 +78,15 @@ pub mod prelude {
   pub use identity_iota_core::IotaDocument;
 
   #[cfg(all(feature = "resolver", not(target_arch = "wasm32")))]
-  #[cfg_attr(docsrs, doc(cfg(feature = "resolver")))]
+  #[cfg_attr(docsrs, doc(cfg(all(feature = "resolver", not(target_arch = "wasm32")))))]
   pub use identity_iota_core::DidResolutionHandler;
 
-  #[cfg(all(feature = "resolver", not(target_arch = "wasm32")))]
+  #[cfg(feature = "resolver")]
   #[cfg_attr(docsrs, doc(cfg(feature = "resolver")))]
   pub use identity_resolver::Resolver;
 }
 
-#[cfg(all(feature = "resolver", not(target_arch = "wasm32")))]
+#[cfg(feature = "resolver")]
 #[cfg_attr(docsrs, doc(cfg(feature = "resolver")))]
 pub mod resolver {
   //! DID resolution utilities

--- a/identity_iota_core/src/lib.rs
+++ b/identity_iota_core/src/lib.rs
@@ -15,7 +15,7 @@
 #![allow(clippy::upper_case_acronyms)]
 
 pub use did::IotaDID;
-#[cfg(feature = "iota-client")]
+#[cfg(all(feature = "iota-client", not(target_arch = "wasm32")))]
 pub use did_resolution::DidResolutionHandler;
 pub use document::*;
 pub use network::NetworkName;
@@ -30,7 +30,7 @@ mod error;
 mod network;
 mod state_metadata;
 
-#[cfg(feature = "iota-client")]
+#[cfg(all(feature = "iota-client", not(target_arch = "wasm32")))]
 mod did_resolution;
 #[cfg(feature = "iota-client")]
 mod iota_interaction_adapter;

--- a/identity_iota_core/src/lib.rs
+++ b/identity_iota_core/src/lib.rs
@@ -15,7 +15,7 @@
 #![allow(clippy::upper_case_acronyms)]
 
 pub use did::IotaDID;
-#[cfg(all(feature = "iota-client", not(target_arch = "wasm32")))]
+#[cfg(feature = "iota-client")]
 pub use did_resolution::DidResolutionHandler;
 pub use document::*;
 pub use network::NetworkName;
@@ -30,7 +30,7 @@ mod error;
 mod network;
 mod state_metadata;
 
-#[cfg(all(feature = "iota-client", not(target_arch = "wasm32")))]
+#[cfg(feature = "iota-client")]
 mod did_resolution;
 #[cfg(feature = "iota-client")]
 mod iota_interaction_adapter;

--- a/identity_resolver/src/resolution/resolver.rs
+++ b/identity_resolver/src/resolution/resolver.rs
@@ -264,7 +264,7 @@ impl<DOC: From<CoreDocument> + 'static> Resolver<DOC, SendSyncCommand<DOC>> {
   }
 }
 
-#[cfg(feature = "iota")]
+#[cfg(all(feature = "iota", not(target_arch = "wasm32")))]
 mod iota_handler {
   use crate::ErrorCause;
 


### PR DESCRIPTION
Re-adds examples for did resolution via `Resolver` API:
- `0_basic/2_resolve_did.ts`
- `1_advanced/4_custom_resolution.ts`

`Resolver` API is re-added, but the `attach_iota_handler` and `attach_multiple_iota_handlers` parts are left out of the WASM build.

The Stardust implementation was already not using those two and was directly using a client with respective traits to resolve the DID. Updated implementation follows the same principle, but uses the new API for this.