### PR TITLE
Limit parallel test execution

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -151,10 +151,10 @@ jobs:
 
       - name: Run tests excluding `custom_time` feature
         if: matrix.os != 'windows-latest'
-        run: cargo test --workspace --release -- --test-threads=2
+        run: cargo test --workspace --release -- --test-threads=1
 
       - name: Run tests with `custom_time` feature
-        run: cargo test --test custom_time --features="custom_time" -- --test-threads=2
+        run: cargo test --test custom_time --features="custom_time" -- --test-threads=1
 
       - name: Run Rust examples
         # run examples only on ubuntu for now

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -151,10 +151,10 @@ jobs:
 
       - name: Run tests excluding `custom_time` feature
         if: matrix.os != 'windows-latest'
-        run: cargo test --test-threads=1 --workspace --release
+        run: cargo test --workspace --release -- --test-threads=1
 
       - name: Run tests with `custom_time` feature
-        run: cargo test --test-threads=1 --test custom_time --features="custom_time"
+        run: cargo test --test custom_time --features="custom_time" -- --test-threads=1
 
       - name: Run Rust examples
         # run examples only on ubuntu for now

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -151,10 +151,10 @@ jobs:
 
       - name: Run tests excluding `custom_time` feature
         if: matrix.os != 'windows-latest'
-        run: cargo test --workspace --release
+        run: cargo test --test-threads=1 --workspace --release
 
       - name: Run tests with `custom_time` feature
-        run: cargo test --test custom_time --features="custom_time"
+        run: cargo test --test-threads=1 --test custom_time --features="custom_time"
 
       - name: Run Rust examples
         # run examples only on ubuntu for now

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -151,10 +151,10 @@ jobs:
 
       - name: Run tests excluding `custom_time` feature
         if: matrix.os != 'windows-latest'
-        run: cargo test --workspace --release -- --test-threads=1
+        run: cargo test --workspace --release -- --test-threads=2
 
       - name: Run tests with `custom_time` feature
-        run: cargo test --test custom_time --features="custom_time" -- --test-threads=1
+        run: cargo test --test custom_time --features="custom_time" -- --test-threads=2
 
       - name: Run Rust examples
         # run examples only on ubuntu for now


### PR DESCRIPTION
# Description of change
Limit parallel test execution as it seems to cause flakiness with the faucet, especially in macos runners.  

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
CI passes

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
