### PR TITLE
feat: Update to iota v1.22.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,10 @@ exclude = ["bindings/wasm/identity_wasm", "bindings/grpc"]
 
 [workspace.dependencies]
 bls12_381_plus = { version = "0.8.17" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction" }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction_ts" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "iota_interaction" }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "iota_interaction_ts" }
 iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "7c1434aabb2e7b11681722edaf1a51ac52941b84", features = ["hash", "serde", "schemars"] }
-product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "product_common" }
+product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "product_common" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false }
 oqs = { version = "0.10", default-features = false, features = ["sigs", "std", "vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,10 @@ exclude = ["bindings/wasm/identity_wasm", "bindings/grpc"]
 
 [workspace.dependencies]
 bls12_381_plus = { version = "0.8.17" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "iota_interaction" }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "iota_interaction_ts" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "e19c78a1bee17e0bf85fcd5b16a2f080cef26274", features = ["hash", "serde", "schemars"] }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "product_common" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction" }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction_ts" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "7c1434aabb2e7b11681722edaf1a51ac52941b84", features = ["hash", "serde", "schemars"] }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "product_common" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false }
 oqs = { version = "0.10", default-features = false, features = ["sigs", "std", "vendored"] }

--- a/bindings/grpc/Cargo.toml
+++ b/bindings/grpc/Cargo.toml
@@ -24,7 +24,7 @@ identity_iota = { path = "../../identity_iota", features = ["resolver", "sd-jwt"
 identity_jose = { path = "../../identity_jose" }
 identity_storage = { path = "../../identity_storage", features = ["memstore"] }
 identity_stronghold = { path = "../../identity_stronghold", features = ["send-sync-storage"] }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", rev = "96196f0da231883ec69cda04892c600ef6afa982" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.22.1" }
 iota-sdk-legacy = { package = "iota-sdk", version = "1.1.2", features = ["stronghold"] }
 prost = "0.13"
 rand = "0.8.5"

--- a/bindings/wasm/identity_wasm/Cargo.toml
+++ b/bindings/wasm/identity_wasm/Cargo.toml
@@ -26,12 +26,12 @@ identity_eddsa_verifier = { path = "../../../identity_eddsa_verifier", default-f
 iota-caip = { git = "https://github.com/iotaledger/iota-caip.git", features = ["serde"] }
 # Remove iota-sdk dependency while working on issue #1445
 iota-sdk = { version = "1.1.5", default-features = false, features = ["serde", "std"] }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction_ts" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "iota_interaction", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "iota_interaction_ts" }
 js-sys = { version = "0.3.61" }
 json-proof-token = "0.4"
 proc_typescript = { version = "0.1.0", path = "./proc_typescript" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "product_common", features = ["core-client", "transaction", "bindings", "gas-station", "default-http-client"] }
+product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "product_common", features = ["core-client", "transaction", "bindings", "gas-station", "default-http-client"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"

--- a/bindings/wasm/identity_wasm/Cargo.toml
+++ b/bindings/wasm/identity_wasm/Cargo.toml
@@ -26,12 +26,12 @@ identity_eddsa_verifier = { path = "../../../identity_eddsa_verifier", default-f
 iota-caip = { git = "https://github.com/iotaledger/iota-caip.git", features = ["serde"] }
 # Remove iota-sdk dependency while working on issue #1445
 iota-sdk = { version = "1.1.5", default-features = false, features = ["serde", "std"] }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "iota_interaction", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "iota_interaction_ts" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction_ts" }
 js-sys = { version = "0.3.61" }
 json-proof-token = "0.4"
 proc_typescript = { version = "0.1.0", path = "./proc_typescript" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "product_common", features = ["core-client", "transaction", "bindings", "gas-station", "default-http-client"] }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "product_common", features = ["core-client", "transaction", "bindings", "gas-station", "default-http-client"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,8 +15,8 @@ iota-caip = { git = "https://github.com/iotaledger/iota-caip.git", features = ["
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.22.1" }
 iota-sdk-legacy = { package = "iota-sdk", version = "1.0", default-features = false, features = ["tls", "client", "stronghold"] }
 json-proof-token.workspace = true
-notarization = { git = "https://github.com/iotaledger/notarization.git", branch = "feat/iota-v1-22", features = ["irl"] }
-product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "product_common", features = ["core-client", "transaction"] }
+notarization = { git = "https://github.com/iotaledger/notarization.git", tag = "v0.1.21", features = ["irl"] }
+product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "product_common", features = ["core-client", "transaction"] }
 rand = "0.8.5"
 sd-jwt = { package = "sd-jwt-payload", version = "0.5.1", default-features = false, features = ["sha"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.3.0" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,11 +12,11 @@ identity_pqc_verifier = { path = "../identity_pqc_verifier", default-features = 
 identity_storage = { path = "../identity_storage", features = ["sd-jwt-signer"] }
 identity_stronghold = { path = "../identity_stronghold", default-features = false, features = ["send-sync-storage"] }
 iota-caip = { git = "https://github.com/iotaledger/iota-caip.git", features = ["iota", "resolver"] }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", rev = "96196f0da231883ec69cda04892c600ef6afa982" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.22.1" }
 iota-sdk-legacy = { package = "iota-sdk", version = "1.0", default-features = false, features = ["tls", "client", "stronghold"] }
 json-proof-token.workspace = true
-notarization = { git = "https://github.com/iotaledger/notarization.git", tag = "v0.1.20", features = ["irl"] }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "product_common", features = ["core-client", "transaction"] }
+notarization = { git = "https://github.com/iotaledger/notarization.git", branch = "feat/iota-v1-22", features = ["irl"] }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "product_common", features = ["core-client", "transaction"] }
 rand = "0.8.5"
 sd-jwt = { package = "sd-jwt-payload", version = "0.5.1", default-features = false, features = ["sha"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.3.0" }

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -24,13 +24,13 @@ identity_verification = { version = "=1.9.6-beta.1", path = "../identity_verific
 iota_interaction.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "iota_interaction", default-features = false }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction", default-features = false }
 
 [dev-dependencies]
 # required for doc test
 anyhow = "1.0.64"
 identity_iota = { version = "=1.9.6-beta.1", path = "./", features = ["memstore"] }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", rev = "96196f0da231883ec69cda04892c600ef6afa982" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.22.1" }
 rand = "0.8.5"
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.3.0" }
 tokio = { version = "1.49.0", features = ["full"] }

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -24,7 +24,7 @@ identity_verification = { version = "=1.9.6-beta.1", path = "../identity_verific
 iota_interaction.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction", default-features = false }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "iota_interaction", default-features = false }
 
 [dev-dependencies]
 # required for doc test

--- a/identity_iota_core/Cargo.toml
+++ b/identity_iota_core/Cargo.toml
@@ -24,7 +24,7 @@ num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["std"] }
 once_cell = { version = "1.18", default-features = false, features = ["std"] }
 prefix-hex = { version = "0.7", default-features = false }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "product_common", default-features = false }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "product_common", default-features = false }
 ref-cast = { version = "1.0.14", default-features = false }
 serde.workspace = true
 serde_json.workspace = true
@@ -47,15 +47,15 @@ secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag
 serde-aux = { version = "4.5.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota-config = { git = "https://github.com/iotaledger/iota.git", package = "iota-config", rev = "96196f0da231883ec69cda04892c600ef6afa982", optional = true }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "iota_interaction" }
-iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "iota_interaction_rust" }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", rev = "96196f0da231883ec69cda04892c600ef6afa982" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", rev = "96196f0da231883ec69cda04892c600ef6afa982", optional = true }
+iota-config = { git = "https://github.com/iotaledger/iota.git", package = "iota-config", tag = "v1.22.1", optional = true }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction" }
+iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction_rust" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.22.1" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.22.1", optional = true }
 tokio = { version = "1.49.0", default-features = false, features = ["macros", "sync", "rt", "process"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "iota_interaction", default-features = false }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction", default-features = false }
 
 # Dependency iota_interaction_ts is always used on wasm32 platform. It is not controlled by the "iota-client" feature
 # because it's unclear how to implement this. wasm32 build will most probably always use the "iota-client" feature

--- a/identity_iota_core/Cargo.toml
+++ b/identity_iota_core/Cargo.toml
@@ -24,7 +24,7 @@ num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["std"] }
 once_cell = { version = "1.18", default-features = false, features = ["std"] }
 prefix-hex = { version = "0.7", default-features = false }
-product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "product_common", default-features = false }
+product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "product_common", default-features = false }
 ref-cast = { version = "1.0.14", default-features = false }
 serde.workspace = true
 serde_json.workspace = true
@@ -48,14 +48,14 @@ serde-aux = { version = "4.5.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 iota-config = { git = "https://github.com/iotaledger/iota.git", package = "iota-config", tag = "v1.22.1", optional = true }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction" }
-iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction_rust" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "iota_interaction" }
+iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "iota_interaction_rust" }
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.22.1" }
 move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.22.1", optional = true }
 tokio = { version = "1.49.0", default-features = false, features = ["macros", "sync", "rt", "process"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction", default-features = false }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "iota_interaction", default-features = false }
 
 # Dependency iota_interaction_ts is always used on wasm32 platform. It is not controlled by the "iota-client" feature
 # because it's unclear how to implement this. wasm32 build will most probably always use the "iota-client" feature

--- a/identity_jose/Cargo.toml
+++ b/identity_jose/Cargo.toml
@@ -25,10 +25,10 @@ thiserror.workspace = true
 zeroize = { version = "1.6", default-features = false, features = ["std", "zeroize_derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "iota_interaction" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "iota_interaction", default-features = false }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction", default-features = false }
 
 [dev-dependencies]
 iota-crypto = { version = "0.23", features = ["ed25519", "random", "hmac"] }

--- a/identity_jose/Cargo.toml
+++ b/identity_jose/Cargo.toml
@@ -25,10 +25,10 @@ thiserror.workspace = true
 zeroize = { version = "1.6", default-features = false, features = ["std", "zeroize_derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "iota_interaction" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction", default-features = false }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "iota_interaction", default-features = false }
 
 [dev-dependencies]
 iota-crypto = { version = "0.23", features = ["ed25519", "random", "hmac"] }

--- a/identity_storage/Cargo.toml
+++ b/identity_storage/Cargo.toml
@@ -40,17 +40,17 @@ tokio = { version = "1.49.0", default-features = false, features = ["macros", "s
 zkryptium = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "iota_interaction", optional = true }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "iota_interaction", default-features = false, optional = true }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction", default-features = false, optional = true }
 
 [dev-dependencies]
 identity_credential = { version = "=1.9.6-beta.1", path = "../identity_credential", features = ["revocation-bitmap"] }
 identity_ecdsa_verifier = { version = "=1.9.6-beta.1", path = "../identity_ecdsa_verifier", default-features = false, features = ["es256"] }
 identity_eddsa_verifier = { version = "=1.9.6-beta.1", path = "../identity_eddsa_verifier", default-features = false, features = ["ed25519"] }
 once_cell = { version = "1.18", default-features = false }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "product_common", default-features = false }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "product_common", default-features = false }
 tokio = { version = "1.49.0", default-features = false, features = ["macros", "sync", "rt"] }
 
 [features]

--- a/identity_storage/Cargo.toml
+++ b/identity_storage/Cargo.toml
@@ -40,17 +40,17 @@ tokio = { version = "1.49.0", default-features = false, features = ["macros", "s
 zkryptium = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction", optional = true }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "iota_interaction", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "iota_interaction", default-features = false, optional = true }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "iota_interaction", default-features = false, optional = true }
 
 [dev-dependencies]
 identity_credential = { version = "=1.9.6-beta.1", path = "../identity_credential", features = ["revocation-bitmap"] }
 identity_ecdsa_verifier = { version = "=1.9.6-beta.1", path = "../identity_ecdsa_verifier", default-features = false, features = ["es256"] }
 identity_eddsa_verifier = { version = "=1.9.6-beta.1", path = "../identity_eddsa_verifier", default-features = false, features = ["ed25519"] }
 once_cell = { version = "1.18", default-features = false }
-product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-22-rc-upstream-merge", package = "product_common", default-features = false }
+product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "product_common", default-features = false }
 tokio = { version = "1.49.0", default-features = false, features = ["macros", "sync", "rt"] }
 
 [features]


### PR DESCRIPTION
# Description of change

Following dependencies have been changed:
- [ ] tokio version update to: -
- [ ] fastcrypto version update to rev = "-"
- [x] iota-sdk-types (`https://github.com/iotaledger/iota-rust-sdk.git`) update to rev = 7c1434aabb2e7b11681722edaf1a51ac52941b84
- [ ] identity_wasm: new peerDep. version for @iota/iota-sdk:
- [ ] identity_wasm: new dependency version for @iota/iota-interaction-ts: _
- [ ] identity_wasm: new dependency version for @iota/notarization: _
- [x] pin all product-core.git dependencies to `tag = "v0.8.17"`
- [x] pin all iota.git dependencies to `tag = "v1.22.1"`
- [x] pin all notarization.git dependencies to `tag = "v0.1.21"`

## Links to any relevant issues
https://github.com/iotaledger/product-core/issues/67