### PR TITLE
Rename types in iota interaction ts and iota interaction rust

### DIFF
--- a/bindings/wasm/identity_wasm/src/rebased/identity.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/identity.rs
@@ -9,7 +9,7 @@ use identity_iota::iota::rebased::migration::OnChainIdentity;
 use identity_iota::iota::rebased::transaction::TransactionInternal;
 use identity_iota::iota::rebased::transaction::TransactionOutputInternal;
 use identity_iota::iota::IotaDocument;
-use iota_interaction_ts::AdapterNativeResponse;
+use iota_interaction_ts::NativeTransactionBlockResponse;
 use tokio::sync::RwLock;
 use wasm_bindgen::prelude::*;
 
@@ -218,7 +218,7 @@ impl WasmTransactionOutputInternalOnChainIdentity {
   }
 
   #[wasm_bindgen(getter)]
-  pub fn response(&self) -> AdapterNativeResponse {
+  pub fn response(&self) -> NativeTransactionBlockResponse {
     self.0.response.clone_native_response()
   }
 }

--- a/bindings/wasm/identity_wasm/src/rebased/proposals/config_change.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/proposals/config_change.rs
@@ -11,7 +11,7 @@ use identity_iota::iota::rebased::proposals::ProposalResult;
 use identity_iota::iota::rebased::proposals::ProposalT;
 use identity_iota::iota::rebased::transaction::TransactionInternal;
 use identity_iota::iota::rebased::transaction::TransactionOutputInternal;
-use iota_interaction_ts::AdapterNativeResponse;
+use iota_interaction_ts::NativeTransactionBlockResponse;
 use tokio::sync::RwLock;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::prelude::JsCast;
@@ -165,7 +165,7 @@ impl WasmApproveConfigChangeProposalTx {
   }
 
   #[wasm_bindgen]
-  pub async fn execute(self, client: &WasmIdentityClient) -> Result<AdapterNativeResponse> {
+  pub async fn execute(self, client: &WasmIdentityClient) -> Result<NativeTransactionBlockResponse> {
     let identity_ref = self.identity.0.read().await;
     self
       .proposal
@@ -209,7 +209,7 @@ impl WasmExecuteConfigChangeProposalTx {
   }
 
   #[wasm_bindgen]
-  pub async fn execute(self, client: &WasmIdentityClient) -> Result<AdapterNativeResponse> {
+  pub async fn execute(self, client: &WasmIdentityClient) -> Result<NativeTransactionBlockResponse> {
     let mut identity_ref = self.identity.0.write().await;
     let proposal = Rc::into_inner(self.proposal.0)
       .ok_or_else(|| js_sys::Error::new("cannot consume proposal; try to drop all other references to it"))?
@@ -229,7 +229,7 @@ impl WasmExecuteConfigChangeProposalTx {
 #[wasm_bindgen(js_name = CreateConfigChangeProposalTxOutput, inspectable, getter_with_clone)]
 pub struct WasmCreateConfigChangeProposalTxOutput {
   pub output: Option<WasmConfigChangeProposal>,
-  pub response: AdapterNativeResponse,
+  pub response: NativeTransactionBlockResponse,
 }
 
 impl From<TransactionOutputInternal<ProposalResult<Proposal<ConfigChange>>>>

--- a/bindings/wasm/identity_wasm/src/rebased/proposals/deactivate_did.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/proposals/deactivate_did.rs
@@ -9,7 +9,7 @@ use identity_iota::iota::rebased::proposals::ProposalResult;
 use identity_iota::iota::rebased::proposals::ProposalT;
 use identity_iota::iota::rebased::transaction::TransactionInternal;
 use identity_iota::iota::rebased::transaction::TransactionOutputInternal;
-use iota_interaction_ts::AdapterNativeResponse;
+use iota_interaction_ts::NativeTransactionBlockResponse;
 use tokio::sync::RwLock;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::prelude::JsCast;
@@ -121,7 +121,7 @@ impl WasmApproveDeativateDidProposalTx {
   }
 
   #[wasm_bindgen]
-  pub async fn execute(self, client: &WasmIdentityClient) -> Result<AdapterNativeResponse> {
+  pub async fn execute(self, client: &WasmIdentityClient) -> Result<NativeTransactionBlockResponse> {
     let identity_ref = self.identity.0.read().await;
     self
       .proposal
@@ -165,7 +165,7 @@ impl WasmExecuteDeactivateDidProposalTx {
   }
 
   #[wasm_bindgen]
-  pub async fn execute(self, client: &WasmIdentityClient) -> Result<AdapterNativeResponse> {
+  pub async fn execute(self, client: &WasmIdentityClient) -> Result<NativeTransactionBlockResponse> {
     let mut identity_ref = self.identity.0.write().await;
     let proposal = Rc::into_inner(self.proposal.0)
       .ok_or_else(|| js_sys::Error::new("cannot consume proposal; try to drop all other references to it"))?
@@ -185,7 +185,7 @@ impl WasmExecuteDeactivateDidProposalTx {
 #[wasm_bindgen(js_name = CreateDeactivateDidProposalTxOutput, inspectable, getter_with_clone)]
 pub struct WasmCreateDeactivateDidProposalTxOutput {
   pub output: Option<WasmProposalDeactivateDid>,
-  pub response: AdapterNativeResponse,
+  pub response: NativeTransactionBlockResponse,
 }
 
 impl From<TransactionOutputInternal<ProposalResult<Proposal<DeactivateDid>>>>

--- a/bindings/wasm/identity_wasm/src/rebased/proposals/send.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/proposals/send.rs
@@ -9,7 +9,7 @@ use identity_iota::iota::rebased::proposals::ProposalT;
 use identity_iota::iota::rebased::proposals::SendAction;
 use identity_iota::iota::rebased::transaction::TransactionInternal;
 use identity_iota::iota::rebased::transaction::TransactionOutputInternal;
-use iota_interaction_ts::AdapterNativeResponse;
+use iota_interaction_ts::NativeTransactionBlockResponse;
 use tokio::sync::RwLock;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::prelude::JsCast;
@@ -139,7 +139,7 @@ impl WasmApproveSendProposalTx {
   }
 
   #[wasm_bindgen]
-  pub async fn execute(self, client: &WasmIdentityClient) -> Result<AdapterNativeResponse> {
+  pub async fn execute(self, client: &WasmIdentityClient) -> Result<NativeTransactionBlockResponse> {
     let identity_ref = self.identity.0.read().await;
     self
       .proposal
@@ -183,7 +183,7 @@ impl WasmExecuteSendProposalTx {
   }
 
   #[wasm_bindgen]
-  pub async fn execute(self, client: &WasmIdentityClient) -> Result<AdapterNativeResponse> {
+  pub async fn execute(self, client: &WasmIdentityClient) -> Result<NativeTransactionBlockResponse> {
     let mut identity_ref = self.identity.0.write().await;
     let proposal = Rc::into_inner(self.proposal.0)
       .ok_or_else(|| js_sys::Error::new("cannot consume proposal; try to drop all other references to it"))?
@@ -203,7 +203,7 @@ impl WasmExecuteSendProposalTx {
 #[wasm_bindgen(js_name = CreateSendProposalTxOutput, inspectable, getter_with_clone)]
 pub struct WasmCreateSendProposalTxOutput {
   pub output: Option<WasmProposalSend>,
-  pub response: AdapterNativeResponse,
+  pub response: NativeTransactionBlockResponse,
 }
 
 impl From<TransactionOutputInternal<ProposalResult<Proposal<SendAction>>>> for WasmCreateSendProposalTxOutput {

--- a/bindings/wasm/identity_wasm/src/rebased/proposals/update_did.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/proposals/update_did.rs
@@ -10,7 +10,7 @@ use identity_iota::iota::rebased::proposals::UpdateDidDocument;
 use identity_iota::iota::rebased::transaction::TransactionInternal;
 use identity_iota::iota::rebased::transaction::TransactionOutputInternal;
 use identity_iota::iota::StateMetadataDocument;
-use iota_interaction_ts::AdapterNativeResponse;
+use iota_interaction_ts::NativeTransactionBlockResponse;
 use tokio::sync::RwLock;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::prelude::JsCast;
@@ -151,7 +151,7 @@ impl WasmApproveUpdateDidDocumentProposalTx {
   }
 
   #[wasm_bindgen]
-  pub async fn execute(self, client: &WasmIdentityClient) -> Result<AdapterNativeResponse> {
+  pub async fn execute(self, client: &WasmIdentityClient) -> Result<NativeTransactionBlockResponse> {
     let identity_ref = self.identity.0.read().await;
     self
       .proposal
@@ -195,7 +195,7 @@ impl WasmExecuteUpdateDidDocumentProposalTx {
   }
 
   #[wasm_bindgen]
-  pub async fn execute(self, client: &WasmIdentityClient) -> Result<AdapterNativeResponse> {
+  pub async fn execute(self, client: &WasmIdentityClient) -> Result<NativeTransactionBlockResponse> {
     let mut identity_ref = self.identity.0.write().await;
     let proposal = Rc::into_inner(self.proposal.inner_proposal)
       .ok_or_else(|| js_sys::Error::new("cannot consume proposal; try to drop all other references to it"))?
@@ -215,7 +215,7 @@ impl WasmExecuteUpdateDidDocumentProposalTx {
 #[wasm_bindgen(js_name = CreateUpdateDidProposalTxOutput, inspectable, getter_with_clone)]
 pub struct WasmCreateUpdateDidProposalTxOutput {
   pub output: Option<WasmProposalUpdateDid>,
-  pub response: AdapterNativeResponse,
+  pub response: NativeTransactionBlockResponse,
 }
 
 impl From<TransactionOutputInternal<ProposalResult<Proposal<UpdateDidDocument>>>>

--- a/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client.rs
@@ -14,7 +14,7 @@ use iota_interaction_ts::bindings::WasmOwnedObjectRef;
 use iota_interaction_ts::WasmPublicKey;
 
 use identity_iota::iota::rebased::Error;
-use iota_interaction_ts::AdapterNativeResponse;
+use iota_interaction_ts::NativeTransactionBlockResponse;
 
 use super::IdentityContainer;
 use super::WasmIdentityBuilder;
@@ -172,7 +172,7 @@ impl WasmTransactionOutputPublishDid {
   }
 
   #[wasm_bindgen(getter)]
-  pub fn response(&self) -> AdapterNativeResponse {
+  pub fn response(&self) -> NativeTransactionBlockResponse {
     self.0.response.clone_native_response()
   }
 }

--- a/bindings/wasm/iota_interaction_ts/lib/iota_client_helpers.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/iota_client_helpers.ts
@@ -16,7 +16,7 @@ import { blake2b } from "@noble/hashes/blake2b";
 
 export type Signer = { sign(data: Uint8Array): Promise<Signature> };
 
-export class IotaTransactionBlockResponseWrapper {
+export class WasmIotaTransactionBlockResponseWrapper {
     response: IotaTransactionBlockResponse;
 
     constructor(response: IotaTransactionBlockResponse) {
@@ -140,7 +140,7 @@ export async function executeTransaction(
     txBcs: Uint8Array,
     signer: Signer,
     gasBudget?: bigint,
-): Promise<IotaTransactionBlockResponseWrapper> {
+): Promise<WasmIotaTransactionBlockResponseWrapper> {
     const txWithGasData = await addGasDataToTransaction(iotaClient, senderAddress, txBcs, gasBudget);
     const signature = await signer.sign(txWithGasData);
     const base64signature = getSignatureValue(signature);
@@ -163,7 +163,7 @@ export async function executeTransaction(
         throw new Error(`transaction returned an unexpected response; ${response?.effects?.status.error}`);
     }
 
-    return new IotaTransactionBlockResponseWrapper(response);
+    return new WasmIotaTransactionBlockResponseWrapper(response);
 }
 
 function getSignatureValue(signature: Signature): string {

--- a/bindings/wasm/iota_interaction_ts/lib/iota_client_helpers.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/iota_client_helpers.ts
@@ -16,7 +16,7 @@ import { blake2b } from "@noble/hashes/blake2b";
 
 export type Signer = { sign(data: Uint8Array): Promise<Signature> };
 
-export class IotaTransactionBlockResponseAdapter {
+export class IotaTransactionBlockResponseWrapper {
     response: IotaTransactionBlockResponse;
 
     constructor(response: IotaTransactionBlockResponse) {
@@ -140,7 +140,7 @@ export async function executeTransaction(
     txBcs: Uint8Array,
     signer: Signer,
     gasBudget?: bigint,
-): Promise<IotaTransactionBlockResponseAdapter> {
+): Promise<IotaTransactionBlockResponseWrapper> {
     const txWithGasData = await addGasDataToTransaction(iotaClient, senderAddress, txBcs, gasBudget);
     const signature = await signer.sign(txWithGasData);
     const base64signature = getSignatureValue(signature);
@@ -163,7 +163,7 @@ export async function executeTransaction(
         throw new Error(`transaction returned an unexpected response; ${response?.effects?.status.error}`);
     }
 
-    return new IotaTransactionBlockResponseAdapter(response);
+    return new IotaTransactionBlockResponseWrapper(response);
 }
 
 function getSignatureValue(signature: Signature): string {

--- a/bindings/wasm/iota_interaction_ts/src/bindings/wasm_iota_client.rs
+++ b/bindings/wasm/iota_interaction_ts/src/bindings/wasm_iota_client.rs
@@ -35,7 +35,7 @@ use serde::Serialize;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
-use super::wasm_types::IotaTransactionBlockResponseAdapter;
+use super::wasm_types::WasmIotaTransactionBlockResponseWrapper;
 use super::wasm_types::PromiseIotaTransactionBlockResponse;
 use super::wasm_types::WasmExecuteTransactionBlockParams;
 use super::WasmWaitForTransactionParams;
@@ -145,7 +145,7 @@ impl ManagedWasmIotaClient {
     signatures: &[SignatureBcs],
     options: Option<IotaTransactionBlockResponseOptions>,
     request_type: Option<ExecuteTransactionRequestType>,
-  ) -> IotaRpcResult<IotaTransactionBlockResponseAdapter> {
+  ) -> IotaRpcResult<WasmIotaTransactionBlockResponseWrapper> {
     let ex_tx_params: WasmExecuteTransactionBlockParams = serde_wasm_bindgen::to_value(
       &ExecuteTransactionBlockParams::new(tx_data_bcs, signatures, options, request_type),
     )
@@ -163,7 +163,7 @@ impl ManagedWasmIotaClient {
       console_log!("Error executing JsFuture::from(promise): {:?}", e);
       IotaRpcError::FfiError(format!("{:?}", e))
     })?;
-    Ok(IotaTransactionBlockResponseAdapter::new(result.into()))
+    Ok(WasmIotaTransactionBlockResponseWrapper::new(result.into()))
   }
 
   /**
@@ -258,7 +258,7 @@ impl ManagedWasmIotaClient {
     &self,
     digest: TransactionDigest,
     options: IotaTransactionBlockResponseOptions,
-  ) -> IotaRpcResult<IotaTransactionBlockResponseAdapter> {
+  ) -> IotaRpcResult<WasmIotaTransactionBlockResponseWrapper> {
     let params: WasmGetTransactionBlockParams =
       serde_wasm_bindgen::to_value(&GetTransactionBlockParams::new(digest.to_string(), Some(options)))
         .map_err(|e| {
@@ -278,7 +278,7 @@ impl ManagedWasmIotaClient {
       IotaRpcError::FfiError(format!("{:?}", e))
     })?;
 
-    Ok(IotaTransactionBlockResponseAdapter::new(result.into()))
+    Ok(WasmIotaTransactionBlockResponseWrapper::new(result.into()))
   }
 
   pub async fn get_reference_gas_price(&self) -> IotaRpcResult<u64> {
@@ -404,7 +404,7 @@ impl ManagedWasmIotaClient {
     options: Option<IotaTransactionBlockResponseOptions>,
     timeout: Option<u64>,
     poll_interval: Option<u64>,
-  ) -> IotaRpcResult<IotaTransactionBlockResponseAdapter> {
+  ) -> IotaRpcResult<WasmIotaTransactionBlockResponseWrapper> {
     let params_object = WaitForTransactionParams::new(digest.to_string(), options, timeout, poll_interval);
     let params: WasmWaitForTransactionParams = serde_json::to_value(&params_object)
       .map_err(|e| {
@@ -426,6 +426,6 @@ impl ManagedWasmIotaClient {
       IotaRpcError::FfiError(format!("{:?}", e))
     })?;
 
-    Ok(IotaTransactionBlockResponseAdapter::new(result.into()))
+    Ok(WasmIotaTransactionBlockResponseWrapper::new(result.into()))
   }
 }

--- a/bindings/wasm/iota_interaction_ts/src/bindings/wasm_iota_client.rs
+++ b/bindings/wasm/iota_interaction_ts/src/bindings/wasm_iota_client.rs
@@ -35,9 +35,9 @@ use serde::Serialize;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
-use super::wasm_types::WasmIotaTransactionBlockResponseWrapper;
 use super::wasm_types::PromiseIotaTransactionBlockResponse;
 use super::wasm_types::WasmExecuteTransactionBlockParams;
+use super::wasm_types::WasmIotaTransactionBlockResponseWrapper;
 use super::WasmWaitForTransactionParams;
 
 use crate::bindings::PromiseIotaObjectResponse;

--- a/bindings/wasm/iota_interaction_ts/src/bindings/wasm_types.rs
+++ b/bindings/wasm/iota_interaction_ts/src/bindings/wasm_types.rs
@@ -368,7 +368,7 @@ impl WasmSharedObjectRef {
 
 #[wasm_bindgen(module = "/lib/iota_client_helpers.ts")]
 extern "C" {
-  // Please note: For unclear reasons the `typescript_type` name and the `pub type` name defined 
+  // Please note: For unclear reasons the `typescript_type` name and the `pub type` name defined
   // in wasm_bindgen extern "C" scopes must be equal. Otherwise, the JS constructor will not be
   // found in the generated js code.
   #[wasm_bindgen(typescript_type = "WasmIotaTransactionBlockResponseWrapper")]

--- a/bindings/wasm/iota_interaction_ts/src/bindings/wasm_types.rs
+++ b/bindings/wasm/iota_interaction_ts/src/bindings/wasm_types.rs
@@ -62,7 +62,7 @@ const TS_SDK_TYPES: &str = r#"
   import { bcs } from "@iota/iota-sdk/bcs";
   import {
     executeTransaction,
-    IotaTransactionBlockResponseWrapper,
+    WasmIotaTransactionBlockResponseWrapper,
   } from "./iota_client_helpers"
 "#;
 
@@ -157,7 +157,7 @@ extern "C" {
   #[derive(Clone)]
   pub type PromisePaginatedCoins;
 
-  #[wasm_bindgen(typescript_type = "Promise<IotaTransactionBlockResponseWrapper>")]
+  #[wasm_bindgen(typescript_type = "Promise<WasmIotaTransactionBlockResponseWrapper>")]
   #[derive(Clone)]
   pub type PromiseIotaTransactionBlockResponseWrapper;
 
@@ -368,7 +368,10 @@ impl WasmSharedObjectRef {
 
 #[wasm_bindgen(module = "/lib/iota_client_helpers.ts")]
 extern "C" {
-  #[wasm_bindgen(typescript_type = "IotaTransactionBlockResponseWrapper")]
+  // Please note: For unclear reasons the `typescript_type` name and the `pub type` name defined 
+  // in wasm_bindgen extern "C" scopes must be equal. Otherwise, the JS constructor will not be
+  // found in the generated js code.
+  #[wasm_bindgen(typescript_type = "WasmIotaTransactionBlockResponseWrapper")]
   #[derive(Clone)]
   pub type WasmIotaTransactionBlockResponseWrapper;
 

--- a/bindings/wasm/iota_interaction_ts/src/bindings/wasm_types.rs
+++ b/bindings/wasm/iota_interaction_ts/src/bindings/wasm_types.rs
@@ -62,7 +62,7 @@ const TS_SDK_TYPES: &str = r#"
   import { bcs } from "@iota/iota-sdk/bcs";
   import {
     executeTransaction,
-    IotaTransactionBlockResponseAdapter,
+    IotaTransactionBlockResponseWrapper,
   } from "./iota_client_helpers"
 "#;
 
@@ -157,9 +157,9 @@ extern "C" {
   #[derive(Clone)]
   pub type PromisePaginatedCoins;
 
-  #[wasm_bindgen(typescript_type = "Promise<IotaTransactionBlockResponseAdapter>")]
+  #[wasm_bindgen(typescript_type = "Promise<IotaTransactionBlockResponseWrapper>")]
   #[derive(Clone)]
-  pub type PromiseIotaTransactionBlockResponseAdapter;
+  pub type PromiseIotaTransactionBlockResponseWrapper;
 
   #[wasm_bindgen(typescript_type = "Signature")]
   pub type WasmIotaSignature;
@@ -368,33 +368,33 @@ impl WasmSharedObjectRef {
 
 #[wasm_bindgen(module = "/lib/iota_client_helpers.ts")]
 extern "C" {
-  #[wasm_bindgen(typescript_type = "IotaTransactionBlockResponseAdapter")]
+  #[wasm_bindgen(typescript_type = "IotaTransactionBlockResponseWrapper")]
   #[derive(Clone)]
-  pub type IotaTransactionBlockResponseAdapter;
+  pub type WasmIotaTransactionBlockResponseWrapper;
 
   #[wasm_bindgen(constructor)]
-  pub fn new(response: WasmIotaTransactionBlockResponse) -> IotaTransactionBlockResponseAdapter;
+  pub fn new(response: WasmIotaTransactionBlockResponse) -> WasmIotaTransactionBlockResponseWrapper;
 
   #[wasm_bindgen(method)]
-  pub fn effects_is_none(this: &IotaTransactionBlockResponseAdapter) -> bool;
+  pub fn effects_is_none(this: &WasmIotaTransactionBlockResponseWrapper) -> bool;
 
   #[wasm_bindgen(method)]
-  pub fn effects_is_some(this: &IotaTransactionBlockResponseAdapter) -> bool;
+  pub fn effects_is_some(this: &WasmIotaTransactionBlockResponseWrapper) -> bool;
 
   #[wasm_bindgen(method)]
-  pub fn to_string(this: &IotaTransactionBlockResponseAdapter) -> String;
+  pub fn to_string(this: &WasmIotaTransactionBlockResponseWrapper) -> String;
 
   #[wasm_bindgen(method)]
-  fn effects_execution_status_inner(this: &IotaTransactionBlockResponseAdapter) -> Option<WasmExecutionStatus>;
+  fn effects_execution_status_inner(this: &WasmIotaTransactionBlockResponseWrapper) -> Option<WasmExecutionStatus>;
 
   #[wasm_bindgen(method)]
-  fn effects_created_inner(this: &IotaTransactionBlockResponseAdapter) -> Option<Vec<WasmOwnedObjectRef>>;
+  fn effects_created_inner(this: &WasmIotaTransactionBlockResponseWrapper) -> Option<Vec<WasmOwnedObjectRef>>;
 
   #[wasm_bindgen(method, js_name = "get_digest")]
-  fn digest_inner(this: &IotaTransactionBlockResponseAdapter) -> String;
+  fn digest_inner(this: &WasmIotaTransactionBlockResponseWrapper) -> String;
 
   #[wasm_bindgen(method, js_name = "get_response")]
-  fn response(this: &IotaTransactionBlockResponseAdapter) -> WasmIotaTransactionBlockResponse;
+  fn response(this: &WasmIotaTransactionBlockResponseWrapper) -> WasmIotaTransactionBlockResponse;
 
   #[wasm_bindgen(js_name = executeTransaction)]
   fn execute_transaction_inner(
@@ -403,7 +403,7 @@ extern "C" {
     tx_bcs: Vec<u8>,              // --> TypeScript: Uint8Array,
     signer: WasmStorageSigner,    // --> TypeScript: Signer (iota_client_helpers module)
     gas_budget: Option<u64>,      // --> TypeScript: optional bigint
-  ) -> PromiseIotaTransactionBlockResponseAdapter;
+  ) -> PromiseIotaTransactionBlockResponseWrapper;
 
   #[wasm_bindgen(js_name = "addGasDataToTransaction")]
   fn add_gas_data_to_transaction_inner(
@@ -466,11 +466,11 @@ struct WasmExecutionStatusAdapter {
   status: ExecutionStatus,
 }
 
-impl IotaTransactionBlockResponseAdapter {
+impl WasmIotaTransactionBlockResponseWrapper {
   pub fn effects_execution_status(&self) -> Option<ExecutionStatus> {
     self.effects_execution_status_inner().map(|s| {
       let state: WasmExecutionStatusAdapter =
-        into_sdk_type(s).expect("[IotaTransactionBlockResponseAdapter] Failed to convert WasmExecutionStatus");
+        into_sdk_type(s).expect("[WasmIotaTransactionBlockResponseWrapper] Failed to convert WasmExecutionStatus");
       state.status
     })
   }
@@ -480,7 +480,7 @@ impl IotaTransactionBlockResponseAdapter {
       vex_obj_ref
         .into_iter()
         .map(|obj| {
-          into_sdk_type(obj).expect("[IotaTransactionBlockResponseAdapter] Failed to convert WasmOwnedObjectRef")
+          into_sdk_type(obj).expect("[WasmIotaTransactionBlockResponseWrapper] Failed to convert WasmOwnedObjectRef")
         })
         .collect()
     })
@@ -498,7 +498,7 @@ pub async fn execute_transaction(
   tx_bcs: ProgrammableTransactionBcs, // --> Binding: Vec<u8>
   signer: WasmStorageSigner,          // --> Binding: WasmStorageSigner
   gas_budget: Option<u64>,            // --> Binding: Option<u64>,
-) -> Result<IotaTransactionBlockResponseAdapter, TsSdkError> {
+) -> Result<WasmIotaTransactionBlockResponseWrapper, TsSdkError> {
   let promise: Promise = Promise::resolve(&execute_transaction_inner(
     iota_client,
     sender_address.to_string(),
@@ -513,7 +513,7 @@ pub async fn execute_transaction(
     TsSdkError::WasmError(message.to_string(), details.to_string())
   })?;
 
-  Ok(IotaTransactionBlockResponseAdapter::new(result.into()))
+  Ok(WasmIotaTransactionBlockResponseWrapper::new(result.into()))
 }
 
 #[derive(Deserialize)]

--- a/bindings/wasm/iota_interaction_ts/src/iota_client_ts_sdk.rs
+++ b/bindings/wasm/iota_interaction_ts/src/iota_client_ts_sdk.rs
@@ -40,7 +40,7 @@ use identity_iota_interaction::SignatureBcs;
 use identity_iota_interaction::TransactionDataBcs;
 
 use crate::bindings::add_gas_data_to_transaction;
-use crate::bindings::IotaTransactionBlockResponseAdapter;
+use crate::bindings::WasmIotaTransactionBlockResponseWrapper;
 use crate::bindings::ManagedWasmIotaClient;
 use crate::bindings::WasmIotaClient;
 use crate::error::TsSdkError;
@@ -49,39 +49,39 @@ use crate::ProgrammableTransaction;
 
 #[allow(dead_code)]
 pub trait IotaTransactionBlockResponseAdaptedT:
-  IotaTransactionBlockResponseT<Error = TsSdkError, NativeResponse = IotaTransactionBlockResponseAdapter>
+  IotaTransactionBlockResponseT<Error = TsSdkError, NativeResponse = WasmIotaTransactionBlockResponseWrapper>
 {
 }
 impl<T> IotaTransactionBlockResponseAdaptedT for T where
-  T: IotaTransactionBlockResponseT<Error = TsSdkError, NativeResponse = IotaTransactionBlockResponseAdapter>
+  T: IotaTransactionBlockResponseT<Error = TsSdkError, NativeResponse = WasmIotaTransactionBlockResponseWrapper>
 {
 }
 #[allow(dead_code)]
 pub type IotaTransactionBlockResponseAdaptedTraitObj =
-  Box<dyn IotaTransactionBlockResponseT<Error = TsSdkError, NativeResponse = IotaTransactionBlockResponseAdapter>>;
+  Box<dyn IotaTransactionBlockResponseT<Error = TsSdkError, NativeResponse = WasmIotaTransactionBlockResponseWrapper>>;
 
 #[allow(dead_code)]
 pub trait QuorumDriverApiAdaptedT:
-  QuorumDriverTrait<Error = TsSdkError, NativeResponse = IotaTransactionBlockResponseAdapter>
+  QuorumDriverTrait<Error = TsSdkError, NativeResponse = WasmIotaTransactionBlockResponseWrapper>
 {
 }
 impl<T> QuorumDriverApiAdaptedT for T where
-  T: QuorumDriverTrait<Error = TsSdkError, NativeResponse = IotaTransactionBlockResponseAdapter>
+  T: QuorumDriverTrait<Error = TsSdkError, NativeResponse = WasmIotaTransactionBlockResponseWrapper>
 {
 }
 #[allow(dead_code)]
 pub type QuorumDriverApiAdaptedTraitObj =
-  Box<dyn QuorumDriverTrait<Error = TsSdkError, NativeResponse = IotaTransactionBlockResponseAdapter>>;
+  Box<dyn QuorumDriverTrait<Error = TsSdkError, NativeResponse = WasmIotaTransactionBlockResponseWrapper>>;
 
 #[allow(dead_code)]
-pub trait ReadApiAdaptedT: ReadTrait<Error = TsSdkError, NativeResponse = IotaTransactionBlockResponseAdapter> {}
+pub trait ReadApiAdaptedT: ReadTrait<Error = TsSdkError, NativeResponse = WasmIotaTransactionBlockResponseWrapper> {}
 impl<T> ReadApiAdaptedT for T where
-  T: ReadTrait<Error = TsSdkError, NativeResponse = IotaTransactionBlockResponseAdapter>
+  T: ReadTrait<Error = TsSdkError, NativeResponse = WasmIotaTransactionBlockResponseWrapper>
 {
 }
 #[allow(dead_code)]
 pub type ReadApiAdaptedTraitObj =
-  Box<dyn ReadTrait<Error = TsSdkError, NativeResponse = IotaTransactionBlockResponseAdapter>>;
+  Box<dyn ReadTrait<Error = TsSdkError, NativeResponse = WasmIotaTransactionBlockResponseWrapper>>;
 
 #[allow(dead_code)]
 pub trait CoinReadApiAdaptedT: CoinReadTrait<Error = TsSdkError> {}
@@ -97,23 +97,23 @@ pub type EventApiAdaptedTraitObj = Box<dyn EventTrait<Error = TsSdkError>>;
 
 #[allow(dead_code)]
 pub trait IotaClientAdaptedT:
-  IotaClientTrait<Error = TsSdkError, NativeResponse = IotaTransactionBlockResponseAdapter>
+  IotaClientTrait<Error = TsSdkError, NativeResponse = WasmIotaTransactionBlockResponseWrapper>
 {
 }
 impl<T> IotaClientAdaptedT for T where
-  T: IotaClientTrait<Error = TsSdkError, NativeResponse = IotaTransactionBlockResponseAdapter>
+  T: IotaClientTrait<Error = TsSdkError, NativeResponse = WasmIotaTransactionBlockResponseWrapper>
 {
 }
 #[allow(dead_code)]
 pub type IotaClientAdaptedTraitObj =
-  Box<dyn IotaClientTrait<Error = TsSdkError, NativeResponse = IotaTransactionBlockResponseAdapter>>;
+  Box<dyn IotaClientTrait<Error = TsSdkError, NativeResponse = WasmIotaTransactionBlockResponseWrapper>>;
 
 pub struct IotaTransactionBlockResponseProvider {
-  response: IotaTransactionBlockResponseAdapter,
+  response: WasmIotaTransactionBlockResponseWrapper,
 }
 
 impl IotaTransactionBlockResponseProvider {
-  pub fn new(response: IotaTransactionBlockResponseAdapter) -> Self {
+  pub fn new(response: WasmIotaTransactionBlockResponseWrapper) -> Self {
     IotaTransactionBlockResponseProvider { response }
   }
 }
@@ -121,7 +121,7 @@ impl IotaTransactionBlockResponseProvider {
 #[async_trait::async_trait(?Send)]
 impl IotaTransactionBlockResponseT for IotaTransactionBlockResponseProvider {
   type Error = TsSdkError;
-  type NativeResponse = IotaTransactionBlockResponseAdapter;
+  type NativeResponse = WasmIotaTransactionBlockResponseWrapper;
 
   fn effects_is_none(&self) -> bool {
     self.response.effects_is_none()
@@ -173,7 +173,7 @@ pub struct ReadAdapter {
 #[async_trait::async_trait(?Send)]
 impl ReadTrait for ReadAdapter {
   type Error = TsSdkError;
-  type NativeResponse = IotaTransactionBlockResponseAdapter;
+  type NativeResponse = WasmIotaTransactionBlockResponseWrapper;
 
   async fn get_chain_identifier(&self) -> Result<String, Self::Error> {
     Ok(self.client.get_chain_identifier().await.unwrap())
@@ -241,7 +241,7 @@ pub struct QuorumDriverAdapter {
 #[async_trait::async_trait(?Send)]
 impl QuorumDriverTrait for QuorumDriverAdapter {
   type Error = TsSdkError;
-  type NativeResponse = IotaTransactionBlockResponseAdapter;
+  type NativeResponse = WasmIotaTransactionBlockResponseWrapper;
 
   async fn execute_transaction_block(
     &self,
@@ -304,7 +304,7 @@ pub struct IotaClientTsSdk {
 #[async_trait::async_trait(?Send)]
 impl IotaClientTrait for IotaClientTsSdk {
   type Error = TsSdkError;
-  type NativeResponse = IotaTransactionBlockResponseAdapter;
+  type NativeResponse = WasmIotaTransactionBlockResponseWrapper;
 
   fn quorum_driver_api(&self) -> QuorumDriverApiAdaptedTraitObj {
     Box::new(QuorumDriverAdapter {

--- a/bindings/wasm/iota_interaction_ts/src/iota_client_ts_sdk.rs
+++ b/bindings/wasm/iota_interaction_ts/src/iota_client_ts_sdk.rs
@@ -40,9 +40,9 @@ use identity_iota_interaction::SignatureBcs;
 use identity_iota_interaction::TransactionDataBcs;
 
 use crate::bindings::add_gas_data_to_transaction;
-use crate::bindings::WasmIotaTransactionBlockResponseWrapper;
 use crate::bindings::ManagedWasmIotaClient;
 use crate::bindings::WasmIotaClient;
+use crate::bindings::WasmIotaTransactionBlockResponseWrapper;
 use crate::error::TsSdkError;
 use crate::error::WasmError;
 use crate::ProgrammableTransaction;
@@ -74,7 +74,10 @@ pub type QuorumDriverApiAdaptedTraitObj =
   Box<dyn QuorumDriverTrait<Error = TsSdkError, NativeResponse = WasmIotaTransactionBlockResponseWrapper>>;
 
 #[allow(dead_code)]
-pub trait ReadApiAdaptedT: ReadTrait<Error = TsSdkError, NativeResponse = WasmIotaTransactionBlockResponseWrapper> {}
+pub trait ReadApiAdaptedT:
+  ReadTrait<Error = TsSdkError, NativeResponse = WasmIotaTransactionBlockResponseWrapper>
+{
+}
 impl<T> ReadApiAdaptedT for T where
   T: ReadTrait<Error = TsSdkError, NativeResponse = WasmIotaTransactionBlockResponseWrapper>
 {

--- a/bindings/wasm/iota_interaction_ts/src/lib.rs
+++ b/bindings/wasm/iota_interaction_ts/src/lib.rs
@@ -19,21 +19,17 @@ mod migration_move_calls;
 #[cfg(target_arch = "wasm32")]
 pub mod transaction_builder;
 
-#[cfg(target_arch = "wasm32")]
-pub use asset_move_calls::AssetMoveCallsTsSdk as AssetMoveCallsAdapter;
-#[cfg(target_arch = "wasm32")]
-pub use identity_move_calls::IdentityMoveCallsTsSdk as IdentityMoveCallsAdapter;
-#[cfg(target_arch = "wasm32")]
-pub use iota_client_ts_sdk::IotaClientTsSdk as IotaClientAdapter;
-#[cfg(target_arch = "wasm32")]
-pub use iota_client_ts_sdk::IotaTransactionBlockResponseProvider as IotaTransactionBlockResponseAdapter;
-#[cfg(target_arch = "wasm32")]
-pub use migration_move_calls::MigrationMoveCallsTsSdk as MigrationMoveCallsAdapter;
-#[cfg(target_arch = "wasm32")]
-pub use transaction_builder::TransactionBuilderTsSdk as TransactionBuilderAdapter;
-
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
+        #[allow(unused_imports)] pub use error::TsSdkError as AdapterError;
+        #[allow(unused_imports)] pub use asset_move_calls::AssetMoveCallsTsSdk as AssetMoveCallsAdapter;
+        #[allow(unused_imports)] pub use identity_move_calls::IdentityMoveCallsTsSdk as IdentityMoveCallsAdapter;
+        #[allow(unused_imports)] pub use iota_client_ts_sdk::IotaClientTsSdk as IotaClientAdapter;
+        #[allow(unused_imports)] pub use iota_client_ts_sdk::IotaTransactionBlockResponseProvider as IotaTransactionBlockResponseAdapter;
+        #[allow(unused_imports)] pub use bindings::WasmIotaTransactionBlockResponseWrapper as NativeTransactionBlockResponse;
+        #[allow(unused_imports)] pub use migration_move_calls::MigrationMoveCallsTsSdk as MigrationMoveCallsAdapter;
+        #[allow(unused_imports)] pub use transaction_builder::TransactionBuilderTsSdk as TransactionBuilderAdapter;
+
         #[allow(unused_imports)] pub use iota_client_ts_sdk::IotaTransactionBlockResponseAdaptedT;
         #[allow(unused_imports)] pub use iota_client_ts_sdk::IotaTransactionBlockResponseAdaptedTraitObj;
         #[allow(unused_imports)] pub use iota_client_ts_sdk::QuorumDriverApiAdaptedT;
@@ -47,8 +43,6 @@ cfg_if::cfg_if! {
         #[allow(unused_imports)] pub use iota_client_ts_sdk::IotaClientAdaptedT;
         #[allow(unused_imports)] pub use iota_client_ts_sdk::IotaClientAdaptedTraitObj;
 
-        #[allow(unused_imports)] pub use error::TsSdkError as AdapterError;
-        #[allow(unused_imports)] pub use bindings::IotaTransactionBlockResponseAdapter as AdapterNativeResponse;
         #[allow(unused_imports)] pub use bindings::ProgrammableTransaction;
         #[allow(unused_imports)] pub use bindings::WasmPublicKey;
         #[allow(unused_imports)] pub use bindings::Ed25519PublicKey as WasmEd25519PublicKey;

--- a/identity_iota_core/src/iota_interaction_rust/mod.rs
+++ b/identity_iota_core/src/iota_interaction_rust/mod.rs
@@ -8,13 +8,14 @@ pub(crate) mod migration_move_calls;
 pub(crate) mod transaction_builder;
 mod utils;
 
+pub(crate) use super::rebased::Error as AdapterError;
 pub(crate) use asset_move_calls::AssetMoveCallsRustSdk as AssetMoveCallsAdapter;
 pub(crate) use identity_move_calls::IdentityMoveCallsRustSdk as IdentityMoveCallsAdapter;
 pub(crate) use iota_client_rust_sdk::IotaClientRustSdk as IotaClientAdapter;
 pub(crate) use iota_client_rust_sdk::IotaTransactionBlockResponseProvider as IotaTransactionBlockResponseAdapter;
+pub(crate) use identity_iota_interaction::rpc_types::IotaTransactionBlockResponse as NativeTransactionBlockResponse;
 pub(crate) use migration_move_calls::MigrationMoveCallsRustSdk as MigrationMoveCallsAdapter;
-#[allow(unused_imports)]
-pub(crate) use transaction_builder::TransactionBuilderRustSdk as TransactionBuilderAdapter;
+#[allow(unused_imports)] pub(crate) use transaction_builder::TransactionBuilderRustSdk as TransactionBuilderAdapter;
 
 #[allow(unused_imports)]
 pub(crate) use iota_client_rust_sdk::CoinReadApiAdaptedT;
@@ -40,8 +41,3 @@ pub(crate) use iota_client_rust_sdk::QuorumDriverApiAdaptedTraitObj;
 pub(crate) use iota_client_rust_sdk::ReadApiAdaptedT;
 #[allow(unused_imports)]
 pub(crate) use iota_client_rust_sdk::ReadApiAdaptedTraitObj;
-
-#[allow(unused_imports)]
-pub(crate) use super::rebased::Error as AdapterError;
-#[allow(unused_imports)]
-pub(crate) use identity_iota_interaction::rpc_types::IotaTransactionBlockResponse as AdapterNativeResponse;

--- a/identity_iota_core/src/iota_interaction_rust/mod.rs
+++ b/identity_iota_core/src/iota_interaction_rust/mod.rs
@@ -10,12 +10,13 @@ mod utils;
 
 pub(crate) use super::rebased::Error as AdapterError;
 pub(crate) use asset_move_calls::AssetMoveCallsRustSdk as AssetMoveCallsAdapter;
+pub(crate) use identity_iota_interaction::rpc_types::IotaTransactionBlockResponse as NativeTransactionBlockResponse;
 pub(crate) use identity_move_calls::IdentityMoveCallsRustSdk as IdentityMoveCallsAdapter;
 pub(crate) use iota_client_rust_sdk::IotaClientRustSdk as IotaClientAdapter;
 pub(crate) use iota_client_rust_sdk::IotaTransactionBlockResponseProvider as IotaTransactionBlockResponseAdapter;
-pub(crate) use identity_iota_interaction::rpc_types::IotaTransactionBlockResponse as NativeTransactionBlockResponse;
 pub(crate) use migration_move_calls::MigrationMoveCallsRustSdk as MigrationMoveCallsAdapter;
-#[allow(unused_imports)] pub(crate) use transaction_builder::TransactionBuilderRustSdk as TransactionBuilderAdapter;
+#[allow(unused_imports)]
+pub(crate) use transaction_builder::TransactionBuilderRustSdk as TransactionBuilderAdapter;
 
 #[allow(unused_imports)]
 pub(crate) use iota_client_rust_sdk::CoinReadApiAdaptedT;

--- a/identity_iota_core/src/rebased/proposals/borrow.rs
+++ b/identity_iota_core/src/rebased/proposals/borrow.rs
@@ -5,9 +5,9 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 
 use crate::iota_interaction_adapter::AdapterError;
-use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
 use crate::iota_interaction_adapter::IotaTransactionBlockResponseAdapter;
+use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use identity_iota_interaction::IdentityMoveCalls;
 use identity_iota_interaction::IotaKeySignature;
 use identity_iota_interaction::IotaTransactionBlockResponseT;
@@ -226,7 +226,10 @@ where
   }
 
   fn parse_tx_effects_internal(
-    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>,
+    _tx_response: &dyn IotaTransactionBlockResponseT<
+      Error = AdapterError,
+      NativeResponse = NativeTransactionBlockResponse,
+    >,
   ) -> Result<Self::Output, Error> {
     Ok(())
   }

--- a/identity_iota_core/src/rebased/proposals/borrow.rs
+++ b/identity_iota_core/src/rebased/proposals/borrow.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 
 use crate::iota_interaction_adapter::AdapterError;
-use crate::iota_interaction_adapter::AdapterNativeResponse;
+use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
 use crate::iota_interaction_adapter::IotaTransactionBlockResponseAdapter;
 use identity_iota_interaction::IdentityMoveCalls;
@@ -226,7 +226,7 @@ where
   }
 
   fn parse_tx_effects_internal(
-    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = AdapterNativeResponse>,
+    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>,
   ) -> Result<Self::Output, Error> {
     Ok(())
   }

--- a/identity_iota_core/src/rebased/proposals/config_change.rs
+++ b/identity_iota_core/src/rebased/proposals/config_change.rs
@@ -8,9 +8,9 @@ use std::ops::DerefMut as _;
 use std::str::FromStr as _;
 
 use crate::iota_interaction_adapter::AdapterError;
-use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
 use crate::iota_interaction_adapter::IotaTransactionBlockResponseAdapter;
+use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use identity_iota_interaction::IdentityMoveCalls;
 use identity_iota_interaction::IotaKeySignature;
 use identity_iota_interaction::IotaTransactionBlockResponseT;
@@ -298,7 +298,10 @@ impl ProposalT for Proposal<ConfigChange> {
   }
 
   fn parse_tx_effects_internal(
-    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>,
+    _tx_response: &dyn IotaTransactionBlockResponseT<
+      Error = AdapterError,
+      NativeResponse = NativeTransactionBlockResponse,
+    >,
   ) -> Result<Self::Output, Error> {
     Ok(())
   }

--- a/identity_iota_core/src/rebased/proposals/config_change.rs
+++ b/identity_iota_core/src/rebased/proposals/config_change.rs
@@ -8,7 +8,7 @@ use std::ops::DerefMut as _;
 use std::str::FromStr as _;
 
 use crate::iota_interaction_adapter::AdapterError;
-use crate::iota_interaction_adapter::AdapterNativeResponse;
+use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
 use crate::iota_interaction_adapter::IotaTransactionBlockResponseAdapter;
 use identity_iota_interaction::IdentityMoveCalls;
@@ -298,7 +298,7 @@ impl ProposalT for Proposal<ConfigChange> {
   }
 
   fn parse_tx_effects_internal(
-    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = AdapterNativeResponse>,
+    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>,
   ) -> Result<Self::Output, Error> {
     Ok(())
   }

--- a/identity_iota_core/src/rebased/proposals/controller.rs
+++ b/identity_iota_core/src/rebased/proposals/controller.rs
@@ -4,7 +4,7 @@
 use std::marker::PhantomData;
 
 use crate::iota_interaction_adapter::AdapterError;
-use crate::iota_interaction_adapter::AdapterNativeResponse;
+use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
 use crate::iota_interaction_adapter::IotaTransactionBlockResponseAdapter;
 use identity_iota_interaction::IdentityMoveCalls;
@@ -235,7 +235,7 @@ where
   }
 
   fn parse_tx_effects_internal(
-    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = AdapterNativeResponse>,
+    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>,
   ) -> Result<Self::Output, Error> {
     Ok(())
   }

--- a/identity_iota_core/src/rebased/proposals/controller.rs
+++ b/identity_iota_core/src/rebased/proposals/controller.rs
@@ -4,9 +4,9 @@
 use std::marker::PhantomData;
 
 use crate::iota_interaction_adapter::AdapterError;
-use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
 use crate::iota_interaction_adapter::IotaTransactionBlockResponseAdapter;
+use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use identity_iota_interaction::IdentityMoveCalls;
 use identity_iota_interaction::IotaKeySignature;
 use identity_iota_interaction::IotaTransactionBlockResponseT;
@@ -235,7 +235,10 @@ where
   }
 
   fn parse_tx_effects_internal(
-    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>,
+    _tx_response: &dyn IotaTransactionBlockResponseT<
+      Error = AdapterError,
+      NativeResponse = NativeTransactionBlockResponse,
+    >,
   ) -> Result<Self::Output, Error> {
     Ok(())
   }

--- a/identity_iota_core/src/rebased/proposals/deactivate_did.rs
+++ b/identity_iota_core/src/rebased/proposals/deactivate_did.rs
@@ -4,7 +4,7 @@
 use std::marker::PhantomData;
 
 use crate::iota_interaction_adapter::AdapterError;
-use crate::iota_interaction_adapter::AdapterNativeResponse;
+use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
 use crate::iota_interaction_adapter::IotaTransactionBlockResponseAdapter;
 use identity_iota_interaction::IdentityMoveCalls;
@@ -117,7 +117,7 @@ impl ProposalT for Proposal<DeactivateDid> {
   }
 
   fn parse_tx_effects_internal(
-    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = AdapterNativeResponse>,
+    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>,
   ) -> Result<Self::Output, Error> {
     Ok(())
   }

--- a/identity_iota_core/src/rebased/proposals/deactivate_did.rs
+++ b/identity_iota_core/src/rebased/proposals/deactivate_did.rs
@@ -4,9 +4,9 @@
 use std::marker::PhantomData;
 
 use crate::iota_interaction_adapter::AdapterError;
-use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
 use crate::iota_interaction_adapter::IotaTransactionBlockResponseAdapter;
+use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use identity_iota_interaction::IdentityMoveCalls;
 use identity_iota_interaction::IotaKeySignature;
 use identity_iota_interaction::IotaTransactionBlockResponseT;
@@ -117,7 +117,10 @@ impl ProposalT for Proposal<DeactivateDid> {
   }
 
   fn parse_tx_effects_internal(
-    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>,
+    _tx_response: &dyn IotaTransactionBlockResponseT<
+      Error = AdapterError,
+      NativeResponse = NativeTransactionBlockResponse,
+    >,
   ) -> Result<Self::Output, Error> {
     Ok(())
   }

--- a/identity_iota_core/src/rebased/proposals/mod.rs
+++ b/identity_iota_core/src/rebased/proposals/mod.rs
@@ -21,7 +21,7 @@ cfg_if::cfg_if! {
   }
 }
 use crate::iota_interaction_adapter::AdapterError;
-use crate::iota_interaction_adapter::AdapterNativeResponse;
+use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
 
 use identity_iota_interaction::IdentityMoveCalls;
@@ -82,7 +82,7 @@ pub trait ProposalT: Sized {
   /// The output of the [`Proposal`]
   type Output;
   /// Platform-agnostic type of the IotaTransactionBlockResponse
-  type Response: IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = AdapterNativeResponse>;
+  type Response: IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>;
 
   /// Creates a new [`Proposal`] with the provided action and expiration.
   async fn create<'i, S>(
@@ -112,7 +112,7 @@ pub trait ProposalT: Sized {
 
   /// For internal platform-agnostic usage only.
   fn parse_tx_effects_internal(
-    tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = AdapterNativeResponse>,
+    tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>,
   ) -> Result<Self::Output, Error>;
 }
 

--- a/identity_iota_core/src/rebased/proposals/mod.rs
+++ b/identity_iota_core/src/rebased/proposals/mod.rs
@@ -21,8 +21,8 @@ cfg_if::cfg_if! {
   }
 }
 use crate::iota_interaction_adapter::AdapterError;
-use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
+use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 
 use identity_iota_interaction::IdentityMoveCalls;
 use identity_iota_interaction::IotaClientTrait;
@@ -112,7 +112,10 @@ pub trait ProposalT: Sized {
 
   /// For internal platform-agnostic usage only.
   fn parse_tx_effects_internal(
-    tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>,
+    tx_response: &dyn IotaTransactionBlockResponseT<
+      Error = AdapterError,
+      NativeResponse = NativeTransactionBlockResponse,
+    >,
   ) -> Result<Self::Output, Error>;
 }
 

--- a/identity_iota_core/src/rebased/proposals/send.rs
+++ b/identity_iota_core/src/rebased/proposals/send.rs
@@ -12,9 +12,9 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::iota_interaction_adapter::AdapterError;
-use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
 use crate::iota_interaction_adapter::IotaTransactionBlockResponseAdapter;
+use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use identity_iota_interaction::IdentityMoveCalls;
 use identity_iota_interaction::IotaKeySignature;
 use identity_iota_interaction::IotaTransactionBlockResponseT;
@@ -193,7 +193,10 @@ impl ProposalT for Proposal<SendAction> {
   }
 
   fn parse_tx_effects_internal(
-    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>,
+    _tx_response: &dyn IotaTransactionBlockResponseT<
+      Error = AdapterError,
+      NativeResponse = NativeTransactionBlockResponse,
+    >,
   ) -> Result<Self::Output, Error> {
     Ok(())
   }

--- a/identity_iota_core/src/rebased/proposals/send.rs
+++ b/identity_iota_core/src/rebased/proposals/send.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::iota_interaction_adapter::AdapterError;
-use crate::iota_interaction_adapter::AdapterNativeResponse;
+use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
 use crate::iota_interaction_adapter::IotaTransactionBlockResponseAdapter;
 use identity_iota_interaction::IdentityMoveCalls;
@@ -193,7 +193,7 @@ impl ProposalT for Proposal<SendAction> {
   }
 
   fn parse_tx_effects_internal(
-    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = AdapterNativeResponse>,
+    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>,
   ) -> Result<Self::Output, Error> {
     Ok(())
   }

--- a/identity_iota_core/src/rebased/proposals/update_did_doc.rs
+++ b/identity_iota_core/src/rebased/proposals/update_did_doc.rs
@@ -4,9 +4,9 @@
 use std::marker::PhantomData;
 
 use crate::iota_interaction_adapter::AdapterError;
-use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
 use crate::iota_interaction_adapter::IotaTransactionBlockResponseAdapter;
+use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use identity_iota_interaction::IdentityMoveCalls;
 use identity_iota_interaction::IotaKeySignature;
 use identity_iota_interaction::IotaTransactionBlockResponseT;
@@ -125,7 +125,10 @@ impl ProposalT for Proposal<UpdateDidDocument> {
   }
 
   fn parse_tx_effects_internal(
-    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>,
+    _tx_response: &dyn IotaTransactionBlockResponseT<
+      Error = AdapterError,
+      NativeResponse = NativeTransactionBlockResponse,
+    >,
   ) -> Result<Self::Output, Error> {
     Ok(())
   }

--- a/identity_iota_core/src/rebased/proposals/update_did_doc.rs
+++ b/identity_iota_core/src/rebased/proposals/update_did_doc.rs
@@ -4,7 +4,7 @@
 use std::marker::PhantomData;
 
 use crate::iota_interaction_adapter::AdapterError;
-use crate::iota_interaction_adapter::AdapterNativeResponse;
+use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
 use crate::iota_interaction_adapter::IotaTransactionBlockResponseAdapter;
 use identity_iota_interaction::IdentityMoveCalls;
@@ -125,7 +125,7 @@ impl ProposalT for Proposal<UpdateDidDocument> {
   }
 
   fn parse_tx_effects_internal(
-    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = AdapterNativeResponse>,
+    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>,
   ) -> Result<Self::Output, Error> {
     Ok(())
   }

--- a/identity_iota_core/src/rebased/proposals/upgrade.rs
+++ b/identity_iota_core/src/rebased/proposals/upgrade.rs
@@ -4,9 +4,9 @@
 use std::marker::PhantomData;
 
 use crate::iota_interaction_adapter::AdapterError;
-use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
 use crate::iota_interaction_adapter::IotaTransactionBlockResponseAdapter;
+use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use identity_iota_interaction::IdentityMoveCalls;
 use identity_iota_interaction::IotaKeySignature;
 use identity_iota_interaction::IotaTransactionBlockResponseT;
@@ -114,7 +114,10 @@ impl ProposalT for Proposal<Upgrade> {
   }
 
   fn parse_tx_effects_internal(
-    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>,
+    _tx_response: &dyn IotaTransactionBlockResponseT<
+      Error = AdapterError,
+      NativeResponse = NativeTransactionBlockResponse,
+    >,
   ) -> Result<Self::Output, Error> {
     Ok(())
   }

--- a/identity_iota_core/src/rebased/proposals/upgrade.rs
+++ b/identity_iota_core/src/rebased/proposals/upgrade.rs
@@ -4,7 +4,7 @@
 use std::marker::PhantomData;
 
 use crate::iota_interaction_adapter::AdapterError;
-use crate::iota_interaction_adapter::AdapterNativeResponse;
+use crate::iota_interaction_adapter::NativeTransactionBlockResponse;
 use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
 use crate::iota_interaction_adapter::IotaTransactionBlockResponseAdapter;
 use identity_iota_interaction::IdentityMoveCalls;
@@ -114,7 +114,7 @@ impl ProposalT for Proposal<Upgrade> {
   }
 
   fn parse_tx_effects_internal(
-    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = AdapterNativeResponse>,
+    _tx_response: &dyn IotaTransactionBlockResponseT<Error = AdapterError, NativeResponse = NativeTransactionBlockResponse>,
   ) -> Result<Self::Output, Error> {
     Ok(())
   }


### PR DESCRIPTION
# Description of change
This PR comprises the following renamings

bindings/wasm/iota_interaction_ts:
* Renamed `bindings::IotaTransactionBlockResponseAdapter` to `bindings::WasmIotaTransactionBlockResponseWrapper` (name is also used for the TS class in iota_client_helpers.ts)

identity_iota_core/src/iota_interaction_rust and
bindings/wasm/iota_interaction_ts:
* Renamed `AdapterNativeResponse` to `NativeTransactionBlockResponse`

## Links to any relevant issues

* fixes issue #1514
* Replaces closed PR #1527

## Type of change
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix
- [x] Refactoring  (a non-breaking change which enhances code quality)

## How the change has been tested
* Current E2E tests for non wasm32 targets run as expected
* Successful wasm32 and non wasm32 build for identity_iota_core:
  wasm32 build: `cargo build --package identity_iota_core --lib --target wasm32-unknown-unknown --no-default-features --features iota-client --features revocation-bitmap`
* NPM build iota_interaction_ts:
   In folder bindings/wasm/iota_interaction_ts:
   * `npm install`
   * `npm run build:nodejs`
* NPM build identity_wasm:
   In folder bindings/wasm/identity_wasm:
   * Prerequisite: NPM build iota_interaction_ts (see above)
   * `npm install`
   * `npm run build:nodejs`
* Successfully ran all identity_wasm examples
   In folder bindings/wasm/identity_wasm:
   * Prerequisite: NPM build identity_wasm (see above)
   * npm run example:node <example-name-goes-here>
