### PR TITLE
Pin dependencies to v0.12.0 rc

### DIFF
--- a/bindings/grpc/Cargo.toml
+++ b/bindings/grpc/Cargo.toml
@@ -24,7 +24,7 @@ identity_iota = { path = "../../identity_iota", features = ["resolver", "sd-jwt"
 identity_jose = { path = "../../identity_jose" }
 identity_storage = { path = "../../identity_storage", features = ["memstore"] }
 identity_stronghold = { path = "../../identity_stronghold", features = ["send-sync-storage"] }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.11.6-rc" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.12.0-rc" }
 iota-sdk-legacy = { package = "iota-sdk", version = "1.1.2", features = ["stronghold"] }
 prost = "0.13"
 rand = "0.8.5"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.62"
 identity_eddsa_verifier = { path = "../identity_eddsa_verifier", default-features = false, features = ["ed25519"] }
 identity_storage = { path = "../identity_storage" }
 identity_stronghold = { path = "../identity_stronghold", default-features = false, features = ["send-sync-storage"] }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.11.6-rc" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.12.0-rc" }
 iota-sdk-legacy = { package = "iota-sdk", version = "1.0", default-features = false, features = ["tls", "client", "stronghold"] }
 json-proof-token.workspace = true
 rand = "0.8.5"

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -30,7 +30,7 @@ identity_iota_interaction = { version = "=1.6.0-alpha", path = "../identity_iota
 # required for doc test
 anyhow = "1.0.64"
 identity_iota = { version = "=1.6.0-alpha", path = "./", features = ["memstore"] }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.11.6-rc" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.12.0-rc" }
 rand = "0.8.5"
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.3.0" }
 tokio = { version = "1.43", features = ["full"] }

--- a/identity_iota_core/Cargo.toml
+++ b/identity_iota_core/Cargo.toml
@@ -44,10 +44,10 @@ serde-aux = { version = "4.5.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 identity_iota_interaction = { version = "=1.6.0-alpha", path = "../identity_iota_interaction", optional = true }
-iota-config = { git = "https://github.com/iotaledger/iota.git", package = "iota-config", tag = "v0.11.6-rc", optional = true }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.11.6-rc", optional = true }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v0.11.6-rc", optional = true }
-shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v0.11.6-rc", optional = true }
+iota-config = { git = "https://github.com/iotaledger/iota.git", package = "iota-config", tag = "v0.12.0-rc", optional = true }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.12.0-rc", optional = true }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v0.12.0-rc", optional = true }
+shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v0.12.0-rc", optional = true }
 tokio = { version = "1.43", default-features = false, optional = true, features = ["macros", "sync", "rt", "process"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/identity_iota_core/packages/iota_identity/Move.lock
+++ b/identity_iota_core/packages/iota_identity/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "27C2591D464A6C0E5FB92A066BADCF3C330B3ABA05305B5AE0C5F2EE7659E7FC"
+manifest_digest = "FF296D70242987085F04C1F86112974684C8E251A195A5FC3442D6514F5EFE36"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Iota", name = "Iota" },
@@ -12,7 +12,7 @@ dependencies = [
 
 [[move.package]]
 id = "Iota"
-source = { git = "https://github.com/iotaledger/iota.git", rev = "45df8ac5533251237ce34f7c6e5cbc099805895e", subdir = "crates/iota-framework/packages/iota-framework" }
+source = { git = "https://github.com/iotaledger/iota.git", rev = "7e49c58b826b34c8e2b61842ef13c8de35a0aee8", subdir = "crates/iota-framework/packages/iota-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -20,11 +20,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/iotaledger/iota.git", rev = "45df8ac5533251237ce34f7c6e5cbc099805895e", subdir = "crates/iota-framework/packages/move-stdlib" }
+source = { git = "https://github.com/iotaledger/iota.git", rev = "7e49c58b826b34c8e2b61842ef13c8de35a0aee8", subdir = "crates/iota-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Stardust"
-source = { git = "https://github.com/iotaledger/iota.git", rev = "45df8ac5533251237ce34f7c6e5cbc099805895e", subdir = "crates/iota-framework/packages/stardust" }
+source = { git = "https://github.com/iotaledger/iota.git", rev = "7e49c58b826b34c8e2b61842ef13c8de35a0aee8", subdir = "crates/iota-framework/packages/stardust" }
 
 dependencies = [
   { id = "Iota", name = "Iota" },
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "0.11.6-rc"
+compiler-version = "0.12.0-rc"
 edition = "2024.beta"
 flavor = "iota"
 

--- a/identity_iota_core/packages/iota_identity/Move.lock
+++ b/identity_iota_core/packages/iota_identity/Move.lock
@@ -51,7 +51,7 @@ latest-published-id = "0x03242ae6b87406bd0eb5d669fbe874ed4003694c0be9c6a9ee7c315
 published-version = "1"
 
 [env.localnet]
-chain-id = "e060d4a9"
-original-published-id = "0x574f5ec6c392dbb835dfe640a6ec1f623e53c735929debae17f847eee44ed0a5"
-latest-published-id = "0x574f5ec6c392dbb835dfe640a6ec1f623e53c735929debae17f847eee44ed0a5"
+chain-id = "461e4e6c"
+original-published-id = "0x7b310d2af24b4d782ebb41d93b4b72bde08546e3e12a00e91b8b8f98442f6656"
+latest-published-id = "0x7b310d2af24b4d782ebb41d93b4b72bde08546e3e12a00e91b8b8f98442f6656"
 published-version = "1"

--- a/identity_iota_core/packages/iota_identity/Move.toml
+++ b/identity_iota_core/packages/iota_identity/Move.toml
@@ -7,10 +7,10 @@ edition = "2024.beta"
 
 [dependencies]
 # 'tag' keyword not supported here, therefore use rev instead
-# 'tag = "v0.8.1-rc"' equals 'rev = "92e66937111c27820e09502dbcb75382835a56e6"', which we use here
-MoveStdlib = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/move-stdlib", rev = "45df8ac5533251237ce34f7c6e5cbc099805895e" }
-Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "45df8ac5533251237ce34f7c6e5cbc099805895e" }
-Stardust = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/stardust", rev = "45df8ac5533251237ce34f7c6e5cbc099805895e" }
+# 'tag = "v0.12.0-rc"' equals 'rev = "7e49c58b826b34c8e2b61842ef13c8de35a0aee8"', which we use here
+MoveStdlib = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/move-stdlib", rev = "7e49c58b826b34c8e2b61842ef13c8de35a0aee8" }
+Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "7e49c58b826b34c8e2b61842ef13c8de35a0aee8" }
+Stardust = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/stardust", rev = "7e49c58b826b34c8e2b61842ef13c8de35a0aee8" }
 
 [addresses]
 iota_identity = "0x0"

--- a/identity_iota_interaction/Cargo.toml
+++ b/identity_iota_interaction/Cargo.toml
@@ -22,11 +22,11 @@ serde.workspace = true
 serde_json.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.11.6-rc" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v0.11.6-rc" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.12.0-rc" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v0.12.0-rc" }
 tokio = { version = "1", optional = true, default-features = false, features = ["process"] }
 
-shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v0.11.6-rc" }
+shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v0.12.0-rc" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bcs = "0.1.4"


### PR DESCRIPTION
# Description of change
The following dependencies have been pinned to specific versions:

Rust:

* iota-.... = "v0.12.0-rc"
* fastcrypto = No change in iotaledger/iota.git repository

JS:

* No change needed as "@iota/iota-sdk": "^0.6.0" is still the latest version
    
Move.toml:
* 'tag = "v0.12.0-rc"' equals 'rev = "7e49c58b826b34c8e2b61842ef13c8de35a0aee8"'
   
## How the change has been tested

`identity_iota_core/tests/e2e` Tests have been run successfully.