### PR TITLE
Revert deranged version pinning

### DIFF
--- a/bindings/wasm/src/credential/jpt_credential_validator/jpt_credential_validation_options.rs
+++ b/bindings/wasm/src/credential/jpt_credential_validator/jpt_credential_validation_options.rs
@@ -17,7 +17,7 @@ impl_wasm_json!(WasmJptCredentialValidationOptions, JptCredentialValidationOptio
 
 #[wasm_bindgen(js_class = JptCredentialValidationOptions)]
 impl WasmJptCredentialValidationOptions {
-  /// Creates a new default istance.
+  /// Creates a new default instance.
   #[wasm_bindgen(constructor)]
   pub fn new(opts: Option<IJptCredentialValidationOptions>) -> Result<WasmJptCredentialValidationOptions> {
     if let Some(opts) = opts {

--- a/bindings/wasm/src/credential/jwt_credential_validation/jwt_credential_validator.rs
+++ b/bindings/wasm/src/credential/jwt_credential_validation/jwt_credential_validator.rs
@@ -171,7 +171,7 @@ impl WasmJwtCredentialValidator {
     JwtCredentialValidatorUtils::check_status(&credential.0, &trusted_issuers, status_check).wasm_result()
   }
 
-  /// Checks wheter the credential status has been revoked using `StatusList2021`.
+  /// Checks whether the credential status has been revoked using `StatusList2021`.
   #[wasm_bindgen(js_name = checkStatusWithStatusList2021)]
   pub fn check_status_with_status_list_2021(
     credential: &WasmCredential,

--- a/bindings/wasm/src/credential/revocation/status_list_2021/credential.rs
+++ b/bindings/wasm/src/credential/revocation/status_list_2021/credential.rs
@@ -167,7 +167,7 @@ impl WasmStatusList2021Credential {
   }
 }
 
-/// Builder type to construct valid {@link StatusList2021Credential} istances.
+/// Builder type to construct valid {@link StatusList2021Credential} instances.
 #[wasm_bindgen(js_name = StatusList2021CredentialBuilder)]
 pub struct WasmStatusList2021CredentialBuilder(StatusList2021CredentialBuilder);
 

--- a/bindings/wasm/src/credential/revocation/validity_timeframe_2024/status.rs
+++ b/bindings/wasm/src/credential/revocation/validity_timeframe_2024/status.rs
@@ -49,7 +49,7 @@ impl WasmRevocationTimeframeStatus {
     self.0.end_validity_timeframe().into()
   }
 
-  /// Return the URL fo the `RevocationBitmapStatus`.
+  /// Return the URL for the `RevocationBitmapStatus`.
   #[wasm_bindgen]
   pub fn id(&self) -> String {
     self.0.id().to_string()

--- a/bindings/wasm/tests/storage.ts
+++ b/bindings/wasm/tests/storage.ts
@@ -119,7 +119,7 @@ describe("#JwkStorageDocument", function() {
             token.toJSON(),
             tokenFromCustomVerification.toJSON(),
         );
-        // Check that customVerifer.verify was indeed called
+        // Check that customVerifier.verify was indeed called
         assert.deepStrictEqual(customVerifier.verifications(), 1);
 
         // Check that issuing a credential as a JWT works
@@ -170,7 +170,7 @@ describe("#JwkStorageDocument", function() {
                 FailFast.AllErrors,
             )
             .credential();
-        // Check that customVerifer.verify was indeed called
+        // Check that customVerifier.verify was indeed called
         assert.deepStrictEqual(customVerifier.verifications(), 2);
         assert.deepStrictEqual(
             credentialRetrievedCustom.toJSON(),
@@ -281,7 +281,7 @@ describe("#JwkStorageDocument", function() {
                 FailFast.AllErrors,
             )
             .credential();
-        // Check that customVerifer.verify was indeed called
+        // Check that customVerifier.verify was indeed called
         assert.deepStrictEqual(customVerifier.verifications(), 2);
         assert.deepStrictEqual(
             credentialRetrievedCustom.toJSON(),

--- a/identity_core/Cargo.toml
+++ b/identity_core/Cargo.toml
@@ -11,9 +11,6 @@ repository.workspace = true
 description = "The core traits and types for the identity-rs library."
 
 [dependencies]
-# pin dependency of `time` and limit range, as `0.4.1` has impl for `usize: PartialOrd<_>`
-# that conflicts with `iota-sdk`s `core` impl, leading to errors in `iota-sdk` crate
-deranged = { version = ">=0.4.0, <0.4.1", default-features = false }
 multibase = { version = "0.9", default-features = false, features = ["std"] }
 serde = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }

--- a/identity_core/src/common/ordered_set.rs
+++ b/identity_core/src/common/ordered_set.rs
@@ -72,7 +72,7 @@ impl<T> OrderedSet<T> {
     self.0.first()
   }
 
-  /// Returns a mutable referece to the first element in the set, or `None` if
+  /// Returns a mutable reference to the first element in the set, or `None` if
   /// the set is empty.
   ///
   /// # Warning

--- a/identity_credential/src/presentation/jwt_serialization.rs
+++ b/identity_credential/src/presentation/jwt_serialization.rs
@@ -261,12 +261,12 @@ mod test {
       Object::from_json(&claims_serialized).unwrap(),
       Object::from_json(claims_json).unwrap()
     );
-    let retrieved_presentaiton: Presentation<Jwt> = PresentationJwtClaims::<'_, Jwt>::from_json(&claims_serialized)
+    let retrieved_presentation: Presentation<Jwt> = PresentationJwtClaims::<'_, Jwt>::from_json(&claims_serialized)
       .unwrap()
       .try_into_presentation()
       .unwrap();
 
-    assert_eq!(presentation, retrieved_presentaiton);
+    assert_eq!(presentation, retrieved_presentation);
   }
 
   #[test]
@@ -301,12 +301,12 @@ mod test {
     "#;
 
     let presentation: Presentation<Jwt> = Presentation::from_json(presentation_json).unwrap();
-    let retrieved_presentaiton: Presentation<Jwt> = PresentationJwtClaims::<'_, Jwt>::from_json(&claims_json)
+    let retrieved_presentation: Presentation<Jwt> = PresentationJwtClaims::<'_, Jwt>::from_json(&claims_json)
       .unwrap()
       .try_into_presentation()
       .unwrap();
 
-    assert_eq!(presentation, retrieved_presentaiton);
+    assert_eq!(presentation, retrieved_presentation);
   }
 
   #[test]

--- a/identity_credential/src/revocation/status_list_2021/status_list.rs
+++ b/identity_credential/src/revocation/status_list_2021/status_list.rs
@@ -39,7 +39,7 @@ impl StatusList2021 {
   /// Returns a new zero-filled [`StatusList2021`] that can hold `num_entries` credential statuses.
   ///
   /// ## Notes:
-  /// - The actual length of the list will be rounded up to the closest multiple of 8 to accomodate for byte sizes.
+  /// - The actual length of the list will be rounded up to the closest multiple of 8 to accommodate for byte sizes.
   /// - `num_entries` must be at least 131,072 which corresponds to a size of 16KB.
   pub fn new(num_entries: usize) -> Result<Self, StatusListError> {
     if num_entries < MINIMUM_LIST_SIZE {

--- a/identity_credential/src/validator/jwt_credential_validation/error.rs
+++ b/identity_credential/src/validator/jwt_credential_validation/error.rs
@@ -27,7 +27,7 @@ pub enum JwtValidationError {
     source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
     /// A message providing more context
     message: &'static str,
-    /// Specifies whether the error ocurred when trying to verify the signature of a presentation holder or
+    /// Specifies whether the error occurred when trying to verify the signature of a presentation holder or
     /// of a credential issuer.
     signer_ctx: SignerContext,
   },

--- a/identity_credential/src/validator/sd_jwt/error.rs
+++ b/identity_credential/src/validator/sd_jwt/error.rs
@@ -28,8 +28,8 @@ pub enum KeyBindingJwtError {
   InvalidNonce,
 
   /// Invalid `aud` value.
-  #[error("provided audiance value does not match the KB-JWT `aud` claim")]
-  AudianceMismatch,
+  #[error("provided audience value does not match the KB-JWT `aud` claim")]
+  AudienceMismatch,
 
   /// Issuance date validation error.
   #[error("KB-JWT `iat` value is invalid, {0}")]

--- a/identity_credential/src/validator/sd_jwt/validator.rs
+++ b/identity_credential/src/validator/sd_jwt/validator.rs
@@ -264,7 +264,7 @@ impl<V: JwsVerifier> SdJwtCredentialValidator<V> {
 
     if let Some(aud) = &options.aud {
       if *aud != kb_jwt_claims.aud {
-        return Err(KeyBindingJwtError::AudianceMismatch);
+        return Err(KeyBindingJwtError::AudienceMismatch);
       }
     }
 

--- a/identity_jose/src/error.rs
+++ b/identity_jose/src/error.rs
@@ -43,7 +43,7 @@ pub enum Error {
   /// Caused by an error during signature verification.
   #[error("signature verification error")]
   SignatureVerificationError(#[source] crate::jws::SignatureVerificationError),
-  /// Caused by a mising header.
+  /// Caused by a missing header.
   #[error("missing header")]
   MissingHeader(&'static str),
   /// Caused by a missing `alg` claim in the protected header.

--- a/identity_jose/src/jws/encoding/utils.rs
+++ b/identity_jose/src/jws/encoding/utils.rs
@@ -21,9 +21,7 @@ impl<'payload> MaybeEncodedPayload<'payload> {
   /// Transform payload according to the b64 extracted from the protected header.  
   /// See: https://tools.ietf.org/html/rfc7797#section-3
   pub(super) fn encode_if_b64(payload: &'payload [u8], protected_header: Option<&JwsHeader>) -> Self {
-    jwu::extract_b64(protected_header)
-      .then(|| MaybeEncodedPayload::Encoded(jwu::encode_b64(payload)))
-      .unwrap_or(MaybeEncodedPayload::NotEncoded(payload))
+    if jwu::extract_b64(protected_header) { MaybeEncodedPayload::Encoded(jwu::encode_b64(payload)) } else { MaybeEncodedPayload::NotEncoded(payload) }
   }
 
   /// Represent the possibly encoded payload as a byte slice.

--- a/identity_jose/src/jws/encoding/utils.rs
+++ b/identity_jose/src/jws/encoding/utils.rs
@@ -21,7 +21,11 @@ impl<'payload> MaybeEncodedPayload<'payload> {
   /// Transform payload according to the b64 extracted from the protected header.  
   /// See: https://tools.ietf.org/html/rfc7797#section-3
   pub(super) fn encode_if_b64(payload: &'payload [u8], protected_header: Option<&JwsHeader>) -> Self {
-    if jwu::extract_b64(protected_header) { MaybeEncodedPayload::Encoded(jwu::encode_b64(payload)) } else { MaybeEncodedPayload::NotEncoded(payload) }
+    if jwu::extract_b64(protected_header) {
+      MaybeEncodedPayload::Encoded(jwu::encode_b64(payload))
+    } else {
+      MaybeEncodedPayload::NotEncoded(payload)
+    }
   }
 
   /// Represent the possibly encoded payload as a byte slice.

--- a/identity_storage/src/storage/tests/kb_jwt.rs
+++ b/identity_storage/src/storage/tests/kb_jwt.rs
@@ -225,7 +225,7 @@ async fn kb_aud() {
   let kb_validation = validator.validate_key_binding_jwt(&sd_jwt, &setup.subject_doc, &options);
   assert!(matches!(
     kb_validation.err().unwrap(),
-    KeyBindingJwtError::AudianceMismatch
+    KeyBindingJwtError::AudienceMismatch
   ));
 }
 

--- a/identity_stronghold/src/storage/mod.rs
+++ b/identity_stronghold/src/storage/mod.rs
@@ -117,7 +117,7 @@ impl StrongholdStorage {
       .map_err(|e| KeyStorageError::new(KeyStorageErrorKind::KeyNotFound).with_source(e))
   }
 
-  /// Attepts to retrieve the public key corresponding to the key of id `key_id`,
+  /// Attempts to retrieve the public key corresponding to the key of id `key_id`,
   /// returning it as a `key_type` encoded public JWK.
   pub async fn get_public_key_with_type(&self, key_id: &KeyId, key_type: StrongholdKeyType) -> KeyStorageResult<Jwk> {
     match key_type {


### PR DESCRIPTION
# Description of change
Reverts `deranged` pinning from #1622.

Also fixes clippy warning.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix
- [x] Chore

## How the change has been tested
Checked build and clippy output locally.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
