### PR TITLE
Fix typedoc issues

### DIFF
--- a/bindings/wasm/identity_wasm/lib/resolver.ts
+++ b/bindings/wasm/identity_wasm/lib/resolver.ts
@@ -14,7 +14,8 @@ import { CoreDocument, IToCoreDocument, Resolver as ResolverInner } from "~ident
  * With the default being `CoreDocument | IToCoreDocument`.
  *
  * Also provides methods for resolving DID Documents associated with
- * verifiable [`Credential`](../../identity_wasm/classes/Credential.md)s and [`Presentation`](../../identity_wasm/classes/Presentation.md)s.
+ * verifiable {@link identity_wasm/node/identity_wasm.Credential | Credential}s
+ * and {@link identity_wasm/node/identity_wasm.Presentation | Presentation}s.
  *
  * # Configuration
  *

--- a/bindings/wasm/identity_wasm/src/common/timestamp.rs
+++ b/bindings/wasm/identity_wasm/src/common/timestamp.rs
@@ -14,6 +14,7 @@ extern "C" {
   pub type OptionTimestamp;
 }
 
+/// A parsed Timestamp.
 #[wasm_bindgen(js_name = Timestamp, inspectable)]
 pub struct WasmTimestamp(pub(crate) Timestamp);
 

--- a/bindings/wasm/identity_wasm/src/credential/credential.rs
+++ b/bindings/wasm/identity_wasm/src/credential/credential.rs
@@ -29,6 +29,7 @@ use crate::credential::WasmProof;
 use crate::error::Result;
 use crate::error::WasmResult;
 
+/// Represents a set of claims describing an entity.
 #[wasm_bindgen(js_name = Credential, inspectable)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WasmCredential(pub(crate) Credential);

--- a/bindings/wasm/identity_wasm/src/credential/jpt_credential_validator/jwp_verification_options.rs
+++ b/bindings/wasm/identity_wasm/src/credential/jpt_credential_validator/jwp_verification_options.rs
@@ -6,6 +6,7 @@ use crate::error::WasmResult;
 use identity_iota::document::verifiable::JwpVerificationOptions;
 use wasm_bindgen::prelude::*;
 
+/// Holds additional options for verifying a JWP
 #[wasm_bindgen(js_name = JwpVerificationOptions, inspectable)]
 #[derive(Clone, Debug, Default)]
 pub struct WasmJwpVerificationOptions(pub(crate) JwpVerificationOptions);

--- a/bindings/wasm/identity_wasm/src/credential/linked_domain_service.rs
+++ b/bindings/wasm/identity_wasm/src/credential/linked_domain_service.rs
@@ -16,11 +16,11 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
+/// A service wrapper for a
+/// [Linked Domain Service Endpoint](https://identity.foundation/.well-known/resources/did-configuration/#linked-domain-service-endpoint).
 #[wasm_bindgen(js_name = LinkedDomainService, inspectable)]
 pub struct WasmLinkedDomainService(LinkedDomainService);
 
-/// A service wrapper for a
-/// [Linked Domain Service Endpoint](https://identity.foundation/.well-known/resources/did-configuration/#linked-domain-service-endpoint).
 #[wasm_bindgen(js_class = LinkedDomainService)]
 impl WasmLinkedDomainService {
   /// Constructs a new {@link LinkedDomainService} that wraps a spec compliant [Linked Domain Service Endpoint](https://identity.foundation/.well-known/resources/did-configuration/#linked-domain-service-endpoint).

--- a/bindings/wasm/identity_wasm/src/credential/linked_verifiable_presentation_service.rs
+++ b/bindings/wasm/identity_wasm/src/credential/linked_verifiable_presentation_service.rs
@@ -16,6 +16,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
+/// A service wrapper for a [Linked Verifiable Presentation Service Endpoint](https://identity.foundation/linked-vp/#linked-verifiable-presentation-service-endpoint).
 #[wasm_bindgen(js_name = LinkedVerifiablePresentationService, inspectable)]
 pub struct WasmLinkedVerifiablePresentationService(LinkedVerifiablePresentationService);
 

--- a/bindings/wasm/identity_wasm/src/credential/presentation/presentation.rs
+++ b/bindings/wasm/identity_wasm/src/credential/presentation/presentation.rs
@@ -21,6 +21,7 @@ use crate::credential::WasmUnknownCredentialContainer;
 use crate::error::Result;
 use crate::error::WasmResult;
 
+/// Represents a bundle of one or more {@link Credential}s.
 #[wasm_bindgen(js_name = Presentation, inspectable)]
 pub struct WasmPresentation(pub(crate) Presentation<UnknownCredential>);
 

--- a/bindings/wasm/identity_wasm/src/credential/revocation/status_list_2021/credential.rs
+++ b/bindings/wasm/identity_wasm/src/credential/revocation/status_list_2021/credential.rs
@@ -53,7 +53,9 @@ impl From<WasmCredentialStatus> for CredentialStatus {
 #[wasm_bindgen(js_name = StatusPurpose)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum WasmStatusPurpose {
+  /// Used for revocation.
   Revocation = 0,
+  /// Used for suspension.
   Suspension = 1,
 }
 

--- a/bindings/wasm/identity_wasm/src/did/jws_verification_options.rs
+++ b/bindings/wasm/identity_wasm/src/did/jws_verification_options.rs
@@ -9,6 +9,7 @@ use wasm_bindgen::prelude::*;
 
 use super::WasmDIDUrl;
 
+/// Holds additional options for verifying a JWS with {@link CoreDocument.verifyJws}.
 #[wasm_bindgen(js_name = JwsVerificationOptions, inspectable)]
 pub struct WasmJwsVerificationOptions(pub(crate) JwsVerificationOptions);
 

--- a/bindings/wasm/identity_wasm/src/iota/iota_metadata_encoding.rs
+++ b/bindings/wasm/identity_wasm/src/iota/iota_metadata_encoding.rs
@@ -6,10 +6,12 @@ use serde_repr::Deserialize_repr;
 use serde_repr::Serialize_repr;
 use wasm_bindgen::prelude::*;
 
+/// Indicates the encoding of a DID document in state metadata.
 #[wasm_bindgen(js_name = StateMetadataEncoding)]
 #[derive(Serialize_repr, Deserialize_repr)]
 #[repr(u8)]
 pub enum WasmStateMetadataEncoding {
+  /// State Metadata encoded as JSON.
   Json = 0,
 }
 

--- a/bindings/wasm/identity_wasm/src/jose/jwk.rs
+++ b/bindings/wasm/identity_wasm/src/jose/jwk.rs
@@ -20,6 +20,9 @@ use crate::jose::WasmJwkUse;
 use crate::jose::WasmJwsAlgorithm;
 use core::ops::Deref;
 
+/// JSON Web Key.
+///
+/// [More Info](https://tools.ietf.org/html/rfc7517#section-4)
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[wasm_bindgen(js_name = Jwk, inspectable)]
 pub struct WasmJwk(pub(crate) Jwk);

--- a/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client.rs
@@ -41,6 +41,10 @@ pub struct WasmIotaTransactionBlockResponseEssence {
   pub effects_created: Option<Vec<WasmOwnedObjectRef>>,
 }
 
+/// A client to interact with identities on the IOTA chain.
+///
+/// Used for read and write operations. If you just want read capabilities,
+/// you can also use {@link IdentityClientReadOnly}, which does not need an account and signing capabilities.
 #[wasm_bindgen(js_name = IdentityClient)]
 pub struct WasmIdentityClient(pub(crate) IdentityClient<WasmTransactionSigner>);
 

--- a/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client_read_only.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client_read_only.rs
@@ -39,6 +39,10 @@ impl IdentityContainer {
   // }
 }
 
+/// A client to interact with identities on the IOTA chain.
+///
+/// Used for read operations, so does not need an account and signing capabilities.
+/// If you want to write to the chain, use {@link IdentityClient}.
 #[wasm_bindgen(js_name = IdentityClientReadOnly)]
 pub struct WasmIdentityClientReadOnly(pub(crate) IdentityClientReadOnly);
 

--- a/bindings/wasm/identity_wasm/src/storage/signature_options.rs
+++ b/bindings/wasm/identity_wasm/src/storage/signature_options.rs
@@ -8,6 +8,7 @@ use identity_iota::core::Url;
 use identity_iota::storage::JwsSignatureOptions;
 use wasm_bindgen::prelude::*;
 
+/// Options for creating a JSON Web Signature.
 #[wasm_bindgen(js_name = JwsSignatureOptions, inspectable)]
 pub struct WasmJwsSignatureOptions(pub(crate) JwsSignatureOptions);
 

--- a/bindings/wasm/typedoc.json
+++ b/bindings/wasm/typedoc.json
@@ -20,5 +20,8 @@
   ],
   "compilerOptions": {
     "skipLibCheck": true
+  },
+  "validation": {
+    "notDocumented": true,
   }
 }

--- a/examples/1_advanced/8_status_list_2021.rs
+++ b/examples/1_advanced/8_status_list_2021.rs
@@ -108,7 +108,7 @@ async fn main() -> anyhow::Result<()> {
   let validator: JwtCredentialValidator<EdDSAJwsVerifier> =
     JwtCredentialValidator::with_signature_verifier(EdDSAJwsVerifier::default());
 
-  // The validator has no way of retriving the status list to check for the
+  // The validator has no way of retrieving the status list to check for the
   // revocation of the credential. Let's skip that pass and perform the operation manually.
   let mut validation_options = JwtCredentialValidationOptions::default();
   validation_options.status = StatusCheck::SkipUnsupported;


### PR DESCRIPTION
# Description of change
PR fixes issues errors that occurred when building typedoc docs.

`wasm-bindgen` version bump has fixed the generation of function documentation for the WASM build. The then valid documentation had unresolvable links, due to target not having documentation.

PR also enables `validation.notDocumented` flag in the typedoc options to have stricter rules regarding missing documentation, e.g. missing enum variant documentation (fixed in PR).

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation Fix

## How the change has been tested
Build docs locally without errors or warnings.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
