### PR TITLE
Pin `derange` version to avoid conflicts in `iota-sdk`

### DIFF
--- a/.github/actions/rust/rust-setup/action.yml
+++ b/.github/actions/rust/rust-setup/action.yml
@@ -90,7 +90,7 @@ runs:
         rustup show
 
     - name: Cache cargo
-      uses: actions/cache@v2.1.7
+      uses: actions/cache@v4
       if: inputs.cargo-cache-enabled == 'true'
       with:
         # https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
@@ -115,7 +115,7 @@ runs:
       shell: bash
 
     - name: Cache build target
-      uses: actions/cache@v2.1.7
+      uses: actions/cache@v4
       if: inputs.target-cache-enabled == 'true'
       with:
         path: ${{ inputs.target-cache-path }}
@@ -127,7 +127,7 @@ runs:
           ${{ inputs.os }}-target-
 
     - name: Cache sccache
-      uses: actions/cache@v2.1.7
+      uses: actions/cache@v4
       if: inputs.sccache-enabled == 'true'
       with:
           path: ${{ inputs.sccache-path }}

--- a/identity_core/Cargo.toml
+++ b/identity_core/Cargo.toml
@@ -11,6 +11,9 @@ repository.workspace = true
 description = "The core traits and types for the identity-rs library."
 
 [dependencies]
+ # pin dependency of `time` and limit range, as `0.4.1` has impl for `usize: PartialOrd<_>`
+ # that conflicts with `iota-sdk`s `core` impl, leading to errors in `iota-sdk` crate
+deranged = { version = ">=0.4.0, <0.4.1", default-features = false }
 multibase = { version = "0.9", default-features = false, features = ["std"] }
 serde = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }

--- a/identity_core/Cargo.toml
+++ b/identity_core/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 description = "The core traits and types for the identity-rs library."
 
 [dependencies]
- # pin dependency of `time` and limit range, as `0.4.1` has impl for `usize: PartialOrd<_>`
- # that conflicts with `iota-sdk`s `core` impl, leading to errors in `iota-sdk` crate
+# pin dependency of `time` and limit range, as `0.4.1` has impl for `usize: PartialOrd<_>`
+# that conflicts with `iota-sdk`s `core` impl, leading to errors in `iota-sdk` crate
 deranged = { version = ">=0.4.0, <0.4.1", default-features = false }
 multibase = { version = "0.9", default-features = false, features = ["std"] }
 serde = { workspace = true, features = ["std"] }


### PR DESCRIPTION
# Description of change
Pin dependency `derange` depdendency of `time` and limit range, as `0.4.1` has impl for `usize: PartialOrd<_>`, that conflicts with `iota-sdk`s `core` impl, leading to errors in `iota-sdk` crate during build.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
Tested build locally.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
