### PR TITLE
 Update signer's `key_id` getter to return `KeyId` instance instead of link

### DIFF
--- a/bindings/wasm/identity_wasm/Cargo.toml
+++ b/bindings/wasm/identity_wasm/Cargo.toml
@@ -27,7 +27,7 @@ iota-sdk = { version = "1.1.5", default-features = false, features = ["serde", "
 js-sys = { version = "0.3.61" }
 json-proof-token = "0.3.4"
 proc_typescript = { version = "0.1.0", path = "./proc_typescript" }
-secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.2.0" }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, branch = "feat/update-key-id-type" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 serde_json = { version = "1.0", default-features = false }

--- a/bindings/wasm/identity_wasm/src/storage/wasm_transaction_signer.rs
+++ b/bindings/wasm/identity_wasm/src/storage/wasm_transaction_signer.rs
@@ -74,8 +74,7 @@ impl Signer<IotaKeySignature> for WasmTransactionSigner {
     })
   }
 
-  fn key_id(&self) -> &String {
-    // TODO: Yikes! Find a way to work around this.
-    Box::leak(Box::new(self.key_id()))
+  fn key_id(&self) -> String {
+    self.key_id()
   }
 }

--- a/bindings/wasm/iota_interaction_ts/Cargo.toml
+++ b/bindings/wasm/iota_interaction_ts/Cargo.toml
@@ -27,7 +27,7 @@ futures = { version = "0.3" }
 identity_core = { version = "=1.6.0-alpha", path = "../../../identity_core" }
 identity_iota_interaction = { version = "=1.6.0-alpha", path = "../../../identity_iota_interaction", default-features = false }
 js-sys = { version = "0.3.61" }
-secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.2.0" }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, branch = "feat/update-key-id-type" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 serde_json.workspace = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ iota-sdk-legacy = { package = "iota-sdk", version = "1.0", default-features = fa
 json-proof-token.workspace = true
 rand = "0.8.5"
 sd-jwt-payload = { version = "0.2.1", default-features = false, features = ["sha"] }
-secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.2.0" }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", branch = "feat/update-key-id-type" }
 serde_json = { version = "1.0", default-features = false }
 tokio = { version = "1.43", default-features = false, features = ["rt", "macros"] }
 

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = "1.0.64"
 identity_iota = { version = "=1.6.0-alpha", path = "./", features = ["memstore"] }
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.10.3-rc" }
 rand = "0.8.5"
-secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.2.0" }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", branch = "feat/update-key-id-type" }
 tokio = { version = "1.43", features = ["full"] }
 
 [features]

--- a/identity_iota_core/Cargo.toml
+++ b/identity_iota_core/Cargo.toml
@@ -39,7 +39,7 @@ iota-crypto = { version = "0.23", optional = true }
 itertools = { version = "0.13.0", optional = true }
 phf = { version = "0.11.2", features = ["macros"] }
 rand = { version = "0.8.5", optional = true }
-secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.2.0", default-features = false, optional = true }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", branch = "feat/update-key-id-type", default-features = false, optional = true }
 serde-aux = { version = "4.5.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/identity_iota_interaction/Cargo.toml
+++ b/identity_iota_interaction/Cargo.toml
@@ -17,7 +17,7 @@ async-trait = { version = "0.1.81", default-features = false }
 cfg-if = "1.0.0"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597", package = "fastcrypto" }
 jsonpath-rust = { version = "0.5.1", optional = true }
-secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.2.0" }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, branch = "feat/update-key-id-type" }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/identity_iota_interaction/src/keytool_signer.rs
+++ b/identity_iota_interaction/src/keytool_signer.rs
@@ -106,8 +106,8 @@ impl KeytoolSigner {
 impl Signer<IotaKeySignature> for KeytoolSigner {
   type KeyId = IotaAddress;
 
-  fn key_id(&self) -> &Self::KeyId {
-    &self.address
+  fn key_id(&self) -> Self::KeyId {
+    self.address
   }
 
   async fn public_key(&self) -> Result<PublicKey, SecretStorageError> {

--- a/identity_storage/Cargo.toml
+++ b/identity_storage/Cargo.toml
@@ -27,7 +27,7 @@ iota-crypto = { version = "0.23.2", default-features = false, features = ["ed255
 json-proof-token = { workspace = true, optional = true }
 rand = { version = "0.8.5", default-features = false, features = ["std", "std_rng"], optional = true }
 seahash = { version = "4.1.0", default-features = false }
-secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.2.0", optional = true }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, branch = "feat/update-key-id-type", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/identity_storage/src/storage/storage_signer.rs
+++ b/identity_storage/src/storage/storage_signer.rs
@@ -79,8 +79,8 @@ where
 {
   type KeyId = KeyId;
 
-  fn key_id(&self) -> &KeyId {
-    &self.key_id
+  fn key_id(&self) -> KeyId {
+    self.key_id.clone()
   }
 
   async fn public_key(&self) -> Result<PublicKey, SecretStorageError> {


### PR DESCRIPTION
# Description of change
Updates `Signer` trait's implementation to return `Self::KeyId` instance instead of a reference in `key_id` getter to follow updated trait. See related PR [here](https://github.com/iotaledger/secret-storage/pull/4).

This makes the getter more flexible, especially in cases, where the key id instance is not owned by the signer, and a reference would have to be created "on the fly", as would have been the case for our WASM implementation.

Current (as of the time opening the PR) references point to PR branch to let CI run its checks. This will be changed to a tag or to the main branch, depending on how soon we tag the changes in `secret-storage`.

## Links to any relevant issues
- fixes #1595

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Ran tests and examples locally.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
