### PR TITLE
Update domain linkage validation for multiple creds by same issuer

### DIFF
--- a/.github/actions/publish/publish-wasm/action.yml
+++ b/.github/actions/publish/publish-wasm/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '16.x'
+        node-version: '20.x'
         registry-url: 'https://registry.npmjs.org'
 
     - name: Download bindings/wasm artifacts

--- a/.github/actions/release/bump-versions/action.yml
+++ b/.github/actions/release/bump-versions/action.yml
@@ -51,7 +51,7 @@ runs:
       uses: actions/setup-node@v2
       if: ${{inputs.release-target == 'wasm'}}
       with:
-        node-version: '16.x'
+        node-version: '20.x'
         registry-url: 'https://registry.npmjs.org'
 
     - name: Bump Wasm npm package version

--- a/.github/actions/rust/rust-setup/action.yml
+++ b/.github/actions/rust/rust-setup/action.yml
@@ -90,7 +90,7 @@ runs:
         rustup show
 
     - name: Cache cargo
-      uses: actions/cache@v2.1.7
+      uses: actions/cache@v4
       if: inputs.cargo-cache-enabled == 'true'
       with:
         # https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
@@ -115,7 +115,7 @@ runs:
       shell: bash
 
     - name: Cache build target
-      uses: actions/cache@v2.1.7
+      uses: actions/cache@v4
       if: inputs.target-cache-enabled == 'true'
       with:
         path: ${{ inputs.target-cache-path }}
@@ -127,7 +127,7 @@ runs:
           ${{ inputs.os }}-target-
 
     - name: Cache sccache
-      uses: actions/cache@v2.1.7
+      uses: actions/cache@v4
       if: inputs.sccache-enabled == 'true'
       with:
           path: ${{ inputs.sccache-path }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install JS dependencies
         run: npm ci
@@ -231,7 +231,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
   
       - name: Install JS dependencies
         run: npm ci
@@ -279,7 +279,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install JS dependencies
         run: npm ci

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -169,8 +169,7 @@ jobs:
   build-wasm:
     needs: check-for-run-condition
     if: ${{ needs.check-for-run-condition.outputs.should-run == 'true' }}
-    # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-build-wasm.yml@main
+    uses: './.github/workflows/shared-build-wasm.yml'
     with:
       output-artifact-name: identity-wasm-bindings-build
 

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -34,6 +34,8 @@ jobs:
       # Download a pre-compiled wasm-bindgen binary.
       - name: Install wasm-bindgen-cli
         uses: jetli/wasm-bindgen-action@24ba6f9fff570246106ac3f80f35185600c3f6c9
+        with:
+          version: '0.2.100'
 
       - name: core clippy check
         uses: actions-rs-plus/clippy-check@b09a9c37c9df7db8b1a5d52e8fe8e0b6e3d574c4

--- a/.github/workflows/rust-automatic-release-and-publish.yml
+++ b/.github/workflows/rust-automatic-release-and-publish.yml
@@ -10,8 +10,7 @@ on:
 jobs:
   call-create-release-workflow:
     if: github.event.pull_request.merged == true
-    # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-release.yml@main
+    uses: './.github/workflows/shared-release.yml'
     with:
       changelog-config-path: ./.github/.github_changelog_generator
       pre-release-tag-regex: ^v[0-9]+\.[0-9]+\.[0-9]+-(?<pre_release>\w+)\.\d+$

--- a/.github/workflows/rust-create-hotfix-pr.yml
+++ b/.github/workflows/rust-create-hotfix-pr.yml
@@ -9,8 +9,7 @@ on:
 
 jobs:
   create-hotfix-pr:
-    # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-create-hotfix-pr.yml@main
+    uses: './.github/workflows/shared-create-hotfix-pr.yml'
     with:
       branch: ${{ github.event.inputs.branch }}
       branch-regex: ^support\/v[0-9]+\.[0-9]+$

--- a/.github/workflows/rust-create-release-pr.yml
+++ b/.github/workflows/rust-create-release-pr.yml
@@ -20,8 +20,7 @@ on:
 jobs:
   create-dev-release-pr:
     if: github.event.inputs.release-type != 'main'
-    # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-create-dev-release-pr.yml@main
+    uses: './.github/workflows/shared-create-dev-release-pr.yml'
     with:
       tag-prefix: v
       tag-postfix: -${{ github.event.inputs.release-type }}.
@@ -34,8 +33,7 @@ jobs:
       GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   create-main-release-pr:
     if: github.event.inputs.release-type == 'main'
-    # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-create-main-release-pr.yml@main
+    uses: './.github/workflows/shared-create-main-release-pr.yml'
     with:
       tag-prefix: v
       tag-base: ${{ github.event.inputs.version }}

--- a/.github/workflows/shared-build-wasm.yml
+++ b/.github/workflows/shared-build-wasm.yml
@@ -55,6 +55,8 @@ jobs:
       # Download a pre-compiled wasm-bindgen binary.
       - name: Install wasm-bindgen-cli
         uses: jetli/wasm-bindgen-action@24ba6f9fff570246106ac3f80f35185600c3f6c9
+        with:
+          version: '0.2.100'
 
       - name: Setup sccache
         uses: './.github/actions/rust/sccache/setup-sccache'

--- a/.github/workflows/shared-build-wasm.yml
+++ b/.github/workflows/shared-build-wasm.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install JS dependencies
         run: npm ci

--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -17,8 +17,7 @@ permissions:
 
 jobs:
   build-wasm: 
-    # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-build-wasm.yml@main
+    uses: './.github/workflows/shared-build-wasm.yml'
     with:
       run-unit-tests: false
       ref: ${{ inputs.ref }}

--- a/.github/workflows/wasm-automatic-release-and-publish.yml
+++ b/.github/workflows/wasm-automatic-release-and-publish.yml
@@ -11,8 +11,7 @@ on:
 jobs:
   call-create-release-workflow:
     if: github.event.pull_request.merged == true
-    # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-release.yml@main
+    uses: './.github/workflows/shared-release.yml'
     with:
       changelog-config-path: ./bindings/wasm/.github_changelog_generator
       pre-release-tag-regex: ^wasm-v[0-9]+\.[0-9]+\.[0-9]+-(?<pre_release>\w+)\.\d+$
@@ -25,8 +24,7 @@ jobs:
   build-wasm: 
     needs: call-create-release-workflow
     if: ${{ needs.call-create-release-workflow.outputs.is-release }}
-    # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-build-wasm.yml@main
+    uses: './.github/workflows/shared-build-wasm.yml'
     with:
       output-artifact-name: identity-wasm-bindings-build
 

--- a/.github/workflows/wasm-create-hotfix-pr.yml
+++ b/.github/workflows/wasm-create-hotfix-pr.yml
@@ -9,8 +9,7 @@ on:
 
 jobs:
   create-hotfix-pr:
-    # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-create-hotfix-pr.yml@main
+    uses: './.github/workflows/shared-create-hotfix-pr.yml'
     with:
       branch: ${{ github.event.inputs.branch }}
       branch-regex: ^support\/wasm-v[0-9]+\.[0-9]+$

--- a/.github/workflows/wasm-create-release-pr.yml
+++ b/.github/workflows/wasm-create-release-pr.yml
@@ -20,8 +20,7 @@ on:
 jobs:
   create-dev-release-pr:
     if: github.event.inputs.release-type != 'main'
-    # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-create-dev-release-pr.yml@main
+    uses: './.github/workflows/shared-create-dev-release-pr.yml'
     with:
       tag-prefix: wasm-v
       tag-postfix: -${{ github.event.inputs.release-type }}.
@@ -37,8 +36,7 @@ jobs:
 
   create-main-release-pr:
     if: github.event.inputs.release-type == 'main'
-    # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-create-main-release-pr.yml@main
+    uses: './.github/workflows/shared-create-main-release-pr.yml'
     with:
       tag-prefix: wasm-v
       tag-base: ${{ github.event.inputs.version }}

--- a/.github/workflows/wasm-publish-to-npm.yml
+++ b/.github/workflows/wasm-publish-to-npm.yml
@@ -18,8 +18,7 @@ on:
 jobs:
 
   build-wasm: 
-    # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-build-wasm.yml@main
+    uses: './.github/workflows/shared-build-wasm.yml'
     with:
       ref: ${{ github.event.inputs.branch }}
       output-artifact-name: identity-wasm-bindings-build

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ We provide a collection of experimental [gRPC services](https://github.com/iotal
 
 ## Prerequisites
 
-- [Rust](https://www.rust-lang.org/) (>= 1.65)
-- [Cargo](https://doc.rust-lang.org/cargo/) (>= 1.65)
+- [Rust](https://www.rust-lang.org/) (latest)
+- [Cargo](https://doc.rust-lang.org/cargo/) (latest)
 
 ## Getting Started
 

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = { version = "1.0", default-features = false }
 serde_repr = { version = "0.1", default-features = false }
 # Want to use the nice API of tokio::sync::RwLock for now even though we can't use threads.
 tokio = { version = "1.29", default-features = false, features = ["sync"] }
-wasm-bindgen = { version = "0.2.85", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.100", features = ["serde-serialize"] }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 zkryptium = "0.2.2"
 

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -44,7 +44,7 @@ npm run build:web
 
 ## Minimum Requirements
 
-The minimum supported version for node is: `v16`
+The minimum supported version for node is: `v20`
 
 ## NodeJS Usage
 

--- a/bindings/wasm/package-lock.json
+++ b/bindings/wasm/package-lock.json
@@ -36,7 +36,7 @@
         "typescript": "^4.7.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "peerDependencies": {
         "@iota/sdk-wasm": "^1.0.4"

--- a/bindings/wasm/package-lock.json
+++ b/bindings/wasm/package-lock.json
@@ -33,8 +33,7 @@
         "txm": "^8.1.0",
         "typedoc": "^0.24.6",
         "typedoc-plugin-markdown": "^3.14.0",
-        "typescript": "^4.7.2",
-        "wasm-opt": "^1.3.0"
+        "typescript": "^4.7.2"
       },
       "engines": {
         "node": ">=16"
@@ -1435,15 +1434,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -2611,18 +2601,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/fs-then-native": {
@@ -4191,31 +4169,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/minipass": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
-      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -5372,23 +5325,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tar": {
-      "version": "6.1.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-      "dev": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/temp-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
@@ -6116,20 +6052,6 @@
       "dev": true,
       "engines": {
         "node": ">=12.17"
-      }
-    },
-    "node_modules/wasm-opt": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/wasm-opt/-/wasm-opt-1.3.0.tgz",
-      "integrity": "sha512-24+IOboX4Sav0bI8Krwf0Y6dnpN4KxYtqpl0qWt86qVLsmayUqx1KMBrJTlQWNC+/dsqzQJjK6QvxNJsZYOgJg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-fetch": "^2.6.7",
-        "tar": "^6.1.11"
-      },
-      "bin": {
-        "wasm-opt": "bin/wasm-opt.js"
       }
     },
     "node_modules/watchpack": {
@@ -7494,12 +7416,6 @@
         "readdirp": "~3.6.0"
       }
     },
-    "chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true
-    },
     "chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -8407,15 +8323,6 @@
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
-      }
-    },
-    "fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0"
       }
     },
     "fs-then-native": {
@@ -9464,25 +9371,6 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
-    "minipass": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
-      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
-    "minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      }
-    },
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -10331,20 +10219,6 @@
       "dev": true,
       "peer": true
     },
-    "tar": {
-      "version": "6.1.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-      "dev": true,
-      "requires": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      }
-    },
     "temp-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
@@ -10868,16 +10742,6 @@
       "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.0.tgz",
       "integrity": "sha512-Uhxps5yZcVNbLEAnb+xaEEMdgTXl9qAQDzKYejG2AZ7qPwRQ81lozY9ECDbjLPNWm7YsO1IK5rsP1KoQzXAcGA==",
       "dev": true
-    },
-    "wasm-opt": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/wasm-opt/-/wasm-opt-1.3.0.tgz",
-      "integrity": "sha512-24+IOboX4Sav0bI8Krwf0Y6dnpN4KxYtqpl0qWt86qVLsmayUqx1KMBrJTlQWNC+/dsqzQJjK6QvxNJsZYOgJg==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^2.6.7",
-        "tar": "^6.1.11"
-      }
     },
     "watchpack": {
       "version": "2.4.0",

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -87,6 +87,6 @@
     "@iota/sdk-wasm": "^1.0.4"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   }
 }

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -13,8 +13,8 @@
     "build:src": "cargo build --lib --release --target wasm32-unknown-unknown",
     "bundle:nodejs": "wasm-bindgen target/wasm32-unknown-unknown/release/identity_wasm.wasm --typescript --weak-refs --target nodejs --out-dir node && node ./build/node && tsc --project ./lib/tsconfig.json && node ./build/replace_paths ./lib/tsconfig.json node",
     "bundle:web": "wasm-bindgen target/wasm32-unknown-unknown/release/identity_wasm.wasm --typescript --weak-refs --target web --out-dir web && node ./build/web && tsc --project ./lib/tsconfig.web.json && node ./build/replace_paths ./lib/tsconfig.web.json web",
-    "build:nodejs": "npm run build:src && npm run bundle:nodejs && wasm-opt -O node/identity_wasm_bg.wasm -o node/identity_wasm_bg.wasm",
-    "build:web": "npm run build:src && npm run bundle:web && wasm-opt -O web/identity_wasm_bg.wasm -o web/identity_wasm_bg.wasm",
+    "build:nodejs": "npm run build:src && npm run bundle:nodejs",
+    "build:web": "npm run build:src && npm run bundle:web",
     "build:docs": "typedoc && npm run fix_docs",
     "build:examples:web": "tsc --project ./examples/tsconfig.web.json && node ./build/replace_paths ./examples/tsconfig.web.json ./examples/dist resolve",
     "build": "npm run build:web && npm run build:nodejs && npm run build:docs",
@@ -74,8 +74,7 @@
     "txm": "^8.1.0",
     "typedoc": "^0.24.6",
     "typedoc-plugin-markdown": "^3.14.0",
-    "typescript": "^4.7.2",
-    "wasm-opt": "^1.3.0"
+    "typescript": "^4.7.2"
   },
   "dependencies": {
     "@noble/ed25519": "^1.7.3",

--- a/bindings/wasm/rust-toolchain.toml
+++ b/bindings/wasm/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # @itsyaasir - Update to latest stable version when wasm-bindgen is updated
-channel = "1.81"
+channel = "stable"
 components = ["rustfmt"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"

--- a/identity_credential/src/domain_linkage/error.rs
+++ b/identity_credential/src/domain_linkage/error.rs
@@ -14,6 +14,28 @@ pub struct DomainLinkageValidationError {
   pub source: Option<Box<dyn Error + Send + Sync + 'static>>,
 }
 
+/// List of errors caused by failures to verify a Domain Linkage configuration or credential.
+#[derive(Debug, thiserror::Error)]
+pub struct DomainLinkageValidationErrorList {
+  /// set of errors
+  pub errors: Vec<DomainLinkageValidationError>,
+}
+
+/// A set of errors coming from validating multiple domain linkage credentials.
+impl DomainLinkageValidationErrorList {
+  /// Create new set of domain linkage validation errors.
+  pub fn new(errors: Vec<DomainLinkageValidationError>) -> Self {
+    Self { errors }
+  }
+}
+
+// Implement for `Error` trait.
+impl std::fmt::Display for DomainLinkageValidationErrorList {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{:?}", self.errors)
+  }
+}
+
 impl std::fmt::Display for DomainLinkageValidationError {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     write!(f, "{}", self.cause)
@@ -69,4 +91,7 @@ pub enum DomainLinkageValidationErrorCause {
   /// Caused by an invalid semantic structure of the Domain Linkage Configuration.
   #[error("invalid semantic structure of the domain linkage configuration")]
   InvalidStructure,
+  /// List of errors stemming from multiple validations.
+  #[error("one or more validations failed")]
+  List,
 }

--- a/identity_iota/README.md
+++ b/identity_iota/README.md
@@ -48,8 +48,8 @@ We provide a collection of experimental [gRPC services](https://github.com/iotal
 
 ## Prerequisites
 
-- [Rust](https://www.rust-lang.org/) (>= 1.65)
-- [Cargo](https://doc.rust-lang.org/cargo/) (>= 1.65)
+- [Rust](https://www.rust-lang.org/) (latest)
+- [Cargo](https://doc.rust-lang.org/cargo/) (latest)
 
 ## Getting Started
 


### PR DESCRIPTION
# Description of change
PR updates behavior for domain linkage validation when having multiple credentials issued by the same issuer:

- `validate_linkage` now allows multiple credentials by same issuer
- adds `validate_linkage_iter` to support custom validation setups here

<!--
## Links to any relevant issues
Be sure to reference any related issues by adding `fixes issue #`.
-->

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tested locally.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
