### PR TITLE
Add waiting for transaction block availability to TS variant of `execute_transaction`

### DIFF
--- a/bindings/wasm/iota_interaction_ts/lib/iota_client_helpers.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/iota_client_helpers.ts
@@ -47,6 +47,10 @@ export class IotaTransactionBlockResponseAdapter {
     get_response(): IotaTransactionBlockResponse {
         return this.response;
     }
+
+    get_digest(): string {
+        return this.response.digest;
+    }
 }
 
 /**

--- a/identity_iota_core/src/iota_interaction_rust/iota_client_rust_sdk.rs
+++ b/identity_iota_core/src/iota_interaction_rust/iota_client_rust_sdk.rs
@@ -161,6 +161,10 @@ impl IotaTransactionBlockResponseT for IotaTransactionBlockResponseProvider {
   fn clone_native_response(&self) -> Self::NativeResponse {
     self.response.clone()
   }
+
+  fn digest(&self) -> Result<TransactionDigest, Self::Error> {
+    Ok(self.response.digest)
+  }
 }
 
 pub(crate) struct QuorumDriverAdapter<'a> {

--- a/identity_iota_interaction/src/iota_client_trait.rs
+++ b/identity_iota_interaction/src/iota_client_trait.rs
@@ -103,6 +103,9 @@ pub trait IotaTransactionBlockResponseT: OptionalSend {
 
   /// Returns a clone of the wrapped platform specific client sdk response
   fn clone_native_response(&self) -> Self::NativeResponse;
+
+  // Returns digest for transaction block.
+  fn digest(&self) -> Result<TransactionDigest, Self::Error>;
 }
 
 #[cfg_attr(not(feature = "send-sync-transaction"), async_trait(?Send))]

--- a/identity_iota_interaction/src/sdk_types/generated_types.rs
+++ b/identity_iota_interaction/src/sdk_types/generated_types.rs
@@ -132,6 +132,7 @@ pub struct GetTransactionBlockParams {
   /// the digest of the queried transaction
   digest: String,
   /// options for specifying the content to be returned
+  #[serde(skip_serializing_if = "Option::is_none")]
   options: Option<IotaTransactionBlockResponseOptions>,
 }
 
@@ -225,6 +226,40 @@ impl GetCoinsParams {
       coin_type,
       cursor,
       limit,
+    }
+  }
+}
+
+/// Params for `wait_for_transaction` / `wait_for_transaction`.
+///
+/// Be careful when serializing with `serde_wasm_bindgen::to_value`, as `#[serde(flatten)]`
+/// will turn the object into a `Map` instead of a plain object in Js.
+/// Prefer serializing with `serde_wasm_bindgen::Serializer::json_compatible` or perform custom serialization.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WaitForTransactionParams {
+  /// Block digest and options for content that should be returned.
+  #[serde(flatten)]
+  get_transaction_block_params: GetTransactionBlockParams,
+  /// The amount of time to wait for a transaction block. Defaults to one minute.
+  #[serde(skip_serializing_if = "Option::is_none")]
+  timeout: Option<u64>,
+  /// The amount of time to wait between checks for the transaction block. Defaults to 2 seconds.
+  #[serde(skip_serializing_if = "Option::is_none")]
+  poll_interval: Option<u64>,
+}
+
+impl WaitForTransactionParams {
+  pub fn new(
+    digest: String,
+    options: Option<IotaTransactionBlockResponseOptions>,
+    timeout: Option<u64>,
+    poll_interval: Option<u64>,
+  ) -> Self {
+    WaitForTransactionParams {
+      get_transaction_block_params: GetTransactionBlockParams::new(digest, options),
+      timeout,
+      poll_interval,
     }
   }
 }


### PR DESCRIPTION
# Description of change
Adds a wait command to TS impl of `execute_transaction`, that ensures that an executed transaction is available.