### PR TITLE
feat: Update to iota v1.8.0-rc - Tests with product-core upstream-merge feature branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ exclude = ["bindings/wasm/identity_wasm", "bindings/grpc"]
 
 [workspace.dependencies]
 bls12_381_plus = { version = "0.8.17" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "iota_interaction" }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "iota_interaction_ts" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "product_common" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "iota_interaction" }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "iota_interaction_ts" }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "product_common" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false }
 strum = { version = "0.25", default-features = false, features = ["std", "derive"] }

--- a/bindings/grpc/Cargo.toml
+++ b/bindings/grpc/Cargo.toml
@@ -24,7 +24,7 @@ identity_iota = { path = "../../identity_iota", features = ["resolver", "sd-jwt"
 identity_jose = { path = "../../identity_jose" }
 identity_storage = { path = "../../identity_storage", features = ["memstore"] }
 identity_stronghold = { path = "../../identity_stronghold", features = ["send-sync-storage"] }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.7.0" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.8.0-rc" }
 iota-sdk-legacy = { package = "iota-sdk", version = "1.1.2", features = ["stronghold"] }
 prost = "0.13"
 rand = "0.8.5"

--- a/bindings/wasm/identity_wasm/Cargo.toml
+++ b/bindings/wasm/identity_wasm/Cargo.toml
@@ -25,12 +25,12 @@ identity_ecdsa_verifier = { path = "../../../identity_ecdsa_verifier", default-f
 identity_eddsa_verifier = { path = "../../../identity_eddsa_verifier", default-features = false, features = ["ed25519"] }
 # Remove iota-sdk dependency while working on issue #1445
 iota-sdk = { version = "1.1.5", default-features = false, features = ["serde", "std"] }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "iota_interaction", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "iota_interaction_ts" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "iota_interaction", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "iota_interaction_ts" }
 js-sys = { version = "0.3.61" }
 json-proof-token = "0.3.4"
 proc_typescript = { version = "0.1.0", path = "./proc_typescript" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "product_common", features = ["core-client", "transaction", "bindings", "gas-station", "default-http-client"] }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "product_common", features = ["core-client", "transaction", "bindings", "gas-station", "default-http-client"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,10 +10,10 @@ anyhow = "1.0.62"
 identity_eddsa_verifier = { path = "../identity_eddsa_verifier", default-features = false, features = ["ed25519"] }
 identity_storage = { path = "../identity_storage" }
 identity_stronghold = { path = "../identity_stronghold", default-features = false, features = ["send-sync-storage"] }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.7.0" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.8.0-rc" }
 iota-sdk-legacy = { package = "iota-sdk", version = "1.0", default-features = false, features = ["tls", "client", "stronghold"] }
 json-proof-token.workspace = true
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "product_common", features = ["core-client", "transaction"] }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "product_common", features = ["core-client", "transaction"] }
 rand = "0.8.5"
 sd-jwt-payload = { version = "0.2.1", default-features = false, features = ["sha"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.3.0" }

--- a/identity_credential/Cargo.toml
+++ b/identity_credential/Cargo.toml
@@ -20,7 +20,7 @@ identity_core = { version = "=1.6.0-beta", path = "../identity_core", default-fe
 identity_did = { version = "=1.6.0-beta", path = "../identity_did", default-features = false }
 identity_document = { version = "=1.6.0-beta", path = "../identity_document", default-features = false }
 identity_verification = { version = "=1.6.0-beta", path = "../identity_verification", default-features = false }
-indexmap = { version = "2.0", default-features = false, features = ["std", "serde"] }
+indexmap = { version = "2.11.0", default-features = false, features = ["std", "serde"] }
 itertools = { version = "0.11", default-features = false, features = ["use_std"], optional = true }
 json-proof-token = { workspace = true, optional = true }
 jsonschema = { version = "0.19", optional = true, default-features = false }

--- a/identity_document/Cargo.toml
+++ b/identity_document/Cargo.toml
@@ -15,7 +15,7 @@ did_url_parser = { version = "0.2.0", features = ["std", "serde"] }
 identity_core = { version = "=1.6.0-beta", path = "../identity_core", default-features = false }
 identity_did = { version = "=1.6.0-beta", path = "../identity_did" }
 identity_verification = { version = "=1.6.0-beta", path = "../identity_verification", default-features = false }
-indexmap = { version = "2.0", default-features = false, features = ["std", "serde"] }
+indexmap = { version = "2.11.0", default-features = false, features = ["std", "serde"] }
 serde.workspace = true
 strum.workspace = true
 thiserror.workspace = true

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -24,13 +24,13 @@ identity_verification = { version = "=1.6.0-beta", path = "../identity_verificat
 iota_interaction.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "iota_interaction", default-features = false }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "iota_interaction", default-features = false }
 
 [dev-dependencies]
 # required for doc test
 anyhow = "1.0.64"
 identity_iota = { version = "=1.6.0-beta", path = "./", features = ["memstore"] }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.7.0" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.8.0-rc" }
 rand = "0.8.5"
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.3.0" }
 tokio = { version = "1.46.1", features = ["full"] }

--- a/identity_iota_core/Cargo.toml
+++ b/identity_iota_core/Cargo.toml
@@ -24,7 +24,7 @@ num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["std"] }
 once_cell = { version = "1.18", default-features = false, features = ["std"] }
 prefix-hex = { version = "0.7", default-features = false }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "product_common", default-features = false }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "product_common", default-features = false }
 ref-cast = { version = "1.0.14", default-features = false }
 serde.workspace = true
 serde_json.workspace = true
@@ -45,16 +45,16 @@ secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag
 serde-aux = { version = "4.5.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota-config = { git = "https://github.com/iotaledger/iota.git", package = "iota-config", tag = "v1.7.0", optional = true }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "iota_interaction", optional = true }
-iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "iota_interaction_rust", optional = true }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.7.0", optional = true }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.7.0", optional = true }
-shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v1.7.0", optional = true }
+iota-config = { git = "https://github.com/iotaledger/iota.git", package = "iota-config", tag = "v1.8.0-rc", optional = true }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "iota_interaction", optional = true }
+iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "iota_interaction_rust", optional = true }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.8.0-rc", optional = true }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.8.0-rc", optional = true }
+shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v1.8.0-rc", optional = true }
 tokio = { version = "1.46.1", default-features = false, features = ["macros", "sync", "rt", "process"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "iota_interaction", default-features = false, optional = true }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "iota_interaction", default-features = false, optional = true }
 
 # Dependency iota_interaction_ts is always used on wasm32 platform. It is not controlled by the "iota-client" feature
 # because it's unclear how to implement this. wasm32 build will most probably always use the "iota-client" feature

--- a/identity_jose/Cargo.toml
+++ b/identity_jose/Cargo.toml
@@ -25,10 +25,10 @@ thiserror.workspace = true
 zeroize = { version = "1.6", default-features = false, features = ["std", "zeroize_derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "iota_interaction" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "iota_interaction" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "iota_interaction", default-features = false }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "iota_interaction", default-features = false }
 
 [dev-dependencies]
 iota-crypto = { version = "0.23", features = ["ed25519", "random", "hmac"] }

--- a/identity_storage/Cargo.toml
+++ b/identity_storage/Cargo.toml
@@ -37,17 +37,17 @@ tokio = { version = "1.46.1", default-features = false, features = ["macros", "s
 zkryptium = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "iota_interaction", optional = true }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "iota_interaction", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "iota_interaction", default-features = false, optional = true }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "iota_interaction", default-features = false, optional = true }
 
 [dev-dependencies]
 identity_credential = { version = "=1.6.0-beta", path = "../identity_credential", features = ["revocation-bitmap"] }
 identity_ecdsa_verifier = { version = "=1.6.0-beta", path = "../identity_ecdsa_verifier", default-features = false, features = ["es256"] }
 identity_eddsa_verifier = { version = "=1.6.0-beta", path = "../identity_eddsa_verifier", default-features = false, features = ["ed25519"] }
 once_cell = { version = "1.18", default-features = false }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "product_common", default-features = false }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-8-0-rc-upstream-merge", package = "product_common", default-features = false }
 tokio = { version = "1.46.1", default-features = false, features = ["macros", "sync", "rt"] }
 
 [features]


### PR DESCRIPTION
> [!WARNING]
> DON'T MERGE THIS PULL REQUEST
>
> This PR is only used to run CI tests against the `product-core` branch `feat/iota-v1-8-0-rc-upstream-merge`

# Description of change

Following dependencies have been changed:

* Use the same `indexmap` dependency constrain `= "2.11.0"` as being used in iota-sdk
* "v1.8.0-rc" update summary:
- [ ] tokio version update to: -
- [ ] fastcrypto version update to rev = "-"
- [ ] identity_wasm: new peerDep. version for @iota/iota-sdk: _
- [x] pin all product-core.git dependencies to `branch = "feat/iota-v1-8-0-rc-upstream-merge"`
- [x] pin all iota.git dependencies to `tag = "v1.8.0-rc"`

## Links to any relevant issues
None