### PR TITLE
Add smaller test and debug improvements

### DIFF
--- a/.github/actions/iota-rebase-sandbox/setup/action.yml
+++ b/.github/actions/iota-rebase-sandbox/setup/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: "Platform to download binary for (linux or macos)"
     required: true
     default: "linux"
+  logfile:
+    description: "Optional log file to store server log as workflow artifact"
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -49,5 +53,10 @@ runs:
       run: |
         # Clear previous configuration
         rm -rf ~/.iota || true 
+
+        # Check log file arg
+        LOGFILE="${{ inputs.logfile }}"
+        echo "Starting server with log file: $LOGFILE"
+
         # Start the network
-        iota start --with-faucet &
+        iota start --with-faucet ${{ inputs.logfile && format('> {0} 2>&1', inputs.logfile) || '' }} &

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -79,6 +79,18 @@ jobs:
     env:
       SCCACHE_DIR: ${{ matrix.sccache-path }}
       RUSTC_WRAPPER: sccache
+      IOTA_SERVER_LOGFILE: >-
+        ${{
+          matrix.os != 'windows-latest' &&
+            format(
+              'iota-server-logs-build-and-test-{0}-{1}-{2}-{3}.txt',
+              matrix.os == 'ubuntu-24.04' && 'linux' || 'macos',
+              github.run_id,
+              github.run_number,
+              github.run_attempt
+            ) ||
+            ''
+        }}
 
     steps:
       - uses: actions/checkout@v3
@@ -135,6 +147,7 @@ jobs:
         uses: './.github/actions/iota-rebase-sandbox/setup'
         with:
           platform: ${{ matrix.os == 'ubuntu-24.04' && 'linux' || 'macos' }}
+          logfile: ${{ env.IOTA_SERVER_LOGFILE }}
 
       - name: test IotaIdentity package
         if: matrix.os != 'windows-latest'
@@ -173,6 +186,15 @@ jobs:
           cd bindings/wasm/identity_wasm
           npm ci
           npm run test:readme:rust
+
+      - name: Archive server logs
+        if: ${{ env.IOTA_SERVER_LOGFILE }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: iota-server-logs-build-and-test-${{ matrix.os == 'ubuntu-24.04' && 'linux' || 'macos' }}.txt
+          path: iota/${{ env.IOTA_SERVER_LOGFILE }}
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Stop sccache
         uses: './.github/actions/rust/sccache/stop-sccache'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,7 +83,7 @@ jobs:
         ${{
           matrix.os != 'windows-latest' &&
             format(
-              'iota-server-logs-build-and-test-{0}-{1}-{2}-{3}.txt',
+              'iota-server-logs-build-and-test-{0}-{1}-{2}-{3}.log',
               matrix.os == 'ubuntu-24.04' && 'linux' || 'macos',
               github.run_id,
               github.run_number,

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -191,7 +191,7 @@ jobs:
         if: ${{ env.IOTA_SERVER_LOGFILE }}
         uses: actions/upload-artifact@v4
         with:
-          name: iota-server-logs-build-and-test-${{ matrix.os == 'ubuntu-24.04' && 'linux' || 'macos' }}.txt
+          name: ${{ env.IOTA_SERVER_LOGFILE }}
           path: iota/${{ env.IOTA_SERVER_LOGFILE }}
           if-no-files-found: error
           retention-days: 1

--- a/bindings/grpc/tests/api/helpers.rs
+++ b/bindings/grpc/tests/api/helpers.rs
@@ -367,20 +367,19 @@ async fn publish_package(active_address: IotaAddress) -> anyhow::Result<ObjectID
     .arg("publish_identity_package.sh")
     .output()
     .await?;
+  let stdout = std::str::from_utf8(&output.stdout).unwrap();
 
   if !output.status.success() {
-    anyhow::bail!(
-      "Failed to publish move package: \n\n{}\n\n{}",
-      std::str::from_utf8(&output.stdout).unwrap(),
-      std::str::from_utf8(&output.stderr).unwrap()
-    );
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    anyhow::bail!("Failed to publish move package: \n\n{stdout}\n\n{stderr}");
   }
 
   let package_id: ObjectID = {
-    let output_str = std::str::from_utf8(&output.stdout).unwrap().trim();
-    ObjectID::from_str(output_str).context(format!(
-      "failed to find IDENTITY_IOTA_PKG_ID in response from: {output_str}"
-    ))?
+    let stdout_trimmed = stdout.trim();
+    ObjectID::from_str(stdout_trimmed).with_context(|| {
+      let stderr = std::str::from_utf8(&output.stderr).unwrap();
+      format!("failed to find IDENTITY_IOTA_PKG_ID in response from: '{stdout_trimmed}'; {stderr}")
+    })?
   };
 
   // Persist package ID in order to avoid publishing the package for every test.

--- a/bindings/wasm/identity_wasm/package.json
+++ b/bindings/wasm/identity_wasm/package.json
@@ -35,7 +35,7 @@
     "test:unit:node": "ts-mocha -p tsconfig.node.json ./tests/*.ts --parallel --exit",
     "cypress": "cypress open",
     "fmt": "dprint fmt",
-    "fix_docs": "find ./docs/wasm/ -type f -name '*.md' -exec sed -Ei 's/(\\.md?#([^#]*)?)#/\\1/' {} +"
+    "fix_docs": "find ./docs/wasm/ -type f -name '*.md' -exec sed -E -i.bak -e 's/(\\.md?#([^#]*)?)#/\\1/' {} ';' -exec rm {}.bak ';'"
   },
   "config": {
     "CYPRESS_VERIFY_TIMEOUT": 100000

--- a/identity_iota_core/scripts/publish_identity_package.sh
+++ b/identity_iota_core/scripts/publish_identity_package.sh
@@ -7,6 +7,12 @@ script_dir=$(cd "$(dirname $0)" && pwd)
 package_dir=$script_dir/../packages/iota_identity
 
 # echo "publishing package from $package_dir"
-package_id=$(iota client publish --with-unpublished-dependencies --skip-dependency-verification --silence-warnings --json --gas-budget 500000000 $package_dir | jq --raw-output '.objectChanges[] | select(.type | contains("published")) | .packageId')
-export IOTA_IDENTITY_PKG_ID=$package_id
+RESPONSE=$(iota client publish --with-unpublished-dependencies --skip-dependency-verification --silence-warnings --json --gas-budget 500000000 $package_dir)
+{ # try
+  PACKAGE_ID=$(echo $RESPONSE | jq --raw-output '.objectChanges[] | select(.type | contains("published")) | .packageId')
+} || { # catch
+  echo $RESPONSE
+}
+
+export IOTA_IDENTITY_PKG_ID=$PACKAGE_ID
 echo "${IOTA_IDENTITY_PKG_ID}"


### PR DESCRIPTION
## Description of change

Adds some smaller improvements to output during tests, and fixes a smaller issue with build:

- `npm run build` now runs without errors on macOS again, as `fix_docs` now works as expected on macOS
- IOTA server logs from CI can now been downloaded (--> "Archive server logs" step)
- `identity_iota_core/scripts/publish_identity_package.sh` script now emits the response if it cannot be parsed, instead of the message that just says, that the JSON could not be parsed
- cli tools error logs in `identity_iota_core` and the GRPC bindings now all include `stderr` where a custom error is thrown