### PR TITLE
Add support for `DelegationToken` and `ControllerToken`

### DIFF
--- a/.github/actions/iota-rebase-sandbox/setup/action.yml
+++ b/.github/actions/iota-rebase-sandbox/setup/action.yml
@@ -106,7 +106,7 @@ runs:
         mkdir -p toml-cli
         cd toml-cli
 
-        DOWNNLOAD_URL = https://github.com/gnprice/toml-cli/releases/download/v0.2.3/toml-0.2.3-x86_64-linux.tar.gz
+        DOWNLOAD_URL=https://github.com/gnprice/toml-cli/releases/download/v0.2.3/toml-0.2.3-x86_64-linux.tar.gz
         echo "Downloading from: $DOWNLOAD_URL"
         curl -L -o toml-cli.tar.gz $DOWNLOAD_URL
         tar -xzf toml-cli.tar.gz

--- a/.github/actions/iota-rebase-sandbox/setup/action.yml
+++ b/.github/actions/iota-rebase-sandbox/setup/action.yml
@@ -110,6 +110,7 @@ runs:
         echo "Downloading from: $DOWNLOAD_URL"
         curl -L -o toml-cli.tar.gz $DOWNLOAD_URL
         tar -xzf toml-cli.tar.gz
+        cd $(ls -d */|head -n 1)
 
         echo "$PWD" >> $GITHUB_PATH
         export PATH="$PWD:$PATH"

--- a/.github/actions/iota-rebase-sandbox/setup/action.yml
+++ b/.github/actions/iota-rebase-sandbox/setup/action.yml
@@ -99,3 +99,20 @@ runs:
 
         # Start the network
         iota start --with-faucet ${{ inputs.logfile && format('> {0} 2>&1', inputs.logfile) || '' }} &
+    - name: Setup TOML CLI utils
+      shell: bash
+      run: |
+        set -e
+        mkdir -p toml-cli
+        cd toml-cli
+
+        DOWNNLOAD_URL = https://github.com/gnprice/toml-cli/releases/download/v0.2.3/toml-0.2.3-x86_64-linux.tar.gz
+        echo "Downloading from: $DOWNLOAD_URL"
+        curl -L -o toml-cli.tar.gz $DOWNLOAD_URL
+        tar -xzf toml-cli.tar.gz
+
+        echo "$PWD" >> $GITHUB_PATH
+        export PATH="$PWD:$PATH"
+
+        which toml || echo "toml not found in PATH"
+        ls -la "$PWD"

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,3 @@ build
 # ignore folder created in CI for downloaded iota binaries
 /iota/
 /toml-cli/
-

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ build
 
 # ignore folder created in CI for downloaded iota binaries
 /iota/
+/toml-cli/
 

--- a/bindings/wasm/identity_wasm/lib/controller.ts
+++ b/bindings/wasm/identity_wasm/lib/controller.ts
@@ -4,11 +4,18 @@ import { DelegationToken } from "~identity_wasm";
  * Permissions of a {@link DelegationToken}.
  */
 export enum DelegatePermissions {
+    /** No permissions. */
     None = 0,
+    /** Delegate can create new proposals. */
     CreateProposal = 1,
+    /** Delegate can approve existing proposals. */
     ApproveProposal = 1 << 1,
+    /** Delegate can execute proposals. */
     ExecuteProposal = 1 << 2,
+    /** Delegate can delete proposals. */
     DeleteProposal = 1 << 3,
+    /** Delegate can remove its controller's approval. */
     RemoveApproval = 1 << 4,
+    /** All permissions. */
     All = 0xffffffff,
 }

--- a/bindings/wasm/identity_wasm/lib/controller.ts
+++ b/bindings/wasm/identity_wasm/lib/controller.ts
@@ -1,0 +1,14 @@
+import { DelegationToken } from "~identity_wasm";
+
+/**
+ * Permissions of a {@link DelegationToken}.
+ */
+export enum DelegatePermissions {
+    None = 0,
+    CreateProposal = 1,
+    ApproveProposal = 1 << 1,
+    ExecuteProposal = 1 << 2,
+    DeleteProposal = 1 << 3,
+    RemoveApproval = 1 << 4,
+    All = 0xffffffff,
+}

--- a/bindings/wasm/identity_wasm/lib/index.ts
+++ b/bindings/wasm/identity_wasm/lib/index.ts
@@ -9,6 +9,7 @@ export * from "./key_id_storage";
 
 export * from "~identity_wasm";
 
+export * from "./controller";
 export * from "./proposal";
 export * from "./transaction_internal";
 

--- a/bindings/wasm/identity_wasm/src/lib.rs
+++ b/bindings/wasm/identity_wasm/src/lib.rs
@@ -59,5 +59,6 @@ import {
   ExecuteProposal,
   UpdateDid,
   ProposalResult,
+  DelegatePermissions
 } from '../lib/index';
 "#;

--- a/bindings/wasm/identity_wasm/src/rebased/controller.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/controller.rs
@@ -146,7 +146,7 @@ impl WasmDelegateToken {
     let effects = wasm_effects.clone().into();
     let (apply_result, rem_effects) = self.0.apply(effects, &client.0).await;
     let rem_wasm_effects = WasmIotaTransactionBlockEffects::from(&rem_effects);
-    Object::assign(&wasm_effects, &rem_wasm_effects);
+    Object::assign(wasm_effects, &rem_wasm_effects);
 
     apply_result.wasm_result().map(WasmDelegationToken)
   }
@@ -206,7 +206,7 @@ impl WasmDelegationTokenRevocation {
     let effects = wasm_effects.clone().into();
     let (apply_result, rem_effects) = self.0.apply(effects, &client.0).await;
     let rem_wasm_effects = WasmIotaTransactionBlockEffects::from(&rem_effects);
-    Object::assign(&wasm_effects, &rem_wasm_effects);
+    Object::assign(wasm_effects, &rem_wasm_effects);
 
     apply_result.wasm_result()
   }
@@ -246,7 +246,7 @@ impl WasmDeleteDelegationToken {
     let effects = wasm_effects.clone().into();
     let (apply_result, rem_effects) = self.0.apply(effects, &client.0).await;
     let rem_wasm_effects = WasmIotaTransactionBlockEffects::from(&rem_effects);
-    Object::assign(&wasm_effects, &rem_wasm_effects);
+    Object::assign(wasm_effects, &rem_wasm_effects);
 
     apply_result.wasm_result()
   }

--- a/bindings/wasm/identity_wasm/src/rebased/controller.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/controller.rs
@@ -1,0 +1,150 @@
+// Copyright 2020-2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use identity_iota::iota::rebased::migration::ControllerCap;
+use identity_iota::iota::rebased::migration::DelegatePermissions;
+use identity_iota::iota::rebased::migration::DelegateToken;
+use identity_iota::iota::rebased::migration::DelegationToken;
+use identity_iota::iota::rebased::transaction_builder::Transaction as _;
+use identity_iota::iota::rebased::transaction_builder::TransactionBuilder;
+use iota_interaction_ts::bindings::WasmIotaTransactionBlockEffects;
+use js_sys::Object;
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::JsCast as _;
+use wasm_bindgen::JsError;
+use wasm_bindgen::JsValue;
+
+use crate::error::wasm_error;
+use crate::error::Result;
+use crate::error::WasmResult;
+
+use super::WasmIdentityClientReadOnly;
+use super::WasmTransactionBuilder;
+
+#[wasm_bindgen(typescript_custom_section)]
+pub const _CONTROLLER_TOKEN_DEF: &str = r#"
+export type ControllerToken = ControllerCap | DelegationToken;
+"#;
+
+/// A token that authenticates its bearer as a controller of a specific shared object.
+#[wasm_bindgen(js_name = ControllerCap)]
+pub struct WasmControllerCap(pub(crate) ControllerCap);
+
+#[wasm_bindgen(js_class = ControllerCap)]
+impl WasmControllerCap {
+  /// Returns the ID of this {@link ControllerCap}.
+  #[wasm_bindgen(getter)]
+  pub fn id(&self) -> String {
+    self.0.id().to_string()
+  }
+
+  /// Returns the ID of the object this token controls.
+  #[wasm_bindgen(getter, js_name = controllerOf)]
+  pub fn controller_of(&self) -> String {
+    self.0.controller_of().to_string()
+  }
+
+  /// Returns whether this controller is allowed to delegate
+  /// its access to the controlled object.
+  #[wasm_bindgen(getter, js_name = canDelegate)]
+  pub fn can_delegate(&self) -> bool {
+    self.0.can_delegate()
+  }
+
+  /// If this token can be delegated, this function will return
+  /// a {@link DelegateTransaction} that will mint a new {@link DelegationToken}
+  /// and send it to `recipient`.
+  #[wasm_bindgen]
+  pub fn delegate(
+    &self,
+    recipient: &str,
+    #[wasm_bindgen(unchecked_param_type = "DelegatePermissions | undefined | null")] permissions: Option<u32>,
+  ) -> Result<WasmTransactionBuilder> {
+    let recipient = recipient.parse().wasm_result()?;
+    let permissions = permissions.map(DelegatePermissions::from);
+
+    let js_tx = self
+      .0
+      .delegate(recipient, permissions)
+      .map(TransactionBuilder::into_inner)
+      .map(WasmDelegateToken)
+      .map(JsValue::from)
+      .ok_or_else(|| JsError::new("this controller cannot delegate its authority"))?;
+
+    Ok(WasmTransactionBuilder::new(js_tx.unchecked_into()))
+  }
+}
+
+/// A token minted by a controller that allows another entity to act in
+/// its stead - with full or reduced permissions.
+#[wasm_bindgen(js_name = DelegationToken)]
+pub struct WasmDelegationToken(pub(crate) DelegationToken);
+
+#[wasm_bindgen(js_class = DelegationToken)]
+impl WasmDelegationToken {
+  /// Returns the ID of this {@link DelegationToken}.
+  #[wasm_bindgen(getter)]
+  pub fn id(&self) -> String {
+    self.0.id().to_string()
+  }
+
+  /// Returns the ID of the {@link ControllerCap} that minted
+  /// this {@link DelegationToken}.
+  #[wasm_bindgen(getter)]
+  pub fn controller(&self) -> String {
+    self.0.controller().to_string()
+  }
+
+  /// Returns the ID of the object this token controls.
+  #[wasm_bindgen(getter, js_name = controllerOf)]
+  pub fn controller_of(&self) -> String {
+    self.0.controller_of().to_string()
+  }
+
+  /// Returns the permissions of this token.
+  #[wasm_bindgen(getter, unchecked_return_type = "DelegatePermissions")]
+  pub fn permissions(&self) -> u32 {
+    self.0.permissions().into()
+  }
+}
+
+#[wasm_bindgen(js_name = DelegateToken)]
+pub struct WasmDelegateToken(pub(crate) DelegateToken);
+
+#[wasm_bindgen(js_class = DelegateToken)]
+impl WasmDelegateToken {
+  #[wasm_bindgen(constructor)]
+  pub fn new(
+    controller_cap: &WasmControllerCap,
+    recipient: &str,
+    #[wasm_bindgen(unchecked_param_type = "DelegatePermissions | undefined | null")] permissions: Option<u32>,
+  ) -> Result<Self> {
+    let recipient = recipient.parse().map_err(wasm_error)?;
+    let token = if let Some(permissions) = permissions {
+      DelegateToken::new_with_permissions(&controller_cap.0, recipient, permissions.into())
+    } else {
+      DelegateToken::new(&controller_cap.0, recipient)
+    };
+    Ok(Self(token))
+  }
+
+  #[wasm_bindgen(js_name = buildProgrammableTransaction)]
+  pub async fn build_programmable_transaction(&self, client: &WasmIdentityClientReadOnly) -> Result<Vec<u8>> {
+    let pt = self.0.build_programmable_transaction(&client.0).await.wasm_result()?;
+    bcs::to_bytes(&pt).wasm_result()
+  }
+
+  #[wasm_bindgen]
+  pub async fn apply(
+    self,
+    wasm_effects: &WasmIotaTransactionBlockEffects,
+    client: &WasmIdentityClientReadOnly,
+  ) -> Result<WasmDelegationToken> {
+    let effects = wasm_effects.clone().into();
+    let (apply_result, rem_effects) = self.0.apply(effects, &client.0).await;
+    let rem_wasm_effects = WasmIotaTransactionBlockEffects::from(&rem_effects);
+    Object::assign(&wasm_effects, &rem_wasm_effects);
+
+    apply_result.wasm_result().map(WasmDelegationToken)
+  }
+}

--- a/bindings/wasm/identity_wasm/src/rebased/controller.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/controller.rs
@@ -5,6 +5,8 @@ use identity_iota::iota::rebased::migration::ControllerCap;
 use identity_iota::iota::rebased::migration::DelegatePermissions;
 use identity_iota::iota::rebased::migration::DelegateToken;
 use identity_iota::iota::rebased::migration::DelegationToken;
+use identity_iota::iota::rebased::migration::DelegationTokenRevocation;
+use identity_iota::iota::rebased::migration::DeleteDelegationToken;
 use identity_iota::iota::rebased::transaction_builder::Transaction as _;
 use identity_iota::iota::rebased::transaction_builder::TransactionBuilder;
 use iota_interaction_ts::bindings::WasmIotaTransactionBlockEffects;
@@ -19,6 +21,7 @@ use crate::error::Result;
 use crate::error::WasmResult;
 
 use super::WasmIdentityClientReadOnly;
+use super::WasmOnChainIdentity;
 use super::WasmTransactionBuilder;
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -146,5 +149,105 @@ impl WasmDelegateToken {
     Object::assign(&wasm_effects, &rem_wasm_effects);
 
     apply_result.wasm_result().map(WasmDelegationToken)
+  }
+}
+
+/// Transaction for revoking / unrevoking a {@link DelegationToken}.
+/// If no `revoke` parameter is passed, or `true` is passed, this transaction
+/// will *revoke* the passed token - *unrevoke* otherwise.
+#[wasm_bindgen(js_name = DelegationTokenRevocation)]
+pub struct WasmDelegationTokenRevocation(pub(crate) DelegationTokenRevocation);
+
+#[wasm_bindgen(js_class = DelegationTokenRevocation)]
+impl WasmDelegationTokenRevocation {
+  #[wasm_bindgen(constructor)]
+  pub fn new(
+    identity: &WasmOnChainIdentity,
+    controller_cap: &WasmControllerCap,
+    delegation_token: &WasmDelegationToken,
+    revoke: Option<bool>,
+  ) -> Result<Self> {
+    let revoke = revoke.unwrap_or(true);
+    let identity = identity.0.try_read().wasm_result()?;
+
+    let inner = if revoke {
+      DelegationTokenRevocation::revoke(&identity, &controller_cap.0, &delegation_token.0).wasm_result()?
+    } else {
+      DelegationTokenRevocation::unrevoke(&identity, &controller_cap.0, &delegation_token.0).wasm_result()?
+    };
+
+    Ok(Self(inner))
+  }
+
+  /// Returns whether this transaction will revoke the given token.
+  #[wasm_bindgen(js_name = isRevocation)]
+  pub fn is_revocation(&self) -> bool {
+    self.0.is_revocation()
+  }
+
+  /// Returns the ID of the token handled by this transaction.
+  #[wasm_bindgen(js_name = tokenId)]
+  pub fn token_id(&self) -> String {
+    self.0.token_id().to_string()
+  }
+
+  #[wasm_bindgen(js_name = buildProgrammableTransaction)]
+  pub async fn build_programmable_transaction(&self, client: &WasmIdentityClientReadOnly) -> Result<Vec<u8>> {
+    let pt = self.0.build_programmable_transaction(&client.0).await.wasm_result()?;
+    bcs::to_bytes(&pt).wasm_result()
+  }
+
+  #[wasm_bindgen]
+  pub async fn apply(
+    self,
+    wasm_effects: &WasmIotaTransactionBlockEffects,
+    client: &WasmIdentityClientReadOnly,
+  ) -> Result<()> {
+    let effects = wasm_effects.clone().into();
+    let (apply_result, rem_effects) = self.0.apply(effects, &client.0).await;
+    let rem_wasm_effects = WasmIotaTransactionBlockEffects::from(&rem_effects);
+    Object::assign(&wasm_effects, &rem_wasm_effects);
+
+    apply_result.wasm_result()
+  }
+}
+
+/// A transaction to delete a given {@link DelegationToken}.
+#[wasm_bindgen(js_name = DeleteDelegationToken)]
+pub struct WasmDeleteDelegationToken(pub(crate) DeleteDelegationToken);
+
+#[wasm_bindgen(js_class = DeleteDelegationToken)]
+impl WasmDeleteDelegationToken {
+  #[wasm_bindgen(constructor)]
+  pub fn new(identity: &WasmOnChainIdentity, delegation_token: WasmDelegationToken) -> Result<Self> {
+    let identity = identity.0.try_read().wasm_result()?;
+    let inner = DeleteDelegationToken::new(&identity, delegation_token.0).wasm_result()?;
+
+    Ok(Self(inner))
+  }
+
+  #[wasm_bindgen(js_name = tokenId)]
+  pub fn token_id(&self) -> String {
+    self.0.token_id().to_string()
+  }
+
+  #[wasm_bindgen(js_name = buildProgrammableTransaction)]
+  pub async fn build_programmable_transaction(&self, client: &WasmIdentityClientReadOnly) -> Result<Vec<u8>> {
+    let pt = self.0.build_programmable_transaction(&client.0).await.wasm_result()?;
+    bcs::to_bytes(&pt).wasm_result()
+  }
+
+  #[wasm_bindgen]
+  pub async fn apply(
+    self,
+    wasm_effects: &WasmIotaTransactionBlockEffects,
+    client: &WasmIdentityClientReadOnly,
+  ) -> Result<()> {
+    let effects = wasm_effects.clone().into();
+    let (apply_result, rem_effects) = self.0.apply(effects, &client.0).await;
+    let rem_wasm_effects = WasmIotaTransactionBlockEffects::from(&rem_effects);
+    Object::assign(&wasm_effects, &rem_wasm_effects);
+
+    apply_result.wasm_result()
   }
 }

--- a/bindings/wasm/identity_wasm/src/rebased/controller.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/controller.rs
@@ -55,7 +55,7 @@ impl WasmControllerCap {
   }
 
   /// If this token can be delegated, this function will return
-  /// a {@link DelegateTransaction} that will mint a new {@link DelegationToken}
+  /// a {@link DelegationToken} Transaction that will mint a new {@link DelegationToken}
   /// and send it to `recipient`.
   #[wasm_bindgen]
   pub fn delegate(

--- a/bindings/wasm/identity_wasm/src/rebased/identity.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/identity.rs
@@ -21,10 +21,14 @@ use crate::error::WasmResult;
 use crate::iota::WasmIotaDocument;
 use crate::rebased::proposals::WasmCreateConfigChangeProposal;
 use crate::rebased::proposals::WasmCreateUpdateDidProposal;
+use crate::rebased::WasmDeleteDelegationToken;
 
 use super::proposals::StringCouple;
 use super::proposals::WasmConfigChange;
 use super::proposals::WasmCreateSendProposal;
+use super::WasmControllerCap;
+use super::WasmDelegationToken;
+use super::WasmDelegationTokenRevocation;
 use super::WasmIdentityClient;
 use super::WasmIdentityClientReadOnly;
 use super::WasmIotaAddress;
@@ -193,6 +197,38 @@ impl WasmOnChainIdentity {
   ) -> Result<WasmTransactionBuilder> {
     let tx = WasmCreateSendProposal::new(self, controller_token, transfer_map, expiration_epoch).wasm_result()?;
     Ok(WasmTransactionBuilder::new(JsValue::from(tx).unchecked_into()))
+  }
+
+  #[wasm_bindgen(
+    js_name = revokeDelegationToken,
+    unchecked_return_type = "TransactionBuilder<DelegationTokenRevocation>",
+  )]
+  pub fn revoke_delegation_token(
+    &self,
+    controller_cap: &WasmControllerCap,
+    delegation_token: &WasmDelegationToken,
+  ) -> Result<WasmDelegationTokenRevocation> {
+    WasmDelegationTokenRevocation::new(self, controller_cap, delegation_token, Some(true))
+  }
+
+  #[wasm_bindgen(
+    js_name = unrevokeDelegationToken,
+    unchecked_return_type = "TransactionBuilder<DelegationTokenRevocation>",
+  )]
+  pub fn unrevoke_delegation_token(
+    &self,
+    controller_cap: &WasmControllerCap,
+    delegation_token: &WasmDelegationToken,
+  ) -> Result<WasmDelegationTokenRevocation> {
+    WasmDelegationTokenRevocation::new(self, controller_cap, delegation_token, Some(false))
+  }
+
+  #[wasm_bindgen(
+    js_name = deleteDelegationToken,
+    unchecked_return_type = "TransactionBuilder<DeleteDelegationToken>",
+  )]
+  pub fn delete_delegation_token(&self, delegation_token: WasmDelegationToken) -> Result<WasmDeleteDelegationToken> {
+    WasmDeleteDelegationToken::new(self, delegation_token)
   }
 }
 

--- a/bindings/wasm/identity_wasm/src/rebased/identity.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/identity.rs
@@ -303,7 +303,7 @@ impl WasmCreateIdentity {
     let effects = wasm_effects.clone().into();
     let (apply_result, rem_effects) = self.0.apply(effects, &client.0).await;
     let rem_wasm_effects = WasmIotaTransactionBlockEffects::from(&rem_effects);
-    Object::assign(&wasm_effects, &rem_wasm_effects);
+    Object::assign(wasm_effects, &rem_wasm_effects);
 
     apply_result.wasm_result().map(WasmOnChainIdentity::new)
   }

--- a/bindings/wasm/identity_wasm/src/rebased/mod.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/mod.rs
@@ -1,12 +1,14 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+mod controller;
 mod identity;
 mod proposals;
 mod transaction_builder;
 mod wasm_identity_client;
 mod wasm_identity_client_read_only;
 
+pub use controller::*;
 pub use identity::*;
 pub use transaction_builder::*;
 pub use wasm_identity_client::*;

--- a/bindings/wasm/identity_wasm/src/rebased/proposals/config_change.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/proposals/config_change.rs
@@ -199,7 +199,7 @@ impl WasmApproveConfigChangeProposal {
       .into_inner();
     let (apply_result, rem_effects) = tx.apply(wasm_effects.clone().into(), &client.0).await;
     let wasm_rem_effects = WasmIotaTransactionBlockEffects::from(&rem_effects);
-    Object::assign(&wasm_effects, &wasm_rem_effects);
+    Object::assign(wasm_effects, &wasm_rem_effects);
 
     apply_result.wasm_result()
   }
@@ -255,7 +255,7 @@ impl WasmExecuteConfigChangeProposal {
       .into_inner();
     let (apply_result, rem_effects) = tx.apply(wasm_effects.clone().into(), &client.0).await;
     let wasm_rem_effects = WasmIotaTransactionBlockEffects::from(&rem_effects);
-    Object::assign(&wasm_effects, &wasm_rem_effects);
+    Object::assign(wasm_effects, &wasm_rem_effects);
 
     apply_result.wasm_result()
   }
@@ -387,7 +387,7 @@ impl WasmCreateConfigChangeProposal {
 
     let (apply_result, rem_effects) = tx.apply(wasm_effects.clone().into(), &client.0).await;
     let rem_wasm_effects = WasmIotaTransactionBlockEffects::from(&rem_effects);
-    Object::assign(&wasm_effects, &rem_wasm_effects);
+    Object::assign(wasm_effects, &rem_wasm_effects);
 
     match apply_result.wasm_result()? {
       ProposalResult::Executed(_) => Ok(None),

--- a/bindings/wasm/identity_wasm/src/rebased/proposals/send.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/proposals/send.rs
@@ -172,7 +172,7 @@ impl WasmApproveSendProposal {
       .into_inner();
     let (apply_result, rem_effects) = tx.apply(wasm_effects.clone().into(), &client.0).await;
     let wasm_rem_effects = WasmIotaTransactionBlockEffects::from(&rem_effects);
-    Object::assign(&wasm_effects, &wasm_rem_effects);
+    Object::assign(wasm_effects, &wasm_rem_effects);
 
     apply_result.wasm_result()
   }
@@ -230,7 +230,7 @@ impl WasmExecuteSendProposal {
       .await;
 
     let wasm_rem_effects = WasmIotaTransactionBlockEffects::from(&rem_effects);
-    Object::assign(&wasm_effects, &wasm_rem_effects);
+    Object::assign(wasm_effects, &wasm_rem_effects);
 
     apply_result.wasm_result()
   }
@@ -317,7 +317,7 @@ impl WasmCreateSendProposal {
 
     let (apply_result, rem_effects) = tx.apply(wasm_effects.clone().into(), &client.0).await;
     let wasm_rem_effects = WasmIotaTransactionBlockEffects::from(&rem_effects);
-    Object::assign(&wasm_effects, &wasm_rem_effects);
+    Object::assign(wasm_effects, &wasm_rem_effects);
 
     match apply_result.wasm_result()? {
       ProposalResult::Pending(proposal) => Ok(Some(WasmProposalSend::new(proposal))),

--- a/bindings/wasm/identity_wasm/src/rebased/proposals/update_did.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/proposals/update_did.rs
@@ -191,7 +191,7 @@ impl WasmApproveUpdateDidDocumentProposal {
       .into_inner();
     let (apply_result, rem_effects) = tx.apply(wasm_effects.clone().into(), &client.0).await;
     let wasm_rem_effects = WasmIotaTransactionBlockEffects::from(&rem_effects);
-    Object::assign(&wasm_effects, &wasm_rem_effects);
+    Object::assign(wasm_effects, &wasm_rem_effects);
 
     apply_result.wasm_result()
   }
@@ -244,7 +244,7 @@ impl WasmExecuteUpdateDidDocumentProposal {
       .into_inner();
     let (apply_result, rem_effects) = tx.apply(wasm_effects.clone().into(), &client.0).await;
     let wasm_rem_effects = WasmIotaTransactionBlockEffects::from(&rem_effects);
-    Object::assign(&wasm_effects, &wasm_rem_effects);
+    Object::assign(wasm_effects, &wasm_rem_effects);
 
     apply_result.wasm_result()
   }
@@ -360,7 +360,7 @@ impl WasmCreateUpdateDidProposal {
 
     let (apply_result, rem_effects) = tx.apply(wasm_effects.clone().into(), &client.0).await;
     let wasm_rem_effects = WasmIotaTransactionBlockEffects::from(&rem_effects);
-    Object::assign(&wasm_effects, &wasm_rem_effects);
+    Object::assign(wasm_effects, &wasm_rem_effects);
 
     let ProposalResult::Pending(proposal) = apply_result.wasm_result()? else {
       return Ok(None);

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/borrow_asset.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/borrow_asset.ts
@@ -4,53 +4,52 @@
 import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
 import { IotaObjectData } from "@iota/iota-sdk/dist/cjs/client";
 import { ObjectRef, Transaction, TransactionArgument } from "@iota/iota-sdk/transactions";
-import { getControllerDelegation, putBackDelegationToken } from "../utils";
+import { controllerTokenRefToTxArgument, putBackControllerToken } from "../utils";
+import { ControllerTokenRef } from "./controller";
 
 export function proposeBorrow(
     identity: SharedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     objects: string[],
     packageId: string,
     expiration?: number,
 ): Promise<Uint8Array> {
     const tx = new Transaction();
-    const cap = tx.objectRef(capability);
-    const [delegationToken, borrow] = getControllerDelegation(tx, cap, packageId);
+    const cap = controllerTokenRefToTxArgument(tx, capability, packageId);
     const identityArg = tx.sharedObjectRef(identity);
     const exp = tx.pure.option("u64", expiration);
     const objectsArg = tx.pure.vector("id", objects);
 
     tx.moveCall({
         target: `${packageId}::identity::propose_borrow`,
-        arguments: [identityArg, delegationToken, exp, objectsArg],
+        arguments: [identityArg, cap.token, exp, objectsArg],
     });
 
-    putBackDelegationToken(tx, cap, delegationToken, borrow, packageId);
+    putBackControllerToken(tx, cap, packageId);
 
     return tx.build();
 }
 
 export function executeBorrow(
     identity: SharedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     proposalId: string,
     objects: IotaObjectData[],
     intentFn: (arg0: Transaction, arg1: Map<string, [TransactionArgument, IotaObjectData]>) => void,
     packageId: string,
 ): Promise<Uint8Array> {
     const tx = new Transaction();
-    const cap = tx.objectRef(capability);
-    const [delegationToken, borrow] = getControllerDelegation(tx, cap, packageId);
+    const cap = controllerTokenRefToTxArgument(tx, capability, packageId);
     const proposal = tx.pure.id(proposalId);
     const identityArg = tx.sharedObjectRef(identity);
 
     let action = tx.moveCall({
         target: `${packageId}::identity::execute_proposal`,
         typeArguments: [`${packageId}::borrow_proposal::Borrow`],
-        arguments: [identityArg, delegationToken, proposal],
+        arguments: [identityArg, cap.token, proposal],
     });
 
-    putBackDelegationToken(tx, cap, delegationToken, borrow, packageId);
+    putBackControllerToken(tx, cap, packageId);
 
     const objectArgMap = new Map<string, [TransactionArgument, IotaObjectData]>();
     for (const obj of objects) {
@@ -84,31 +83,30 @@ export function executeBorrow(
 
 export function createAndExecuteBorrow(
     identity: SharedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     objects: IotaObjectData[],
     intentFn: (arg0: Transaction, arg1: Map<string, [TransactionArgument, IotaObjectData]>) => void,
     packageId: string,
     expiration?: number,
 ): Promise<Uint8Array> {
     const tx = new Transaction();
-    const cap = tx.objectRef(capability);
-    const [delegationToken, borrow] = getControllerDelegation(tx, cap, packageId);
+    const cap = controllerTokenRefToTxArgument(tx, capability, packageId);
     const identityArg = tx.sharedObjectRef(identity);
     const exp = tx.pure.option("u64", expiration);
     const objectsArg = tx.pure.vector("id", objects.map(obj => obj.objectId));
 
     const proposal = tx.moveCall({
         target: `${packageId}::identity::propose_borrow`,
-        arguments: [identityArg, delegationToken, exp, objectsArg],
+        arguments: [identityArg, cap.token, exp, objectsArg],
     });
 
     let action = tx.moveCall({
         target: `${packageId}::identity::execute_proposal`,
         typeArguments: [`${packageId}::borrow_proposal::Borrow`],
-        arguments: [identityArg, delegationToken, proposal],
+        arguments: [identityArg, cap.token, proposal],
     });
 
-    putBackDelegationToken(tx, cap, delegationToken, borrow, packageId);
+    putBackControllerToken(tx, cap, packageId);
 
     const objectArgMap = new Map<string, [TransactionArgument, IotaObjectData]>();
     for (const obj of objects) {

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/config.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/config.ts
@@ -3,11 +3,12 @@
 
 import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
 import { ObjectRef, Transaction } from "@iota/iota-sdk/transactions";
-import { getControllerDelegation, putBackDelegationToken } from "../utils";
+import { controllerTokenRefToTxArgument, putBackControllerToken } from "../utils";
+import { ControllerTokenRef } from "./controller";
 
 export function proposeConfigChange(
     identity: SharedObjectRef,
-    controllerCap: ObjectRef,
+    capability: ControllerTokenRef,
     controllersToAdd: [string, number][],
     controllersToRemove: string[],
     controllersToUpdate: [string, number][],
@@ -33,41 +34,39 @@ export function proposeConfigChange(
     });
 
     const identityArg = tx.sharedObjectRef(identity);
-    const cap = tx.objectRef(controllerCap);
-    const [delegationToken, borrow] = getControllerDelegation(tx, cap, packageId);
+    const cap = controllerTokenRefToTxArgument(tx, capability, packageId);
     const thresholdArg = tx.pure.option("u64", threshold);
     const exp = tx.pure.option("u64", expiration);
     const controllersToRemoveArg = tx.pure.vector("id", controllersToRemove);
 
     tx.moveCall({
         target: `${packageId}::identity::propose_config_change`,
-        arguments: [identityArg, delegationToken, exp, thresholdArg, controllersToAddArg, controllersToRemoveArg,
+        arguments: [identityArg, cap.token, exp, thresholdArg, controllersToAddArg, controllersToRemoveArg,
             controllersToUpdateArg],
     });
 
-    putBackDelegationToken(tx, cap, delegationToken, borrow, packageId);
+    putBackControllerToken(tx, cap, packageId);
 
     return tx.build();
 }
 
 export function executeConfigChange(
     identity: SharedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     proposalId: string,
     packageId: string,
 ): Promise<Uint8Array> {
     const tx = new Transaction();
-    const cap = tx.objectRef(capability);
-    const [delegationToken, borrow] = getControllerDelegation(tx, cap, packageId);
+    const cap = controllerTokenRefToTxArgument(tx, capability, packageId);
     const proposal = tx.pure.id(proposalId);
     const identityArg = tx.sharedObjectRef(identity);
 
     tx.moveCall({
         target: `${packageId}::identity::execute_config_change`,
-        arguments: [identityArg, delegationToken, proposal],
+        arguments: [identityArg, cap.token, proposal],
     });
 
-    putBackDelegationToken(tx, cap, delegationToken, borrow, packageId);
+    putBackControllerToken(tx, cap, packageId);
 
     return tx.build();
 }

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/controller.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/controller.ts
@@ -1,7 +1,6 @@
 // Copyright 2020-2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { bcs } from "@iota/iota-sdk/bcs";
 import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
 import { ObjectRef, Transaction } from "@iota/iota-sdk/transactions";
 

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/controller.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/controller.ts
@@ -1,0 +1,90 @@
+// Copyright 2020-2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { bcs } from "@iota/iota-sdk/bcs";
+import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
+import { ObjectRef, Transaction } from "@iota/iota-sdk/transactions";
+
+export interface ControllerTokenRef {
+    objectRef: ObjectRef;
+    type: "ControllerCap" | "DelegationToken";
+}
+
+export async function delegateControllerCap(
+    controllerCap: ObjectRef,
+    recipient: string,
+    permissions: number,
+    packageId: string,
+): Promise<Uint8Array> {
+    const tx = new Transaction();
+    const cap = tx.objectRef(controllerCap);
+    const recipientAddress = tx.pure.address(recipient);
+    const permissionsArg = tx.pure.u32(permissions);
+
+    const delegationToken = tx.moveCall({
+        target: `${packageId}::controller::delegate_with_permissions`,
+        arguments: [cap, permissionsArg],
+    });
+
+    tx.transferObjects([delegationToken], recipientAddress);
+
+    return tx.build({ onlyTransactionKind: true });
+}
+
+export async function revokeDelegationToken(
+    identity: SharedObjectRef,
+    controllerCap: ObjectRef,
+    delegationTokenId: string,
+    packageId: string,
+): Promise<Uint8Array> {
+    const tx = new Transaction();
+
+    const identityArg = tx.sharedObjectRef(identity);
+    const controllerCapArg = tx.objectRef(controllerCap);
+    const tokenIdArg = tx.pure.id(delegationTokenId);
+
+    tx.moveCall({
+        target: `${packageId}::identity::revoke_delegation_token`,
+        arguments: [identityArg, controllerCapArg, tokenIdArg],
+    });
+
+    return tx.build({ onlyTransactionKind: true });
+}
+
+export async function unrevokeDelegationToken(
+    identity: SharedObjectRef,
+    controllerCap: ObjectRef,
+    delegationTokenId: string,
+    packageId: string,
+): Promise<Uint8Array> {
+    const tx = new Transaction();
+
+    const identityArg = tx.sharedObjectRef(identity);
+    const controllerCapArg = tx.objectRef(controllerCap);
+    const tokenIdArg = tx.pure.id(delegationTokenId);
+
+    tx.moveCall({
+        target: `${packageId}::identity::unrevoke_delegation_token`,
+        arguments: [identityArg, controllerCapArg, tokenIdArg],
+    });
+
+    return tx.build({ onlyTransactionKind: true });
+}
+
+export async function destroyDelegationToken(
+    identity: SharedObjectRef,
+    delegationToken: ObjectRef,
+    packageId: string,
+): Promise<Uint8Array> {
+    const tx = new Transaction();
+
+    const identityArg = tx.sharedObjectRef(identity);
+    const tokenArg = tx.objectRef(delegationToken);
+
+    tx.moveCall({
+        target: `${packageId}::identity::destroy_delegation_token`,
+        arguments: [identityArg, tokenArg],
+    });
+
+    return tx.build({ onlyTransactionKind: true });
+}

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/controller_execution.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/controller_execution.ts
@@ -3,53 +3,52 @@
 
 import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
 import { ObjectRef, Transaction, TransactionArgument } from "@iota/iota-sdk/transactions";
-import { getControllerDelegation, putBackDelegationToken } from "../utils";
+import { controllerTokenRefToTxArgument, putBackControllerToken } from "../utils";
+import { ControllerTokenRef } from "./controller";
 
 export function proposeControllerExecution(
     identity: SharedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     controllerCapId: string,
     packageId: string,
     expiration?: number,
 ): Promise<Uint8Array> {
     const tx = new Transaction();
-    const cap = tx.objectRef(capability);
-    const [delegationToken, borrow] = getControllerDelegation(tx, cap, packageId);
+    const cap = controllerTokenRefToTxArgument(tx, capability, packageId);
     const identityArg = tx.sharedObjectRef(identity);
     const exp = tx.pure.option("u64", expiration);
     const controllerCapIdArg = tx.pure.id(controllerCapId);
 
     tx.moveCall({
         target: `${packageId}::identity::propose_controller_execution`,
-        arguments: [identityArg, delegationToken, controllerCapIdArg, exp],
+        arguments: [identityArg, cap.token, controllerCapIdArg, exp],
     });
 
-    putBackDelegationToken(tx, cap, delegationToken, borrow, packageId);
+    putBackControllerToken(tx, cap, packageId);
 
     return tx.build();
 }
 
 export function executeControllerExecution(
     identity: SharedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     proposalId: string,
     controllerCapRef: ObjectRef,
     intentFn: (arg0: Transaction, arg1: TransactionArgument) => void,
     packageId: string,
 ): Promise<Uint8Array> {
     const tx = new Transaction();
-    const cap = tx.objectRef(capability);
-    const [delegationToken, borrow] = getControllerDelegation(tx, cap, packageId);
+    const cap = controllerTokenRefToTxArgument(tx, capability, packageId);
     const proposal = tx.pure.id(proposalId);
     const identityArg = tx.sharedObjectRef(identity);
 
     let action = tx.moveCall({
         target: `${packageId}::identity::execute_proposal`,
         typeArguments: [`${packageId}::borrow_proposal::Borrow`],
-        arguments: [identityArg, delegationToken, proposal],
+        arguments: [identityArg, cap.token, proposal],
     });
 
-    putBackDelegationToken(tx, cap, delegationToken, borrow, packageId);
+    putBackControllerToken(tx, cap, packageId);
 
     const receiving = tx.receivingRef(controllerCapRef);
     const BorrowedControllerCap = tx.moveCall({
@@ -69,31 +68,30 @@ export function executeControllerExecution(
 
 export function createAndExecuteControllerExecution(
     identity: SharedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     controllerCapRef: ObjectRef,
     intentFn: (arg0: Transaction, arg1: TransactionArgument) => void,
     packageId: string,
     expiration?: number,
 ): Promise<Uint8Array> {
     const tx = new Transaction();
-    const cap = tx.objectRef(capability);
-    const [delegationToken, borrow] = getControllerDelegation(tx, cap, packageId);
+    const cap = controllerTokenRefToTxArgument(tx, capability, packageId);
     const identityArg = tx.sharedObjectRef(identity);
     const exp = tx.pure.option("u64", expiration);
     const controller_cap_id = tx.pure.id(controllerCapRef.objectId);
 
     const proposal = tx.moveCall({
         target: `${packageId}::identity::propose_controller_execution`,
-        arguments: [identityArg, delegationToken, controller_cap_id, exp],
+        arguments: [identityArg, cap.token, controller_cap_id, exp],
     });
 
     let action = tx.moveCall({
         target: `${packageId}::identity::execute_proposal`,
         typeArguments: [`${packageId}::borrow_proposal::Borrow`],
-        arguments: [identityArg, delegationToken, proposal],
+        arguments: [identityArg, cap.token, proposal],
     });
 
-    putBackDelegationToken(tx, cap, delegationToken, borrow, packageId);
+    putBackControllerToken(tx, cap, packageId);
 
     const receiving = tx.receivingRef(controllerCapRef);
     const borrowedControllerCap = tx.moveCall({

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/create.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/create.ts
@@ -20,22 +20,27 @@ export async function create(didDoc: Uint8Array | undefined, packageId: string):
 
 export async function newWithControllers(
     didDoc: Uint8Array | undefined,
-    controllers: [string, number][],
+    controllers: [string, number, boolean][],
     threshold: number,
     packageId: string,
 ): Promise<Uint8Array> {
     const tx = new Transaction();
-    const ids = tx.pure.vector("address", controllers.map(controller => controller[0]));
-    const vps = tx.pure.vector("u64", controllers.map(controller => controller[1]));
+    const controllers_no_delegate = controllers.filter(([_addr, _vp, can_delegate]) => !can_delegate);
+    const controllers_delegate = controllers.filter(([_addr, _vp, can_delegate]) => can_delegate);
+    const ids = tx.pure.vector("address", controllers_no_delegate.map(controller => controller[0]));
+    const vps = tx.pure.vector("u64", controllers_no_delegate.map(controller => controller[1]));
+
+    const ids_delegate = tx.pure.vector("address", controllers_delegate.map(controller => controller[0]));
+    const vps_delegate = tx.pure.vector("u64", controllers_delegate.map(controller => controller[1]));
     const controllersArg = tx.moveCall({
         target: `${packageId}::utils::vec_map_from_keys_values`,
         typeArguments: ["address", "u64"],
         arguments: [ids, vps],
     });
     const controllersThatCanDelegate = tx.moveCall({
-        target: "0x2::vec_map::empty",
+        target: `${packageId}::utils::vec_map_from_keys_values`,
         typeArguments: ["address", "u64"],
-        arguments: [],
+        arguments: [ids_delegate, vps_delegate],
     });
     const didDocArg = tx.pure(bcs.option(bcs.vector(bcs.U8)).serialize(didDoc));
     const clock = getClockRef(tx);
@@ -46,12 +51,5 @@ export async function newWithControllers(
         arguments: [didDocArg, controllersArg, controllersThatCanDelegate, thresholdArg, clock],
     });
 
-    const tx_kind_bcs = await tx.build({ onlyTransactionKind: true });
-    try {
-        const tx_kind = bcs.TransactionKind.parse(tx_kind_bcs);
-    } catch (e) {
-        console.error(`failed to deserialize tx kind: ${e}`);
-    } finally {
-        return tx_kind_bcs;
-    }
+    return await tx.build({ onlyTransactionKind: true });
 }

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/index.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/index.ts
@@ -3,6 +3,7 @@
 
 export * from "./borrow_asset";
 export * from "./config";
+export * from "./controller";
 export * from "./controller_execution";
 export * from "./create";
 export * from "./proposal";

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/proposal.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/proposal.ts
@@ -3,28 +3,28 @@
 
 import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
 import { ObjectRef, Transaction } from "@iota/iota-sdk/transactions";
-import { getControllerDelegation, putBackDelegationToken } from "../utils";
+import { controllerTokenRefToTxArgument, putBackControllerToken } from "../utils";
+import { ControllerTokenRef } from "./controller";
 
 export function approve(
     identity: SharedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     proposalId: string,
     proposalType: string,
     packageId: string,
 ): Promise<Uint8Array> {
     const tx = new Transaction();
-    const cap = tx.objectRef(capability);
-    const [delegationToken, borrow] = getControllerDelegation(tx, cap, packageId);
+    const cap = controllerTokenRefToTxArgument(tx, capability, packageId);
     const identityArg = tx.sharedObjectRef(identity);
     const proposal = tx.pure.id(proposalId);
 
     tx.moveCall({
         target: `${packageId}::identity::approve_proposal`,
         typeArguments: [proposalType],
-        arguments: [identityArg, delegationToken, proposal],
+        arguments: [identityArg, cap.token, proposal],
     });
 
-    putBackDelegationToken(tx, cap, delegationToken, borrow, packageId);
+    putBackControllerToken(tx, cap, packageId);
 
     return tx.build();
 }

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/upgrade.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/upgrade.ts
@@ -3,7 +3,7 @@
 
 import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
 import { Transaction } from "@iota/iota-sdk/transactions";
-import { controllerTokenRefToTxArgument, putBackControllerToken } from "move_calls/utils";
+import { controllerTokenRefToTxArgument, putBackControllerToken } from "../utils";
 import { ControllerTokenRef } from "./controller";
 
 export function proposeUpgrade(

--- a/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/upgrade.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/move_calls/identity/upgrade.ts
@@ -2,42 +2,48 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { SharedObjectRef } from "@iota/iota-sdk/dist/cjs/bcs/types";
-import { ObjectRef, Transaction } from "@iota/iota-sdk/transactions";
+import { Transaction } from "@iota/iota-sdk/transactions";
+import { controllerTokenRefToTxArgument, putBackControllerToken } from "move_calls/utils";
+import { ControllerTokenRef } from "./controller";
 
 export function proposeUpgrade(
     identity: SharedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     packageId: string,
     expiration?: number,
 ): Promise<Uint8Array> {
     const tx = new Transaction();
-    const cap = tx.objectRef(capability);
+    const cap = controllerTokenRefToTxArgument(tx, capability, packageId);
     const identityArg = tx.sharedObjectRef(identity);
     const exp = tx.pure.option("u64", expiration);
 
     tx.moveCall({
         target: `${packageId}::identity::propose_upgrade`,
-        arguments: [identityArg, cap, exp],
+        arguments: [identityArg, cap.token, exp],
     });
+
+    putBackControllerToken(tx, cap, packageId);
 
     return tx.build();
 }
 
 export function executeUpgrade(
     identity: SharedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     proposalId: string,
     packageId: string,
 ): Promise<Uint8Array> {
     const tx = new Transaction();
-    const cap = tx.objectRef(capability);
+    const cap = controllerTokenRefToTxArgument(tx, capability, packageId);
     const proposal = tx.pure.id(proposalId);
     const identityArg = tx.sharedObjectRef(identity);
 
     tx.moveCall({
         target: `${packageId}::identity::execute_upgrade`,
-        arguments: [identityArg, cap, proposal],
+        arguments: [identityArg, cap.token, proposal],
     });
+
+    putBackControllerToken(tx, cap, packageId);
 
     return tx.build();
 }

--- a/bindings/wasm/iota_interaction_ts/src/identity_move_calls.rs
+++ b/bindings/wasm/iota_interaction_ts/src/identity_move_calls.rs
@@ -265,7 +265,7 @@ extern "C" {
 
 impl From<ControllerTokenRef> for WasmControllerTokenRef {
   fn from(value: ControllerTokenRef) -> Self {
-    use js_sys::Object;    
+    use js_sys::Object;
     use js_sys::Reflect;
 
     let wasm_object_ref = WasmObjectRef::from(value.object_ref());

--- a/identity_iota_core/packages/iota_identity/Move.lock
+++ b/identity_iota_core/packages/iota_identity/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "FF296D70242987085F04C1F86112974684C8E251A195A5FC3442D6514F5EFE36"
+manifest_digest = "DD7923F96DC7B66EAD8117E8FA3CE6D0BE0C45B82C4B4D9BBC6621EC61423432"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Iota", name = "Iota" },
@@ -32,8 +32,8 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "0.11.6-rc"
-edition = "2024.beta"
+compiler-version = "0.12.0-alpha"
+edition = "2024"
 flavor = "iota"
 
 [env]
@@ -47,8 +47,8 @@ published-version = "1"
 [env.devnet]
 chain-id = "e678123a"
 original-published-id = "0xe6fa03d273131066036f1d2d4c3d919b9abbca93910769f26a924c7a01811103"
-latest-published-id = "0xe6fa03d273131066036f1d2d4c3d919b9abbca93910769f26a924c7a01811103"
-published-version = "1"
+latest-published-id = "0x6a976d3da90db5d27f8a0c13b3268a37e582b455cfc7bf72d6461f6e8f668823"
+published-version = "2"
 
 [env.localnet]
 chain-id = "9b577f07"

--- a/identity_iota_core/packages/iota_identity/Move.lock
+++ b/identity_iota_core/packages/iota_identity/Move.lock
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "0.12.0-alpha"
+compiler-version = "0.12.0-rc"
 edition = "2024"
 flavor = "iota"
 
@@ -41,8 +41,8 @@ flavor = "iota"
 [env.testnet]
 chain-id = "2304aa97"
 original-published-id = "0x222741bbdff74b42df48a7b4733185e9b24becb8ccfbafe8eac864ab4e4cc555"
-latest-published-id = "0x222741bbdff74b42df48a7b4733185e9b24becb8ccfbafe8eac864ab4e4cc555"
-published-version = "1"
+latest-published-id = "0x3403da7ec4cd2ff9bdf6f34c0b8df5a2bd62c798089feb0d2ebf1c2e953296dc"
+published-version = "2"
 
 [env.devnet]
 chain-id = "e678123a"

--- a/identity_iota_core/packages/iota_identity/Move.lock
+++ b/identity_iota_core/packages/iota_identity/Move.lock
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "0.12.0-rc"
+compiler-version = "0.11.6-rc"
 edition = "2024.beta"
 flavor = "iota"
 
@@ -51,7 +51,7 @@ latest-published-id = "0x03242ae6b87406bd0eb5d669fbe874ed4003694c0be9c6a9ee7c315
 published-version = "1"
 
 [env.localnet]
-chain-id = "461e4e6c"
-original-published-id = "0x7b310d2af24b4d782ebb41d93b4b72bde08546e3e12a00e91b8b8f98442f6656"
-latest-published-id = "0x7b310d2af24b4d782ebb41d93b4b72bde08546e3e12a00e91b8b8f98442f6656"
+chain-id = "9b577f07"
+original-published-id = "0xbad02818629ab7a4d6b9e2facb051305fc0952e7296e431a6aee8ae88b9b72c5"
+latest-published-id = "0xbad02818629ab7a4d6b9e2facb051305fc0952e7296e431a6aee8ae88b9b72c5"
 published-version = "1"

--- a/identity_iota_core/packages/iota_identity/Move.lock
+++ b/identity_iota_core/packages/iota_identity/Move.lock
@@ -46,8 +46,8 @@ published-version = "1"
 
 [env.devnet]
 chain-id = "e678123a"
-original-published-id = "0x03242ae6b87406bd0eb5d669fbe874ed4003694c0be9c6a9ee7c315e6461a553"
-latest-published-id = "0x03242ae6b87406bd0eb5d669fbe874ed4003694c0be9c6a9ee7c315e6461a553"
+original-published-id = "0xe6fa03d273131066036f1d2d4c3d919b9abbca93910769f26a924c7a01811103"
+latest-published-id = "0xe6fa03d273131066036f1d2d4c3d919b9abbca93910769f26a924c7a01811103"
 published-version = "1"
 
 [env.localnet]

--- a/identity_iota_core/packages/iota_identity/Move.toml
+++ b/identity_iota_core/packages/iota_identity/Move.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "IotaIdentity"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 # 'tag' keyword not supported here, therefore use rev instead

--- a/identity_iota_core/packages/iota_identity/sources/asset.move
+++ b/identity_iota_core/packages/iota_identity/sources/asset.move
@@ -57,7 +57,7 @@ module iota_identity::asset {
         mutable: bool,
         transferable: bool,
         deletable: bool,
-        ctx: &mut TxContext
+        ctx: &mut TxContext,
     ) {
         new_with_address(inner, ctx.sender(), mutable, transferable, deletable, ctx);
     }
@@ -71,7 +71,7 @@ module iota_identity::asset {
     public fun borrow<T: store>(self: &AuthenticatedAsset<T>): &T {
         &self.inner
     }
-    
+
     /// Mutably borrow the content of an `AuthenticatedAsset`.
     /// This operation will fail if `AuthenticatedAsset` is configured as non-mutable.
     public fun borrow_mut<T: store>(self: &mut AuthenticatedAsset<T>): &mut T {
@@ -184,7 +184,7 @@ module iota_identity::asset {
     public fun accept<T: store>(
         self: &mut TransferProposal,
         cap: RecipientCap,
-        asset: transfer::Receiving<AuthenticatedAsset<T>>
+        asset: transfer::Receiving<AuthenticatedAsset<T>>,
     ) {
         assert!(self.recipient_cap_id == object::id(&cap), EInvalidRecipient);
         let mut asset = transfer::receive(&mut self.id, asset);
@@ -230,11 +230,11 @@ module iota_identity::asset {
         delete_transfer(proposal);
         delete_sender_cap(cap);
     }
-    
+
     public(package) fun delete_sender_cap(cap: SenderCap) {
         let SenderCap {
             id,
-            ..
+            ..,
         } = cap;
         object::delete(id);
     }
@@ -242,7 +242,7 @@ module iota_identity::asset {
     public fun delete_recipient_cap(cap: RecipientCap) {
         let RecipientCap {
             id,
-            ..
+            ..,
         } = cap;
         object::delete(id);
     }
@@ -263,8 +263,14 @@ module iota_identity::asset {
 
 #[test_only]
 module iota_identity::asset_tests {
-    use iota_identity::asset::{Self, AuthenticatedAsset, EImmutable, ENonTransferable, ENonDeletable};
     use iota::test_scenario;
+    use iota_identity::asset::{
+        Self,
+        AuthenticatedAsset,
+        EImmutable,
+        ENonTransferable,
+        ENonDeletable
+    };
 
     const ALICE: address = @0x471c3;
     const BOB: address = @0xb0b;
@@ -276,7 +282,7 @@ module iota_identity::asset_tests {
         asset::new<u32>(42, scenario.ctx());
         scenario.next_tx(ALICE);
 
-        // Alice fetches her newly created asset and attempts to modify it. 
+        // Alice fetches her newly created asset and attempts to modify it.
         let mut asset = scenario.take_from_address<AuthenticatedAsset<u32>>(ALICE);
         *asset.borrow_mut() = 420;
 
@@ -292,7 +298,7 @@ module iota_identity::asset_tests {
         asset::new<u32>(42, scenario.ctx());
         scenario.next_tx(ALICE);
 
-        // Alice fetches her newly created asset and attempts to send it to Bob. 
+        // Alice fetches her newly created asset and attempts to send it to Bob.
         let asset = scenario.take_from_address<AuthenticatedAsset<u32>>(ALICE);
         asset.transfer(BOB, scenario.ctx());
 
@@ -307,9 +313,9 @@ module iota_identity::asset_tests {
         asset::new<u32>(42, scenario.ctx());
         scenario.next_tx(ALICE);
 
-        // Alice fetches her newly created asset and attempts to delete it. 
+        // Alice fetches her newly created asset and attempts to delete it.
         let asset = scenario.take_from_address<AuthenticatedAsset<u32>>(ALICE);
-        asset.delete(); 
+        asset.delete();
 
         scenario.next_tx(ALICE);
         scenario.end();

--- a/identity_iota_core/packages/iota_identity/sources/controller.move
+++ b/identity_iota_core/packages/iota_identity/sources/controller.move
@@ -1,352 +1,390 @@
 module iota_identity::controller {
-  use iota::transfer::Receiving;
-  use iota::borrow::{Self, Referent, Borrow};
-  use iota_identity::permissions;  
+    use iota::borrow::{Self, Referent, Borrow};
+    use iota::transfer::Receiving;
+    use iota_identity::permissions;
 
-  public use fun delete_controller_cap as ControllerCap.delete;
-  public use fun delete_delegation_token as DelegationToken.delete;
-  public use fun delegation_token_id as DelegationToken.id;
-  public use fun delegation_token_controller_of as DelegationToken.controller_of;
+    public use fun delete_controller_cap as ControllerCap.delete;
+    public use fun delete_delegation_token as DelegationToken.delete;
+    public use fun delegation_token_id as DelegationToken.id;
+    public use fun delegation_token_controller_of as DelegationToken.controller_of;
 
-  /// This `ControllerCap` cannot delegate access.
-  const ECannotDelegate: u64 = 0;
-  // The permission of the provided `DelegationToken` are not
-  // valid to perform this operation.
-  const EInvalidPermissions: u64 = 1;
+    /// This `ControllerCap` cannot delegate access.
+    const ECannotDelegate: u64 = 0;
+    // The permission of the provided `DelegationToken` are not
+    // valid to perform this operation.
+    const EInvalidPermissions: u64 = 1;
 
-  /// Event that is created when a new `DelegationToken` is minted.
-  public struct NewDelegationTokenEvent has copy, drop {
-    controller: ID,
-    token: ID,
-    permissions: u32,
-  }
-
-  /// Capability that allows to access mutative APIs of a `Multicontroller`.
-  public struct ControllerCap has key {
-    id: UID,
-    controller_of: ID,
-    can_delegate: bool,
-    access_token: Referent<DelegationToken>,
-  }
-
-  public fun id(self: &ControllerCap): &UID {
-    &self.id
-  }
-
-  /// Returns the ID of the object controller by this token.
-  public fun controller_of(self: &ControllerCap): ID {
-    self.controller_of
-  }
-
-  /// Borrows this `ControllerCap`'s access token.
-  public fun borrow(self: &mut ControllerCap): (DelegationToken, Borrow) {
-    self.access_token.borrow()
-  }
-
-  /// Returns the borrowed access token together with the hot potato.
-  public fun put_back(self: &mut ControllerCap, token: DelegationToken, borrow: Borrow) {
-    self.access_token.put_back(token, borrow);
-  }
-
-  /// Creates a delegation token for this controller. The created `DelegationToken`
-  /// will have full permissions. Use `delegate_with_permissions` to set or unset
-  /// specific permissions.
-  public fun delegate(self: &ControllerCap, ctx: &mut TxContext): DelegationToken {
-    assert!(self.can_delegate, ECannotDelegate);
-    new_delegation_token(self.id.to_inner(), self.controller_of, permissions::all(), ctx)
-  }
-
-  /// Creates a delegation token for this controller, specifying the delegate's permissions.
-  public fun delegate_with_permissions(self: &ControllerCap, permissions: u32, ctx: &mut TxContext): DelegationToken {
-    assert!(self.can_delegate, ECannotDelegate);
-    new_delegation_token(self.id.to_inner(), self.controller_of, permissions, ctx)
-  }
-
-  /// A token that allows an entity to act in a Controller's stead.
-  public struct DelegationToken has key, store {
-    id: UID,
-    permissions: u32,
-    controller: ID,
-    controller_of: ID,
-  }
-
-  /// Returns the ID of this `DelegationToken`.
-  public fun delegation_token_id(self: &DelegationToken): ID {
-    self.id.to_inner()
-  }
-
-  /// Returns the controller's ID of this `DelegationToken`.
-  public fun controller(self: &DelegationToken): ID {
-    self.controller
-  }
-
-  public fun delegation_token_controller_of(self: &DelegationToken): ID {
-    self.controller_of
-  }
-
-  /// Returns the permissions of this `DelegationToken`.
-  public fun permissions(self: &DelegationToken): u32 {
-    self.permissions
-  }
-
-  /// Returns true if this `DelegationToken` has permission `permission`.
-  public fun has_permission(self: &DelegationToken, permission: u32): bool {
-    self.permissions & permission != 0
-  }
-
-  /// Aborts if this `DelegationToken` doesn't have permission `permission`.
-  public fun assert_has_permission(self: &DelegationToken, permission: u32) {
-    assert!(self.has_permission(permission), EInvalidPermissions)
-  }
-
-  /// Creates a new `ControllerCap`.
-  public(package) fun new(can_delegate: bool, controller_of: ID, ctx: &mut TxContext): ControllerCap {
-    let id = object::new(ctx);
-    let access_token = borrow::new(new_delegation_token(
-      id.to_inner(), 
-      controller_of, 
-      permissions::all(), 
-      ctx
-    ), ctx);
-
-    ControllerCap {
-      id,
-      access_token,
-      controller_of,
-      can_delegate,
+    /// Event that is created when a new `DelegationToken` is minted.
+    public struct NewDelegationTokenEvent has copy, drop {
+        controller: ID,
+        token: ID,
+        permissions: u32,
     }
-  }
 
-  /// Transfer a `ControllerCap`.
-  public(package) fun transfer(cap: ControllerCap, recipient: address) {
-    transfer::transfer(cap, recipient)
-  }
-
-  /// Receives a `ControllerCap`.
-  public(package) fun receive(owner: &mut UID, cap: Receiving<ControllerCap>): ControllerCap {
-    transfer::receive(owner, cap)
-  }
-
-  public(package) fun new_delegation_token(
-    controller: ID,
-    controller_of: ID,
-    permissions: u32,
-    ctx: &mut TxContext
-  ): DelegationToken {
-    let id = object::new(ctx);
-
-    iota::event::emit(NewDelegationTokenEvent {
-      controller,
-      token: id.to_inner(),
-      permissions,
-    });
-
-    DelegationToken {
-      id,
-      controller,
-      controller_of,
-      permissions,
+    /// Capability that allows to access mutative APIs of a `Multicontroller`.
+    public struct ControllerCap has key {
+        id: UID,
+        controller_of: ID,
+        can_delegate: bool,
+        access_token: Referent<DelegationToken>,
     }
-  }
 
-  public(package) fun delete_controller_cap(cap: ControllerCap) {
-    let ControllerCap {
-      access_token,
-      id,
-      ..
-    } = cap;
+    public fun id(self: &ControllerCap): &UID {
+        &self.id
+    }
 
-    delete_delegation_token(access_token.destroy());
-    object::delete(id);
-  }
+    /// Returns the ID of the object controller by this token.
+    public fun controller_of(self: &ControllerCap): ID {
+        self.controller_of
+    }
 
-  public(package) fun delete_delegation_token(token: DelegationToken) {
-    let DelegationToken {
-      id,
-      ..
-    } = token;
-    object::delete(id);
-  }
+    /// Borrows this `ControllerCap`'s access token.
+    public fun borrow(self: &mut ControllerCap): (DelegationToken, Borrow) {
+        self.access_token.borrow()
+    }
+
+    /// Returns the borrowed access token together with the hot potato.
+    public fun put_back(self: &mut ControllerCap, token: DelegationToken, borrow: Borrow) {
+        self.access_token.put_back(token, borrow);
+    }
+
+    /// Creates a delegation token for this controller. The created `DelegationToken`
+    /// will have full permissions. Use `delegate_with_permissions` to set or unset
+    /// specific permissions.
+    public fun delegate(self: &ControllerCap, ctx: &mut TxContext): DelegationToken {
+        assert!(self.can_delegate, ECannotDelegate);
+        new_delegation_token(self.id.to_inner(), self.controller_of, permissions::all(), ctx)
+    }
+
+    /// Creates a delegation token for this controller, specifying the delegate's permissions.
+    public fun delegate_with_permissions(
+        self: &ControllerCap,
+        permissions: u32,
+        ctx: &mut TxContext,
+    ): DelegationToken {
+        assert!(self.can_delegate, ECannotDelegate);
+        new_delegation_token(self.id.to_inner(), self.controller_of, permissions, ctx)
+    }
+
+    /// A token that allows an entity to act in a Controller's stead.
+    public struct DelegationToken has key, store {
+        id: UID,
+        permissions: u32,
+        controller: ID,
+        controller_of: ID,
+    }
+
+    /// Returns the ID of this `DelegationToken`.
+    public fun delegation_token_id(self: &DelegationToken): ID {
+        self.id.to_inner()
+    }
+
+    /// Returns the controller's ID of this `DelegationToken`.
+    public fun controller(self: &DelegationToken): ID {
+        self.controller
+    }
+
+    public fun delegation_token_controller_of(self: &DelegationToken): ID {
+        self.controller_of
+    }
+
+    /// Returns the permissions of this `DelegationToken`.
+    public fun permissions(self: &DelegationToken): u32 {
+        self.permissions
+    }
+
+    /// Returns true if this `DelegationToken` has permission `permission`.
+    public fun has_permission(self: &DelegationToken, permission: u32): bool {
+        self.permissions & permission != 0
+    }
+
+    /// Aborts if this `DelegationToken` doesn't have permission `permission`.
+    public fun assert_has_permission(self: &DelegationToken, permission: u32) {
+        assert!(self.has_permission(permission), EInvalidPermissions)
+    }
+
+    /// Creates a new `ControllerCap`.
+    public(package) fun new(
+        can_delegate: bool,
+        controller_of: ID,
+        ctx: &mut TxContext,
+    ): ControllerCap {
+        let id = object::new(ctx);
+        let access_token = borrow::new(
+            new_delegation_token(
+                id.to_inner(),
+                controller_of,
+                permissions::all(),
+                ctx,
+            ),
+            ctx,
+        );
+
+        ControllerCap {
+            id,
+            access_token,
+            controller_of,
+            can_delegate,
+        }
+    }
+
+    /// Transfer a `ControllerCap`.
+    public(package) fun transfer(cap: ControllerCap, recipient: address) {
+        transfer::transfer(cap, recipient)
+    }
+
+    /// Receives a `ControllerCap`.
+    public(package) fun receive(owner: &mut UID, cap: Receiving<ControllerCap>): ControllerCap {
+        transfer::receive(owner, cap)
+    }
+
+    public(package) fun new_delegation_token(
+        controller: ID,
+        controller_of: ID,
+        permissions: u32,
+        ctx: &mut TxContext,
+    ): DelegationToken {
+        let id = object::new(ctx);
+
+        iota::event::emit(NewDelegationTokenEvent {
+            controller,
+            token: id.to_inner(),
+            permissions,
+        });
+
+        DelegationToken {
+            id,
+            controller,
+            controller_of,
+            permissions,
+        }
+    }
+
+    public(package) fun delete_controller_cap(cap: ControllerCap) {
+        let ControllerCap {
+            access_token,
+            id,
+            ..,
+        } = cap;
+
+        delete_delegation_token(access_token.destroy());
+        object::delete(id);
+    }
+
+    public(package) fun delete_delegation_token(token: DelegationToken) {
+        let DelegationToken {
+            id,
+            ..,
+        } = token;
+        object::delete(id);
+    }
 }
 
 #[test_only]
 module iota_identity::controller_tests {
-  use iota::test_scenario;
-  use iota_identity::controller::{Self, ControllerCap, ECannotDelegate, EInvalidPermissions};
-  use iota_identity::permissions;
-  use iota_identity::multicontroller::{Self, Multicontroller};
+    use iota::test_scenario;
+    use iota_identity::controller::{Self, ControllerCap, ECannotDelegate, EInvalidPermissions};
+    use iota_identity::multicontroller::{Self, Multicontroller};
+    use iota_identity::permissions;
 
-  fun controllee_id(): ID {
-    object::id_from_address(@0x123456)
-  }
+    fun controllee_id(): ID {
+        object::id_from_address(@0x123456)
+    }
 
-  #[test, expected_failure(abort_code = ECannotDelegate)]
-  fun test_only_delegatable_controllers_can_create_delegation_tokens() {
-    let owner = @0x1;
-    let mut scenario = test_scenario::begin(owner);
+    #[test, expected_failure(abort_code = ECannotDelegate)]
+    fun test_only_delegatable_controllers_can_create_delegation_tokens() {
+        let owner = @0x1;
+        let mut scenario = test_scenario::begin(owner);
 
-    let non_delegatable = controller::new(false, controllee_id(), scenario.ctx());
-    let delegation_token = non_delegatable.delegate(scenario.ctx());
+        let non_delegatable = controller::new(false, controllee_id(), scenario.ctx());
+        let delegation_token = non_delegatable.delegate(scenario.ctx());
 
-    delegation_token.delete();
-    non_delegatable.delete();
-    scenario.end();
-  }
-  
-  #[test, expected_failure(abort_code = EInvalidPermissions)]
-  fun delegate_cannot_create_proposal_when_missing_permission() {
-    let controller = @0x1;
-    let mut scenario = test_scenario::begin(controller);
+        delegation_token.delete();
+        non_delegatable.delete();
+        scenario.end();
+    }
 
-    let mut multicontroller: Multicontroller<u64> = multicontroller::new(0, true, controllee_id(), scenario.ctx());
-    scenario.next_tx(controller);
+    #[test, expected_failure(abort_code = EInvalidPermissions)]
+    fun delegate_cannot_create_proposal_when_missing_permission() {
+        let controller = @0x1;
+        let mut scenario = test_scenario::begin(controller);
 
-    let controller_cap = scenario.take_from_address<ControllerCap>(controller);
-    let delegation_token = controller_cap.delegate_with_permissions(
-      permissions::all() & permissions::not(permissions::can_create_proposal()),
-      scenario.ctx(),
-    );
+        let mut multicontroller: Multicontroller<u64> = multicontroller::new(
+            0,
+            true,
+            controllee_id(),
+            scenario.ctx(),
+        );
+        scenario.next_tx(controller);
 
-    scenario.next_tx(controller);
+        let controller_cap = scenario.take_from_address<ControllerCap>(controller);
+        let delegation_token = controller_cap.delegate_with_permissions(
+            permissions::all() & permissions::not(permissions::can_create_proposal()),
+            scenario.ctx(),
+        );
 
-    multicontroller.create_proposal<_, u64>(
-      &delegation_token,
-      0,
-      option::none(),
-      scenario.ctx(),
-    );
+        scenario.next_tx(controller);
 
-    abort(0)
-  }
+        multicontroller.create_proposal<_, u64>(
+            &delegation_token,
+            0,
+            option::none(),
+            scenario.ctx(),
+        );
 
-  #[test, expected_failure(abort_code = EInvalidPermissions)]
-  fun delegate_cannot_execute_proposal_when_missing_permission() {
-    let controller = @0x1;
-    let mut scenario = test_scenario::begin(controller);
+        abort (0)
+    }
 
-    let mut multicontroller: Multicontroller<u64> = multicontroller::new(0, true, controllee_id(), scenario.ctx());
-    scenario.next_tx(controller);
+    #[test, expected_failure(abort_code = EInvalidPermissions)]
+    fun delegate_cannot_execute_proposal_when_missing_permission() {
+        let controller = @0x1;
+        let mut scenario = test_scenario::begin(controller);
 
-    let controller_cap = scenario.take_from_address<ControllerCap>(controller);
-    let delegation_token = controller_cap.delegate_with_permissions(
-      permissions::all() & permissions::not(permissions::can_execute_proposal()),
-      scenario.ctx(),
-    );
+        let mut multicontroller: Multicontroller<u64> = multicontroller::new(
+            0,
+            true,
+            controllee_id(),
+            scenario.ctx(),
+        );
+        scenario.next_tx(controller);
 
-    scenario.next_tx(controller);
+        let controller_cap = scenario.take_from_address<ControllerCap>(controller);
+        let delegation_token = controller_cap.delegate_with_permissions(
+            permissions::all() & permissions::not(permissions::can_execute_proposal()),
+            scenario.ctx(),
+        );
 
-    let proposal_id = multicontroller.create_proposal<_, u64>(
-      &delegation_token,
-      0,
-      option::none(),
-      scenario.ctx(),
-    );
+        scenario.next_tx(controller);
 
-    multicontroller.execute_proposal<_, u64>(
-      &delegation_token,
-      proposal_id,
-      scenario.ctx(),
-    ).unwrap();
+        let proposal_id = multicontroller.create_proposal<_, u64>(
+            &delegation_token,
+            0,
+            option::none(),
+            scenario.ctx(),
+        );
 
-    abort(0)
-  }
+        multicontroller
+            .execute_proposal<_, u64>(
+                &delegation_token,
+                proposal_id,
+                scenario.ctx(),
+            )
+            .unwrap();
 
-  #[test, expected_failure(abort_code = EInvalidPermissions)]
-  fun delegate_cannot_approve_proposal_when_missing_permission() {
-    let controller = @0x1;
-    let mut scenario = test_scenario::begin(controller);
+        abort (0)
+    }
 
-    let mut multicontroller: Multicontroller<u64> = multicontroller::new(0, true, controllee_id(), scenario.ctx());
-    scenario.next_tx(controller);
+    #[test, expected_failure(abort_code = EInvalidPermissions)]
+    fun delegate_cannot_approve_proposal_when_missing_permission() {
+        let controller = @0x1;
+        let mut scenario = test_scenario::begin(controller);
 
-    let controller_cap = scenario.take_from_address<ControllerCap>(controller);
-    let delegation_token = controller_cap.delegate_with_permissions(
-      permissions::all() & permissions::not(permissions::can_approve_proposal()),
-      scenario.ctx(),
-    );
+        let mut multicontroller: Multicontroller<u64> = multicontroller::new(
+            0,
+            true,
+            controllee_id(),
+            scenario.ctx(),
+        );
+        scenario.next_tx(controller);
 
-    scenario.next_tx(controller);
+        let controller_cap = scenario.take_from_address<ControllerCap>(controller);
+        let delegation_token = controller_cap.delegate_with_permissions(
+            permissions::all() & permissions::not(permissions::can_approve_proposal()),
+            scenario.ctx(),
+        );
 
-    let proposal_id = multicontroller.create_proposal<_, u64>(
-      &delegation_token,
-      0,
-      option::none(),
-      scenario.ctx(),
-    );
+        scenario.next_tx(controller);
 
-    multicontroller.approve_proposal<_, u64>(
-      &delegation_token,
-      proposal_id,
-    );
+        let proposal_id = multicontroller.create_proposal<_, u64>(
+            &delegation_token,
+            0,
+            option::none(),
+            scenario.ctx(),
+        );
 
-    abort(0)
-  }
+        multicontroller.approve_proposal<_, u64>(
+            &delegation_token,
+            proposal_id,
+        );
 
-  #[test, expected_failure(abort_code = EInvalidPermissions)]
-  fun delegate_cannot_remove_approval_when_missing_permission() {
-    let controller = @0x1;
-    let mut scenario = test_scenario::begin(controller);
+        abort (0)
+    }
 
-    let mut multicontroller: Multicontroller<u64> = multicontroller::new(0, true, controllee_id(), scenario.ctx());
-    scenario.next_tx(controller);
+    #[test, expected_failure(abort_code = EInvalidPermissions)]
+    fun delegate_cannot_remove_approval_when_missing_permission() {
+        let controller = @0x1;
+        let mut scenario = test_scenario::begin(controller);
 
-    let controller_cap = scenario.take_from_address<ControllerCap>(controller);
-    let delegation_token = controller_cap.delegate_with_permissions(
-      permissions::all() & permissions::not(permissions::can_remove_approval()),
-      scenario.ctx(),
-    );
+        let mut multicontroller: Multicontroller<u64> = multicontroller::new(
+            0,
+            true,
+            controllee_id(),
+            scenario.ctx(),
+        );
+        scenario.next_tx(controller);
 
-    scenario.next_tx(controller);
+        let controller_cap = scenario.take_from_address<ControllerCap>(controller);
+        let delegation_token = controller_cap.delegate_with_permissions(
+            permissions::all() & permissions::not(permissions::can_remove_approval()),
+            scenario.ctx(),
+        );
 
-    let proposal_id = multicontroller.create_proposal<_, u64>(
-      &delegation_token,
-      0,
-      option::none(),
-      scenario.ctx(),
-    );
+        scenario.next_tx(controller);
 
-    multicontroller.remove_approval<_, u64>(
-      &delegation_token,
-      proposal_id,
-    );
+        let proposal_id = multicontroller.create_proposal<_, u64>(
+            &delegation_token,
+            0,
+            option::none(),
+            scenario.ctx(),
+        );
 
-    abort(0)
-  }
+        multicontroller.remove_approval<_, u64>(
+            &delegation_token,
+            proposal_id,
+        );
 
-  #[test, expected_failure(abort_code = EInvalidPermissions)]
-  fun delegate_cannot_delete_proposal_when_missing_permission() {
-    let controller = @0x1;
-    let mut scenario = test_scenario::begin(controller);
+        abort (0)
+    }
 
-    let mut multicontroller: Multicontroller<u64> = multicontroller::new(0, true, controllee_id(), scenario.ctx());
-    scenario.next_tx(controller);
+    #[test, expected_failure(abort_code = EInvalidPermissions)]
+    fun delegate_cannot_delete_proposal_when_missing_permission() {
+        let controller = @0x1;
+        let mut scenario = test_scenario::begin(controller);
 
-    let controller_cap = scenario.take_from_address<ControllerCap>(controller);
-    let delegation_token = controller_cap.delegate_with_permissions(
-      permissions::all() & permissions::not(permissions::can_remove_approval()),
-      scenario.ctx(),
-    );
+        let mut multicontroller: Multicontroller<u64> = multicontroller::new(
+            0,
+            true,
+            controllee_id(),
+            scenario.ctx(),
+        );
+        scenario.next_tx(controller);
 
-    scenario.next_tx(controller);
+        let controller_cap = scenario.take_from_address<ControllerCap>(controller);
+        let delegation_token = controller_cap.delegate_with_permissions(
+            permissions::all() & permissions::not(permissions::can_remove_approval()),
+            scenario.ctx(),
+        );
 
-    let proposal_id = multicontroller.create_proposal<_, u64>(
-      &delegation_token,
-      0,
-      option::none(),
-      scenario.ctx(),
-    );
+        scenario.next_tx(controller);
 
-    multicontroller.remove_approval<_, u64>(
-      &delegation_token,
-      proposal_id,
-    );
+        let proposal_id = multicontroller.create_proposal<_, u64>(
+            &delegation_token,
+            0,
+            option::none(),
+            scenario.ctx(),
+        );
 
-    multicontroller.delete_proposal<_, u64>(
-      &delegation_token,
-      proposal_id,
-      scenario.ctx()
-    );
+        multicontroller.remove_approval<_, u64>(
+            &delegation_token,
+            proposal_id,
+        );
 
-    abort(0)
-  }
+        multicontroller.delete_proposal<_, u64>(
+            &delegation_token,
+            proposal_id,
+            scenario.ctx(),
+        );
+
+        abort (0)
+    }
 }

--- a/identity_iota_core/packages/iota_identity/sources/migration_registry.move
+++ b/identity_iota_core/packages/iota_identity/sources/migration_registry.move
@@ -1,54 +1,56 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-module iota_identity::migration_registry {
-    use iota::{dynamic_field as field, transfer::share_object, event};
+module iota_identity::migration_registry;
 
-    const BEACON_BYTES: vector<u8> = b"identity.rs_pkg";
+use iota::dynamic_field as field;
+use iota::event;
+use iota::transfer::share_object;
 
-    /// One time witness needed to construct a singleton `MigrationRegistry`.
-    public struct MIGRATION_REGISTRY has drop {}
+const BEACON_BYTES: vector<u8> = b"identity.rs_pkg";
 
-    /// Event type that is fired upon creation of a `MigrationRegistry`.
-    public struct MigrationRegistryCreated has copy, drop {
-        id: ID,
-        beacon: vector<u8>,
-    }
+/// One time witness needed to construct a singleton `MigrationRegistry`.
+public struct MIGRATION_REGISTRY has drop {}
 
-    /// Object that tracks migrated alias outputs to their corresponding object IDs.
-    public struct MigrationRegistry has key {
-        id: UID,
-    }
+/// Event type that is fired upon creation of a `MigrationRegistry`.
+public struct MigrationRegistryCreated has copy, drop {
+    id: ID,
+    beacon: vector<u8>,
+}
 
-    /// Creates a singleton instance of `MigrationRegistry` when publishing this package.
-    fun init(_otw: MIGRATION_REGISTRY, ctx: &mut TxContext) {
-        let id = object::new(ctx);
-        let registry_id = id.to_inner();
-        let registry = MigrationRegistry {
-            id,
-        };
-        share_object(registry);
-        // Signal the creation of a migration registry.
-        event::emit(MigrationRegistryCreated { id: registry_id, beacon: BEACON_BYTES });
-    }
+/// Object that tracks migrated alias outputs to their corresponding object IDs.
+public struct MigrationRegistry has key {
+    id: UID,
+}
 
-    /// Checks whether the given alias ID exists in the migration registry.
-    public fun exists(self: &MigrationRegistry, alias_id: ID): bool {
-        field::exists_(&self.id, alias_id)
-    }
+/// Creates a singleton instance of `MigrationRegistry` when publishing this package.
+fun init(_otw: MIGRATION_REGISTRY, ctx: &mut TxContext) {
+    let id = object::new(ctx);
+    let registry_id = id.to_inner();
+    let registry = MigrationRegistry {
+        id,
+    };
+    share_object(registry);
+    // Signal the creation of a migration registry.
+    event::emit(MigrationRegistryCreated { id: registry_id, beacon: BEACON_BYTES });
+}
 
-    /// Lookup an alias ID into the migration registry.
-    public fun lookup(self: &MigrationRegistry, alias_id: ID): ID {
-        *field::borrow<ID, ID>(&self.id, alias_id)
-    }
+/// Checks whether the given alias ID exists in the migration registry.
+public fun exists(self: &MigrationRegistry, alias_id: ID): bool {
+    field::exists_(&self.id, alias_id)
+}
 
-    /// Adds a new Alias ID -> Object ID binding to the regitry.
-    public(package) fun add(self: &mut MigrationRegistry, alias_id: ID, identity_id: ID) {
-        field::add(&mut self.id, alias_id, identity_id);
-    }
+/// Lookup an alias ID into the migration registry.
+public fun lookup(self: &MigrationRegistry, alias_id: ID): ID {
+    *field::borrow<ID, ID>(&self.id, alias_id)
+}
 
-    #[test_only]
-    public fun init_testing(ctx: &mut TxContext) {
-        init(MIGRATION_REGISTRY {}, ctx);
-    }
+/// Adds a new Alias ID -> Object ID binding to the regitry.
+public(package) fun add(self: &mut MigrationRegistry, alias_id: ID, identity_id: ID) {
+    field::add(&mut self.id, alias_id, identity_id);
+}
+
+#[test_only]
+public fun init_testing(ctx: &mut TxContext) {
+    init(MIGRATION_REGISTRY {}, ctx);
 }

--- a/identity_iota_core/packages/iota_identity/sources/multicontroller.move
+++ b/identity_iota_core/packages/iota_identity/sources/multicontroller.move
@@ -150,6 +150,8 @@ module iota_identity::multicontroller {
 
     public(package) fun assert_is_member<V>(multi: &Multicontroller<V>, cap: &DelegationToken) {
         assert!(multi.controllers.contains(&cap.controller()), EInvalidController);
+        // Make sure the presented token hasn't been revoked.
+        assert!(!multi.revoked_tokens.contains(&cap.id()), EInvalidController);
     }
 
     /// Creates a new proposal for `Multicontroller` `multi`.

--- a/identity_iota_core/packages/iota_identity/sources/multicontroller.move
+++ b/identity_iota_core/packages/iota_identity/sources/multicontroller.move
@@ -1,434 +1,456 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-module iota_identity::multicontroller {
-    use iota::{object_bag::{Self, ObjectBag}, vec_map::{Self, VecMap}, vec_set::{Self, VecSet}};
-    use iota_identity::controller::{Self, DelegationToken, ControllerCap};
-    use iota_identity::permissions;
+module iota_identity::multicontroller;
 
-    const EInvalidController: u64 = 0;
-    const EControllerAlreadyVoted: u64 = 1;    
-    const EThresholdNotReached: u64 = 2;
-    const EInvalidThreshold: u64 = 3;
-    const EExpiredProposal: u64 = 4;
-    const ENotVotedYet: u64 = 5;
-    const EProposalNotFound: u64 = 6;
-    const ECannotDelete: u64 = 7;
+use iota::object_bag::{Self, ObjectBag};
+use iota::vec_map::{Self, VecMap};
+use iota::vec_set::{Self, VecSet};
+use iota_identity::controller::{Self, DelegationToken, ControllerCap};
+use iota_identity::permissions;
 
-    /// Shares control of a value `V` with multiple entities called controllers.
-    public struct Multicontroller<V> has store {
-        threshold: u64,
-        owner: ID,
-        controllers: VecMap<ID, u64>,
-        controlled_value: V,
-        active_proposals: vector<ID>,
-        proposals: ObjectBag,
-        revoked_tokens: VecSet<ID>,
+const EInvalidController: u64 = 0;
+const EControllerAlreadyVoted: u64 = 1;
+const EThresholdNotReached: u64 = 2;
+const EInvalidThreshold: u64 = 3;
+const EExpiredProposal: u64 = 4;
+const ENotVotedYet: u64 = 5;
+const EProposalNotFound: u64 = 6;
+const ECannotDelete: u64 = 7;
+
+/// Shares control of a value `V` with multiple entities called controllers.
+public struct Multicontroller<V> has store {
+    threshold: u64,
+    owner: ID,
+    controllers: VecMap<ID, u64>,
+    controlled_value: V,
+    active_proposals: vector<ID>,
+    proposals: ObjectBag,
+    revoked_tokens: VecSet<ID>,
+}
+
+/// Wraps a `V` in `Multicontroller`, making the tx's sender a controller with
+/// voting power 1.
+public fun new<V>(
+    controlled_value: V,
+    can_delegate: bool,
+    owner: ID,
+    ctx: &mut TxContext,
+): Multicontroller<V> {
+    new_with_controller(controlled_value, ctx.sender(), can_delegate, owner, ctx)
+}
+
+/// Wraps a `V` in `Multicontroller` and sends `controller` a `ControllerCap`.
+public fun new_with_controller<V>(
+    controlled_value: V,
+    controller: address,
+    can_delegate: bool,
+    owner: ID,
+    ctx: &mut TxContext,
+): Multicontroller<V> {
+    let mut controllers = vec_map::empty();
+    controllers.insert(controller, 1);
+
+    if (can_delegate) {
+        new_with_controllers(controlled_value, vec_map::empty(), controllers, 1, owner, ctx)
+    } else {
+        new_with_controllers(controlled_value, controllers, vec_map::empty(), 1, owner, ctx)
     }
+}
 
-    /// Wraps a `V` in `Multicontroller`, making the tx's sender a controller with
-    /// voting power 1.
-    public fun new<V>(
-        controlled_value: V,
-        can_delegate: bool,
-        owner: ID,
-        ctx: &mut TxContext
-    ): Multicontroller<V> {
-        new_with_controller(controlled_value, ctx.sender(), can_delegate, owner, ctx)
+/// Wraps a `V` in `Multicontroller`, settings `threshold` as the threshold,
+/// and using `controllers` to set controllers: i.e. each `(recipient, voting power)`
+/// in `controllers` results in `recipient` obtaining a `ControllerCap` with the
+/// specified voting power.
+/// Controllers that are able to delegate their access, should be passed through
+/// `controllers_that_can_delegate` parameter.
+public fun new_with_controllers<V>(
+    controlled_value: V,
+    controllers: VecMap<address, u64>,
+    controllers_that_can_delegate: VecMap<address, u64>,
+    threshold: u64,
+    owner: ID,
+    ctx: &mut TxContext,
+): Multicontroller<V> {
+    let (mut addrs, mut vps) = controllers.into_keys_values();
+    let mut controllers = vec_map::empty();
+    while (!addrs.is_empty()) {
+        let addr = addrs.pop_back();
+        let vp = vps.pop_back();
+
+        let cap = controller::new(false, owner, ctx);
+        controllers.insert(cap.id().to_inner(), vp);
+
+        cap.transfer(addr)
+    };
+
+    let (mut addrs, mut vps) = controllers_that_can_delegate.into_keys_values();
+    while (!addrs.is_empty()) {
+        let addr = addrs.pop_back();
+        let vp = vps.pop_back();
+
+        let cap = controller::new(true, owner, ctx);
+        controllers.insert(cap.id().to_inner(), vp);
+
+        cap.transfer(addr)
+    };
+
+    let mut multi = Multicontroller {
+        controlled_value,
+        controllers,
+        owner,
+        threshold,
+        active_proposals: vector[],
+        proposals: object_bag::new(ctx),
+        revoked_tokens: vec_set::empty(),
+    };
+    multi.set_threshold(threshold);
+
+    multi
+}
+
+/// Structure that encapsulates the logic required to make changes
+/// to a multicontrolled value.
+public struct Proposal<T: store> has key, store {
+    id: UID,
+    votes: u64,
+    voters: VecSet<ID>,
+    expiration_epoch: Option<u64>,
+    action: T,
+}
+
+/// Returns `true` if `Proposal` `self` is expired.
+public fun is_expired<T: store>(self: &Proposal<T>, ctx: &mut TxContext): bool {
+    if (self.expiration_epoch.is_some()) {
+        let expiration = *self.expiration_epoch.borrow();
+        expiration < ctx.epoch()
+    } else {
+        false
     }
+}
 
-    /// Wraps a `V` in `Multicontroller` and sends `controller` a `ControllerCap`.
-    public fun new_with_controller<V>(
-        controlled_value: V,
-        controller: address,
-        can_delegate: bool,
-        owner: ID,
-        ctx: &mut TxContext
-    ): Multicontroller<V> {
-        let mut controllers = vec_map::empty();
-        controllers.insert(controller, 1);
+/// Structure that encapsulate the kind of change that will be performed
+/// when a proposal is carried out.
+public struct Action<T: store> {
+    inner: T,
+}
 
-        if (can_delegate) {
-            new_with_controllers(controlled_value, vec_map::empty(), controllers, 1, owner, ctx)
-        } else {
-            new_with_controllers(controlled_value, controllers, vec_map::empty(), 1, owner, ctx)
-        }
-    }
+/// Consumes `Action` returning the inner value.
+public fun unwrap<T: store>(action: Action<T>): T {
+    let Action { inner } = action;
+    inner
+}
 
-    /// Wraps a `V` in `Multicontroller`, settings `threshold` as the threshold,
-    /// and using `controllers` to set controllers: i.e. each `(recipient, voting power)`
-    /// in `controllers` results in `recipient` obtaining a `ControllerCap` with the
-    /// specified voting power.
-    /// Controllers that are able to delegate their access, should be passed through
-    /// `controllers_that_can_delegate` parameter.
-    public fun new_with_controllers<V>(
-        controlled_value: V,
-        controllers: VecMap<address, u64>,
-        controllers_that_can_delegate: VecMap<address, u64>,
-        threshold: u64,
-        owner: ID,
-        ctx: &mut TxContext,
-    ): Multicontroller<V> {
-        let (mut addrs, mut vps) = controllers.into_keys_values();
-        let mut controllers = vec_map::empty();
-        while(!addrs.is_empty()) {
-            let addr = addrs.pop_back();
-            let vp = vps.pop_back();
+/// Borrows the content of `action`.
+public fun borrow<T: store>(action: &Action<T>): &T {
+    &action.inner
+}
 
-            let cap = controller::new(false, owner, ctx);
-            controllers.insert(cap.id().to_inner(), vp);
+/// Mutably borrows the content of `action`.
+public fun borrow_mut<T: store>(action: &mut Action<T>): &mut T {
+    &mut action.inner
+}
 
-            cap.transfer(addr)
-        };
+public(package) fun assert_is_member<V>(multi: &Multicontroller<V>, cap: &DelegationToken) {
+    assert!(multi.controllers.contains(&cap.controller()), EInvalidController);
+    // Make sure the presented token hasn't been revoked.
+    assert!(!multi.revoked_tokens.contains(&cap.id()), EInvalidController);
+}
 
-        let (mut addrs, mut vps) = controllers_that_can_delegate.into_keys_values();
-        while(!addrs.is_empty()) {
-            let addr = addrs.pop_back();
-            let vp = vps.pop_back();
+/// Creates a new proposal for `Multicontroller` `multi`.
+public fun create_proposal<V, T: store>(
+    multi: &mut Multicontroller<V>,
+    cap: &DelegationToken,
+    action: T,
+    expiration_epoch: Option<u64>,
+    ctx: &mut TxContext,
+): ID {
+    multi.assert_is_member(cap);
+    cap.assert_has_permission(permissions::can_create_proposal());
 
-            let cap = controller::new(true, owner, ctx);
-            controllers.insert(cap.id().to_inner(), vp);
+    let cap_id = cap.controller();
+    let voting_power = multi.voting_power(cap_id);
 
-            cap.transfer(addr)
-        };
+    let proposal = Proposal {
+        id: object::new(ctx),
+        votes: voting_power,
+        voters: vec_set::singleton(cap_id),
+        expiration_epoch,
+        action,
+    };
 
-        let mut multi = Multicontroller {
-            controlled_value,
-            controllers,
-            owner,
-            threshold,
-            active_proposals: vector[],
-            proposals: object_bag::new(ctx),
-            revoked_tokens: vec_set::empty(),
-        };
-        multi.set_threshold(threshold);
+    let proposal_id = object::id(&proposal);
+    multi.proposals.add(proposal_id, proposal);
+    multi.active_proposals.push_back(proposal_id);
+    proposal_id
+}
 
-        multi
-    }
+/// Approves an active `Proposal` in `multi`.
+public fun approve_proposal<V, T: store>(
+    multi: &mut Multicontroller<V>,
+    cap: &DelegationToken,
+    proposal_id: ID,
+) {
+    multi.assert_is_member(cap);
+    cap.assert_has_permission(permissions::can_approve_proposal());
 
-    /// Structure that encapsulates the logic required to make changes
-    /// to a multicontrolled value.
-    public struct Proposal<T: store> has key, store {
-        id: UID,
-        votes: u64,
-        voters: VecSet<ID>,
-        expiration_epoch: Option<u64>,
-        action: T,
-    }
+    let cap_id = cap.controller();
+    let voting_power = multi.voting_power(cap_id);
 
-    /// Returns `true` if `Proposal` `self` is expired.
-    public fun is_expired<T: store>(self: &Proposal<T>, ctx: &mut TxContext): bool {
-        if (self.expiration_epoch.is_some()) {
-            let expiration = *self.expiration_epoch.borrow();
-            expiration < ctx.epoch()
-        } else {
-            false
-        }
-    }
+    let proposal = multi.proposals.borrow_mut<ID, Proposal<T>>(proposal_id);
+    assert!(!proposal.voters.contains(&cap_id), EControllerAlreadyVoted);
 
-    /// Structure that encapsulate the kind of change that will be performed
-    /// when a proposal is carried out.
-    public struct Action<T: store> {
-        inner: T,
-    }
+    proposal.votes = proposal.votes + voting_power;
+    proposal.voters.insert(cap_id);
+}
 
-    /// Consumes `Action` returning the inner value.
-    public fun unwrap<T: store>(action: Action<T>): T {
-        let Action { inner } = action;
-        inner
-    }
+/// Consumes the `multi`'s active `Proposal` with id `proposal_id`,
+/// returning its inner `Action`.
+/// This call fails if `multi`'s threshold has not been reached.
+public fun execute_proposal<V, T: store>(
+    multi: &mut Multicontroller<V>,
+    cap: &DelegationToken,
+    proposal_id: ID,
+    ctx: &mut TxContext,
+): Action<T> {
+    multi.assert_is_member(cap);
+    cap.assert_has_permission(permissions::can_execute_proposal());
 
-    /// Borrows the content of `action`.
-    public fun borrow<T: store>(action: &Action<T>): &T {
-        &action.inner
-    }
+    let proposal = multi.proposals.remove<ID, Proposal<T>>(proposal_id);
+    assert!(proposal.votes >= multi.threshold, EThresholdNotReached);
+    assert!(!proposal.is_expired(ctx), EExpiredProposal);
 
-    /// Mutably borrows the content of `action`.
-    public fun borrow_mut<T: store>(action: &mut Action<T>): &mut T {
-        &mut action.inner
-    }
+    let Proposal {
+        id,
+        votes: _,
+        voters: _,
+        expiration_epoch: _,
+        action: inner,
+    } = proposal;
 
-    public(package) fun assert_is_member<V>(multi: &Multicontroller<V>, cap: &DelegationToken) {
-        assert!(multi.controllers.contains(&cap.controller()), EInvalidController);
-        // Make sure the presented token hasn't been revoked.
-        assert!(!multi.revoked_tokens.contains(&cap.id()), EInvalidController);
-    }
+    id.delete();
 
-    /// Creates a new proposal for `Multicontroller` `multi`.
-    public fun create_proposal<V, T: store>(
-        multi: &mut Multicontroller<V>,
-        cap: &DelegationToken,
-        action: T,
-        expiration_epoch: Option<u64>,
-        ctx: &mut TxContext,
-    ): ID {
-        multi.assert_is_member(cap);
-        cap.assert_has_permission(permissions::can_create_proposal());
+    let (present, i) = multi.active_proposals.index_of(&proposal_id);
+    assert!(present, EProposalNotFound);
 
-        let cap_id = cap.controller();
-        let voting_power = multi.voting_power(cap_id);
+    multi.active_proposals.remove(i);
 
-        let proposal = Proposal {
-            id: object::new(ctx),
-            votes: voting_power,
-            voters: vec_set::singleton(cap_id),
-            expiration_epoch,
-            action,
-        };
+    Action { inner }
+}
 
-        let proposal_id = object::id(&proposal);
-        multi.proposals.add(proposal_id, proposal);
-        multi.active_proposals.push_back(proposal_id);
-        proposal_id
-    }
+/// Removes the approval given by the controller owning `cap` on `Proposal`
+/// `proposal_id`.
+public fun remove_approval<V, T: store>(
+    multi: &mut Multicontroller<V>,
+    cap: &DelegationToken,
+    proposal_id: ID,
+) {
+    cap.assert_has_permission(permissions::can_remove_approval());
 
-    /// Approves an active `Proposal` in `multi`.
-    public fun approve_proposal<V, T: store>(
-        multi: &mut Multicontroller<V>,
-        cap: &DelegationToken,
-        proposal_id: ID,
-    ) {
-        multi.assert_is_member(cap);
-        cap.assert_has_permission(permissions::can_approve_proposal());
+    let cap_id = cap.controller();
+    let vp = multi.voting_power(cap_id);
 
-        let cap_id = cap.controller();
-        let voting_power = multi.voting_power(cap_id);
+    let proposal = multi.proposals.borrow_mut<ID, Proposal<T>>(proposal_id);
+    assert!(proposal.voters.contains(&cap_id), ENotVotedYet);
 
-        let proposal = multi.proposals.borrow_mut<ID, Proposal<T>>(proposal_id);
-        assert!(!proposal.voters.contains(&cap_id), EControllerAlreadyVoted);
+    proposal.voters.remove(&cap_id);
+    proposal.votes = proposal.votes - vp;
+}
 
-        proposal.votes = proposal.votes + voting_power;
-        proposal.voters.insert(cap_id);
-    }
+/// Removes a proposal no one has voted for.
+public fun delete_proposal<V, T: store + drop>(
+    multi: &mut Multicontroller<V>,
+    cap: &DelegationToken,
+    proposal_id: ID,
+    ctx: &mut TxContext,
+) {
+    cap.assert_has_permission(permissions::can_delete_proposal());
 
-    /// Consumes the `multi`'s active `Proposal` with id `proposal_id`,
-    /// returning its inner `Action`.
-    /// This call fails if `multi`'s threshold has not been reached.
-    public fun execute_proposal<V, T: store>(
-        multi: &mut Multicontroller<V>,
-        cap: &DelegationToken,
-        proposal_id: ID,
-        ctx: &mut TxContext,
-    ): Action<T> {
-        multi.assert_is_member(cap);
-        cap.assert_has_permission(permissions::can_execute_proposal());
+    let proposal = multi.proposals.remove<ID, Proposal<T>>(proposal_id);
+    assert!(proposal.votes == 0 || proposal.is_expired(ctx), ECannotDelete);
 
-        let proposal = multi.proposals.remove<ID, Proposal<T>>(proposal_id);
-        assert!(proposal.votes >= multi.threshold, EThresholdNotReached);
-        assert!(!proposal.is_expired(ctx), EExpiredProposal);
+    let Proposal {
+        id,
+        votes: _,
+        voters: _,
+        expiration_epoch: _,
+        action: _,
+    } = proposal;
 
-        let Proposal {
-            id,
-            votes: _,
-            voters: _,
-            expiration_epoch: _,
-            action: inner,
-        } = proposal;
+    id.delete();
 
-        id.delete();
+    let (present, i) = multi.active_proposals.index_of(&proposal_id);
+    assert!(present, EProposalNotFound);
 
-        let (present, i) = multi.active_proposals.index_of(&proposal_id);
-        assert!(present, EProposalNotFound);
+    multi.active_proposals.remove(i);
+}
 
-        multi.active_proposals.remove(i);
+/// Returns a reference to `multi`'s value.
+public fun value<V: store>(multi: &Multicontroller<V>): &V {
+    &multi.controlled_value
+}
 
-        Action { inner }
-    }
+/// Returns the list of `multi`'s controllers - i.e. the `ID` of its `ControllerCap`s.
+public fun controllers<V>(multi: &Multicontroller<V>): vector<ID> {
+    multi.controllers.keys()
+}
 
-    /// Removes the approval given by the controller owning `cap` on `Proposal`
-    /// `proposal_id`.
-    public fun remove_approval<V, T: store>(
-        multi: &mut Multicontroller<V>,
-        cap: &DelegationToken,
-        proposal_id: ID,
-    ) {
-        cap.assert_has_permission(permissions::can_remove_approval());
+/// Returns `multi`'s threshold.
+public fun threshold<V>(multi: &Multicontroller<V>): u64 {
+    multi.threshold
+}
 
-        let cap_id = cap.controller();
-        let vp = multi.voting_power(cap_id);
+/// Returns the voting power of a given controller, identified by its `ID`.
+public fun voting_power<V>(multi: &Multicontroller<V>, controller_id: ID): u64 {
+    *multi.controllers.get(&controller_id)
+}
 
-        let proposal = multi.proposals.borrow_mut<ID, Proposal<T>>(proposal_id);
-        assert!(proposal.voters.contains(&cap_id), ENotVotedYet);
+public(package) fun set_voting_power<V>(
+    multi: &mut Multicontroller<V>,
+    controller_id: ID,
+    vp: u64,
+) {
+    assert!(multi.controllers().contains(&controller_id), EInvalidController);
+    *multi.controllers.get_mut(&controller_id) = vp;
+}
 
-        proposal.voters.remove(&cap_id);
-        proposal.votes = proposal.votes - vp;
-    }
+/// Returns the sum of all controllers voting powers.
+public fun max_votes<V>(multi: &Multicontroller<V>): u64 {
+    let (_, mut values) = multi.controllers.into_keys_values();
+    let mut sum = 0;
+    while (!values.is_empty()) {
+        sum = sum + values.pop_back();
+    };
 
-    /// Removes a proposal no one has voted for.
-    public fun delete_proposal<V, T: store + drop>(
-        multi: &mut Multicontroller<V>,
-        cap: &DelegationToken,
-        proposal_id: ID,
-        ctx: &mut TxContext,
-    ) {
-        cap.assert_has_permission(permissions::can_delete_proposal());
+    sum
+}
 
-        let proposal = multi.proposals.remove<ID, Proposal<T>>(proposal_id);
-        assert!(proposal.votes == 0 || proposal.is_expired(ctx), ECannotDelete);
+/// Revoke the `DelegationToken` with `ID` `deny_id`. Only controllers can perform this operation.
+public fun revoke_token<V>(self: &mut Multicontroller<V>, cap: &ControllerCap, deny_id: ID) {
+    assert!(self.controllers.contains(object::borrow_id(cap)), EInvalidController);
+    self.revoked_tokens.insert(deny_id);
+}
 
-        let Proposal {
-            id,
-            votes: _,
-            voters: _,
-            expiration_epoch: _,
-            action: _,
-        } = proposal;
+/// Un-revoke a `DelegationToken`.
+public fun unrevoke_token<V>(self: &mut Multicontroller<V>, cap: &ControllerCap, token_id: ID) {
+    assert!(self.controllers.contains(object::borrow_id(cap)), EInvalidController);
+    self.revoked_tokens.remove(&token_id);
+}
 
-        id.delete();
+/// Destroys a `ControllerCap`. Can only be used after a controller has been removed from
+/// the controller committee.
+public fun destroy_controller_cap<V>(self: &mut Multicontroller<V>, cap: ControllerCap) {
+    assert!(!self.controllers.contains(&cap.id().to_inner()), EInvalidController);
+    assert!(cap.controller_of() == self.owner, EInvalidController);
 
-        let (present, i) = multi.active_proposals.index_of(&proposal_id);
-        assert!(present, EProposalNotFound);
+    cap.delete();
+}
 
-        multi.active_proposals.remove(i);
-    }
+public fun remove_and_destroy_controller<V>(self: &mut Multicontroller<V>, cap: ControllerCap) {
+    assert!(cap.controller_of() == self.owner, EInvalidController);
 
-    /// Returns a reference to `multi`'s value.
-    public fun value<V: store>(multi: &Multicontroller<V>): &V {
-        &multi.controlled_value
-    }
+    let controller_id = object::id(&cap);
+    if (self.controllers.contains(&controller_id)) {
+        self.controllers.remove(&controller_id);
+    };
 
-    /// Returns the list of `multi`'s controllers - i.e. the `ID` of its `ControllerCap`s.
-    public fun controllers<V>(multi: &Multicontroller<V>): vector<ID> {
-        multi.controllers.keys()
-    }
+    cap.delete();
+}
 
-    /// Returns `multi`'s threshold.
-    public fun threshold<V>(multi: &Multicontroller<V>): u64 {
-        multi.threshold
-    }
-
-    /// Returns the voting power of a given controller, identified by its `ID`.
-    public fun voting_power<V>(multi: &Multicontroller<V>, controller_id: ID): u64 {
-        *multi.controllers.get(&controller_id)
-    }
-
-    public(package) fun set_voting_power<V>(multi: &mut Multicontroller<V>, controller_id: ID, vp: u64) {
-        assert!(multi.controllers().contains(&controller_id), EInvalidController);
-        *multi.controllers.get_mut(&controller_id) = vp;
-    }
-
-    /// Returns the sum of all controllers voting powers.
-    public fun max_votes<V>(multi: &Multicontroller<V>): u64 {
-        let (_, mut values) = multi.controllers.into_keys_values();
-        let mut sum = 0;
-        while (!values.is_empty()) {
-            sum = sum + values.pop_back();
-        };
-
-        sum
-    }
-
-    /// Revoke the `DelegationToken` with `ID` `deny_id`. Only controllers can perform this operation.
-    public fun revoke_token<V>(self: &mut Multicontroller<V>, cap: &ControllerCap, deny_id: ID) {
-        assert!(self.controllers.contains(object::borrow_id(cap)), EInvalidController);
-        self.revoked_tokens.insert(deny_id);
-    }
-
-    /// Un-revoke a `DelegationToken`.
-    public fun unrevoke_token<V>(self: &mut Multicontroller<V>, cap: &ControllerCap, token_id: ID) {
-        assert!(self.controllers.contains(object::borrow_id(cap)), EInvalidController);
+/// Destroys a `DelegationToken`.
+public fun destroy_delegation_token<V>(self: &mut Multicontroller<V>, token: DelegationToken) {
+    let token_id = object::id(&token);
+    let is_revoked = self.revoked_tokens.contains(&token_id);
+    if (is_revoked) {
         self.revoked_tokens.remove(&token_id);
+    };
+
+    token.delete();
+}
+
+/// Deletes this `Multicontroller` returning the wrapped value.
+/// This function can only be called if there are no active proposals.
+public fun delete<V>(self: Multicontroller<V>): V {
+    assert!(self.active_proposals.is_empty(), ECannotDelete);
+
+    let Multicontroller {
+        controlled_value,
+        proposals,
+        ..,
+    } = self;
+
+    proposals.destroy_empty();
+    controlled_value
+}
+
+public(package) fun unpack_action<T: store>(action: Action<T>): T {
+    let Action { inner } = action;
+    inner
+}
+
+public(package) fun is_proposal_approved<V, A: store>(
+    multi: &Multicontroller<V>,
+    proposal_id: ID,
+): bool {
+    let proposal = multi.proposals.borrow<ID, Proposal<A>>(proposal_id);
+    proposal.votes >= multi.threshold
+}
+
+public(package) fun add_members<V>(
+    multi: &mut Multicontroller<V>,
+    to_add: VecMap<address, u64>,
+    ctx: &mut TxContext,
+) {
+    let mut i = 0;
+    while (i < to_add.size()) {
+        let (addr, vp) = to_add.get_entry_by_idx(i);
+        let new_cap = controller::new(false, multi.owner, ctx);
+        multi.controllers.insert(new_cap.id().to_inner(), *vp);
+        new_cap.transfer(*addr);
+        i = i + 1;
     }
+}
 
-    /// Destroys a `ControllerCap`. Can only be used after a controller has been removed from
-    /// the controller committee.
-    public fun destroy_controller_cap<V>(self: &mut Multicontroller<V>, cap: ControllerCap) {
-        assert!(!self.controllers.contains(&cap.id().to_inner()), EInvalidController);
-        assert!(cap.controller_of() == self.owner, EInvalidController);
-
-        cap.delete();
+public(package) fun remove_members<V>(multi: &mut Multicontroller<V>, mut to_remove: vector<ID>) {
+    while (!to_remove.is_empty()) {
+        let id = to_remove.pop_back();
+        multi.controllers.remove(&id);
     }
+}
 
-    public fun remove_and_destroy_controller<V>(self: &mut Multicontroller<V>, cap: ControllerCap) {
-        assert!(cap.controller_of() == self.owner, EInvalidController);
+public(package) fun update_members<V>(
+    multi: &mut Multicontroller<V>,
+    mut to_update: VecMap<ID, u64>,
+) {
+    while (!to_update.is_empty()) {
+        let (controller, vp) = to_update.pop();
 
-        let controller_id = object::id(&cap);
-        if (self.controllers.contains(&controller_id)) {
-            self.controllers.remove(&controller_id);
-        };
-
-        cap.delete();
+        multi.set_voting_power(controller, vp);
     }
+}
 
-    /// Destroys a `DelegationToken`.
-    public fun destroy_delegation_token<V>(self: &mut Multicontroller<V>, token: DelegationToken) {
-        let token_id = object::id(&token);
-        let is_revoked = self.revoked_tokens.contains(&token_id);
-        if (is_revoked) {
-            self.revoked_tokens.remove(&token_id);
-        };
+public(package) fun set_threshold<V>(multi: &mut Multicontroller<V>, threshold: u64) {
+    assert!(threshold <= multi.max_votes(), EInvalidThreshold);
+    multi.threshold = threshold;
+}
 
-        token.delete();
-    }
+public(package) fun set_controlled_value<V: store + drop>(
+    multi: &mut Multicontroller<V>,
+    controlled_value: V,
+) {
+    multi.controlled_value = controlled_value;
+}
 
-    /// Deletes this `Multicontroller` returning the wrapped value.
-    /// This function can only be called if there are no active proposals.
-    public fun delete<V>(self: Multicontroller<V>): V {
-        assert!(self.active_proposals.is_empty(), ECannotDelete);
-        
-        let Multicontroller {
-            controlled_value,
-            proposals,
-            ..
-        } = self;
+public(package) fun force_delete_proposal<V, T: drop + store>(
+    self: &mut Multicontroller<V>,
+    proposal_id: ID,
+) {
+    let proposal = self.proposals.remove<ID, Proposal<T>>(proposal_id);
 
-        proposals.destroy_empty();
-        controlled_value
-    }
+    let Proposal<T> {
+        id,
+        ..,
+    } = proposal;
 
-    public(package) fun unpack_action<T: store>(action: Action<T>): T {
-        let Action { inner } = action;
-        inner
-    }
-
-    public(package) fun is_proposal_approved<V, A: store>(multi: &Multicontroller<V>, proposal_id: ID): bool {
-        let proposal = multi.proposals.borrow<ID, Proposal<A>>(proposal_id);
-        proposal.votes >= multi.threshold
-    }
-
-    public(package) fun add_members<V>(multi: &mut Multicontroller<V>, to_add: VecMap<address, u64>, ctx: &mut TxContext) {
-        let mut i = 0;
-        while (i < to_add.size()) {
-            let (addr, vp) = to_add.get_entry_by_idx(i);
-            let new_cap = controller::new(false, multi.owner, ctx);
-            multi.controllers.insert(new_cap.id().to_inner(), *vp);
-            new_cap.transfer(*addr);
-            i = i + 1;
-        }
-    }
-
-    public(package) fun remove_members<V>(multi: &mut Multicontroller<V>, mut to_remove: vector<ID>) {
-        while (!to_remove.is_empty()) {
-            let id = to_remove.pop_back();
-            multi.controllers.remove(&id);
-        }
-    }
-
-    public(package) fun update_members<V>(multi: &mut Multicontroller<V>, mut to_update: VecMap<ID, u64>) {
-        while (!to_update.is_empty()) {
-            let (controller, vp) = to_update.pop();
-
-            multi.set_voting_power(controller, vp);
-        }
-    }
-
-    public(package) fun set_threshold<V>(multi: &mut Multicontroller<V>, threshold: u64) {
-        assert!(threshold <= multi.max_votes(), EInvalidThreshold);
-        multi.threshold = threshold;
-    }
-
-    public(package) fun set_controlled_value<V: store + drop>(multi: &mut Multicontroller<V>, controlled_value: V) {
-        multi.controlled_value = controlled_value;
-    }
-
-    public(package) fun force_delete_proposal<V, T: drop + store>(self: &mut Multicontroller<V>, proposal_id: ID) {
-        let proposal = self.proposals.remove<ID, Proposal<T>>(proposal_id);
-
-        let Proposal<T> {
-            id,
-            ..
-        } = proposal;
-
-        id.delete();
-    }
+    id.delete();
 }

--- a/identity_iota_core/packages/iota_identity/sources/multicontroller.move
+++ b/identity_iota_core/packages/iota_identity/sources/multicontroller.move
@@ -72,28 +72,22 @@ public fun new_with_controllers<V>(
     owner: ID,
     ctx: &mut TxContext,
 ): Multicontroller<V> {
-    let (mut addrs, mut vps) = controllers.into_keys_values();
+    let (addrs, vps) = controllers.into_keys_values();
     let mut controllers = vec_map::empty();
-    while (!addrs.is_empty()) {
-        let addr = addrs.pop_back();
-        let vp = vps.pop_back();
-
+    vector::zip_do!(addrs, vps, |addr, vp| {
         let cap = controller::new(false, owner, ctx);
         controllers.insert(cap.id().to_inner(), vp);
 
-        cap.transfer(addr)
-    };
+        cap.transfer(addr);
+    });
 
-    let (mut addrs, mut vps) = controllers_that_can_delegate.into_keys_values();
-    while (!addrs.is_empty()) {
-        let addr = addrs.pop_back();
-        let vp = vps.pop_back();
-
+    let (addrs, vps) = controllers_that_can_delegate.into_keys_values();
+    vector::zip_do!(addrs, vps, |addr, vp| {
         let cap = controller::new(true, owner, ctx);
         controllers.insert(cap.id().to_inner(), vp);
 
         cap.transfer(addr)
-    };
+    });
 
     let mut multi = Multicontroller {
         controlled_value,

--- a/identity_iota_core/packages/iota_identity/sources/permissions.move
+++ b/identity_iota_core/packages/iota_identity/sources/permissions.move
@@ -1,24 +1,30 @@
-module iota_identity::permissions {
-  /// Permission that enables a controller's delegate to create proposals.
-  const CAN_CREATE_PROPOSAL: u32 = 0x1;  
-  /// Permission that enables a controller's delegate to approve proposals.
-  const CAN_APPROVE_PROPOSAL: u32 = 0x1 << 1;
-  /// Permission that enables a controller's delegate to execute proposals.
-  const CAN_EXECUTE_PROPOSAL: u32 = 0x1 << 2;
-  /// Permission that enables a controller's delegate to delete proposals.
-  const CAN_DELETE_PROPOSAL: u32 = 0x1 << 3;
-  /// Permission that enables a controller's delegate to remove a proposal's approval.
-  const CAN_REMOVE_APPROVAL: u32 = 0x1 << 4;
-  const ALL_PERMISSIONS: u32 = 0xFFFFFFFF;
+module iota_identity::permissions;
 
-  public fun can_create_proposal(): u32 { CAN_CREATE_PROPOSAL }
-  public fun can_approve_proposal(): u32 { CAN_APPROVE_PROPOSAL }
-  public fun can_execute_proposal(): u32 { CAN_EXECUTE_PROPOSAL }
-  public fun can_delete_proposal(): u32 { CAN_DELETE_PROPOSAL }
-  public fun can_remove_approval(): u32 { CAN_REMOVE_APPROVAL }
-  public fun all(): u32 { ALL_PERMISSIONS }
-  /// Negate a permission
-  public fun not(permission: u32): u32 {
+/// Permission that enables a controller's delegate to create proposals.
+const CAN_CREATE_PROPOSAL: u32 = 0x1;
+/// Permission that enables a controller's delegate to approve proposals.
+const CAN_APPROVE_PROPOSAL: u32 = 0x1 << 1;
+/// Permission that enables a controller's delegate to execute proposals.
+const CAN_EXECUTE_PROPOSAL: u32 = 0x1 << 2;
+/// Permission that enables a controller's delegate to delete proposals.
+const CAN_DELETE_PROPOSAL: u32 = 0x1 << 3;
+/// Permission that enables a controller's delegate to remove a proposal's approval.
+const CAN_REMOVE_APPROVAL: u32 = 0x1 << 4;
+const ALL_PERMISSIONS: u32 = 0xFFFFFFFF;
+
+public fun can_create_proposal(): u32 { CAN_CREATE_PROPOSAL }
+
+public fun can_approve_proposal(): u32 { CAN_APPROVE_PROPOSAL }
+
+public fun can_execute_proposal(): u32 { CAN_EXECUTE_PROPOSAL }
+
+public fun can_delete_proposal(): u32 { CAN_DELETE_PROPOSAL }
+
+public fun can_remove_approval(): u32 { CAN_REMOVE_APPROVAL }
+
+public fun all(): u32 { ALL_PERMISSIONS }
+
+/// Negate a permission
+public fun not(permission: u32): u32 {
     permission ^ all()
-  }
 }

--- a/identity_iota_core/packages/iota_identity/sources/proposals/borrow.move
+++ b/identity_iota_core/packages/iota_identity/sources/proposals/borrow.move
@@ -1,44 +1,45 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-module iota_identity::borrow_proposal {
-  use iota_identity::multicontroller::{Multicontroller, Action};
-  use iota_identity::controller::DelegationToken;
-  use iota::transfer::Receiving;
+module iota_identity::borrow_proposal;
 
-  const EInvalidObject: u64 = 0;
-  const EInvalidOwner: u64 = 1;
-  const EUnreturnedObjects: u64 = 2;
-  
-  /// Action used to "borrow" assets in a transaction - enforcing their return.
-  public struct Borrow has store, drop {
+use iota::transfer::Receiving;
+use iota_identity::controller::DelegationToken;
+use iota_identity::multicontroller::{Multicontroller, Action};
+
+const EInvalidObject: u64 = 0;
+const EInvalidOwner: u64 = 1;
+const EUnreturnedObjects: u64 = 2;
+
+/// Action used to "borrow" assets in a transaction - enforcing their return.
+public struct Borrow has drop, store {
     objects: vector<ID>,
     objects_to_return: vector<ID>,
     owner: address,
-  }
+}
 
-  /// Propose the borrowing of a set of assets owned by this multicontroller.
-  public fun propose_borrow<V>(
+/// Propose the borrowing of a set of assets owned by this multicontroller.
+public fun propose_borrow<V>(
     multi: &mut Multicontroller<V>,
     cap: &DelegationToken,
     expiration: Option<u64>,
     objects: vector<ID>,
     owner: address,
     ctx: &mut TxContext,
-  ): ID {
+): ID {
     let action = Borrow { objects, objects_to_return: vector::empty(), owner };
 
     multi.create_proposal(cap, action, expiration, ctx)
-  }
+}
 
-  /// Borrows an asset from this action. This function will fail if:
-  /// - the received object is not among `Borrow::objects`;
-  /// - controllee does not have the same address as `Borrow::owner`;
-  public fun borrow<T: key + store>(
+/// Borrows an asset from this action. This function will fail if:
+/// - the received object is not among `Borrow::objects`;
+/// - controllee does not have the same address as `Borrow::owner`;
+public fun borrow<T: key + store>(
     action: &mut Action<Borrow>,
     controllee: &mut UID,
     receiving: Receiving<T>,
-  ): T {
+): T {
     let borrow_action = action.borrow_mut();
     assert!(borrow_action.owner == controllee.to_address(), EInvalidOwner);
     let receiving_object_id = receiving.receiving_object_id();
@@ -49,13 +50,10 @@ module iota_identity::borrow_proposal {
     borrow_action.objects_to_return.push_back(receiving_object_id);
 
     transfer::public_receive(controllee, receiving)
-  }
+}
 
-  /// Transfer a borrowed object back to its original owner.
-  public fun put_back<T: key + store>(
-    action: &mut Action<Borrow>,
-    obj: T,
-  ) {
+/// Transfer a borrowed object back to its original owner.
+public fun put_back<T: key + store>(action: &mut Action<Borrow>, obj: T) {
     let borrow_action = action.borrow_mut();
     let object_id = object::id(&obj);
     let (contains, obj_idx) = borrow_action.objects_to_return.index_of(&object_id);
@@ -63,13 +61,10 @@ module iota_identity::borrow_proposal {
 
     borrow_action.objects_to_return.swap_remove(obj_idx);
     transfer::public_transfer(obj, borrow_action.owner);
-  }
+}
 
-  /// Consumes a borrow action.
-  public fun conclude_borrow(
-    action: Action<Borrow>
-  ) {
+/// Consumes a borrow action.
+public fun conclude_borrow(action: Action<Borrow>) {
     let Borrow { objects: _, objects_to_return, owner: _ } = action.unpack_action();
     assert!(objects_to_return.is_empty(), EUnreturnedObjects);
-  }
 }

--- a/identity_iota_core/packages/iota_identity/sources/proposals/config.move
+++ b/identity_iota_core/packages/iota_identity/sources/proposals/config.move
@@ -1,108 +1,108 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-module iota_identity::config_proposal {
-    use iota_identity::multicontroller::Multicontroller;
-    use iota_identity::controller::DelegationToken;
-    use iota::vec_map::VecMap;
+module iota_identity::config_proposal;
 
-    const ENotMember: u64 = 0;
-    const EInvalidThreshold: u64 = 1;
+use iota::vec_map::VecMap;
+use iota_identity::controller::DelegationToken;
+use iota_identity::multicontroller::Multicontroller;
 
-    public struct Modify has store, drop {
-        threshold: Option<u64>,
-        controllers_to_add: VecMap<address, u64>,
-        controllers_to_remove: vector<ID>,
-        controllers_to_update: VecMap<ID, u64>,
-    }
+const ENotMember: u64 = 0;
+const EInvalidThreshold: u64 = 1;
 
-    public fun propose_modify<V>(
-        multi: &mut Multicontroller<V>,
-        cap: &DelegationToken,
-        expiration: Option<u64>,
-        mut threshold: Option<u64>,
-        controllers_to_add: VecMap<address, u64>,
-        controllers_to_remove: vector<ID>,
-        controllers_to_update: VecMap<ID, u64>,
-        ctx: &mut TxContext,
-    ): ID {
-        let mut max_votes = 0;
-        let (mut cs, mut vps) = controllers_to_update.into_keys_values();
-        while (!cs.is_empty()) {
-            let c = cs.pop_back();
-            let vp = vps.pop_back();
-            assert!(multi.controllers().contains(&c), ENotMember);
-            max_votes = max_votes + vp;
+public struct Modify has drop, store {
+    threshold: Option<u64>,
+    controllers_to_add: VecMap<address, u64>,
+    controllers_to_remove: vector<ID>,
+    controllers_to_update: VecMap<ID, u64>,
+}
+
+public fun propose_modify<V>(
+    multi: &mut Multicontroller<V>,
+    cap: &DelegationToken,
+    expiration: Option<u64>,
+    mut threshold: Option<u64>,
+    controllers_to_add: VecMap<address, u64>,
+    controllers_to_remove: vector<ID>,
+    controllers_to_update: VecMap<ID, u64>,
+    ctx: &mut TxContext,
+): ID {
+    let mut max_votes = 0;
+    let (mut cs, mut vps) = controllers_to_update.into_keys_values();
+    while (!cs.is_empty()) {
+        let c = cs.pop_back();
+        let vp = vps.pop_back();
+        assert!(multi.controllers().contains(&c), ENotMember);
+        max_votes = max_votes + vp;
+    };
+    let (_, mut voting_powers) = controllers_to_add.into_keys_values();
+    let mut voting_power_increase = 0;
+    while (!voting_powers.is_empty()) {
+        let voting_power = voting_powers.pop_back();
+
+        voting_power_increase = voting_power_increase + voting_power;
+    };
+    voting_powers.destroy_empty();
+
+    let mut i = 0;
+    let mut voting_power_decrease = 0;
+    while (i < controllers_to_remove.length()) {
+        let controller_id = controllers_to_remove[i];
+        assert!(multi.controllers().contains(&controller_id), ENotMember);
+        let mut vp = multi.voting_power(controller_id);
+        if (controllers_to_update.contains(&controller_id)) {
+            vp = *controllers_to_update.get(&controller_id);
         };
-        let (_, mut voting_powers) = controllers_to_add.into_keys_values();
-        let mut voting_power_increase = 0;
-        while (!voting_powers.is_empty()) {
-            let voting_power = voting_powers.pop_back();
+        voting_power_decrease = voting_power_decrease + vp;
+        i = i + 1;
+    };
 
-            voting_power_increase = voting_power_increase + voting_power;
+    let mut i = 0;
+    while (i < multi.controllers().length()) {
+        let controller_id = multi.controllers()[i];
+        if (!controllers_to_update.contains(&controller_id)) {
+            max_votes = max_votes + multi.voting_power(controller_id);
         };
-        voting_powers.destroy_empty();
+        i = i + 1;
+    };
 
-        let mut i = 0;
-        let mut voting_power_decrease = 0;
-        while (i < controllers_to_remove.length()) {
-            let controller_id = controllers_to_remove[i];
-            assert!(multi.controllers().contains(&controller_id), ENotMember);
-            let mut vp = multi.voting_power(controller_id);
-            if (controllers_to_update.contains(&controller_id)) {
-                vp = *controllers_to_update.get(&controller_id);
-            };
-            voting_power_decrease = voting_power_decrease + vp;
-            i = i + 1;
-        };
+    let new_max_votes = max_votes + voting_power_increase - voting_power_decrease;
 
-        let mut i = 0;
-        while (i < multi.controllers().length()) {
-            let controller_id = multi.controllers()[i];
-            if (!controllers_to_update.contains(&controller_id)) {
-                max_votes = max_votes + multi.voting_power(controller_id);
-            };
-            i = i + 1;
-        };
+    let threshold = if (threshold.is_some()) {
+        let threshold = threshold.extract();
+        threshold
+    } else {
+        multi.threshold()
+    };
 
-        let new_max_votes = max_votes + voting_power_increase - voting_power_decrease;
+    assert!(threshold > 0 && threshold <= new_max_votes, EInvalidThreshold);
 
-        let threshold = if (threshold.is_some()) {
-            let threshold = threshold.extract();
-            threshold
-        } else {
-            multi.threshold()
-        };
+    let action = Modify {
+        threshold: option::some(threshold),
+        controllers_to_add,
+        controllers_to_remove,
+        controllers_to_update,
+    };
 
-        assert!(threshold > 0 && threshold <= new_max_votes, EInvalidThreshold);
+    multi.create_proposal(cap, action, expiration, ctx)
+}
 
-        let action = Modify {
-            threshold: option::some(threshold),
-            controllers_to_add,
-            controllers_to_remove,
-            controllers_to_update,
-        };
+public fun execute_modify<V>(
+    multi: &mut Multicontroller<V>,
+    cap: &DelegationToken,
+    proposal_id: ID,
+    ctx: &mut TxContext,
+) {
+    let action = multi.execute_proposal(cap, proposal_id, ctx);
+    let Modify {
+        mut threshold,
+        controllers_to_add,
+        controllers_to_remove,
+        controllers_to_update,
+    } = action.unpack_action();
 
-        multi.create_proposal(cap, action, expiration, ctx)
-    }
-
-    public fun execute_modify<V>(
-        multi: &mut Multicontroller<V>,
-        cap: &DelegationToken,
-        proposal_id: ID,
-        ctx: &mut TxContext,
-    ) {
-        let action = multi.execute_proposal(cap, proposal_id, ctx);
-        let Modify {
-            mut threshold,
-            controllers_to_add,
-            controllers_to_remove,
-            controllers_to_update
-        } = action.unpack_action();
-
-        if (threshold.is_some()) multi.set_threshold(threshold.extract());
-        multi.update_members(controllers_to_update);
-        multi.add_members(controllers_to_add, ctx);
-        multi.remove_members(controllers_to_remove);
-    }
+    if (threshold.is_some()) multi.set_threshold(threshold.extract());
+    multi.update_members(controllers_to_update);
+    multi.add_members(controllers_to_add, ctx);
+    multi.remove_members(controllers_to_remove);
 }

--- a/identity_iota_core/packages/iota_identity/sources/proposals/config.move
+++ b/identity_iota_core/packages/iota_identity/sources/proposals/config.move
@@ -21,59 +21,38 @@ public fun propose_modify<V>(
     multi: &mut Multicontroller<V>,
     cap: &DelegationToken,
     expiration: Option<u64>,
-    mut threshold: Option<u64>,
+    threshold: Option<u64>,
     controllers_to_add: VecMap<address, u64>,
     controllers_to_remove: vector<ID>,
     controllers_to_update: VecMap<ID, u64>,
     ctx: &mut TxContext,
 ): ID {
     let mut max_votes = 0;
-    let (mut cs, mut vps) = controllers_to_update.into_keys_values();
-    while (!cs.is_empty()) {
-        let c = cs.pop_back();
-        let vp = vps.pop_back();
+    let (cs, vps) = controllers_to_update.into_keys_values();
+    vector::zip_do!(cs, vps, |c, vp| {
         assert!(multi.controllers().contains(&c), ENotMember);
         max_votes = max_votes + vp;
-    };
-    let (_, mut voting_powers) = controllers_to_add.into_keys_values();
-    let mut voting_power_increase = 0;
-    while (!voting_powers.is_empty()) {
-        let voting_power = voting_powers.pop_back();
+    });
+    let (_, voting_powers) = controllers_to_add.into_keys_values();
+    let voting_power_increase = voting_powers.fold!(0, |acc, vp| acc + vp);
 
-        voting_power_increase = voting_power_increase + voting_power;
-    };
-    voting_powers.destroy_empty();
-
-    let mut i = 0;
-    let mut voting_power_decrease = 0;
-    while (i < controllers_to_remove.length()) {
-        let controller_id = controllers_to_remove[i];
+    let voting_power_decrease = controllers_to_remove.fold!(0, |acc, controller_id| {
         assert!(multi.controllers().contains(&controller_id), ENotMember);
         let mut vp = multi.voting_power(controller_id);
         if (controllers_to_update.contains(&controller_id)) {
             vp = *controllers_to_update.get(&controller_id);
         };
-        voting_power_decrease = voting_power_decrease + vp;
-        i = i + 1;
-    };
+        acc + vp
+    });
 
-    let mut i = 0;
-    while (i < multi.controllers().length()) {
-        let controller_id = multi.controllers()[i];
+    multi.controllers().do!(|controller_id| {
         if (!controllers_to_update.contains(&controller_id)) {
             max_votes = max_votes + multi.voting_power(controller_id);
         };
-        i = i + 1;
-    };
+    });
 
     let new_max_votes = max_votes + voting_power_increase - voting_power_decrease;
-
-    let threshold = if (threshold.is_some()) {
-        let threshold = threshold.extract();
-        threshold
-    } else {
-        multi.threshold()
-    };
+    let threshold = threshold.destroy_or!(multi.threshold());
 
     assert!(threshold > 0 && threshold <= new_max_votes, EInvalidThreshold);
 

--- a/identity_iota_core/packages/iota_identity/sources/proposals/controller.move
+++ b/identity_iota_core/packages/iota_identity/sources/proposals/controller.move
@@ -1,56 +1,53 @@
-module iota_identity::controller_proposal {
-  use iota::transfer::Receiving;
-  use iota_identity::controller::{Self, ControllerCap};
-  use iota_identity::multicontroller::Action;
+module iota_identity::controller_proposal;
 
-  /// The received `ControllerCap` does not match the one
-  /// specified in the `ControllerExecution` action.
-  const EControllerCapMismatch: u64 = 0;
-  /// The provided `UID` is not the `UID` of the `Identity`
-  /// specified in the action.
-  const EInvalidIdentityUID: u64 = 1;
+use iota::transfer::Receiving;
+use iota_identity::controller::{Self, ControllerCap};
+use iota_identity::multicontroller::Action;
 
-  /// Borrow a given `ControllerCap` from an `Identity` for 
-  /// a single transaction.
-  public struct ControllerExecution has store, drop {
+/// The received `ControllerCap` does not match the one
+/// specified in the `ControllerExecution` action.
+const EControllerCapMismatch: u64 = 0;
+/// The provided `UID` is not the `UID` of the `Identity`
+/// specified in the action.
+const EInvalidIdentityUID: u64 = 1;
+
+/// Borrow a given `ControllerCap` from an `Identity` for
+/// a single transaction.
+public struct ControllerExecution has drop, store {
     /// ID of the `ControllerCap` to borrow.
     controller_cap: ID,
     /// The address of the `Identity` that owns
     /// the `ControllerCap` we are borrowing.
     identity: address,
-  }
+}
 
-  /// Returns a new `ControllerExecution` that - in a Proposal - allows whoever
-  /// executes it to receive `identity`'s `ControllerCap` (the one that has ID `controller_cap`)
-  /// for the duration of a single transaction.
-  public fun new(controller_cap: ID, identity: address): ControllerExecution {
+/// Returns a new `ControllerExecution` that - in a Proposal - allows whoever
+/// executes it to receive `identity`'s `ControllerCap` (the one that has ID `controller_cap`)
+/// for the duration of a single transaction.
+public fun new(controller_cap: ID, identity: address): ControllerExecution {
     ControllerExecution {
-      controller_cap,
-      identity,
+        controller_cap,
+        identity,
     }
-  }
+}
 
-  /// Returns the `ControllerCap` specified in this action.
-  public fun receive(
+/// Returns the `ControllerCap` specified in this action.
+public fun receive(
     self: &mut Action<ControllerExecution>,
     identity: &mut UID,
-    cap: Receiving<ControllerCap>
-  ): ControllerCap {
+    cap: Receiving<ControllerCap>,
+): ControllerCap {
     assert!(identity.to_address() == self.borrow().identity, EInvalidIdentityUID);
     assert!(cap.receiving_object_id() == self.borrow().controller_cap, EControllerCapMismatch);
 
-    controller::receive(identity, cap)     
-  }
+    controller::receive(identity, cap)
+}
 
-  /// Consumes a `ControllerExecution` action by returning the borrowed `ControllerCap`
-  /// to the corresponding `Identity`.
-  public fun put_back(
-    action: Action<ControllerExecution>,
-    cap: ControllerCap,
-  ) {
+/// Consumes a `ControllerExecution` action by returning the borrowed `ControllerCap`
+/// to the corresponding `Identity`.
+public fun put_back(action: Action<ControllerExecution>, cap: ControllerCap) {
     let ControllerExecution { identity, controller_cap } = action.unwrap();
     assert!(object::id(&cap) == controller_cap, EControllerCapMismatch);
 
     cap.transfer(identity);
-  }
 }

--- a/identity_iota_core/packages/iota_identity/sources/proposals/delete.move
+++ b/identity_iota_core/packages/iota_identity/sources/proposals/delete.move
@@ -1,11 +1,10 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-module iota_identity::delete_proposal {
-    public struct Delete has store, copy, drop {}
+module iota_identity::delete_proposal;
 
-    public fun new(): Delete {
-        Delete {}
-    }
+public struct Delete has copy, drop, store {}
+
+public fun new(): Delete {
+    Delete {}
 }
-

--- a/identity_iota_core/packages/iota_identity/sources/proposals/transfer.move
+++ b/identity_iota_core/packages/iota_identity/sources/proposals/transfer.move
@@ -1,59 +1,59 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-module iota_identity::transfer_proposal {
-    use iota_identity::multicontroller::{Multicontroller, Action};
-    use iota_identity::controller::DelegationToken;
-    use iota::transfer::Receiving;
+module iota_identity::transfer_proposal;
 
-    const EDifferentLength: u64 = 0;
-    const EUnsentAssets: u64 = 1;
-    const EInvalidObject: u64 = 2;
+use iota::transfer::Receiving;
+use iota_identity::controller::DelegationToken;
+use iota_identity::multicontroller::{Multicontroller, Action};
 
-    public struct Send has store, drop {
-        objects: vector<ID>,
-        recipients: vector<address>,
-    }
+const EDifferentLength: u64 = 0;
+const EUnsentAssets: u64 = 1;
+const EInvalidObject: u64 = 2;
 
-    public fun propose_send<V>(
-        multi: &mut Multicontroller<V>,
-        cap: &DelegationToken,
-        expiration: Option<u64>,
-        objects: vector<ID>,
-        recipients: vector<address>,
-        ctx: &mut TxContext,
-    ): ID {
-        assert!(objects.length() == recipients.length(), EDifferentLength);
-        let action = Send { objects, recipients };
+public struct Send has drop, store {
+    objects: vector<ID>,
+    recipients: vector<address>,
+}
 
-        multi.create_proposal(cap, action,expiration, ctx)
-    }
+public fun propose_send<V>(
+    multi: &mut Multicontroller<V>,
+    cap: &DelegationToken,
+    expiration: Option<u64>,
+    objects: vector<ID>,
+    recipients: vector<address>,
+    ctx: &mut TxContext,
+): ID {
+    assert!(objects.length() == recipients.length(), EDifferentLength);
+    let action = Send { objects, recipients };
 
-    public fun send<T: key + store>(
-        action: &mut Action<Send>,
-        controllee: &mut UID,
-        received: Receiving<T>,
-    ) {
-        let send_action = action.borrow_mut();
-        let object_id = received.receiving_object_id();
-        let (object_exists, object_idx) = send_action.objects.index_of(&object_id);
-        // Check that the received object is among the objects that are actually supposed to be sent.
-        assert!(object_exists, EInvalidObject);
+    multi.create_proposal(cap, action, expiration, ctx)
+}
 
-        let object = transfer::public_receive(controllee, received);
-        // Get the corresponding recipient.
-        let recipient = send_action.recipients.swap_remove(object_idx);
+public fun send<T: key + store>(
+    action: &mut Action<Send>,
+    controllee: &mut UID,
+    received: Receiving<T>,
+) {
+    let send_action = action.borrow_mut();
+    let object_id = received.receiving_object_id();
+    let (object_exists, object_idx) = send_action.objects.index_of(&object_id);
+    // Check that the received object is among the objects that are actually supposed to be sent.
+    assert!(object_exists, EInvalidObject);
 
-        transfer::public_transfer(object, recipient);
-        // Update the list of objects that have not been sent yet.
-        send_action.objects.swap_remove(object_idx);
-    }
+    let object = transfer::public_receive(controllee, received);
+    // Get the corresponding recipient.
+    let recipient = send_action.recipients.swap_remove(object_idx);
 
-    public fun complete_send(action: Action<Send>) {
-        let Send { objects, recipients } = action.unpack_action();
-        assert!(recipients.is_empty() && objects.is_empty(), EUnsentAssets);
+    transfer::public_transfer(object, recipient);
+    // Update the list of objects that have not been sent yet.
+    send_action.objects.swap_remove(object_idx);
+}
 
-        recipients.destroy_empty();
-        objects.destroy_empty();
-    }
+public fun complete_send(action: Action<Send>) {
+    let Send { objects, recipients } = action.unpack_action();
+    assert!(recipients.is_empty() && objects.is_empty(), EUnsentAssets);
+
+    recipients.destroy_empty();
+    objects.destroy_empty();
 }

--- a/identity_iota_core/packages/iota_identity/sources/proposals/upgrade.move
+++ b/identity_iota_core/packages/iota_identity/sources/proposals/upgrade.move
@@ -1,12 +1,12 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-module iota_identity::upgrade_proposal {
-  /// Proposal's action used to upgrade an `Identity` to the package's current version.
-  public struct Upgrade has store, copy, drop {}
+module iota_identity::upgrade_proposal;
 
-  /// Creates a new `Upgrade` action.
-  public fun new(): Upgrade {
+/// Proposal's action used to upgrade an `Identity` to the package's current version.
+public struct Upgrade has copy, drop, store {}
+
+/// Creates a new `Upgrade` action.
+public fun new(): Upgrade {
     Upgrade {}
-  }
 }

--- a/identity_iota_core/packages/iota_identity/sources/proposals/value.move
+++ b/identity_iota_core/packages/iota_identity/sources/proposals/value.move
@@ -1,39 +1,39 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-module iota_identity::update_value_proposal {
-    use iota_identity::multicontroller::Multicontroller;
-    use iota_identity::controller::DelegationToken;
+module iota_identity::update_value_proposal;
 
-    public struct UpdateValue<V: store> has store, drop {
-        new_value: V,
-    }
+use iota_identity::controller::DelegationToken;
+use iota_identity::multicontroller::Multicontroller;
 
-    public fun propose_update<V: store>(
-        multi: &mut Multicontroller<V>,
-        cap: &DelegationToken,
-        new_value: V,
-        expiration: Option<u64>,
-        ctx: &mut TxContext,
-    ): ID {
-        let update_action = UpdateValue { new_value };
-        multi.create_proposal(cap, update_action, expiration, ctx)
-    } 
+public struct UpdateValue<V: store> has drop, store {
+    new_value: V,
+}
 
-    public fun execute_update<V: store + drop>(
-        multi: &mut Multicontroller<V>,
-        cap: &DelegationToken,
-        proposal_id: ID,
-        ctx: &mut TxContext,
-    ) {
-        let action = multi.execute_proposal(cap, proposal_id, ctx);
-        let UpdateValue { new_value } = action.unpack_action();
+public fun propose_update<V: store>(
+    multi: &mut Multicontroller<V>,
+    cap: &DelegationToken,
+    new_value: V,
+    expiration: Option<u64>,
+    ctx: &mut TxContext,
+): ID {
+    let update_action = UpdateValue { new_value };
+    multi.create_proposal(cap, update_action, expiration, ctx)
+}
 
-        multi.set_controlled_value(new_value)
-    }
+public fun execute_update<V: store + drop>(
+    multi: &mut Multicontroller<V>,
+    cap: &DelegationToken,
+    proposal_id: ID,
+    ctx: &mut TxContext,
+) {
+    let action = multi.execute_proposal(cap, proposal_id, ctx);
+    let UpdateValue { new_value } = action.unpack_action();
 
-    public(package) fun into_inner<V: store>(self: UpdateValue<V>): V {
-        let UpdateValue { new_value } = self;
-        new_value
-    }
+    multi.set_controlled_value(new_value)
+}
+
+public(package) fun into_inner<V: store>(self: UpdateValue<V>): V {
+    let UpdateValue { new_value } = self;
+    new_value
 }

--- a/identity_iota_core/packages/iota_identity/sources/public_vc.move
+++ b/identity_iota_core/packages/iota_identity/sources/public_vc.move
@@ -1,20 +1,20 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-module iota_identity::public_vc {
-    public struct PublicVc has store {
-        data: vector<u8>,
-    }
+module iota_identity::public_vc;
 
-    public fun new(data: vector<u8>): PublicVc {
-        PublicVc { data }
-    }
+public struct PublicVc has store {
+    data: vector<u8>,
+}
 
-    public fun data(self: &PublicVc): &vector<u8> {
-        &self.data
-    }
+public fun new(data: vector<u8>): PublicVc {
+    PublicVc { data }
+}
 
-    public fun set_data(self: &mut PublicVc, data: vector<u8>) {
-        self.data = data
-    }
+public fun data(self: &PublicVc): &vector<u8> {
+    &self.data
+}
+
+public fun set_data(self: &mut PublicVc, data: vector<u8>) {
+    self.data = data
 }

--- a/identity_iota_core/packages/iota_identity/sources/utils.move
+++ b/identity_iota_core/packages/iota_identity/sources/utils.move
@@ -5,24 +5,11 @@ module iota_identity::utils;
 
 use iota::vec_map::{Self, VecMap};
 
-const ELengthMismatch: u64 = 0;
-
 public fun vec_map_from_keys_values<K: store + copy, V: store>(
-    mut keys: vector<K>,
-    mut values: vector<V>,
+    keys: vector<K>,
+    values: vector<V>,
 ): VecMap<K, V> {
-    assert!(keys.length() == values.length(), ELengthMismatch);
-
-    let mut map = vec_map::empty<K, V>();
-    while (!keys.is_empty()) {
-        let key = keys.swap_remove(0);
-        let value = values.swap_remove(0);
-        map.insert(key, value);
-    };
-    keys.destroy_empty();
-    values.destroy_empty();
-
-    map
+    vec_map::from_keys_values(keys, values)
 }
 
 #[test]

--- a/identity_iota_core/packages/iota_identity/sources/utils.move
+++ b/identity_iota_core/packages/iota_identity/sources/utils.move
@@ -1,35 +1,35 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-module iota_identity::utils {
-    use iota::vec_map::{Self, VecMap};
+module iota_identity::utils;
 
-    const ELengthMismatch: u64 = 0;
+use iota::vec_map::{Self, VecMap};
 
-    public fun vec_map_from_keys_values<K: store + copy, V: store>(
-        mut keys: vector<K>,
-        mut values: vector<V>,
-    ): VecMap<K, V> {
-        assert!(keys.length() == values.length(), ELengthMismatch);
-        
-        let mut map = vec_map::empty<K, V>();
-        while (!keys.is_empty()) {
-            let key = keys.swap_remove(0);
-            let value = values.swap_remove(0);
-            map.insert(key, value);
-        };
-        keys.destroy_empty();
-        values.destroy_empty();
+const ELengthMismatch: u64 = 0;
 
-        map
-    }
+public fun vec_map_from_keys_values<K: store + copy, V: store>(
+    mut keys: vector<K>,
+    mut values: vector<V>,
+): VecMap<K, V> {
+    assert!(keys.length() == values.length(), ELengthMismatch);
 
-    #[test]
-    fun from_keys_values_works() {
-        let addresses = vector[@0x1, @0x2];
-        let vps = vector[1, 1];
+    let mut map = vec_map::empty<K, V>();
+    while (!keys.is_empty()) {
+        let key = keys.swap_remove(0);
+        let value = values.swap_remove(0);
+        map.insert(key, value);
+    };
+    keys.destroy_empty();
+    values.destroy_empty();
 
-        let map = vec_map_from_keys_values(addresses, vps);
-        assert!(map.size() == 2, 0);
-    }
+    map
+}
+
+#[test]
+fun from_keys_values_works() {
+    let addresses = vector[@0x1, @0x2];
+    let vps = vector[1, 1];
+
+    let map = vec_map_from_keys_values(addresses, vps);
+    assert!(map.size() == 2, 0);
 }

--- a/identity_iota_core/scripts/upgrade_identity_package.sh
+++ b/identity_iota_core/scripts/upgrade_identity_package.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Copyright 2020-2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+script_dir=$(cd "$(dirname $0)" && pwd)
+package_dir=$script_dir/../packages/iota_identity
+
+chain_id=$(iota client chain-identifier)
+current_pkg_id=$(toml get "$package_dir/Move.lock" env | jq --raw-output "map(values | select(.[\"chain-id\"] == \"$chain_id\") .[\"latest-published-id\"]) | first")
+upgrade_cap_id=$(iota client objects --json | jq --raw-output "map(select(.data.type == \"0x2::package::UpgradeCap\" and .data.content.fields.package == \"$current_pkg_id\")) | first | .data.objectId")
+
+iota client upgrade --upgrade-capability $upgrade_cap_id $package_dir

--- a/identity_iota_core/src/iota_interaction_rust/identity_move_calls.rs
+++ b/identity_iota_core/src/iota_interaction_rust/identity_move_calls.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
+use identity_iota_interaction::ControllerTokenRef;
 use identity_iota_interaction::OptionalSend;
 use itertools::Itertools;
 
@@ -35,25 +36,61 @@ use crate::rebased::proposals::SendAction;
 use crate::rebased::rebased_err;
 use crate::rebased::Error;
 
+enum ControllerTokenArg {
+  Controller {
+    cap: Argument,
+    token: Argument,
+    borrow: Argument,
+  },
+  Delegate(Argument),
+}
+
+impl ControllerTokenArg {
+  fn from_ref(controller_ref: ControllerTokenRef, ptb: &mut PrgrTxBuilder, package: ObjectID) -> Result<Self, Error> {
+    let token_arg = ptb
+      .obj(ObjectArg::ImmOrOwnedObject(controller_ref.object_ref()))
+      .map_err(rebased_err)?;
+    match controller_ref {
+      ControllerTokenRef::Delegate(_) => Ok(ControllerTokenArg::Delegate(token_arg)),
+      ControllerTokenRef::Controller(_) => {
+        let cap = token_arg;
+        let (token, borrow) = utils::get_controller_delegation(ptb, cap, package);
+
+        Ok(Self::Controller { cap, token, borrow })
+      }
+    }
+  }
+
+  fn arg(&self) -> Argument {
+    match self {
+      Self::Controller { token, .. } => *token,
+      Self::Delegate(token) => *token,
+    }
+  }
+
+  fn put_back(self, ptb: &mut PrgrTxBuilder, package_id: ObjectID) {
+    if let Self::Controller { cap, token, borrow } = self {
+      utils::put_back_delegation_token(ptb, cap, token, borrow, package_id);
+    }
+  }
+}
+
 struct ProposalContext {
   ptb: PrgrTxBuilder,
-  controller_cap: Argument,
-  delegation_token: Argument,
-  borrow: Argument,
+  capability: ControllerTokenArg,
   identity: Argument,
   proposal_id: Argument,
 }
 
 fn borrow_proposal_impl(
   identity: OwnedObjectRef,
-  capability: ObjectRef,
+  capability: ControllerTokenRef,
   objects: Vec<ObjectID>,
   expiration: Option<u64>,
   package_id: ObjectID,
 ) -> anyhow::Result<ProposalContext> {
   let mut ptb = PrgrTxBuilder::new();
-  let cap_arg = ptb.obj(ObjectArg::ImmOrOwnedObject(capability))?;
-  let (delegation_token, borrow) = utils::get_controller_delegation(&mut ptb, cap_arg, package_id);
+  let capability = ControllerTokenArg::from_ref(capability, &mut ptb, package_id)?;
   let identity_arg = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true)?;
   let exp_arg = utils::option_to_move(expiration, &mut ptb, package_id)?;
   let objects_arg = ptb.pure(objects)?;
@@ -63,15 +100,13 @@ fn borrow_proposal_impl(
     ident_str!("identity").into(),
     ident_str!("propose_borrow").into(),
     vec![],
-    vec![identity_arg, delegation_token, exp_arg, objects_arg],
+    vec![identity_arg, capability.arg(), exp_arg, objects_arg],
   );
 
   Ok(ProposalContext {
     ptb,
     identity: identity_arg,
-    controller_cap: cap_arg,
-    delegation_token,
-    borrow,
+    capability,
     proposal_id,
   })
 }
@@ -147,14 +182,13 @@ fn execute_borrow_impl<F: BorrowIntentFnInternalT<PrgrTxBuilder>>(
 
 fn controller_execution_impl(
   identity: OwnedObjectRef,
-  capability: ObjectRef,
+  capability: ControllerTokenRef,
   controller_cap_id: ObjectID,
   expiration: Option<u64>,
   package_id: ObjectID,
 ) -> anyhow::Result<ProposalContext> {
   let mut ptb = PrgrTxBuilder::new();
-  let cap_arg = ptb.obj(ObjectArg::ImmOrOwnedObject(capability))?;
-  let (delegation_token, borrow) = utils::get_controller_delegation(&mut ptb, cap_arg, package_id);
+  let capability = ControllerTokenArg::from_ref(capability, &mut ptb, package_id)?;
   let identity_arg = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true)?;
   let controller_cap_id = ptb.pure(controller_cap_id)?;
   let exp_arg = utils::option_to_move(expiration, &mut ptb, package_id)?;
@@ -164,14 +198,12 @@ fn controller_execution_impl(
     ident_str!("identity").into(),
     ident_str!("propose_controller_execution").into(),
     vec![],
-    vec![identity_arg, delegation_token, controller_cap_id, exp_arg],
+    vec![identity_arg, capability.arg(), controller_cap_id, exp_arg],
   );
 
   Ok(ProposalContext {
     ptb,
-    controller_cap: cap_arg,
-    delegation_token,
-    borrow,
+    capability,
     identity: identity_arg,
     proposal_id,
   })
@@ -222,14 +254,13 @@ fn execute_controller_execution_impl<F: ControllerIntentFnInternalT<PrgrTxBuilde
 
 fn send_proposal_impl(
   identity: OwnedObjectRef,
-  capability: ObjectRef,
+  capability: ControllerTokenRef,
   transfer_map: Vec<(ObjectID, IotaAddress)>,
   expiration: Option<u64>,
   package_id: ObjectID,
 ) -> anyhow::Result<ProposalContext> {
   let mut ptb = PrgrTxBuilder::new();
-  let cap_arg = ptb.obj(ObjectArg::ImmOrOwnedObject(capability))?;
-  let (delegation_token, borrow) = utils::get_controller_delegation(&mut ptb, cap_arg, package_id);
+  let capability = ControllerTokenArg::from_ref(capability, &mut ptb, package_id)?;
   let identity_arg = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true)?;
   let exp_arg = utils::option_to_move(expiration, &mut ptb, package_id)?;
   let (objects, recipients) = {
@@ -245,15 +276,13 @@ fn send_proposal_impl(
     ident_str!("identity").into(),
     ident_str!("propose_send").into(),
     vec![],
-    vec![identity_arg, delegation_token, exp_arg, objects, recipients],
+    vec![identity_arg, capability.arg(), exp_arg, objects, recipients],
   );
 
   Ok(ProposalContext {
     ptb,
     identity: identity_arg,
-    controller_cap: cap_arg,
-    delegation_token,
-    borrow,
+    capability,
     proposal_id,
   })
 }
@@ -312,27 +341,23 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
 
   fn propose_borrow(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     objects: Vec<ObjectID>,
     expiration: Option<u64>,
     package_id: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error> {
     let ProposalContext {
-      mut ptb,
-      controller_cap,
-      delegation_token,
-      borrow,
-      ..
+      mut ptb, capability, ..
     } = borrow_proposal_impl(identity, capability, objects, expiration, package_id)?;
 
-    utils::put_back_delegation_token(&mut ptb, controller_cap, delegation_token, borrow, package_id);
+    capability.put_back(&mut ptb, package_id);
 
     Ok(bcs::to_bytes(&ptb.finish())?)
   }
 
   fn execute_borrow<F: BorrowIntentFnInternalT<Self::NativeTxBuilder>>(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     proposal_id: ObjectID,
     objects: Vec<IotaObjectData>,
     intent_fn: F,
@@ -341,28 +366,27 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
     let mut internal_ptb = TransactionBuilderRustSdk::new(PrgrTxBuilder::new());
     let ptb = internal_ptb.as_native_tx_builder();
     let identity = utils::owned_ref_to_shared_object_arg(identity, ptb, true)?;
-    let controller_cap = ptb.obj(ObjectArg::ImmOrOwnedObject(capability))?;
-    let (delegation_token, borrow) = utils::get_controller_delegation(ptb, controller_cap, package);
+    let capability = ControllerTokenArg::from_ref(capability, ptb, package)?;
     let proposal_id = ptb.pure(proposal_id)?;
 
     execute_borrow_impl(
       ptb,
       identity,
-      delegation_token,
+      capability.arg(),
       proposal_id,
       objects,
       intent_fn,
       package,
     )?;
 
-    utils::put_back_delegation_token(ptb, controller_cap, delegation_token, borrow, package);
+    capability.put_back(ptb, package);
 
     internal_ptb.finish()
   }
 
   fn create_and_execute_borrow<F: BorrowIntentFnInternalT<Self::NativeTxBuilder>>(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     objects: Vec<IotaObjectData>,
     intent_fn: F,
     expiration: Option<u64>,
@@ -370,9 +394,7 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
   ) -> anyhow::Result<ProgrammableTransactionBcs, Self::Error> {
     let ProposalContext {
       mut ptb,
-      controller_cap,
-      delegation_token,
-      borrow,
+      capability,
       identity,
       proposal_id,
     } = borrow_proposal_impl(
@@ -386,21 +408,21 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
     execute_borrow_impl(
       &mut ptb,
       identity,
-      delegation_token,
+      capability.arg(),
       proposal_id,
       objects,
       intent_fn,
       package_id,
     )?;
 
-    utils::put_back_delegation_token(&mut ptb, controller_cap, delegation_token, borrow, package_id);
+    capability.put_back(&mut ptb, package_id);
 
     Ok(bcs::to_bytes(&ptb.finish())?)
   }
 
   fn propose_config_change<I1, I2>(
     identity: OwnedObjectRef,
-    controller_cap: ObjectRef,
+    controller_cap: ControllerTokenRef,
     expiration: Option<u64>,
     threshold: Option<u64>,
     controllers_to_add: I1,
@@ -441,10 +463,7 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
       )
     };
     let identity = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true).map_err(rebased_err)?;
-    let controller_cap = ptb
-      .obj(ObjectArg::ImmOrOwnedObject(controller_cap))
-      .map_err(rebased_err)?;
-    let (delegation_token, borrow) = utils::get_controller_delegation(&mut ptb, controller_cap, package);
+    let capability = ControllerTokenArg::from_ref(controller_cap, &mut ptb, package)?;
     let expiration = utils::option_to_move(expiration, &mut ptb, package).map_err(rebased_err)?;
     let threshold = utils::option_to_move(threshold, &mut ptb, package).map_err(rebased_err)?;
     let controllers_to_remove = ptb.pure(controllers_to_remove).map_err(rebased_err)?;
@@ -456,7 +475,7 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
       vec![],
       vec![
         identity,
-        delegation_token,
+        capability.arg(),
         expiration,
         threshold,
         controllers_to_add,
@@ -465,60 +484,53 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
       ],
     );
 
-    utils::put_back_delegation_token(&mut ptb, controller_cap, delegation_token, borrow, package);
+    capability.put_back(&mut ptb, package);
 
     Ok(bcs::to_bytes(&ptb.finish())?)
   }
 
   fn execute_config_change(
     identity: OwnedObjectRef,
-    controller_cap: ObjectRef,
+    controller_cap: ControllerTokenRef,
     proposal_id: ObjectID,
     package: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error> {
     let mut ptb = PrgrTxBuilder::new();
 
     let identity = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true).map_err(rebased_err)?;
-    let controller_cap = ptb
-      .obj(ObjectArg::ImmOrOwnedObject(controller_cap))
-      .map_err(rebased_err)?;
-    let (delegation_token, borrow) = utils::get_controller_delegation(&mut ptb, controller_cap, package);
+    let capability = ControllerTokenArg::from_ref(controller_cap, &mut ptb, package)?;
     let proposal_id = ptb.pure(proposal_id).map_err(rebased_err)?;
     ptb.programmable_move_call(
       package,
       ident_str!("identity").into(),
       ident_str!("execute_config_change").into(),
       vec![],
-      vec![identity, delegation_token, proposal_id],
+      vec![identity, capability.arg(), proposal_id],
     );
 
-    utils::put_back_delegation_token(&mut ptb, controller_cap, delegation_token, borrow, package);
+    capability.put_back(&mut ptb, package);
 
     Ok(bcs::to_bytes(&ptb.finish())?)
   }
 
   fn propose_controller_execution(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     controller_cap_id: ObjectID,
     expiration: Option<u64>,
     package_id: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error> {
     let ProposalContext {
-      mut ptb,
-      controller_cap,
-      delegation_token,
-      borrow,
-      ..
+      mut ptb, capability, ..
     } = controller_execution_impl(identity, capability, controller_cap_id, expiration, package_id)?;
-    utils::put_back_delegation_token(&mut ptb, controller_cap, delegation_token, borrow, package_id);
+    capability.put_back(&mut ptb, package_id);
 
     Ok(bcs::to_bytes(&ptb.finish())?)
   }
 
   fn execute_controller_execution<F: ControllerIntentFnInternalT<Self::NativeTxBuilder>>(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     proposal_id: ObjectID,
     borrowing_controller_cap_ref: ObjectRef,
     intent_fn: F,
@@ -526,28 +538,27 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
   ) -> Result<ProgrammableTransactionBcs, Self::Error> {
     let mut ptb = PrgrTxBuilder::new();
     let identity = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true)?;
-    let controller_cap = ptb.obj(ObjectArg::ImmOrOwnedObject(capability))?;
-    let (delegation_token, borrow) = utils::get_controller_delegation(&mut ptb, controller_cap, package);
+    let capability = ControllerTokenArg::from_ref(capability, &mut ptb, package)?;
     let proposal_id = ptb.pure(proposal_id)?;
 
     execute_controller_execution_impl(
       &mut ptb,
       identity,
       proposal_id,
-      delegation_token,
+      capability.arg(),
       borrowing_controller_cap_ref,
       intent_fn,
       package,
     )?;
 
-    utils::put_back_delegation_token(&mut ptb, controller_cap, delegation_token, borrow, package);
+    capability.put_back(&mut ptb, package);
 
     Ok(bcs::to_bytes(&ptb.finish())?)
   }
 
   fn create_and_execute_controller_execution<F: ControllerIntentFnInternalT<Self::NativeTxBuilder>>(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     expiration: Option<u64>,
     borrowing_controller_cap_ref: ObjectRef,
     intent_fn: F,
@@ -555,9 +566,7 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
   ) -> Result<ProgrammableTransactionBcs, Self::Error> {
     let ProposalContext {
       mut ptb,
-      controller_cap,
-      delegation_token,
-      borrow,
+      capability,
       proposal_id,
       identity,
     } = controller_execution_impl(
@@ -572,13 +581,13 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
       &mut ptb,
       identity,
       proposal_id,
-      delegation_token,
+      capability.arg(),
       borrowing_controller_cap_ref,
       intent_fn,
       package_id,
     )?;
 
-    utils::put_back_delegation_token(&mut ptb, controller_cap, delegation_token, borrow, package_id);
+    capability.put_back(&mut ptb, package_id);
 
     Ok(bcs::to_bytes(&ptb.finish())?)
   }
@@ -665,17 +674,14 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
 
   fn approve_proposal<T: MoveType>(
     identity: OwnedObjectRef,
-    controller_cap: ObjectRef,
+    controller_cap: ControllerTokenRef,
     proposal_id: ObjectID,
     package: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error> {
     let mut ptb = PrgrTxBuilder::new();
     let identity = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true)
       .map_err(|e| Error::TransactionBuildingFailed(e.to_string()))?;
-    let controller_cap = ptb
-      .obj(ObjectArg::ImmOrOwnedObject(controller_cap))
-      .map_err(|e| Error::InvalidArgument(e.to_string()))?;
-    let (delegation_token, borrow) = utils::get_controller_delegation(&mut ptb, controller_cap, package);
+    let capability = ControllerTokenArg::from_ref(controller_cap, &mut ptb, package)?;
     let proposal_id = ptb
       .pure(proposal_id)
       .map_err(|e| Error::InvalidArgument(e.to_string()))?;
@@ -685,57 +691,52 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
       ident_str!("identity").into(),
       ident_str!("approve_proposal").into(),
       vec![T::move_type(package)],
-      vec![identity, delegation_token, proposal_id],
+      vec![identity, capability.arg(), proposal_id],
     );
 
-    utils::put_back_delegation_token(&mut ptb, controller_cap, delegation_token, borrow, package);
+    capability.put_back(&mut ptb, package);
 
     Ok(bcs::to_bytes(&ptb.finish())?)
   }
 
   fn propose_send(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     transfer_map: Vec<(ObjectID, IotaAddress)>,
     expiration: Option<u64>,
     package_id: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error> {
     let ProposalContext {
-      mut ptb,
-      controller_cap,
-      delegation_token,
-      borrow,
-      ..
+      mut ptb, capability, ..
     } = send_proposal_impl(identity, capability, transfer_map, expiration, package_id)?;
 
-    utils::put_back_delegation_token(&mut ptb, controller_cap, delegation_token, borrow, package_id);
+    capability.put_back(&mut ptb, package_id);
 
     Ok(bcs::to_bytes(&ptb.finish())?)
   }
 
   fn execute_send(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     proposal_id: ObjectID,
     objects: Vec<(ObjectRef, TypeTag)>,
     package: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error> {
     let mut ptb = PrgrTxBuilder::new();
     let identity = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true)?;
-    let controller_cap = ptb.obj(ObjectArg::ImmOrOwnedObject(capability))?;
-    let (delegation_token, borrow) = utils::get_controller_delegation(&mut ptb, controller_cap, package);
+    let capability = ControllerTokenArg::from_ref(capability, &mut ptb, package)?;
     let proposal_id = ptb.pure(proposal_id)?;
 
-    execute_send_impl(&mut ptb, identity, delegation_token, proposal_id, objects, package)?;
+    execute_send_impl(&mut ptb, identity, capability.arg(), proposal_id, objects, package)?;
 
-    utils::put_back_delegation_token(&mut ptb, controller_cap, delegation_token, borrow, package);
+    capability.put_back(&mut ptb, package);
 
     Ok(bcs::to_bytes(&ptb.finish())?)
   }
 
   fn create_and_execute_send(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     transfer_map: Vec<(ObjectID, IotaAddress)>,
     expiration: Option<u64>,
     objects: Vec<(ObjectRef, TypeTag)>,
@@ -744,29 +745,26 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
     let ProposalContext {
       mut ptb,
       identity,
-      controller_cap,
-      delegation_token,
-      borrow,
+      capability,
       proposal_id,
     } = send_proposal_impl(identity, capability, transfer_map, expiration, package)?;
 
-    execute_send_impl(&mut ptb, identity, delegation_token, proposal_id, objects, package)?;
+    execute_send_impl(&mut ptb, identity, capability.arg(), proposal_id, objects, package)?;
 
-    utils::put_back_delegation_token(&mut ptb, controller_cap, delegation_token, borrow, package);
+    capability.put_back(&mut ptb, package);
 
     Ok(bcs::to_bytes(&ptb.finish())?)
   }
 
   async fn propose_update(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     did_doc: Option<&[u8]>,
     expiration: Option<u64>,
     package_id: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error> {
     let mut ptb = PrgrTxBuilder::new();
-    let cap_arg = ptb.obj(ObjectArg::ImmOrOwnedObject(capability)).map_err(rebased_err)?;
-    let (delegation_token, borrow) = utils::get_controller_delegation(&mut ptb, cap_arg, package_id);
+    let capability = ControllerTokenArg::from_ref(capability, &mut ptb, package_id)?;
     let identity_arg = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true).map_err(rebased_err)?;
     let exp_arg = utils::option_to_move(expiration, &mut ptb, package_id).map_err(rebased_err)?;
     let doc_arg = ptb.pure(did_doc).map_err(rebased_err)?;
@@ -777,23 +775,22 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
       ident_str!("identity").into(),
       ident_str!("propose_update").into(),
       vec![],
-      vec![identity_arg, delegation_token, doc_arg, exp_arg, clock],
+      vec![identity_arg, capability.arg(), doc_arg, exp_arg, clock],
     );
 
-    utils::put_back_delegation_token(&mut ptb, cap_arg, delegation_token, borrow, package_id);
+    capability.put_back(&mut ptb, package_id);
 
     Ok(bcs::to_bytes(&ptb.finish())?)
   }
 
   async fn execute_update(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     proposal_id: ObjectID,
     package_id: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error> {
     let mut ptb = PrgrTxBuilder::new();
-    let cap_arg = ptb.obj(ObjectArg::ImmOrOwnedObject(capability)).map_err(rebased_err)?;
-    let (delegation_token, borrow) = utils::get_controller_delegation(&mut ptb, cap_arg, package_id);
+    let capability = ControllerTokenArg::from_ref(capability, &mut ptb, package_id)?;
     let proposal_id = ptb.pure(proposal_id).map_err(rebased_err)?;
     let identity_arg = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true).map_err(rebased_err)?;
     let clock = utils::get_clock_ref(&mut ptb);
@@ -803,23 +800,23 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
       ident_str!("identity").into(),
       ident_str!("execute_update").into(),
       vec![],
-      vec![identity_arg, delegation_token, proposal_id, clock],
+      vec![identity_arg, capability.arg(), proposal_id, clock],
     );
 
-    utils::put_back_delegation_token(&mut ptb, cap_arg, delegation_token, borrow, package_id);
+    capability.put_back(&mut ptb, package_id);
 
     Ok(bcs::to_bytes(&ptb.finish())?)
   }
 
   fn propose_upgrade(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     expiration: Option<u64>,
     package_id: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error> {
     let mut ptb = PrgrTxBuilder::new();
-    let cap_arg = ptb.obj(ObjectArg::ImmOrOwnedObject(capability)).map_err(rebased_err)?;
-    let identity_arg = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true).map_err(rebased_err)?;
+    let capability = ControllerTokenArg::from_ref(capability, &mut ptb, package_id)?;
+    let identity_arg = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true)?;
     let exp_arg = utils::option_to_move(expiration, &mut ptb, package_id).map_err(rebased_err)?;
 
     let _proposal_id = ptb.programmable_move_call(
@@ -827,20 +824,22 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
       ident_str!("identity").into(),
       ident_str!("propose_upgrade").into(),
       vec![],
-      vec![identity_arg, cap_arg, exp_arg],
+      vec![identity_arg, capability.arg(), exp_arg],
     );
+
+    capability.put_back(&mut ptb, package_id);
 
     Ok(bcs::to_bytes(&ptb.finish())?)
   }
 
   fn execute_upgrade(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     proposal_id: ObjectID,
     package_id: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error> {
     let mut ptb = PrgrTxBuilder::new();
-    let cap_arg = ptb.obj(ObjectArg::ImmOrOwnedObject(capability)).map_err(rebased_err)?;
+    let capability = ControllerTokenArg::from_ref(capability, &mut ptb, package_id)?;
     let proposal_id = ptb.pure(proposal_id).map_err(rebased_err)?;
     let identity_arg = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true).map_err(rebased_err)?;
 
@@ -849,8 +848,35 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
       ident_str!("identity").into(),
       ident_str!("execute_upgrade").into(),
       vec![],
-      vec![identity_arg, cap_arg, proposal_id],
+      vec![identity_arg, capability.arg(), proposal_id],
     );
+
+    capability.put_back(&mut ptb, package_id);
+
+    Ok(bcs::to_bytes(&ptb.finish())?)
+  }
+
+  async fn delegate_controller_cap(
+    controller_cap: ObjectRef,
+    recipient: IotaAddress,
+    permissions: u32,
+    package: ObjectID,
+  ) -> Result<ProgrammableTransactionBcs, Error> {
+    let mut ptb = PrgrTxBuilder::new();
+    let cap = ptb
+      .obj(ObjectArg::ImmOrOwnedObject(controller_cap))
+      .map_err(rebased_err)?;
+    let permissions = ptb.pure(permissions).map_err(rebased_err)?;
+
+    let delegation_token = ptb.programmable_move_call(
+      package,
+      ident_str!("controller").into(),
+      ident_str!("delegate_with_permissions").into(),
+      vec![],
+      vec![cap, permissions],
+    );
+
+    ptb.transfer_arg(recipient, delegation_token);
 
     Ok(bcs::to_bytes(&ptb.finish())?)
   }

--- a/identity_iota_core/src/iota_interaction_rust/identity_move_calls.rs
+++ b/identity_iota_core/src/iota_interaction_rust/identity_move_calls.rs
@@ -880,4 +880,74 @@ impl IdentityMoveCalls for IdentityMoveCallsRustSdk {
 
     Ok(bcs::to_bytes(&ptb.finish())?)
   }
+
+  async fn revoke_delegation_token(
+    identity: OwnedObjectRef,
+    controller_cap: ObjectRef,
+    delegation_token_id: ObjectID,
+    package: ObjectID,
+  ) -> Result<ProgrammableTransactionBcs, Error> {
+    let mut ptb = PrgrTxBuilder::new();
+    let identity = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true)?;
+    let cap = ptb
+      .obj(ObjectArg::ImmOrOwnedObject(controller_cap))
+      .map_err(rebased_err)?;
+    let delegation_token_id = ptb.pure(delegation_token_id).map_err(rebased_err)?;
+
+    ptb.programmable_move_call(
+      package,
+      ident_str!("identity").into(),
+      ident_str!("revoke_token").into(),
+      vec![],
+      vec![identity, cap, delegation_token_id],
+    );
+
+    Ok(bcs::to_bytes(&ptb.finish())?)
+  }
+
+  async fn unrevoke_delegation_token(
+    identity: OwnedObjectRef,
+    controller_cap: ObjectRef,
+    delegation_token_id: ObjectID,
+    package: ObjectID,
+  ) -> Result<ProgrammableTransactionBcs, Error> {
+    let mut ptb = PrgrTxBuilder::new();
+    let identity = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true)?;
+    let cap = ptb
+      .obj(ObjectArg::ImmOrOwnedObject(controller_cap))
+      .map_err(rebased_err)?;
+    let delegation_token_id = ptb.pure(delegation_token_id).map_err(rebased_err)?;
+
+    ptb.programmable_move_call(
+      package,
+      ident_str!("identity").into(),
+      ident_str!("unrevoke_token").into(),
+      vec![],
+      vec![identity, cap, delegation_token_id],
+    );
+
+    Ok(bcs::to_bytes(&ptb.finish())?)
+  }
+
+  async fn destroy_delegation_token(
+    identity: OwnedObjectRef,
+    delegation_token: ObjectRef,
+    package: ObjectID,
+  ) -> Result<ProgrammableTransactionBcs, Error> {
+    let mut ptb = PrgrTxBuilder::new();
+    let identity = utils::owned_ref_to_shared_object_arg(identity, &mut ptb, true)?;
+    let delegation_token = ptb
+      .obj(ObjectArg::ImmOrOwnedObject(delegation_token))
+      .map_err(rebased_err)?;
+
+    ptb.programmable_move_call(
+      package,
+      ident_str!("identity").into(),
+      ident_str!("destroy_delegation_token").into(),
+      vec![],
+      vec![identity, delegation_token],
+    );
+
+    Ok(bcs::to_bytes(&ptb.finish())?)
+  }
 }

--- a/identity_iota_core/src/rebased/client/full_client.rs
+++ b/identity_iota_core/src/rebased/client/full_client.rs
@@ -271,9 +271,13 @@ impl PublishDidDocument {
     let did_doc = StateMetadataDocument::from(self.did_document.clone())
       .pack(StateMetadataEncoding::Json)
       .map_err(|e| Error::TransactionBuildingFailed(e.to_string()))?;
-    let programmable_tx_bcs =
-      IdentityMoveCallsAdapter::new_with_controllers(Some(&did_doc), [(self.controller, 1)], 1, client.package_id())
-        .await?;
+    let programmable_tx_bcs = IdentityMoveCallsAdapter::new_with_controllers(
+      Some(&did_doc),
+      [(self.controller, 1, false)],
+      1,
+      client.package_id(),
+    )
+    .await?;
     Ok(bcs::from_bytes(&programmable_tx_bcs)?)
   }
 }

--- a/identity_iota_core/src/rebased/iota/well_known_networks.rs
+++ b/identity_iota_core/src/rebased/iota/well_known_networks.rs
@@ -11,12 +11,14 @@ use crate::NetworkName;
 pub(crate) static IOTA_NETWORKS: Map<&str, IdentityNetworkMetadata> = phf_map! {
   "e678123a" => IdentityNetworkMetadata::new(
     Some("devnet"),
-    &["0x03242ae6b87406bd0eb5d669fbe874ed4003694c0be9c6a9ee7c315e6461a553"],
+    &["0x6a976d3da90db5d27f8a0c13b3268a37e582b455cfc7bf72d6461f6e8f668823",
+      "0x03242ae6b87406bd0eb5d669fbe874ed4003694c0be9c6a9ee7c315e6461a553"],
     "0x0x940ae1c2c48dade9ec01cc1eebab33ab6fecadda422ea18b105c47839fc64425",
   ),
   "2304aa97" => IdentityNetworkMetadata::new(
     Some("testnet"),
-    &["0x222741bbdff74b42df48a7b4733185e9b24becb8ccfbafe8eac864ab4e4cc555"],
+    &["0x3403da7ec4cd2ff9bdf6f34c0b8df5a2bd62c798089feb0d2ebf1c2e953296dc",
+      "0x222741bbdff74b42df48a7b4733185e9b24becb8ccfbafe8eac864ab4e4cc555"],
     "0xaacb529c289aec9de2a474faaa4ef68b04632bb6a5d08372ca5b60e3df659f59",
   ),
 };

--- a/identity_iota_core/src/rebased/migration/controller_token.rs
+++ b/identity_iota_core/src/rebased/migration/controller_token.rs
@@ -28,7 +28,7 @@ use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
 
-use crate::iota_interaction_rust::IdentityMoveCallsAdapter;
+use crate::iota_interaction_adapter::IdentityMoveCallsAdapter;
 use crate::rebased::client::IdentityClientReadOnly;
 use crate::rebased::transaction_builder::Transaction;
 use crate::rebased::transaction_builder::TransactionBuilder;
@@ -128,8 +128,7 @@ impl ControllerToken {
   }
 }
 
-/// An object that authenticates the actor presenting it
-/// as a controller of shared object.
+/// A token that authenticates its bearer as a controller of a specific shared object.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ControllerCap {
   #[serde(deserialize_with = "deserialize_from_uid")]
@@ -197,7 +196,7 @@ impl From<ControllerCap> for ControllerToken {
   }
 }
 
-/// A token minted by a controller that allows another to act in
+/// A token minted by a controller that allows another entity to act in
 /// its stead - with full or reduced permissions.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DelegationToken {
@@ -223,6 +222,11 @@ impl DelegationToken {
   /// Returns the ID of the object this token controls.
   pub fn controller_of(&self) -> ObjectID {
     self.controller_of
+  }
+
+  /// Returns the permissions of this token.
+  pub fn permissions(&self) -> DelegatePermissions {
+    self.permissions
   }
 }
 
@@ -256,6 +260,18 @@ pub struct DelegatePermissions(u32);
 impl Default for DelegatePermissions {
   fn default() -> Self {
     Self(u32::MAX)
+  }
+}
+
+impl From<u32> for DelegatePermissions {
+  fn from(value: u32) -> Self {
+    Self(value)
+  }
+}
+
+impl From<DelegatePermissions> for u32 {
+  fn from(value: DelegatePermissions) -> Self {
+    value.0
   }
 }
 

--- a/identity_iota_core/src/rebased/migration/controller_token.rs
+++ b/identity_iota_core/src/rebased/migration/controller_token.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2024 IOTA Stiftung
+// Copyright 2020-2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use identity_iota_interaction::types::base_types::ObjectID;
@@ -9,13 +9,82 @@ use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
 
+/// A token that proves ownership over an object.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ControllerToken {
+  /// A Controller Capability.
+  Controller(ControllerCap),
+  /// A Delegation Token.
+  Delegate(DelegationToken),
+}
+
+impl ControllerToken {
+  /// Returns the ID of this [ControllerToken].
+  pub fn id(&self) -> ObjectID {
+    match self {
+      Self::Controller(controller) => controller.id,
+      Self::Delegate(delegate) => delegate.id,
+    }
+  }
+
+  /// Returns the ID of the object this token controls.
+  pub fn controller_of(&self) -> ObjectID {
+    match self {
+      Self::Controller(controller) => controller.controller_of,
+      Self::Delegate(delegate) => delegate.controller_of,
+    }
+  }
+
+  /// Returns a reference to [ControllerCap], if this token is a [ControllerCap].
+  pub fn as_controller(&self) -> Option<&ControllerCap> {
+    match self {
+      Self::Controller(controller) => Some(controller),
+      Self::Delegate(_) => None,
+    }
+  }
+
+  /// Attepts to return the [ControllerToken::Controller] variant of this [ControllerToken].
+  pub fn try_controller(self) -> Option<ControllerCap> {
+    match self {
+      Self::Controller(controller) => Some(controller),
+      Self::Delegate(_) => None,
+    }
+  }
+
+  /// Returns a reference to [DelegationToken], if this token is a [DelegationToken].
+  pub fn as_delegate(&self) -> Option<&DelegationToken> {
+    match self {
+      Self::Controller(_) => None,
+      Self::Delegate(delegate) => Some(delegate),
+    }
+  }
+
+  /// Attepts to return the [ControllerToken::Delegate] variant of this [ControllerToken].
+  pub fn try_delegate(self) -> Option<DelegationToken> {
+    match self {
+      Self::Controller(_) => None,
+      Self::Delegate(delegate) => Some(delegate),
+    }
+  }
+
+  /// Returns the Move type of this token.
+  pub fn move_type(&self, package: ObjectID) -> TypeTag {
+    match self {
+      Self::Controller(_) => ControllerCap::move_type(package),
+      Self::Delegate(_) => DelegationToken::move_type(package),
+    }
+  }
+}
+
 /// An object that authenticates the actor presenting it
 /// as a controller of shared object.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ControllerToken {
+pub struct ControllerCap {
   #[serde(deserialize_with = "deserialize_from_uid")]
   id: ObjectID,
   controller_of: ObjectID,
+  can_delegate: bool,
 }
 
 fn deserialize_from_uid<'de, D>(deserializer: D) -> Result<ObjectID, D::Error>
@@ -25,7 +94,7 @@ where
   UID::deserialize(deserializer).map(|uid| *uid.object_id())
 }
 
-impl MoveType for ControllerToken {
+impl MoveType for ControllerCap {
   fn move_type(package: ObjectID) -> TypeTag {
     format!("{package}::controller::ControllerCap")
       .parse()
@@ -33,14 +102,70 @@ impl MoveType for ControllerToken {
   }
 }
 
-impl ControllerToken {
-  /// ID of this [ControllerToken].
+impl ControllerCap {
+  /// Returns the ID of this [ControllerCap].
   pub fn id(&self) -> ObjectID {
     self.id
   }
 
-  /// ID of the object this token controls.
+  /// Returns the ID of the object this token controls.
   pub fn controller_of(&self) -> ObjectID {
     self.controller_of
+  }
+
+  /// Returns whether this controller is allowed to delegate
+  /// its access to the controlled object.
+  pub fn can_delegate(&self) -> bool {
+    self.can_delegate
+  }
+}
+
+impl From<ControllerCap> for ControllerToken {
+  fn from(cap: ControllerCap) -> Self {
+    Self::Controller(cap)
+  }
+}
+
+/// A token minted by a controller that allows another to act in
+/// its stead - with full or reduced permissions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegationToken {
+  #[serde(deserialize_with = "deserialize_from_uid")]
+  id: ObjectID,
+  #[serde(rename = "permissions")]
+  _permissions: u32,
+  controller: ObjectID,
+  controller_of: ObjectID,
+}
+
+impl DelegationToken {
+  /// Returns the ID of this [DelegationToken].
+  pub fn id(&self) -> ObjectID {
+    self.id
+  }
+
+  /// Returns the ID of the [ControllerCap] that minted
+  /// this [DelegationToken].
+  pub fn controller(&self) -> ObjectID {
+    self.controller
+  }
+
+  /// Returns the ID of the object this token controls.
+  pub fn controller_of(&self) -> ObjectID {
+    self.controller_of
+  }
+}
+
+impl From<DelegationToken> for ControllerToken {
+  fn from(value: DelegationToken) -> Self {
+    Self::Delegate(value)
+  }
+}
+
+impl MoveType for DelegationToken {
+  fn move_type(package: ObjectID) -> TypeTag {
+    format!("{package}::controller::DelegationToken")
+      .parse()
+      .expect("valid Move type")
   }
 }

--- a/identity_iota_core/src/rebased/migration/controller_token.rs
+++ b/identity_iota_core/src/rebased/migration/controller_token.rs
@@ -437,7 +437,7 @@ impl Transaction for DelegateToken {
     let (Some(i), Some(token)) = (target_token_pos, target_token) else {
       return (
         Err(Error::TransactionUnexpectedResponse(
-          "failed to find the correct identity in this transaction's effects".to_owned(),
+          "failed to find the correct delegate token in this transaction's effects".to_owned(),
         )),
         effects,
       );

--- a/identity_iota_core/src/rebased/migration/controller_token.rs
+++ b/identity_iota_core/src/rebased/migration/controller_token.rs
@@ -1,13 +1,37 @@
 // Copyright 2020-2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::BitAnd;
+use std::ops::BitAndAssign;
+use std::ops::BitOr;
+use std::ops::BitOrAssign;
+use std::ops::BitXor;
+use std::ops::BitXorAssign;
+use std::ops::Not;
+
+use async_trait::async_trait;
+use identity_iota_interaction::rpc_types::IotaExecutionStatus;
+use identity_iota_interaction::rpc_types::IotaTransactionBlockEffects;
+use identity_iota_interaction::rpc_types::IotaTransactionBlockEffectsAPI as _;
+use identity_iota_interaction::types::base_types::IotaAddress;
 use identity_iota_interaction::types::base_types::ObjectID;
 use identity_iota_interaction::types::id::UID;
+use identity_iota_interaction::types::object::Owner;
+use identity_iota_interaction::types::transaction::ProgrammableTransaction;
 use identity_iota_interaction::types::TypeTag;
+use identity_iota_interaction::ControllerTokenRef;
+use identity_iota_interaction::IdentityMoveCalls;
+use identity_iota_interaction::IotaTransactionBlockEffectsMutAPI as _;
 use identity_iota_interaction::MoveType;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
+
+use crate::iota_interaction_rust::IdentityMoveCallsAdapter;
+use crate::rebased::client::IdentityClientReadOnly;
+use crate::rebased::transaction_builder::Transaction;
+use crate::rebased::transaction_builder::TransactionBuilder;
+use crate::rebased::Error;
 
 /// A token that proves ownership over an object.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -25,6 +49,16 @@ impl ControllerToken {
     match self {
       Self::Controller(controller) => controller.id,
       Self::Delegate(delegate) => delegate.id,
+    }
+  }
+
+  /// Returns the ID of the this token's controller.
+  /// For [ControllerToken::Controller] this is the same as its ID, but
+  /// for [ControllerToken::Delegate] this is [DelegationToken::controller].
+  pub fn controller_id(&self) -> ObjectID {
+    match self {
+      Self::Controller(controller) => controller.id,
+      Self::Delegate(delegate) => delegate.controller,
     }
   }
 
@@ -75,6 +109,20 @@ impl ControllerToken {
       Self::Delegate(_) => DelegationToken::move_type(package),
     }
   }
+
+  pub(crate) async fn controller_ref(&self, client: &IdentityClientReadOnly) -> Result<ControllerTokenRef, Error> {
+    let obj_ref = client
+      .get_object_ref_by_id(self.id())
+      .await?
+      .expect("token exists on-chain")
+      .reference
+      .to_object_ref();
+
+    Ok(match self {
+      Self::Controller(_) => ControllerTokenRef::Controller(obj_ref),
+      Self::Delegate(_) => ControllerTokenRef::Delegate(obj_ref),
+    })
+  }
 }
 
 /// An object that authenticates the actor presenting it
@@ -118,6 +166,26 @@ impl ControllerCap {
   pub fn can_delegate(&self) -> bool {
     self.can_delegate
   }
+
+  /// If this token can be delegated, this function will return
+  /// a [DelegateTransaction] that will mint a new [DelegationToken]
+  /// and send it to `recipient`.
+  pub fn delegate(
+    &self,
+    recipient: IotaAddress,
+    permissions: Option<DelegatePermissions>,
+  ) -> Option<TransactionBuilder<DelegateToken>> {
+    if !self.can_delegate {
+      return None;
+    }
+
+    let tx = {
+      let permissions = permissions.unwrap_or_default();
+      DelegateToken::new_with_permissions(self, recipient, permissions)
+    };
+
+    Some(TransactionBuilder::new(tx))
+  }
 }
 
 impl From<ControllerCap> for ControllerToken {
@@ -132,8 +200,7 @@ impl From<ControllerCap> for ControllerToken {
 pub struct DelegationToken {
   #[serde(deserialize_with = "deserialize_from_uid")]
   id: ObjectID,
-  #[serde(rename = "permissions")]
-  _permissions: u32,
+  permissions: DelegatePermissions,
   controller: ObjectID,
   controller_of: ObjectID,
 }
@@ -167,5 +234,198 @@ impl MoveType for DelegationToken {
     format!("{package}::controller::DelegationToken")
       .parse()
       .expect("valid Move type")
+  }
+}
+
+/// Permissions of a [DelegationToken].
+///
+/// Permissions can be operated on as if they were bit vectors:
+/// ```
+/// use identity_iota_core::rebased::migration::DelegatePermissions;
+///
+/// let permissions = DelegatePermissions::CREATE_PROPOSAL | DelegatePermissions::APPROVE_PROPOSAL;
+/// assert!(permissions & DelegatePermissions::DELETE_PROPOSAL == DelegatePermissions::NONE);
+/// ```
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(transparent)]
+pub struct DelegatePermissions(u32);
+
+impl Default for DelegatePermissions {
+  fn default() -> Self {
+    Self(u32::MAX)
+  }
+}
+
+impl DelegatePermissions {
+  /// No permissions.
+  pub const NONE: Self = Self(0);
+  /// Permission that enables the creation of new proposals.
+  pub const CREATE_PROPOSAL: Self = Self(1);
+  /// Permission that enables the approval of existing proposals.
+  pub const APPROVE_PROPOSAL: Self = Self(1 << 1);
+  /// Permission that enables the execution of existing proposals.
+  pub const EXECUTE_PROPOSAL: Self = Self(1 << 2);
+  /// Permission that enables the deletion of existing proposals.
+  pub const DELETE_PROPOSAL: Self = Self(1 << 3);
+  /// Permission that enables the remove of one's approval for an existing proposal.
+  pub const REMOVE_APPROVAL: Self = Self(1 << 4);
+  /// All permissions.
+  pub const ALL: Self = Self(u32::MAX);
+
+  /// Returns whether this set of permissions contains `permission`.
+  /// ```
+  /// use identity_iota_core::rebased::migration::DelegatePermissions;
+  ///
+  /// let all_permissions = DelegatePermissions::ALL;
+  /// assert_eq!(
+  ///   all_permissions.has(DelegatePermissions::CREATE_PROPOSAL),
+  ///   true
+  /// );
+  /// ```
+  pub fn has(&self, permission: Self) -> bool {
+    *self | permission != Self::NONE
+  }
+}
+
+impl Not for DelegatePermissions {
+  type Output = Self;
+  fn not(self) -> Self::Output {
+    Self(!self.0)
+  }
+}
+impl BitOr for DelegatePermissions {
+  type Output = Self;
+  fn bitor(self, rhs: Self) -> Self::Output {
+    Self(self.0 | rhs.0)
+  }
+}
+impl BitOrAssign for DelegatePermissions {
+  fn bitor_assign(&mut self, rhs: Self) {
+    self.0 |= rhs.0;
+  }
+}
+impl BitAnd for DelegatePermissions {
+  type Output = Self;
+  fn bitand(self, rhs: Self) -> Self::Output {
+    Self(self.0 & rhs.0)
+  }
+}
+impl BitAndAssign for DelegatePermissions {
+  fn bitand_assign(&mut self, rhs: Self) {
+    self.0 &= rhs.0;
+  }
+}
+impl BitXor for DelegatePermissions {
+  type Output = Self;
+  fn bitxor(self, rhs: Self) -> Self::Output {
+    Self(self.0 ^ rhs.0)
+  }
+}
+impl BitXorAssign for DelegatePermissions {
+  fn bitxor_assign(&mut self, rhs: Self) {
+    self.0 ^= rhs.0;
+  }
+}
+
+/// A [Transaction] that creates a new [DelegationToken]
+/// for a given [ControllerCap].
+#[derive(Debug, Clone)]
+pub struct DelegateToken {
+  cap_id: ObjectID,
+  permissions: DelegatePermissions,
+  recipient: IotaAddress,
+}
+
+impl DelegateToken {
+  /// Creates a new [DelegateToken] transaction that will create a new [DelegationToken] with all permissions
+  /// for `controller_cap` and send it to `recipient`.
+  pub fn new(controller_cap: &ControllerCap, recipient: IotaAddress) -> Self {
+    Self::new_with_permissions(controller_cap, recipient, DelegatePermissions::default())
+  }
+
+  /// Same as [DelegateToken::new] but permissions for the new token can be specified.
+  pub fn new_with_permissions(
+    controller_cap: &ControllerCap,
+    recipient: IotaAddress,
+    permissions: DelegatePermissions,
+  ) -> Self {
+    Self {
+      cap_id: controller_cap.id(),
+      permissions,
+      recipient,
+    }
+  }
+}
+
+#[cfg_attr(feature = "send-sync", async_trait)]
+#[cfg_attr(not(feature = "send-sync"), async_trait(?Send))]
+impl Transaction for DelegateToken {
+  type Output = DelegationToken;
+
+  async fn build_programmable_transaction(
+    &self,
+    client: &IdentityClientReadOnly,
+  ) -> Result<ProgrammableTransaction, Error> {
+    let controller_cap_ref = client
+      .get_object_ref_by_id(self.cap_id)
+      .await?
+      .expect("ControllerCap exists on-chain")
+      .reference
+      .to_object_ref();
+
+    let ptb_bcs = IdentityMoveCallsAdapter::delegate_controller_cap(
+      controller_cap_ref,
+      self.recipient,
+      self.permissions.0,
+      client.package_id(),
+    )
+    .await?;
+    Ok(bcs::from_bytes(&ptb_bcs)?)
+  }
+
+  async fn apply(
+    self,
+    mut effects: IotaTransactionBlockEffects,
+    client: &IdentityClientReadOnly,
+  ) -> (Result<Self::Output, Error>, IotaTransactionBlockEffects) {
+    if let IotaExecutionStatus::Failure { error } = effects.status() {
+      return (Err(Error::TransactionUnexpectedResponse(error.clone())), effects);
+    }
+
+    let created_objects = effects
+      .created()
+      .iter()
+      .enumerate()
+      .filter(|(_, elem)| matches!(elem.owner, Owner::AddressOwner(addr) if addr == self.recipient))
+      .map(|(i, obj)| (i, obj.object_id()));
+
+    let is_target_token = |delegation_token: &DelegationToken| -> bool {
+      delegation_token.controller == self.cap_id && delegation_token.permissions == self.permissions
+    };
+    let mut target_token_pos = None;
+    let mut target_token = None;
+    for (i, obj_id) in created_objects {
+      match client.get_object_by_id(obj_id).await {
+        Ok(token) if is_target_token(&token) => {
+          target_token_pos = Some(i);
+          target_token = Some(token);
+          break;
+        }
+        _ => continue,
+      }
+    }
+
+    let (Some(i), Some(token)) = (target_token_pos, target_token) else {
+      return (
+        Err(Error::TransactionUnexpectedResponse(
+          "failed to find the correct identity in this transaction's effects".to_owned(),
+        )),
+        effects,
+      );
+    };
+
+    effects.created_mut().swap_remove(i);
+
+    (Ok(token), effects)
   }
 }

--- a/identity_iota_core/src/rebased/migration/identity.rs
+++ b/identity_iota_core/src/rebased/migration/identity.rs
@@ -56,6 +56,7 @@ use identity_iota_interaction::MoveType;
 use super::ControllerCap;
 use super::ControllerToken;
 use super::DelegationToken;
+use super::DelegationTokenRevocation;
 use super::Multicontroller;
 use super::UnmigratedAlias;
 
@@ -317,6 +318,24 @@ impl OnChainIdentity {
     }
 
     Ok(history)
+  }
+
+  /// Returns a [Transaction] to revoke a [DelegationToken].
+  pub fn revoke_delegation_token(
+    &self,
+    controller_capability: &ControllerCap,
+    delegation_token: &DelegationToken,
+  ) -> Result<TransactionBuilder<DelegationTokenRevocation>, Error> {
+    DelegationTokenRevocation::revoke(self, controller_capability, delegation_token).map(TransactionBuilder::new)
+  }
+
+  /// Returns a [Transaction] to *un*revoke a [DelegationToken].
+  pub fn unrevoke_delegation_token(
+    &self,
+    controller_capability: &ControllerCap,
+    delegation_token: &DelegationToken,
+  ) -> Result<TransactionBuilder<DelegationTokenRevocation>, Error> {
+    DelegationTokenRevocation::unrevoke(self, controller_capability, delegation_token).map(TransactionBuilder::new)
   }
 }
 

--- a/identity_iota_core/src/rebased/migration/identity.rs
+++ b/identity_iota_core/src/rebased/migration/identity.rs
@@ -57,6 +57,7 @@ use super::ControllerCap;
 use super::ControllerToken;
 use super::DelegationToken;
 use super::DelegationTokenRevocation;
+use super::DeleteDelegationToken;
 use super::Multicontroller;
 use super::UnmigratedAlias;
 
@@ -336,6 +337,14 @@ impl OnChainIdentity {
     delegation_token: &DelegationToken,
   ) -> Result<TransactionBuilder<DelegationTokenRevocation>, Error> {
     DelegationTokenRevocation::unrevoke(self, controller_capability, delegation_token).map(TransactionBuilder::new)
+  }
+
+  /// Returns a [Transaction] to delete a [DelegationToken].
+  pub fn delete_delegation_token(
+    &self,
+    delegation_token: DelegationToken,
+  ) -> Result<TransactionBuilder<DeleteDelegationToken>, Error> {
+    DeleteDelegationToken::new(self, delegation_token).map(TransactionBuilder::new)
   }
 }
 

--- a/identity_iota_core/src/rebased/proposals/borrow.rs
+++ b/identity_iota_core/src/rebased/proposals/borrow.rs
@@ -182,14 +182,9 @@ where
       .get_object_ref_by_id(identity.id())
       .await?
       .expect("identity exists on-chain");
-    let controller_cap_ref = client
-      .get_object_ref_by_id(controller_token.id())
-      .await?
-      .ok_or_else(|| Error::Identity(format!("controller token {} doesn't exist", controller_token.id())))?
-      .reference
-      .to_object_ref();
+    let controller_cap_ref = controller_token.controller_ref(client).await?;
     let can_execute = identity
-      .controller_voting_power(controller_cap_ref.0)
+      .controller_voting_power(controller_token.controller_id())
       .expect("is a controller of identity")
       >= identity.threshold();
     let maybe_intent_fn = action.intent_fn.into_inner();
@@ -307,12 +302,8 @@ where
       .get_object_ref_by_id(identity.id())
       .await?
       .expect("identity exists on-chain");
-    let controller_cap_ref = client
-      .get_object_ref_by_id(*controller_token)
-      .await?
-      .ok_or_else(|| Error::Identity(format!("controller token {} doesn't exist", controller_token)))?
-      .reference
-      .to_object_ref();
+    let controller_token = client.get_object_by_id::<ControllerToken>(*controller_token).await?;
+    let controller_token_ref = controller_token.controller_ref(client).await?;
 
     // Construct a list of `(ObjectRef, TypeTag)` from the list of objects to send.
     let object_data_list = {
@@ -328,7 +319,7 @@ where
 
     let tx = IdentityMoveCallsAdapter::execute_borrow(
       identity_ref,
-      controller_cap_ref,
+      controller_token_ref,
       *proposal_id,
       object_data_list,
       borrow_action

--- a/identity_iota_core/src/rebased/proposals/config_change.rs
+++ b/identity_iota_core/src/rebased/proposals/config_change.rs
@@ -243,14 +243,9 @@ impl ProposalT for Proposal<ConfigChange> {
       .get_object_ref_by_id(identity.id())
       .await?
       .expect("identity exists on-chain");
-    let controller_cap_ref = client
-      .get_object_ref_by_id(controller_token.id())
-      .await?
-      .ok_or_else(|| Error::Identity(format!("controller token {} doesn't exist", controller_token.id())))?
-      .reference
-      .to_object_ref();
+    let controller_cap_ref = controller_token.controller_ref(client).await?;
     let sender_vp = identity
-      .controller_voting_power(controller_cap_ref.0)
+      .controller_voting_power(controller_token.controller_id())
       .expect("controller exists");
     let chained_execution = sender_vp >= identity.threshold();
     let tx = IdentityMoveCallsAdapter::propose_config_change(
@@ -292,12 +287,7 @@ impl ProposalT for Proposal<ConfigChange> {
       .get_object_ref_by_id(identity.id())
       .await?
       .expect("identity exists on-chain");
-    let controller_cap_ref = client
-      .get_object_ref_by_id(controller_token.id())
-      .await?
-      .ok_or_else(|| Error::Identity(format!("controller token {} doesn't exist", controller_token.id())))?
-      .reference
-      .to_object_ref();
+    let controller_cap_ref = controller_token.controller_ref(client).await?;
 
     let tx = IdentityMoveCallsAdapter::execute_config_change(
       identity_ref,

--- a/identity_iota_core/src/rebased/proposals/controller.rs
+++ b/identity_iota_core/src/rebased/proposals/controller.rs
@@ -172,16 +172,11 @@ where
       .get_object_ref_by_id(identity.id())
       .await?
       .expect("identity exists on-chain");
-    let controller_cap_ref = client
-      .get_object_ref_by_id(controller_token.id())
-      .await?
-      .ok_or_else(|| Error::Identity(format!("controller token {} doesn't exist", controller_token.id())))?
-      .reference
-      .to_object_ref();
+    let controller_cap_ref = controller_token.controller_ref(client).await?;
     let maybe_intent_fn = action.intent_fn.into_inner();
     let chained_execution = maybe_intent_fn.is_some()
       && identity
-        .controller_voting_power(controller_cap_ref.0)
+        .controller_voting_power(controller_token.controller_id())
         .expect("is an identity's controller")
         >= identity.threshold();
 
@@ -308,12 +303,8 @@ where
       .get_object_ref_by_id(identity.id())
       .await?
       .expect("identity exists on-chain");
-    let controller_cap_ref = client
-      .get_object_ref_by_id(*controller_token)
-      .await?
-      .ok_or_else(|| Error::Identity(format!("controller token {} doesn't exist", controller_token)))?
-      .reference
-      .to_object_ref();
+    let controller_token = client.get_object_by_id::<ControllerToken>(*controller_token).await?;
+    let controller_cap_ref = controller_token.controller_ref(client).await?;
 
     let borrowing_cap_id = action.0.controller_cap;
     let borrowing_controller_cap_ref = client

--- a/identity_iota_core/src/rebased/proposals/mod.rs
+++ b/identity_iota_core/src/rebased/proposals/mod.rs
@@ -291,7 +291,7 @@ where
 pub struct ApproveProposal<'p, 'i, A> {
   proposal: &'p mut Proposal<A>,
   identity: &'i OnChainIdentity,
-  controller_token: ObjectID,
+  controller_token: ControllerToken,
   cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
@@ -313,7 +313,7 @@ impl<'p, 'i, A> ApproveProposal<'p, 'i, A> {
     Ok(Self {
       proposal,
       identity,
-      controller_token: controller_token.id(),
+      controller_token: controller_token.clone(),
       cached_ptb: OnceCell::new(),
     })
   }
@@ -330,13 +330,10 @@ impl<A: MoveType> ApproveProposal<'_, '_, A> {
       .get_object_ref_by_id(identity.id())
       .await?
       .ok_or_else(|| Error::Identity(format!("identity {} doesn't exist", identity.id())))?;
-    let controller_cap = client
-      .get_object_ref_by_id(*controller_token)
-      .await?
-      .ok_or_else(|| Error::Identity(format!("controller token {} doesn't exist", controller_token)))?;
+    let controller_cap = controller_token.controller_ref(client).await?;
     let tx = <IdentityMoveCallsAdapter as IdentityMoveCalls>::approve_proposal::<A>(
       identity_ref.clone(),
-      controller_cap.reference.to_object_ref(),
+      controller_cap,
       proposal.id(),
       client.package_id(),
     )?;
@@ -375,7 +372,7 @@ where
     if proposal_was_updated {
       let vp = self
         .identity
-        .controller_voting_power(self.controller_token)
+        .controller_voting_power(self.controller_token.controller_id())
         .expect("is identity's controller");
       *self.proposal.votes_mut() = self.proposal.votes() + vp;
       (Ok(()), effects)

--- a/identity_iota_core/src/rebased/proposals/send.rs
+++ b/identity_iota_core/src/rebased/proposals/send.rs
@@ -103,14 +103,9 @@ impl ProposalT for Proposal<SendAction> {
       .get_object_ref_by_id(identity.id())
       .await?
       .expect("identity exists on-chain");
-    let controller_cap_ref = client
-      .get_object_ref_by_id(controller_token.id())
-      .await?
-      .ok_or_else(|| Error::Identity(format!("controller token {} doesn't exist", controller_token.id())))?
-      .reference
-      .to_object_ref();
+    let controller_cap_ref = controller_token.controller_ref(client).await?;
     let can_execute = identity
-      .controller_voting_power(controller_cap_ref.0)
+      .controller_voting_power(controller_token.controller_id())
       .expect("controller_cap is for this identity")
       >= identity.threshold();
     let tx = if can_execute {
@@ -170,12 +165,7 @@ impl ProposalT for Proposal<SendAction> {
       .get_object_ref_by_id(identity.id())
       .await?
       .expect("identity exists on-chain");
-    let controller_cap_ref = client
-      .get_object_ref_by_id(controller_token.id())
-      .await?
-      .ok_or_else(|| Error::Identity(format!("controller token {} doesn't exist", controller_token.id())))?
-      .reference
-      .to_object_ref();
+    let controller_cap_ref = controller_token.controller_ref(client).await?;
 
     // Construct a list of `(ObjectRef, TypeTag)` from the list of objects to send.
     let object_type_list = {

--- a/identity_iota_core/src/rebased/proposals/update_did_doc.rs
+++ b/identity_iota_core/src/rebased/proposals/update_did_doc.rs
@@ -92,14 +92,9 @@ impl ProposalT for Proposal<UpdateDidDocument> {
       .get_object_ref_by_id(identity.id())
       .await?
       .expect("identity exists on-chain");
-    let controller_cap_ref = client
-      .get_object_ref_by_id(controller_token.id())
-      .await?
-      .ok_or_else(|| Error::Identity(format!("controller token {} doesn't exist", controller_token.id())))?
-      .reference
-      .to_object_ref();
+    let controller_cap_ref = controller_token.controller_ref(client).await?;
     let sender_vp = identity
-      .controller_voting_power(controller_cap_ref.0)
+      .controller_voting_power(controller_token.controller_id())
       .expect("controller exists");
     let chained_execution = sender_vp >= identity.threshold();
     let tx = IdentityMoveCallsAdapter::propose_update(
@@ -144,12 +139,7 @@ impl ProposalT for Proposal<UpdateDidDocument> {
       .get_object_ref_by_id(identity.id())
       .await?
       .expect("identity exists on-chain");
-    let controller_cap_ref = client
-      .get_object_ref_by_id(controller_token.id())
-      .await?
-      .ok_or_else(|| Error::Identity(format!("controller token {} doesn't exist", controller_token.id())))?
-      .reference
-      .to_object_ref();
+    let controller_cap_ref = controller_token.controller_ref(client).await?;
 
     let tx =
       IdentityMoveCallsAdapter::execute_update(identity_ref, controller_cap_ref, proposal_id, client.package_id())

--- a/identity_iota_core/src/rebased/proposals/upgrade.rs
+++ b/identity_iota_core/src/rebased/proposals/upgrade.rs
@@ -69,14 +69,9 @@ impl ProposalT for Proposal<Upgrade> {
       .get_object_ref_by_id(identity.id())
       .await?
       .expect("identity exists on-chain");
-    let controller_cap_ref = client
-      .get_object_ref_by_id(controller_token.id())
-      .await?
-      .ok_or_else(|| Error::Identity(format!("controller token {} doesn't exist", controller_token.id())))?
-      .reference
-      .to_object_ref();
+    let controller_cap_ref = controller_token.controller_ref(client).await?;
     let sender_vp = identity
-      .controller_voting_power(controller_cap_ref.0)
+      .controller_voting_power(controller_token.controller_id())
       .expect("controller exists");
     let chained_execution = sender_vp >= identity.threshold();
     let tx =
@@ -110,12 +105,7 @@ impl ProposalT for Proposal<Upgrade> {
       .get_object_ref_by_id(identity.id())
       .await?
       .expect("identity exists on-chain");
-    let controller_cap_ref = client
-      .get_object_ref_by_id(controller_token.id())
-      .await?
-      .ok_or_else(|| Error::Identity(format!("controller token {} doesn't exist", controller_token.id())))?
-      .reference
-      .to_object_ref();
+    let controller_cap_ref = controller_token.controller_ref(client).await?;
 
     let tx =
       IdentityMoveCallsAdapter::execute_upgrade(identity_ref, controller_cap_ref, proposal_id, client.package_id())

--- a/identity_iota_core/tests/e2e/identity.rs
+++ b/identity_iota_core/tests/e2e/identity.rs
@@ -10,6 +10,7 @@ use crate::common::TEST_GAS_BUDGET;
 use identity_iota_core::rebased::client::get_object_id_from_did;
 use identity_iota_core::rebased::migration::has_previous_version;
 use identity_iota_core::rebased::migration::ControllerToken;
+use identity_iota_core::rebased::migration::DelegationToken;
 use identity_iota_core::rebased::migration::Identity;
 use identity_iota_core::rebased::proposals::ProposalResult;
 use identity_iota_core::IotaDID;
@@ -598,6 +599,18 @@ async fn controller_delegation_works() -> anyhow::Result<()> {
     .await?
     .output;
   assert!(matches!(res, ProposalResult::Pending(_)));
+
+  // The owner of the token can delete it whenever.
+  let bobs_delegation_token_id = bobs_delegation_token.id();
+  identity
+    .delete_delegation_token(bobs_delegation_token.try_delegate().unwrap())?
+    .build_and_execute(&alice_client)
+    .await?;
+
+  let maybe_obj = alice_client
+    .get_object_by_id::<DelegationToken>(bobs_delegation_token_id)
+    .await;
+  assert!(maybe_obj.is_err());
 
   Ok(())
 }

--- a/identity_iota_interaction/src/move_call_traits.rs
+++ b/identity_iota_interaction/src/move_call_traits.rs
@@ -181,7 +181,7 @@ pub trait IdentityMoveCalls {
     package_id: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error>;
 
-  async fn new_with_controllers<C: IntoIterator<Item = (IotaAddress, u64)> + OptionalSend>(
+  async fn new_with_controllers<C: IntoIterator<Item = (IotaAddress, u64, bool)> + OptionalSend>(
     did_doc: Option<&[u8]>,
     controllers: C,
     threshold: u64,

--- a/identity_iota_interaction/src/move_call_traits.rs
+++ b/identity_iota_interaction/src/move_call_traits.rs
@@ -20,6 +20,25 @@ use crate::MoveType;
 use crate::OptionalSend;
 use crate::ProgrammableTransactionBcs;
 
+#[derive(Debug, Clone, Copy)]
+pub enum ControllerTokenRef {
+  Controller(ObjectRef),
+  Delegate(ObjectRef),
+}
+
+impl ControllerTokenRef {
+  pub fn is_controller_cap(&self) -> bool {
+    matches!(self, ControllerTokenRef::Controller(_))
+  }
+
+  pub fn object_ref(&self) -> ObjectRef {
+    match self {
+      Self::Controller(obj_ref) => *obj_ref,
+      Self::Delegate(obj_ref) => *obj_ref,
+    }
+  }
+}
+
 pub trait AssetMoveCalls {
   type Error;
 
@@ -96,7 +115,7 @@ pub trait IdentityMoveCalls {
 
   fn propose_borrow(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     objects: Vec<ObjectID>,
     expiration: Option<u64>,
     package_id: ObjectID,
@@ -104,7 +123,7 @@ pub trait IdentityMoveCalls {
 
   fn execute_borrow<F: BorrowIntentFnInternalT<Self::NativeTxBuilder>>(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     proposal_id: ObjectID,
     objects: Vec<IotaObjectData>,
     intent_fn: F,
@@ -113,7 +132,7 @@ pub trait IdentityMoveCalls {
 
   fn create_and_execute_borrow<F>(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     objects: Vec<IotaObjectData>,
     intent_fn: F,
     expiration: Option<u64>,
@@ -129,7 +148,7 @@ pub trait IdentityMoveCalls {
   #[allow(clippy::too_many_arguments)]
   fn propose_config_change<I1, I2>(
     identity: OwnedObjectRef,
-    controller_cap: ObjectRef,
+    controller_cap: ControllerTokenRef,
     expiration: Option<u64>,
     threshold: Option<u64>,
     controllers_to_add: I1,
@@ -143,14 +162,14 @@ pub trait IdentityMoveCalls {
 
   fn execute_config_change(
     identity: OwnedObjectRef,
-    controller_cap: ObjectRef,
+    controller_cap: ControllerTokenRef,
     proposal_id: ObjectID,
     package: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error>;
 
   fn propose_controller_execution(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     controller_cap_id: ObjectID,
     expiration: Option<u64>,
     package_id: ObjectID,
@@ -158,7 +177,7 @@ pub trait IdentityMoveCalls {
 
   fn execute_controller_execution<F: ControllerIntentFnInternalT<Self::NativeTxBuilder>>(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     proposal_id: ObjectID,
     borrowing_controller_cap_ref: ObjectRef,
     intent_fn: F,
@@ -167,7 +186,7 @@ pub trait IdentityMoveCalls {
 
   fn create_and_execute_controller_execution<F>(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     expiration: Option<u64>,
     borrowing_controller_cap_ref: ObjectRef,
     intent_fn: F,
@@ -190,14 +209,14 @@ pub trait IdentityMoveCalls {
 
   fn approve_proposal<T: MoveType>(
     identity: OwnedObjectRef,
-    controller_cap: ObjectRef,
+    controller_cap: ControllerTokenRef,
     proposal_id: ObjectID,
     package: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error>;
 
   fn propose_send(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     transfer_map: Vec<(ObjectID, IotaAddress)>,
     expiration: Option<u64>,
     package_id: ObjectID,
@@ -205,7 +224,7 @@ pub trait IdentityMoveCalls {
 
   fn execute_send(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     proposal_id: ObjectID,
     objects: Vec<(ObjectRef, TypeTag)>,
     package: ObjectID,
@@ -213,7 +232,7 @@ pub trait IdentityMoveCalls {
 
   async fn propose_update(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     did_doc: Option<&[u8]>,
     expiration: Option<u64>,
     package_id: ObjectID,
@@ -221,14 +240,14 @@ pub trait IdentityMoveCalls {
 
   async fn execute_update(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     proposal_id: ObjectID,
     package_id: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error>;
 
   fn create_and_execute_send(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     transfer_map: Vec<(ObjectID, IotaAddress)>,
     expiration: Option<u64>,
     objects: Vec<(ObjectRef, TypeTag)>,
@@ -237,15 +256,22 @@ pub trait IdentityMoveCalls {
 
   fn propose_upgrade(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     expiration: Option<u64>,
     package_id: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error>;
 
   fn execute_upgrade(
     identity: OwnedObjectRef,
-    capability: ObjectRef,
+    capability: ControllerTokenRef,
     proposal_id: ObjectID,
     package_id: ObjectID,
+  ) -> Result<ProgrammableTransactionBcs, Self::Error>;
+
+  async fn delegate_controller_cap(
+    controller_cap: ObjectRef,
+    recipient: IotaAddress,
+    permissions: u32,
+    package: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error>;
 }

--- a/identity_iota_interaction/src/move_call_traits.rs
+++ b/identity_iota_interaction/src/move_call_traits.rs
@@ -274,4 +274,24 @@ pub trait IdentityMoveCalls {
     permissions: u32,
     package: ObjectID,
   ) -> Result<ProgrammableTransactionBcs, Self::Error>;
+
+  async fn revoke_delegation_token(
+    identity: OwnedObjectRef,
+    controller_cap: ObjectRef,
+    delegation_token_id: ObjectID,
+    package: ObjectID,
+  ) -> Result<ProgrammableTransactionBcs, Self::Error>;
+
+  async fn unrevoke_delegation_token(
+    identity: OwnedObjectRef,
+    controller_cap: ObjectRef,
+    delegation_token_id: ObjectID,
+    package: ObjectID,
+  ) -> Result<ProgrammableTransactionBcs, Self::Error>;
+
+  async fn destroy_delegation_token(
+    identity: OwnedObjectRef,
+    delegation_token: ObjectRef,
+    package: ObjectID,
+  ) -> Result<ProgrammableTransactionBcs, Self::Error>;
 }


### PR DESCRIPTION
# Description of change
All `Identity`'s APIs require a token that authenticates the caller as an `Identity`'s controller. Access to such APIs though is not strictly limited to controllers but it can also be granted to other entities through the *delegation* of a controller's token `ControllerCap`. Delegating a controller's access requires minting a new kind of token called `DelegationToken`, that allows its bearer to act in the stead of the controller that minted it, with either full or limited permissions.

Now `ControllerToken` doesn't represent just a `ControllerCap` - as it was before this PR - but it represents *either* a `ControllerCap` or a `DelegationToken`.

## Links to any relevant issues
Resolves #1440 

## Type of change
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested
New E2E test for all operations that use `DelegationToken` + doc tests.
