### PR TITLE
Update Sandbox Start Command in CI

### DIFF
--- a/.github/actions/iota-rebase-sandbox/setup/action.yml
+++ b/.github/actions/iota-rebase-sandbox/setup/action.yml
@@ -97,7 +97,7 @@ runs:
         echo "Starting server with log file: $LOGFILE"
 
         # Start the network
-        iota start --with-faucet ${{ inputs.logfile && format('> {0} 2>&1', inputs.logfile) || '' }} &
+        iota-localnet start --with-faucet ${{ inputs.logfile && format('> {0} 2>&1', inputs.logfile) || '' }} &
     - name: Setup TOML CLI utils
       shell: bash
       run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,13 +26,22 @@ on:
     - cron:  '5 0 * * *' # everyday, 00:05, used for testnet scheduled test
     - cron:  '10 0 * * *' # everyday, 00:10 used for devnet scheduled test
 
+  workflow_dispatch:
+    inputs:
+      iota_version:
+        type: choice
+        description: 'IOTA network to use.'
+        options:
+          - testnet
+          - devnet
+
 env:
   RUST_BACKTRACE: full
   CARGO_INCREMENTAL: 0 # disabled to reduce target cache size and improve sccache (https://github.com/mozilla/sccache#known-caveats)
   SCCACHE_CACHE_SIZE: 2G
   SCCACHE_IDLE_TIMEOUT: 0
   # SCCACHE_RECACHE: 1 # uncomment to clear sccache cache, then re-comment
-  IOTA_VERSION: ${{github.event.schedule && (github.event.schedule == '5 0 * * *' && 'testnet' || 'devnet')}}
+  IOTA_VERSION: ${{ inputs.iota_version || (github.event.schedule && (github.event.schedule == '5 0 * * *' && 'testnet' || 'devnet')) }}
 
 jobs:
   check-for-run-condition:
@@ -217,7 +226,7 @@ jobs:
           npm run test:readme:rust
 
       - name: Archive server logs
-        if: ${{ env.IOTA_SERVER_LOGFILE }}
+        if: ${{ always() && env.IOTA_SERVER_LOGFILE }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.IOTA_SERVER_LOGFILE }}


### PR DESCRIPTION
Update CI to follow [IOTA client updates](https://github.com/iotaledger/iota/pull/10663).

For easier testing in the future:

- `Build and run tests` action can now be triggered manually
- IOTA server logs are now always saved as an artifact 