### PR TITLE
Credential's context is a set even when a single context value is present

### DIFF
--- a/bindings/wasm/src/resolver/wasm_resolver.rs
+++ b/bindings/wasm/src/resolver/wasm_resolver.rs
@@ -175,7 +175,6 @@ impl WasmResolver {
         .await
         .map_err(WasmError::from)
         .map_err(JsValue::from)
-        .map(JsValue::from)
     });
 
     Ok(promise.unchecked_into::<PromiseIToCoreDocument>())
@@ -223,7 +222,6 @@ impl WasmResolver {
         .map(|documents| {
           documents
             .into_iter()
-            .map(JsValue::from)
             .collect::<js_sys::Array>()
             .unchecked_into::<JsValue>()
         })

--- a/identity_credential/src/credential/credential.rs
+++ b/identity_credential/src/credential/credential.rs
@@ -203,6 +203,7 @@ mod tests {
   use identity_core::common::Url;
   use identity_core::convert::FromJson;
 
+  use crate::credential::credential::BASE_CONTEXT;
   use crate::credential::Credential;
   use crate::credential::Subject;
 
@@ -237,7 +238,7 @@ mod tests {
 
   #[test]
   fn credential_with_single_context_is_list_of_contexts_with_single_item() {
-    let credential = Credential::builder(serde_json::Value::default())
+    let mut credential = Credential::builder(serde_json::Value::default())
       .id(Url::parse("https://example.com/credentials/123").unwrap())
       .issuer(Url::parse("https://example.com").unwrap())
       .subject(Subject::with_id(Url::parse("https://example.com/users/123").unwrap()))
@@ -246,5 +247,10 @@ mod tests {
 
     assert!(matches!(credential.context, OneOrMany::Many(_)));
     assert_eq!(credential.context.len(), 1);
+    assert!(credential.check_structure().is_ok());
+
+    // Check backward compatibility with previously created credentials.
+    credential.context = OneOrMany::One(BASE_CONTEXT.clone());
+    assert!(credential.check_structure().is_ok());
   }
 }


### PR DESCRIPTION
# Description of change
Make sure Credential's context gets serialized as a Set even when only the default context is present.

## Links to any relevant issues
Closes issue #1550

## Type of change
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Added a test.

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
