### PR TITLE
Fix document consuming in WASM when publishing updates 

### DIFF
--- a/bindings/wasm/identity_wasm/src/iota/iota_document.rs
+++ b/bindings/wasm/identity_wasm/src/iota/iota_document.rs
@@ -112,6 +112,7 @@ impl IotaDocumentLock {
 /// Note: All methods that involve reading from this class may potentially raise an error
 /// if the object is being concurrently modified.
 #[wasm_bindgen(js_name = IotaDocument, inspectable)]
+#[derive(Clone)]
 pub struct WasmIotaDocument(pub(crate) Rc<IotaDocumentLock>);
 
 #[wasm_bindgen(js_class = IotaDocument)]

--- a/bindings/wasm/identity_wasm/src/rebased/identity.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/identity.rs
@@ -84,10 +84,10 @@ impl WasmOnChainIdentity {
   #[wasm_bindgen(js_name = updateDidDocument)]
   pub fn update_did_document(
     &self,
-    updated_doc: WasmIotaDocument,
+    updated_doc: &WasmIotaDocument,
     expiration_epoch: Option<u64>,
   ) -> WasmCreateUpdateDidProposalTx {
-    WasmCreateUpdateDidProposalTx::new(self, updated_doc, expiration_epoch)
+    WasmCreateUpdateDidProposalTx::new(self, updated_doc.clone(), expiration_epoch)
   }
 
   #[wasm_bindgen(js_name = deactivateDid)]

--- a/bindings/wasm/iota_interaction_ts/lib/iota_client_helpers.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/iota_client_helpers.ts
@@ -47,6 +47,10 @@ export class IotaTransactionBlockResponseAdapter {
     get_response(): IotaTransactionBlockResponse {
         return this.response;
     }
+
+    get_digest(): string {
+        return this.response.digest;
+    }
 }
 
 /**

--- a/identity_iota_interaction/src/iota_client_trait.rs
+++ b/identity_iota_interaction/src/iota_client_trait.rs
@@ -103,6 +103,9 @@ pub trait IotaTransactionBlockResponseT: OptionalSend {
 
   /// Returns a clone of the wrapped platform specific client sdk response
   fn clone_native_response(&self) -> Self::NativeResponse;
+
+  // Returns digest for transaction block.
+  fn digest(&self) -> Result<TransactionDigest, Self::Error>;
 }
 
 #[cfg_attr(not(feature = "send-sync-transaction"), async_trait(?Send))]

--- a/identity_iota_interaction/src/sdk_types/generated_types.rs
+++ b/identity_iota_interaction/src/sdk_types/generated_types.rs
@@ -132,6 +132,7 @@ pub struct GetTransactionBlockParams {
   /// the digest of the queried transaction
   digest: String,
   /// options for specifying the content to be returned
+  #[serde(skip_serializing_if = "Option::is_none")]
   options: Option<IotaTransactionBlockResponseOptions>,
 }
 
@@ -225,6 +226,40 @@ impl GetCoinsParams {
       coin_type,
       cursor,
       limit,
+    }
+  }
+}
+
+/// Params for `wait_for_transaction` / `wait_for_transaction`.
+///
+/// Be careful when serializing with `serde_wasm_bindgen::to_value`, as `#[serde(flatten)]`
+/// will turn the object into a `Map` instead of a plain object in Js.
+/// Prefer serializing with `serde_wasm_bindgen::Serializer::json_compatible` or perform custom serialization.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WaitForTransactionParams {
+  /// Block digest and options for content that should be returned.
+  #[serde(flatten)]
+  get_transaction_block_params: GetTransactionBlockParams,
+  /// The amount of time to wait for a transaction block. Defaults to one minute.
+  #[serde(skip_serializing_if = "Option::is_none")]
+  timeout: Option<u64>,
+  /// The amount of time to wait between checks for the transaction block. Defaults to 2 seconds.
+  #[serde(skip_serializing_if = "Option::is_none")]
+  poll_interval: Option<u64>,
+}
+
+impl WaitForTransactionParams {
+  pub fn new(
+    digest: String,
+    options: Option<IotaTransactionBlockResponseOptions>,
+    timeout: Option<u64>,
+    poll_interval: Option<u64>,
+  ) -> Self {
+    WaitForTransactionParams {
+      get_transaction_block_params: GetTransactionBlockParams::new(digest, options),
+      timeout,
+      poll_interval,
     }
   }
 }


### PR DESCRIPTION
## Description of change
Fix consuming of document arguments when publishing document updates in WASM.

Documents are now cloned instead of passing it to follow up steps.