### PR TITLE
Replace wasm-opt in bindings dep with local version

### DIFF
--- a/.github/workflows/shared-build-wasm.yml
+++ b/.github/workflows/shared-build-wasm.yml
@@ -58,6 +58,13 @@ jobs:
         uses: jetli/wasm-bindgen-action@24ba6f9fff570246106ac3f80f35185600c3f6c9
         with:
           version: '0.2.108'
+  
+      # Install wasm-opt from binaryen repository.
+      - name: Install binaryen
+        uses: sigoden/install-binary@v1
+        with:
+          repo: WebAssembly/binaryen
+          name: wasm-opt
 
       - name: Setup sccache
         uses: './.github/actions/rust/sccache/setup-sccache'

--- a/bindings/wasm/identity_wasm/README.md
+++ b/bindings/wasm/identity_wasm/README.md
@@ -34,16 +34,30 @@ to [rustup.rs](https://rustup.rs) for the installation.
 - [Cargo](https://doc.rust-lang.org/cargo/) (>= 1.65)
 - for running example: a local network node with the IOTA identity package deployed as described [here](./local-network-setup.md)
 
-### 1. Install `wasm-bindgen-cli`
+### 1. Install Local Tooling
 
-If you want to build the library from source,
-you will first need to manually install [`wasm-bindgen-cli`](https://github.com/rustwasm/wasm-bindgen).
+If you want to build the library from source you have to install additional build tools locally.
+
+### Install `wasm-bindgen-cli`
+
+First you need to install [`wasm-bindgen-cli`](https://github.com/rustwasm/wasm-bindgen).
 A manual installation is required because we use the [Weak References](https://rustwasm.github.io/wasm-bindgen/reference/weak-references.html) feature,
 which [`wasm-pack` does not expose](https://github.com/rustwasm/wasm-pack/issues/930).
 
 ```bash
 cargo install --force wasm-bindgen-cli
 ```
+
+### Install `wasm-opt`
+
+To reduce the size of the wasm package, it is optimized with `wasm-opt`, which is part of [`binaryen`](https://github.com/WebAssembly/binaryen).
+
+You can either download a [release of binaryen](https://github.com/WebAssembly/binaryen/releases) and make the bin folder available in your PATH or check if your operating system tooling offers a more convenient way of installing the binaries like APT, Homebrew, etc.
+
+Some examples:
+
+- Linux via APT: `sudo apt-get update && sudo apt-get -y install binaryen` (taken from [here](https://installati.one/install-binaryen-ubuntu-22-04/))
+- MacOS via Homebrew: `brew install binaryen` (see [Homebrew entry](https://formulae.brew.sh/formula/binaryen))
 
 ### 2. Install Dependencies
 

--- a/bindings/wasm/identity_wasm/package-lock.json
+++ b/bindings/wasm/identity_wasm/package-lock.json
@@ -38,8 +38,7 @@
         "txm": "^8.1.0",
         "typedoc": "^0.27.6",
         "typedoc-plugin-markdown": "^4.4.1",
-        "typescript": "^5.7.3",
-        "wasm-opt": "^1.4.0"
+        "typescript": "^5.7.3"
       },
       "engines": {
         "node": ">=20"
@@ -1620,14 +1619,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "dev": true,
@@ -2649,28 +2640,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/fs-then-native": {
@@ -4194,37 +4163,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/minipass": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "dev": true,
@@ -5544,22 +5482,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tar": {
-      "version": "6.2.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/temp-path": {
       "version": "1.0.0",
       "dev": true,
@@ -6350,19 +6272,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.17"
-      }
-    },
-    "node_modules/wasm-opt": {
-      "version": "1.4.0",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.9",
-        "tar": "^6.1.13"
-      },
-      "bin": {
-        "wasm-opt": "bin/wasm-opt.js"
       }
     },
     "node_modules/watchpack": {

--- a/bindings/wasm/identity_wasm/package.json
+++ b/bindings/wasm/identity_wasm/package.json
@@ -70,8 +70,7 @@
     "txm": "^8.1.0",
     "typedoc": "^0.27.6",
     "typedoc-plugin-markdown": "^4.4.1",
-    "typescript": "^5.7.3",
-    "wasm-opt": "^1.4.0"
+    "typescript": "^5.7.3"
   },
   "dependencies": {
     "@iota/iota-interaction-ts": "^0.14.0",


### PR DESCRIPTION
# Description of change

Remove outed `wasm-opt` installed via NPM, and add the requirement to have `wasm-opt` installed locally, which allows using newer versions, that are compatible with the latest Rust toolchain versions.

This solves the error thrown by `wasm-opt` when building the WASM bindings, which lead to skipping the optimization process.

## Links to any relevant issues

Fixes issue #1811.

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Checked build process locally, manually dispatched workflow in GitHub CI [see here](https://github.com/iotaledger/identity/actions/runs/27021843656/job/79751576990).

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes