### PR TITLE
WASM IdentityClient doesn't consume the given read-only client nor signer

### DIFF
--- a/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client.rs
@@ -77,9 +77,11 @@ impl WasmIdentityClient {
   }
 
   #[wasm_bindgen(js_name = create)]
-  pub async fn new(client: WasmIdentityClientReadOnly, signer: WasmTransactionSigner) -> Result<WasmIdentityClient> {
+  pub async fn new(client: &WasmIdentityClientReadOnly, signer: &WasmTransactionSigner) -> Result<WasmIdentityClient> {
     #[allow(deprecated)]
-    let inner_client = IdentityClient::new(client.0, signer).await.wasm_result()?;
+    let inner_client = IdentityClient::new(client.0.clone(), signer.clone())
+      .await
+      .wasm_result()?;
     Ok(WasmIdentityClient(inner_client))
   }
 


### PR DESCRIPTION
# Description of change
Avoid consuming the read-only client when constructing an instance of `IdentityClient`.